### PR TITLE
Remove non-existent property from DistributedApplicationFactory

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -164,7 +164,6 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         var additionalConfig = new Dictionary<string, string?>();
         SetDefault("DcpPublisher:ContainerRuntimeInitializationTimeout", "00:00:30");
         SetDefault("DcpPublisher:RandomizePorts", "true");
-        SetDefault("DcpPublisher:DeleteResourcesOnShutdown", "true");
         SetDefault("DcpPublisher:ResourceNameSuffix", $"{Random.Shared.Next():x}");
 
         var appHostProjectPath = ResolveProjectPath(entryPointAssembly);


### PR DESCRIPTION
## Description

In https://github.com/dotnet/aspire/pull/7098, the `DeleteResourcesOnShutdown` option was removed. This PR removes the corresponding line from DistributedApplicationFactory which set that property, since it no longer has any effect.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
