### PR TITLE
Fix Typo: 'Anlytics' -> 'Analytics' in Aspire.Hosting.Azure.OperationalInsights

### DIFF
--- a/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>aspire integration hosting azure</PackageTags>
-    <Description>Azure Log Anlytics resource types for .NET Aspire.</Description>
+    <Description>Azure Log Analytics resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureLogAnalytics_256x.png</PackageIconFullPath>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

I was searching nuget packages for `Aspire.Hosting...` and noticed this typo in the description of one of the packages. This PR is simply the typo fix. 

Fixes #7338

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
