### PR TITLE
[Testing] Populate AppHost environment from launch profile and support launch profile override

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -137,7 +137,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         OnBuilt(application);
     }
 
-    internal static void PreConfigureBuilderOptions(
+    private static void PreConfigureBuilderOptions(
         DistributedApplicationOptions applicationOptions,
         HostApplicationBuilderSettings hostBuilderOptions,
         string[] args,
@@ -148,24 +148,29 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
             { } existing => [.. existing, .. args],
             null => args
         };
-
-        applicationOptions.Args = applicationOptions.Args switch
-        {
-            { } existing => [.. existing, .. args],
-            null => args
-        };
+        applicationOptions.Args = hostBuilderOptions.Args;
 
         hostBuilderOptions.EnvironmentName = Environments.Development;
         hostBuilderOptions.ApplicationName = entryPointAssembly.GetName().Name ?? string.Empty;
         applicationOptions.AssemblyName = entryPointAssembly.GetName().Name ?? string.Empty;
         applicationOptions.DisableDashboard = true;
         applicationOptions.EnableResourceLogging = true;
-        var cfg = hostBuilderOptions.Configuration ??= new();
+        var existingConfig = new ConfigurationManager();
+        existingConfig.AddCommandLine(applicationOptions.Args ?? []);
+        if (hostBuilderOptions.Configuration is not null)
+        {
+            existingConfig.AddConfiguration(hostBuilderOptions.Configuration);
+        }
+
         var additionalConfig = new Dictionary<string, string?>();
         SetDefault("DcpPublisher:ContainerRuntimeInitializationTimeout", "00:00:30");
         SetDefault("DcpPublisher:RandomizePorts", "true");
         SetDefault("DcpPublisher:DeleteResourcesOnShutdown", "true");
         SetDefault("DcpPublisher:ResourceNameSuffix", $"{Random.Shared.Next():x}");
+
+        // Make sure we have a dashboard URL and OTLP endpoint URL.
+        SetDefault("ASPNETCORE_URLS", "http://localhost:8080");
+        SetDefault("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL", "http://localhost:4317");
 
         var appHostProjectPath = ResolveProjectPath(entryPointAssembly);
         if (!string.IsNullOrEmpty(appHostProjectPath) && Directory.Exists(appHostProjectPath))
@@ -173,32 +178,95 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
             hostBuilderOptions.ContentRootPath = appHostProjectPath;
         }
 
-        // Populate the default launch profile name.
-        var appHostLaunchSettings = GetLaunchSettings(appHostProjectPath);
-        if (appHostLaunchSettings?.Profiles.FirstOrDefault().Key is { } defaultLaunchProfileName)
-        {
-            SetDefault("AppHost:DefaultLaunchProfileName", defaultLaunchProfileName);
-        }
+        hostBuilderOptions.Configuration ??= new();
+        hostBuilderOptions.Configuration.AddInMemoryCollection(additionalConfig);
 
-        // Make sure we have a dashboard URL and OTLP endpoint URL.
-        SetDefault("ASPNETCORE_URLS", "http://localhost:8080");
-        SetDefault("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL", "http://localhost:4317");
-        cfg.AddInMemoryCollection(additionalConfig);
         void SetDefault(string key, string? value)
         {
-            if (cfg[key] is null)
+            if (existingConfig[key] is null)
             {
                 additionalConfig[key] = value;
             }
         }
     }
 
-    internal void OnBuilderCreatingCore(
+    internal static void ConfigureBuilder(
+        string[] args,
+        DistributedApplicationOptions applicationOptions,
+        HostApplicationBuilderSettings hostBuilderOptions,
+        Assembly entryPointAssembly,
+        Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder)
+    {
+        PreConfigureBuilderOptions(applicationOptions, hostBuilderOptions, args, entryPointAssembly);
+        configureBuilder(applicationOptions, hostBuilderOptions);
+        PostConfigureBuilderOptions(hostBuilderOptions, entryPointAssembly);
+    }
+
+    private void OnBuilderCreatingCore(
         DistributedApplicationOptions applicationOptions,
         HostApplicationBuilderSettings hostBuilderOptions)
     {
-        PreConfigureBuilderOptions(applicationOptions, hostBuilderOptions, args, _entryPoint.Assembly);
-        OnBuilderCreating(applicationOptions, hostBuilderOptions);
+        ConfigureBuilder(args, applicationOptions, hostBuilderOptions, _entryPoint.Assembly, OnBuilderCreating);
+    }
+
+    private static void PostConfigureBuilderOptions(
+        HostApplicationBuilderSettings hostBuilderOptions,
+        Assembly entryPointAssembly)
+    {
+        var existingConfig = new ConfigurationManager();
+        existingConfig.AddCommandLine(hostBuilderOptions.Args ?? []);
+        if (hostBuilderOptions.Configuration is not null)
+        {
+            existingConfig.AddConfiguration(hostBuilderOptions.Configuration);
+        }
+
+        var additionalConfig = new Dictionary<string, string?>();
+        var appHostProjectPath = ResolveProjectPath(entryPointAssembly);
+
+        // Populate the launch profile name.
+        var appHostLaunchSettings = GetLaunchSettings(appHostProjectPath);
+        var launchProfileName = existingConfig["DOTNET_LAUNCH_PROFILE"];
+
+        // Load the launch profile and populate configuration with environment variables.
+        if (appHostLaunchSettings is not null)
+        {
+            var launchProfiles = appHostLaunchSettings.Profiles;
+            LaunchProfile? launchProfile;
+            if (string.IsNullOrEmpty(launchProfileName))
+            {
+                // If a launch profile was not specified, select the first launch profile.
+                var firstLaunchProfile = launchProfiles.FirstOrDefault();
+                launchProfile = firstLaunchProfile.Value;
+                SetDefault("DOTNET_LAUNCH_PROFILE", firstLaunchProfile.Key);
+            }
+            else
+            {
+                if (!launchProfiles.TryGetValue(launchProfileName, out launchProfile))
+                {
+                    throw new InvalidOperationException($"The configured launch profile, '{launchProfileName}', was not found in the launch settings file.");
+                }
+            }
+
+            // Populate config from env vars.
+            if (launchProfile?.EnvironmentVariables is { Count: > 0 } envVars)
+            {
+                foreach (var (key, value) in envVars)
+                {
+                    SetDefault(key, value);
+                }
+            }
+        }
+
+        hostBuilderOptions.Configuration ??= new();
+        hostBuilderOptions.Configuration.AddInMemoryCollection(additionalConfig);
+
+        void SetDefault(string key, string? value)
+        {
+            if (existingConfig[key] is null)
+            {
+                additionalConfig[key] = value;
+            }
+        }
     }
 
     private static string? ResolveProjectPath(Assembly? assembly)

--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
@@ -287,8 +287,7 @@ public static class DistributedApplicationTestingBuilder
         {
             var builder = TestingBuilderFactory.CreateBuilder(args, onConstructing: (applicationOptions, hostBuilderOptions) =>
             {
-                DistributedApplicationFactory.PreConfigureBuilderOptions(applicationOptions, hostBuilderOptions, args, FindApplicationAssembly());
-                configureBuilder(applicationOptions, hostBuilderOptions);
+                DistributedApplicationFactory.ConfigureBuilder(args, applicationOptions, hostBuilderOptions, FindApplicationAssembly(), configureBuilder);
             });
 
             if (!builder.Configuration.GetValue("ASPIRE_TESTING_DISABLE_HTTP_CLIENT", false))

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -331,7 +331,7 @@ public static class ProjectResourceBuilderExtensions
         else
         {
             var appHostDefaultLaunchProfileName = builder.ApplicationBuilder.Configuration["AppHost:DefaultLaunchProfileName"]
-                ?? Environment.GetEnvironmentVariable("DOTNET_LAUNCH_PROFILE");
+                ?? builder.ApplicationBuilder.Configuration["DOTNET_LAUNCH_PROFILE"];
             if (!string.IsNullOrEmpty(appHostDefaultLaunchProfileName))
             {
                 builder.WithAnnotation(new DefaultLaunchProfileAnnotation(appHostDefaultLaunchProfileName));

--- a/tests/Aspire.Hosting.Testing.Tests/Properties/launchSettings.json
+++ b/tests/Aspire.Hosting.Testing.Tests/Properties/launchSettings.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "LAUNCH_PROFILE_VAR_FROM_APP_HOST": "app-host-is-https"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "LAUNCH_PROFILE_VAR_FROM_APP_HOST": "app-host-is-http"
+      }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -176,6 +176,170 @@ public class TestingBuilderTests
         Assert.Throws<InvalidOperationException>(() => app.CreateHttpClient("mywebapp1"));
     }
 
+    /// <summary>
+    /// Tests that arguments propagate into the application host.
+    /// </summary>
+    [Theory]
+    [RequiresDocker]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ArgsPropagateToAppHostConfiguration(bool genericEntryPoint, bool directArgs)
+    {
+        string[] args = directArgs ? ["APP_HOST_ARG=42"] : [];
+        Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder = directArgs switch
+        {
+            true => (_, _) => { },
+            false => (dao, habs) => habs.Args = ["APP_HOST_ARG=42"]
+        };
+
+        IDistributedApplicationTestingBuilder builder;
+        if (genericEntryPoint)
+        {
+            builder = await (DistributedApplicationTestingBuilder.CreateAsync<Projects.TestingAppHost1_AppHost>(args, configureBuilder));
+        }
+        else
+        {
+            builder = await (DistributedApplicationTestingBuilder.CreateAsync(typeof(Projects.TestingAppHost1_AppHost), args, configureBuilder));
+        }
+
+        await using var app = await builder.BuildAsync();
+        await app.StartAsync();
+
+        // Wait for the application to be ready
+        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
+        var appHostArg = await httpClient.GetStringAsync("/get-app-host-arg");
+        Assert.NotNull(appHostArg);
+        Assert.Equal("42", appHostArg);
+    }
+
+    /// <summary>
+    /// Tests that arguments propagate into the application host.
+    /// </summary>
+    [Theory]
+    [RequiresDocker]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ArgsPropagateToAppHostConfigurationAdHocBuilder(bool directArgs)
+    {
+        IDistributedApplicationTestingBuilder builder;
+        if (directArgs)
+        {
+            builder = DistributedApplicationTestingBuilder.Create(["APP_HOST_ARG=42"]);
+        }
+        else
+        {
+            builder = DistributedApplicationTestingBuilder.Create([], (dao, habs) => habs.Args = ["APP_HOST_ARG=42"]);
+        }
+
+        builder.AddProject<Projects.TestingAppHost1_MyWebApp>("mywebapp1")
+            .WithEnvironment("APP_HOST_ARG", builder.Configuration["APP_HOST_ARG"])
+            .WithEnvironment("LAUNCH_PROFILE_VAR_FROM_APP_HOST", builder.Configuration["LAUNCH_PROFILE_VAR_FROM_APP_HOST"]);
+        await using var app = await builder.BuildAsync();
+        await app.StartAsync();
+
+        // Wait for the application to be ready
+        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
+        var appHostArg = await httpClient.GetStringAsync("/get-app-host-arg");
+        Assert.NotNull(appHostArg);
+        Assert.Equal("42", appHostArg);
+    }
+
+    /// <summary>
+    /// Tests that setting the launch profile works and results in environment variables from the launch profile
+    /// populating in configuration.
+    /// </summary>
+    [Theory]
+    [RequiresDocker]
+    [InlineData("http", false)]
+    [InlineData("http", true)]
+    [InlineData("https", false)]
+    [InlineData("https", true)]
+    public async Task CanOverrideLaunchProfileViaArgs(string launchProfileName, bool directArgs)
+    {
+        var arg = $"DOTNET_LAUNCH_PROFILE={launchProfileName}";
+        string[] args;
+        Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder;
+        if (directArgs)
+        {
+            args = [arg];
+            configureBuilder = (_, _) => { };
+        }
+        else
+        {
+            args = [];
+            configureBuilder = (dao, habs) => habs.Args = [arg];
+        }
+
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.TestingAppHost1_AppHost>(args, configureBuilder);
+        await using var app = await appHost.BuildAsync();
+        await app.StartAsync();
+
+        // Wait for the application to be ready
+        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
+        var appHostArg = await httpClient.GetStringAsync("/get-launch-profile-var");
+        Assert.NotNull(appHostArg);
+        Assert.Equal($"it-is-{launchProfileName}", appHostArg);
+
+        // Check that, aside from the launch profile, the app host loaded environment settings from its launch profile
+        var appHostLaunchProfileVar = await httpClient.GetStringAsync("/get-launch-profile-var-from-app-host");
+        Assert.NotNull(appHostLaunchProfileVar);
+        Assert.Equal($"app-host-is-{launchProfileName}", appHostLaunchProfileVar);
+    }
+
+    /// <summary>
+    /// Tests that setting the launch profile works and results in environment variables from the launch profile
+    /// populating in configuration.
+    /// </summary>
+    [Theory]
+    [RequiresDocker]
+    [InlineData("http", false)]
+    [InlineData("http", true)]
+    [InlineData("https", false)]
+    [InlineData("https", true)]
+    public async Task CanOverrideLaunchProfileViaArgsAdHocBuilder(string launchProfileName, bool directArgs)
+    {
+        var arg = $"DOTNET_LAUNCH_PROFILE={launchProfileName}";
+        string[] args;
+        Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder;
+        if (directArgs)
+        {
+            args = [arg];
+            configureBuilder = (_, _) => { };
+        }
+        else
+        {
+            args = [];
+            configureBuilder = (dao, habs) => habs.Args = [arg];
+        }
+
+        var builder = DistributedApplicationTestingBuilder.Create(args, configureBuilder);
+        builder.AddProject<Projects.TestingAppHost1_MyWebApp>("mywebapp1")
+            .WithEnvironment("LAUNCH_PROFILE_VAR_FROM_APP_HOST", builder.Configuration["LAUNCH_PROFILE_VAR_FROM_APP_HOST"]);
+        await using var app = await builder.BuildAsync();
+        await app.StartAsync();
+
+        // Wait for the application to be ready
+        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
+        var appHostArg = await httpClient.GetStringAsync("/get-launch-profile-var");
+        Assert.NotNull(appHostArg);
+        Assert.Equal($"it-is-{launchProfileName}", appHostArg);
+
+        // Check that, aside from the launch profile, the app host loaded environment settings from its launch profile
+        var appHostLaunchProfileVar = await httpClient.GetStringAsync("/get-launch-profile-var-from-app-host");
+        Assert.NotNull(appHostLaunchProfileVar);
+        Assert.Equal($"app-host-is-{launchProfileName}", appHostLaunchProfileVar);
+    }
+
     [Theory]
     [RequiresDocker]
     [InlineData(false)]
@@ -203,7 +367,7 @@ public class TestingBuilderTests
         await using var app = await appHost.BuildAsync();
         await app.StartAsync();
         var config = app.Services.GetRequiredService<IConfiguration>();
-        var profileName = config["AppHost:DefaultLaunchProfileName"];
+        var profileName = config["DOTNET_LAUNCH_PROFILE"];
         Assert.Equal("https", profileName);
 
         // Wait for the application to be ready

--- a/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
+++ b/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -9,10 +10,15 @@ builder.Configuration["ConnectionStrings:cs"] = "testconnection";
 
 builder.AddConnectionString("cs");
 builder.AddRedis("redis1");
-builder.AddProject<Projects.TestingAppHost1_MyWebApp>("mywebapp1")
-    .WithEndpoint("http", ea => ea.IsProxied = false)
-    .WithEndpoint("https", ea => ea.IsProxied = false)
-    .WithExternalHttpEndpoints();
+var webApp = builder.AddProject<Projects.TestingAppHost1_MyWebApp>("mywebapp1")
+    .WithEnvironment("APP_HOST_ARG", builder.Configuration["APP_HOST_ARG"])
+    .WithEnvironment("LAUNCH_PROFILE_VAR_FROM_APP_HOST", builder.Configuration["LAUNCH_PROFILE_VAR_FROM_APP_HOST"]);
+
+if (builder.Configuration.GetValue("USE_HTTPS", false))
+{
+    webApp.WithExternalHttpEndpoints();
+}
+
 builder.AddProject<Projects.TestingAppHost1_MyWorker>("myworker1")
     .WithEndpoint(name: "myendpoint1");
 builder.AddPostgres("postgres1");

--- a/tests/TestingAppHost1/TestingAppHost1.AppHost/Properties/launchSettings.json
+++ b/tests/TestingAppHost1/TestingAppHost1.AppHost/Properties/launchSettings.json
@@ -9,7 +9,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16158"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16158",
+        "LAUNCH_PROFILE_VAR_FROM_APP_HOST": "app-host-is-https",
+        "USE_HTTPS": "true"
       }
     },
     "http": {
@@ -23,7 +25,9 @@
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16040",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17040",
         "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "LAUNCH_PROFILE_VAR_FROM_APP_HOST": "app-host-is-http",
+        "USE_HTTPS": "false"
       }
     }
   }

--- a/tests/TestingAppHost1/TestingAppHost1.MyWebApp/Program.cs
+++ b/tests/TestingAppHost1/TestingAppHost1.MyWebApp/Program.cs
@@ -34,6 +34,21 @@ app.MapGet("/weatherforecast", () =>
 })
 .WithName("GetWeatherForecast");
 
+app.MapGet("/get-launch-profile-var", () =>
+{
+    return app.Configuration["LAUNCH_PROFILE_VAR"];
+}).WithName("GetLaunchProfileVar");
+
+app.MapGet("/get-app-host-arg", () =>
+{
+    return app.Configuration["APP_HOST_ARG"];
+}).WithName("GetAppHostArg");
+
+app.MapGet("/get-launch-profile-var-from-app-host", () =>
+{
+    return app.Configuration["LAUNCH_PROFILE_VAR_FROM_APP_HOST"];
+}).WithName("GetLaunchProfileVarFromAppHost");
+
 app.Run();
 
 sealed record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)

--- a/tests/TestingAppHost1/TestingAppHost1.MyWebApp/Properties/launchSettings.json
+++ b/tests/TestingAppHost1/TestingAppHost1.MyWebApp/Properties/launchSettings.json
@@ -16,7 +16,8 @@
       "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5150",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "LAUNCH_PROFILE_VAR": "it-is-http"
       }
     },
     "https": {
@@ -26,7 +27,8 @@
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7097;http://localhost:5150",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "LAUNCH_PROFILE_VAR": "it-is-https"
       }
     },
     "IIS Express": {


### PR DESCRIPTION
## Description

Fixes #5093

This PR simulates launch profile loading for the testing host. It does not mutate the process' environment since that could cause issues with concurrently running tests. Instead, it propagates the environment variables specified in the AppHost's launch profile to the AppHost's configuration.

This PR sets the `DOTNET_LAUNCH_PROFILE` environment variable to the name of the first launch profile if not overridden. It does not consider the `DOTNET_LAUNCH_PROFILE` from the test runner's environment.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
