### PR TITLE
Add the ability to set parent relationships in the dashboard

### DIFF
--- a/playground/Redis/Redis.AppHost/Program.cs
+++ b/playground/Redis/Redis.AppHost/Program.cs
@@ -1,9 +1,9 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var redis = builder.AddRedis("redis")
-    .WithDataVolume()
-    .WithRedisCommander(c => c.WithHostPort(33803))
-    .WithRedisInsight(c => c.WithHostPort(41567));
+var redis = builder.AddRedis("redis");
+redis.WithDataVolume()
+    .WithRedisCommander(c => c.WithHostPort(33803).WithParentRelationship(redis.Resource))
+    .WithRedisInsight(c => c.WithHostPort(41567).WithParentRelationship(redis.Resource));
 
 var garnet = builder.AddGarnet("garnet")
     .WithDataVolume();

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -174,6 +174,7 @@ public static class AzureEventHubsExtensions
         // Create a separate storage emulator for the Event Hub one
         var storageResource = builder.ApplicationBuilder
                 .AddAzureStorage($"{builder.Resource.Name}-storage")
+                .WithParentRelationship(builder.Resource)
                 .RunAsEmulator();
 
         var storage = storageResource.Resource;

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -64,8 +64,7 @@ public static class AzureFunctionsProjectResourceExtensions
             }
             else
             {
-                storage = builder.AddAzureStorage(storageResourceName)
-                    .RunAsEmulator().Resource;
+                storage = builder.AddAzureStorage(storageResourceName).RunAsEmulator().Resource;
             }
         }
 

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -64,7 +64,9 @@ public static class AzureFunctionsProjectResourceExtensions
             }
             else
             {
-                storage = builder.AddAzureStorage(storageResourceName).RunAsEmulator().Resource;
+                storage = builder.AddAzureStorage(storageResourceName)
+                    .WithParentRelationship(resource)
+                    .RunAsEmulator().Resource;
             }
         }
 

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -65,7 +65,6 @@ public static class AzureFunctionsProjectResourceExtensions
             else
             {
                 storage = builder.AddAzureStorage(storageResourceName)
-                    .WithParentRelationship(resource)
                     .RunAsEmulator().Resource;
             }
         }

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -264,7 +264,8 @@ public static class AzureServiceBusExtensions
                 .WithImageRegistry(ServiceBusEmulatorContainerImageTags.AzureSqlEdgeRegistry)
                 .WithEndpoint(targetPort: 1433, name: "tcp")
                 .WithEnvironment("ACCEPT_EULA", "Y")
-                .WithEnvironment("MSSQL_SA_PASSWORD", password);
+                .WithEnvironment("MSSQL_SA_PASSWORD", password)
+                .WithParentRelationship(builder.Resource);
 
         builder.WithAnnotation(new EnvironmentCallbackAnnotation((EnvironmentCallbackContext context) =>
         {

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -99,13 +99,6 @@ internal sealed class AzureProvisioner(
             return;
         }
 
-        static IResource? SelectParentResource(IResource resource) => resource switch
-        {
-            IAzureResource ar => ar,
-            IResourceWithParent rp => SelectParentResource(rp.Parent),
-            _ => null
-        };
-
         // Create a map of parents to their children used to propagate state changes later.
         _parentChildLookup = appModel.Resources.OfType<IResourceWithParent>().ToLookup(r => r.Parent);
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -111,12 +111,12 @@ internal sealed class BicepProvisioner(
         {
             ResourceType = resource.GetType().Name,
             State = new("Starting", KnownResourceStateStyles.Info),
-            Properties = [
+            Properties = state.Properties.SetResourcePropertyRange([
                 new("azure.subscription.id", context.Subscription.Id.Name),
                 new("azure.resource.group", context.ResourceGroup.Id.Name),
                 new("azure.tenant.domain", context.Tenant.Data.DefaultDomain),
                 new("azure.location", context.Location.ToString()),
-            ]
+            ])
         }).ConfigureAwait(false);
 
         var resourceLogger = loggerService.GetLogger(resource);

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -158,6 +158,7 @@ public static class MongoDBBuilderExtensions
                                                         .WithImageRegistry(MongoDBContainerImageTags.MongoExpressRegistry)
                                                         .WithEnvironment(context => ConfigureMongoExpressContainer(context, builder.Resource))
                                                         .WithHttpEndpoint(targetPort: 8081, name: "http")
+                                                        .WithParentRelationship(builder.Resource)
                                                         .ExcludeFromManifest();
 
         configureContainer?.Invoke(resourceBuilder);

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -40,14 +40,14 @@ internal class ResourceSnapshotBuilder
             State = state,
             // Map a container exit code of -1 (unknown) to null
             ExitCode = container.Status?.ExitCode is null or Conventions.UnknownExitCode ? null : container.Status.ExitCode,
-            Properties = [
+            Properties = previous.Properties.SetResourcePropertyRange([
                 new(KnownProperties.Container.Image, container.Spec.Image),
                 new(KnownProperties.Container.Id, containerId),
                 new(KnownProperties.Container.Command, container.Spec.Command),
                 new(KnownProperties.Container.Args, container.Status?.EffectiveArgs ?? []) { IsSensitive = true },
                 new(KnownProperties.Container.Ports, GetPorts()),
                 new(KnownProperties.Container.Lifetime, GetContainerLifetime()),
-            ],
+            ]),
             EnvironmentVariables = environment,
             CreationTimeStamp = container.Metadata.CreationTimestamp?.ToUniversalTime(),
             StartTimeStamp = container.Status?.StartupTimestamp?.ToUniversalTime(),
@@ -111,13 +111,13 @@ internal class ResourceSnapshotBuilder
                 ResourceType = KnownResourceTypes.Project,
                 State = state,
                 ExitCode = executable.Status?.ExitCode,
-                Properties = [
+                Properties = previous.Properties.SetResourcePropertyRange([
                     new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
                     new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
                     new(KnownProperties.Executable.Args, executable.Status?.EffectiveArgs ?? []) { IsSensitive = true },
                     new(KnownProperties.Executable.Pid, executable.Status?.ProcessId),
                     new(KnownProperties.Project.Path, projectPath)
-                ],
+                ]),
                 EnvironmentVariables = environment,
                 CreationTimeStamp = executable.Metadata.CreationTimestamp?.ToUniversalTime(),
                 StartTimeStamp = executable.Status?.StartupTimestamp?.ToUniversalTime(),
@@ -132,12 +132,12 @@ internal class ResourceSnapshotBuilder
             ResourceType = KnownResourceTypes.Executable,
             State = state,
             ExitCode = executable.Status?.ExitCode,
-            Properties = [
+            Properties = previous.Properties.SetResourcePropertyRange([
                 new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
                 new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
                 new(KnownProperties.Executable.Args, executable.Status?.EffectiveArgs ?? []) { IsSensitive = true },
                 new(KnownProperties.Executable.Pid, executable.Status?.ProcessId)
-            ],
+            ]),
             EnvironmentVariables = environment,
             CreationTimeStamp = executable.Metadata.CreationTimestamp?.ToUniversalTime(),
             StartTimeStamp = executable.Status?.StartupTimestamp?.ToUniversalTime(),

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -16,7 +16,7 @@ internal sealed class ApplicationOrchestrator
 {
     private readonly IDcpExecutor _dcpExecutor;
     private readonly DistributedApplicationModel _model;
-    private readonly ILookup<IResource?, IResourceWithParent> _parentChildLookup;
+    private readonly ILookup<IResource, IResource> _parentChildLookup;
     private readonly IDistributedApplicationLifecycleHook[] _lifecycleHooks;
     private readonly ResourceNotificationService _notificationService;
     private readonly IDistributedApplicationEventing _eventing;
@@ -33,7 +33,7 @@ internal sealed class ApplicationOrchestrator
     {
         _dcpExecutor = dcpExecutor;
         _model = model;
-        _parentChildLookup = GetParentChildLookup(model);
+        _parentChildLookup = RelationshipEvaluator.GetParentChildLookup(model);
         _lifecycleHooks = lifecycleHooks.ToArray();
         _notificationService = notificationService;
         _eventing = eventing;
@@ -107,6 +107,8 @@ internal sealed class ApplicationOrchestrator
                     HealthReports = GetInitialHealthReports(context.Resource)
                 })
                 .ConfigureAwait(false);
+
+                await SetExecutableChildResourceAsync(context.Resource).ConfigureAwait(false);
                 break;
             case KnownResourceTypes.Container:
                 await _notificationService.PublishUpdateAsync(context.Resource, s => s with
@@ -217,22 +219,6 @@ internal sealed class ApplicationOrchestrator
         await _dcpExecutor.StopResourceAsync(resourceReference, cancellationToken).ConfigureAwait(false);
     }
 
-    private static ILookup<IResource?, IResourceWithParent> GetParentChildLookup(DistributedApplicationModel model)
-    {
-        static IResource? SelectParentContainerResource(IResource resource) => resource switch
-        {
-            IResourceWithParent rp => SelectParentContainerResource(rp.Parent),
-            IResource r when r.IsContainer() => r,
-            _ => null
-        };
-
-        // parent -> children lookup
-        return model.Resources.OfType<IResourceWithParent>()
-                              .Select(x => (Child: x, Root: SelectParentContainerResource(x.Parent)))
-                              .Where(x => x.Root is not null)
-                              .ToLookup(x => x.Root, x => x.Child);
-    }
-
     private async Task SetChildResourceAsync(IResource resource, string parentName, string? state, DateTime? startTimeStamp, DateTime? stopTimeStamp)
     {
         foreach (var child in _parentChildLookup[resource])
@@ -242,6 +228,21 @@ internal sealed class ApplicationOrchestrator
                 State = state,
                 StartTimeStamp = startTimeStamp,
                 StopTimeStamp = stopTimeStamp,
+                Properties = s.Properties.SetResourceProperty(KnownProperties.Resource.ParentName, parentName)
+            }).ConfigureAwait(false);
+        }
+    }
+
+    private async Task SetExecutableChildResourceAsync(IResource resource)
+    {
+        // the parent name needs to be an instance name, not the resource name.
+        // parent the children under the first resource instance.
+        var parentName = resource.GetResolvedResourceNames()[0];
+
+        foreach (var child in _parentChildLookup[resource])
+        {
+            await _notificationService.PublishUpdateAsync(child, s => s with
+            {
                 Properties = s.Properties.SetResourceProperty(KnownProperties.Resource.ParentName, parentName)
             }).ConfigureAwait(false);
         }
@@ -286,7 +287,8 @@ internal sealed class ApplicationOrchestrator
         // we need to dispatch the event for the children.
         if (_parentChildLookup[resource] is { } children)
         {
-            foreach (var child in children.OfType<IResourceWithConnectionString>())
+            // only dispatch the event for children that have a connection string and are IResourceWithParent, not parented by annotations.
+            foreach (var child in children.OfType<IResourceWithConnectionString>().Where(c => c is IResourceWithParent))
             {
                 var childConnectionStringAvailableEvent = new ConnectionStringAvailableEvent(child, _serviceProvider);
                 await _eventing.PublishAsync(childConnectionStringAvailableEvent, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Orchestrator/RelationshipEvaluator.cs
+++ b/src/Aspire.Hosting/Orchestrator/RelationshipEvaluator.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Orchestrator;
+
+internal static class RelationshipEvaluator
+{
+    public static ILookup<IResource, IResource> GetParentChildLookup(DistributedApplicationModel model)
+    {
+        static IResource? SelectParentContainerResource(IResource resource) => resource switch
+        {
+            IResourceWithParent rp => SelectParentContainerResource(rp.Parent),
+            IResource r when r.IsContainer() => r,
+            _ => null
+        };
+
+        // parent -> children lookup
+        // Built from IResourceWithParent first, then from annotations.
+        return model.Resources.OfType<IResourceWithParent>()
+                              .Select(x => (Child: (IResource)x, Root: SelectParentContainerResource(x.Parent)))
+                              .Where(x => x.Root is not null)
+                              .Concat(GetParentChildRelationshipsFromAnnotations(model))
+                              .ToLookup(x => x.Root!, x => x.Child);
+    }
+
+    private static IEnumerable<(IResource Child, IResource? Root)> GetParentChildRelationshipsFromAnnotations(DistributedApplicationModel model)
+    {
+        static bool TryGetParent(IResource resource, [NotNullWhen(true)] out IResource? parent)
+        {
+            if (resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relations) &&
+                   relations.LastOrDefault(r => r.Type == KnownRelationshipTypes.Parent) is { } parentRelationship)
+            {
+                parent = parentRelationship.Resource;
+                return true;
+            }
+
+            parent = default;
+            return false;
+        }
+
+        static IResource? SelectParentResource(IResource? resource) => resource switch
+        {
+            IResource r when TryGetParent(r, out var parent) => parent,
+            _ => null
+        };
+
+        var result = model.Resources.Select(x => (Child: x, Parent: SelectParentResource(x)))
+                                    .Where(x => x.Parent is not null)
+                                    .ToArray();
+
+        ValidateRelationships(result!);
+
+        static IResource? SelectRootResource(IResource? resource) => resource switch
+        {
+            IResource r when TryGetParent(r, out var parent) => SelectRootResource(parent) ?? parent,
+            _ => null
+        };
+
+        // translate the result to child -> root, which the dashboard expects
+        return result.Select(x => (x.Child, Root: SelectRootResource(x.Child)));
+    }
+
+    private static void ValidateRelationships((IResource Child, IResource Parent)[] relationships)
+    {
+        if (relationships.Length == 0)
+        {
+            return;
+        }
+
+        var childToParentLookup = relationships.ToDictionary(x => x.Child, x => x.Parent);
+
+        // ensure no circular dependencies
+        var visited = new Stack<IResource>();
+        foreach (var relation in relationships)
+        {
+            ValidateNoCircularDependencies(childToParentLookup, relation.Child, visited);
+        }
+
+        static void ValidateNoCircularDependencies(Dictionary<IResource, IResource> childToParentLookup, IResource child, Stack<IResource> visited)
+        {
+            visited.Push(child);
+            if (childToParentLookup.TryGetValue(child, out var parent))
+            {
+                if (visited.Contains(parent))
+                {
+                    throw new InvalidOperationException($"Circular dependency detected: {string.Join(" -> ", visited)} -> {parent}");
+                }
+                ValidateNoCircularDependencies(childToParentLookup, parent, visited);
+            }
+            visited.Pop();
+        }
+    }
+}

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -276,6 +276,7 @@ static Aspire.Hosting.ResourceBuilderExtensions.WithCommand<T>(this Aspire.Hosti
 static Aspire.Hosting.ResourceBuilderExtensions.WithHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! key) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHttpHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string? path = null, int? statusCode = null, string? endpointName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHttpsHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string? path = null, int? statusCode = null, string? endpointName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithParentRelationship<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResource! parent) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithRelationship<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResource! resource, string! type) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.Utils.VolumeNameGenerator.Generate<T>(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! suffix) -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1064,4 +1064,34 @@ public static class ResourceBuilderExtensions
 
         return builder.WithAnnotation(new ResourceRelationshipAnnotation(resource, type));
     }
+
+    /// <summary>
+    /// Adds a <see cref="ResourceRelationshipAnnotation"/> to the resource annotations to add a parent-child relationship.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="parent">The parent of <paramref name="builder"/>.</param>
+    /// <returns>A resource builder.</returns>
+    /// <remarks>
+    /// <para>
+    /// The <c>WithParentRelationship</c> method is used to add parent relationships to the resource. Relationships are used to link
+    /// resources together in UI.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// This example shows adding a relationship between two resources.
+    /// <code lang="C#">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var backend = builder.AddProject&lt;Projects.Backend&gt;("backend");
+    /// 
+    /// var frontend = builder.AddProject&lt;Projects.Manager&gt;("frontend")
+    ///                      .WithParentRelationship(backend.Resource);
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<T> WithParentRelationship<T>(
+        this IResourceBuilder<T> builder,
+        IResource parent) where T : IResource
+    {
+        return builder.WithRelationship(parent, KnownRelationshipTypes.Parent);
+    }
 }

--- a/src/Shared/CustomResourceSnapshotExtensions.cs
+++ b/src/Shared/CustomResourceSnapshotExtensions.cs
@@ -30,4 +30,37 @@ internal static class CustomResourceSnapshotExtensions
         // Add property.
         return [.. properties, new ResourcePropertySnapshot(name, value)];
     }
+
+    internal static ImmutableArray<ResourcePropertySnapshot> SetResourcePropertyRange(this ImmutableArray<ResourcePropertySnapshot> properties, IEnumerable<ResourcePropertySnapshot> newValues)
+    {
+        var existingProperties = new List<ResourcePropertySnapshot>(properties);
+        var propertiesToAdd = new List<ResourcePropertySnapshot>();
+
+        foreach (var newValue in newValues)
+        {
+            var found = false;
+            for (var i = 0; i < existingProperties.Count; i++)
+            {
+                var existingProperty = existingProperties[i];
+
+                if (string.Equals(existingProperty.Name, newValue.Name, StringComparisons.ResourcePropertyName))
+                {
+                    if (existingProperty.Value != newValue.Value)
+                    {
+                        existingProperties[i] = existingProperty with { Value = newValue.Value };
+                    }
+
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                propertiesToAdd.Add(newValue);
+            }
+        }
+
+        return [.. existingProperties, .. propertiesToAdd];
+    }
 }

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -7,6 +7,7 @@ using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Orchestrator;
 using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -61,6 +62,193 @@ public class ApplicationOrchestratorTests
         Assert.Equal(parentResourceId, childParentResourceId);
     }
 
+    [Fact]
+    public async Task WithParentRelationshipSetsParentPropertyCorrectly()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var parent = builder.AddContainer("parent", "image");
+        var child = builder.AddContainer("child", "image").WithParentRelationship(parent.Resource);
+        var child2 = builder.AddContainer("child2", "image").WithParentRelationship(parent.Resource);
+
+        var nestedChild = builder.AddContainer("nested-child", "image").WithParentRelationship(child.Resource);
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events);
+        await appOrchestrator.RunApplicationAsync();
+
+        string? parentResourceId = null;
+        string? childParentResourceId = null;
+        string? child2ParentResourceId = null;
+        string? nestedChildParentResourceId = null;
+        var watchResourceTask = Task.Run(async () =>
+        {
+            await foreach (var item in resourceNotificationService.WatchAsync())
+            {
+                if (item.Resource == parent.Resource)
+                {
+                    parentResourceId = item.ResourceId;
+                }
+                else if (item.Resource == child.Resource)
+                {
+                    childParentResourceId = item.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.ParentName)?.Value?.ToString();
+                }
+                else if (item.Resource == nestedChild.Resource)
+                {
+                    nestedChildParentResourceId = item.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.ParentName)?.Value?.ToString();
+                }
+                else if (item.Resource == child2.Resource)
+                {
+                    child2ParentResourceId = item.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.ParentName)?.Value?.ToString();
+                }
+
+                if (parentResourceId != null && childParentResourceId != null && nestedChildParentResourceId != null && child2ParentResourceId != null)
+                {
+                    return;
+                }
+            }
+        });
+
+        await events.PublishAsync(new OnResourceStartingContext(CancellationToken.None, KnownResourceTypes.Container, parent.Resource, parent.Resource.Name));
+
+        await watchResourceTask.DefaultTimeout();
+
+        Assert.Equal(parentResourceId, childParentResourceId);
+        Assert.Equal(parentResourceId, child2ParentResourceId);
+
+        // Nested child should have parent set to the root parent, not direct parent
+        Assert.Equal(parentResourceId, nestedChildParentResourceId);
+    }
+
+    [Fact]
+    public async Task LastWithParentRelationshipWins()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var firstParent = builder.AddContainer("firstParent", "image");
+        var secondParent = builder.AddContainer("secondParent", "image");
+
+        var child = builder.AddContainer("child", "image");
+
+        child.WithParentRelationship(firstParent.Resource);
+        child.WithParentRelationship(secondParent.Resource);
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events);
+        await appOrchestrator.RunApplicationAsync();
+
+        string? firstParentResourceId = null;
+        string? secondParentResourceId = null;
+        string? childParentResourceId = null;
+        var watchResourceTask = Task.Run(async () =>
+        {
+            await foreach (var item in resourceNotificationService.WatchAsync())
+            {
+                if (item.Resource == firstParent.Resource)
+                {
+                    firstParentResourceId = item.ResourceId;
+                }
+                else if (item.Resource == secondParent.Resource)
+                {
+                    secondParentResourceId = item.ResourceId;
+                }
+                else if (item.Resource == child.Resource)
+                {
+                    childParentResourceId = item.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.ParentName)?.Value?.ToString();
+                }
+
+                if (firstParentResourceId != null && secondParentResourceId != null && childParentResourceId != null)
+                {
+                    return;
+                }
+            }
+        });
+
+        await events.PublishAsync(new OnResourceStartingContext(CancellationToken.None, KnownResourceTypes.Container, firstParent.Resource, firstParent.Resource.Name));
+        await events.PublishAsync(new OnResourceStartingContext(CancellationToken.None, KnownResourceTypes.Container, secondParent.Resource, secondParent.Resource.Name));
+
+        await watchResourceTask.DefaultTimeout();
+
+        // child should be parented to the last parent set
+        Assert.Equal(secondParentResourceId, childParentResourceId);
+    }
+
+    [Fact]
+    public async Task WithParentRelationshipWorksWithProjects()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectA = builder.AddProject<ProjectA>("projecta");
+        var projectB = builder.AddProject<ProjectB>("projectb").WithParentRelationship(projectA.Resource);
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events);
+        await appOrchestrator.RunApplicationAsync();
+
+        string? projectAResourceId = null;
+        string? projectBParentResourceId = null;
+        var watchResourceTask = Task.Run(async () =>
+        {
+            await foreach (var item in resourceNotificationService.WatchAsync())
+            {
+                if (item.Resource == projectA.Resource)
+                {
+                    projectAResourceId = item.ResourceId;
+                }
+                else if (item.Resource == projectB.Resource)
+                {
+                    projectBParentResourceId = item.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.ParentName)?.Value?.ToString();
+                }
+
+                if (projectAResourceId != null && projectBParentResourceId != null)
+                {
+                    return;
+                }
+            }
+        });
+
+        await events.PublishAsync(new OnResourceStartingContext(CancellationToken.None, KnownResourceTypes.Container, projectA.Resource, projectA.Resource.Name));
+        await events.PublishAsync(new OnResourceStartingContext(CancellationToken.None, KnownResourceTypes.Container, projectB.Resource, projectB.Resource.Name));
+
+        await watchResourceTask.DefaultTimeout();
+
+        Assert.Equal(projectAResourceId, projectBParentResourceId);
+    }
+
+    [Fact]
+    public void DetectsCircularDependency()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var container1 = builder.AddContainer("container1", "image");
+        var container2 = builder.AddContainer("container2", "image2");
+        var container3 = builder.AddContainer("container3", "image3");
+
+        container1.WithParentRelationship(container2.Resource);
+        container2.WithParentRelationship(container3.Resource);
+        container3.WithParentRelationship(container1.Resource);
+
+        using var app = builder.Build();
+
+        var e = Assert.Throws<InvalidOperationException>(() => app.Services.GetService<ApplicationOrchestrator>());
+        Assert.Contains("Circular dependency detected", e.Message);
+    }
+
     private static ApplicationOrchestrator CreateOrchestrator(
         DistributedApplicationModel distributedAppModel,
         ResourceNotificationService notificationService,
@@ -94,5 +282,18 @@ public class ApplicationOrchestratorTests
     private sealed class CustomChildResource(string name, IResource parent) : Resource(name), IResourceWithParent
     {
         public IResource Parent => parent;
+    }
+
+    private sealed class ProjectA : IProjectMetadata
+    {
+        public string ProjectPath => "projectA";
+
+        public LaunchSettings LaunchSettings { get; } = new();
+    }
+
+    private sealed class ProjectB : IProjectMetadata
+    {
+        public string ProjectPath => "projectB";
+        public LaunchSettings LaunchSettings { get; } = new();
     }
 }


### PR DESCRIPTION
## Description

Add a new API - WithParentRelationship that can be set to nest resources.

Fix an issue in snapshot properties where it was overwriting previous properties by setting to
a new collection on publish. Needs to update/append to the property collection.

Allow Projects to be parents, not just Containers.

Fix #7259

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
