### PR TITLE
Fix EventHubs GetNamespaceFromSettings

### DIFF
--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubsComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubsComponent.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Security.Cryptography;
 using Aspire.Azure.Common;
 using Aspire.Azure.Messaging.EventHubs;
 using Azure.Core;
@@ -56,15 +55,15 @@ internal abstract class EventHubsComponent<TSettings, TClient, TClientOptions> :
                 : new Uri(settings.FullyQualifiedNamespace).Host;
 
             // This is likely to be similar to {yournamespace}.servicebus.windows.net or {yournamespace}.servicebus.chinacloudapi.cn
-            if (ns.Contains(".servicebus", StringComparison.OrdinalIgnoreCase))
+            var serviceBusIndex = ns.IndexOf(".servicebus", StringComparison.OrdinalIgnoreCase);
+            if (serviceBusIndex != -1)
             {
-                ns = ns[..ns.IndexOf(".servicebus")];
+                ns = ns[..serviceBusIndex];
             }
             else
             {
-                // Use a random prefix if no meaningful name is found e.g., "localhost", "127.0.0.1".
-                // This is used to create blob containers names that are unique in the referenced storage account.
-                RandomNumberGenerator.GetHexString(12, true);
+                // sanitize the namespace if it's not a servicebus namespace
+                ns = ns.Replace(".", "-");
             }
         }
         catch (Exception ex) when (ex is FormatException or IndexOutOfRangeException)

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventProcessorClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventProcessorClientComponent.cs
@@ -97,17 +97,14 @@ internal sealed class EventProcessorClientComponent()
         // name specified in the settings.
         bool shouldTryCreateIfNotExists = false;
 
+        // Do we have a container name provided in the settings?
         if (string.IsNullOrWhiteSpace(settings.BlobContainerName))
         {
+            // If not, we'll create a container name based on the namespace, event hub name and consumer group
             var ns = GetNamespaceFromSettings(settings);
 
-            // Do we have a container name provided in the settings?
-            if (string.IsNullOrWhiteSpace(settings.BlobContainerName))
-            {
-                // If not, we'll create a container name based on the namespace, event hub name and consumer group
-                settings.BlobContainerName = $"{ns}-{settings.EventHubName}-{consumerGroup}";
-                shouldTryCreateIfNotExists = true;
-            }
+            settings.BlobContainerName = $"{ns}-{settings.EventHubName}-{consumerGroup}";
+            shouldTryCreateIfNotExists = true;
         }
 
         var containerClient = blobClient.GetBlobContainerClient(settings.BlobContainerName);

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/Aspire.Azure.Messaging.EventHubs.Tests.csproj
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/Aspire.Azure.Messaging.EventHubs.Tests.csproj
@@ -11,6 +11,8 @@
 
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Storage.Blobs\Aspire.Azure.Storage.Blobs.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
+
+    <Compile Include="..\Aspire.Azure.Security.KeyVault.Tests\MockTransport.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

We were calling RandomNumberGenerator.GetHexString and not using the result. The original intention was to use a random container name if we couldn't see ".servicebus" in the host name.

Instead of using a random name, just sanitize the host name and use it, so it is deterministc.

Fix #4886

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No

cc @oising