### PR TITLE
Add IDistributedApplicaitonBuilder.GetResourceBuilder API

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Extensions for <see cref="IDistributedApplicationBuilder"/>.
+/// </summary>
+public static class DistributedApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Creates a new resource builder based on the name of an existing resource.
+    /// </summary>
+    /// <typeparam name="T">Type of resource.</typeparam>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The name of an existing resource.</param>
+    /// <returns>A resource builder.</returns>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="CreateResourceBuilder{T}(IDistributedApplicationBuilder, string)"/> method is used to create an <see cref="IResourceBuilder{T}"/>
+    /// for a specific resource where the original resource builder cannot be referenced. This does not create a new resource, but instead returns a
+    /// resource builder for an existing resource based on its name.
+    /// </para>
+    /// <para>
+    /// This method is typically used when testing .NET Aspire applications where the original resource builder cannot be
+    /// referenced directly. Using the <see cref="CreateResourceBuilder{T}(IDistributedApplicationBuilder, string)"/> method allows for easier mutation
+    /// of resources within the test scenario.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// In this example, the MyAspireApp.AppHost project has previously added a Redis resource named "cache" to the application host. The test project,
+    /// MyAspireApp.AppHost.Tests, modifies that resource so that it sleeps instead of starting the Redis container. This allows the test case to verify
+    /// that the application's health check returns an 'Unhealthy' status when the Redis resource is not available.
+    /// <code>
+    /// [Fact]
+    /// public async Task GetWebResourceHealthReturnsUnhealthyWhenRedisUnavailable()
+    /// {
+    ///     // Arrange
+    ///     var appHost = await DistributedApplicationTestingBuilder.CreateAsync&lt;Projects.MyAspireApp_AppHost&gt;();
+    ///
+    ///     // Get the "cache" resource and modify it to sleep for 1 day instead of starting Redis.
+    ///     var redis = appHost.CreateResourceBuilder&lt;ContainerResource&gt;("cache"));
+    ///     redis.WithEntrypoint("sleep 1d");
+    ///
+    ///     await using var app = await appHost.BuildAsync();
+    ///     await app.StartAsync();
+    ///
+    ///     // Act
+    ///     var httpClient = new HttpClient { BaseAddress = app.GetEndpoint("webfrontend") };
+    ///     var response = await httpClient.GetAsync("/health");
+    ///
+    ///     // Assert
+    ///     Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+    ///     Assert.Equal("Unhealthy", await response.Content.ReadAsStringAsync());
+    /// }
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<T> CreateResourceBuilder<T>(this IDistributedApplicationBuilder builder, string name) where T : IResource
+    {
+        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+        ArgumentNullException.ThrowIfNullOrEmpty(name, nameof(name));
+        var resource = builder.Resources.FirstOrDefault(r => string.Equals(r.Name, name, StringComparison.OrdinalIgnoreCase));
+        if (resource is null)
+        {
+            throw new InvalidOperationException($"Resource '{name}' was not found.");
+        }
+
+        if (resource is not T typedResource)
+        {
+            throw new InvalidOperationException($"Resource '{name}' of type '{resource.GetType()}' is not assignable to requested type '{typeof(T).Name}'.");
+        }
+
+        return builder.CreateResourceBuilder(typedResource);
+    }
+}
+

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -189,6 +189,7 @@ Aspire.Hosting.ApplicationModel.WaitType.WaitForCompletion = 1 -> Aspire.Hosting
 Aspire.Hosting.ApplicationModel.WaitType.WaitUntilHealthy = 0 -> Aspire.Hosting.ApplicationModel.WaitType
 Aspire.Hosting.DistributedApplicationBuilder.AppHostPath.get -> string!
 Aspire.Hosting.DistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eventing.IDistributedApplicationEventing!
+Aspire.Hosting.DistributedApplicationBuilderExtensions
 Aspire.Hosting.DistributedApplicationOptions.EnableResourceLogging.get -> bool
 Aspire.Hosting.DistributedApplicationOptions.EnableResourceLogging.set -> void
 Aspire.Hosting.Eventing.DistributedApplicationEventing
@@ -256,6 +257,7 @@ static Aspire.Hosting.ContainerResourceBuilderExtensions.WithImage<T>(this Aspir
 static Aspire.Hosting.ContainerResourceBuilderExtensions.WithImageRegistry<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, string? registry) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
 static Aspire.Hosting.ContainerResourceBuilderExtensions.WithLifetime<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, Aspire.Hosting.ApplicationModel.ContainerLifetime lifetime) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
 static Aspire.Hosting.ContainerResourceBuilderExtensions.WithVolume<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, string? name, string! target, bool isReadOnly = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
+static Aspire.Hosting.DistributedApplicationBuilderExtensions.CreateResourceBuilder<T>(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ExecutableResourceBuilderExtensions.PublishAsDockerFile<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
 static Aspire.Hosting.ExecutableResourceBuilderExtensions.PublishAsDockerFile<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!>? configure) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
 static Aspire.Hosting.ExecutableResourceBuilderExtensions.PublishAsDockerFile<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.DockerBuildArg!>? buildArgs) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class DistributedApplicationBuilderExtensionsTests
+{
+    [Fact]
+    public void CreateResourceBuilderByNameRequiresExistingResource()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var missingException = Assert.Throws<InvalidOperationException>(() => appBuilder.CreateResourceBuilder<RedisResource>("non-existent-resource"));
+        Assert.Contains("not found", missingException.Message);
+    }
+
+    [Fact]
+    public void CreateResourceBuilderByNameRequiresCompatibleType()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var originalRedis = appBuilder.AddRedis("redis");
+        var incorrectTypeException = Assert.Throws<InvalidOperationException>(() => appBuilder.CreateResourceBuilder<PostgresServerResource>("redis"));
+        Assert.Contains("not assignable", incorrectTypeException.Message);
+    }
+
+    [Fact]
+    public void CreateResourceBuilderByNameSupportsUpCast()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var originalRedis = appBuilder.AddRedis("redis");
+
+        // RedisResource implements ContainerResource, so this is acceptable.
+        var newRedisBuilder = appBuilder.CreateResourceBuilder<ContainerResource>("redis");
+        Assert.Same(originalRedis.Resource, newRedisBuilder.Resource);
+    }
+
+    [Fact]
+    public void CreateResourceBuilderByReturnsSameResourceInstance()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var originalRedis = appBuilder.AddRedis("redis");
+        var newRedisBuilder = appBuilder.CreateResourceBuilder<RedisResource>("redis");
+        Assert.Same(originalRedis.Resource, newRedisBuilder.Resource);
+    }
+}


### PR DESCRIPTION
## Description

This PR adds an extension method `IDistributedApplicationBuilder.CreateResourceBuilder<T>(string name) where T : IResource` intended to make it easier for tests to get and modify resources added by the AppHost.

Fixes #3022

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
