### PR TITLE
Switch to strongly-type resource scope for existing resources

### DIFF
--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -41,7 +41,7 @@ public static class AzureServiceBusExtensions
                 serviceBusNamespace.Name = existingResourceName;
                 if (existingAnnotation.ResourceGroupParameter is not null)
                 {
-                    infrastructure.AspireResource.Scope["resourceGroup"] = existingAnnotation.ResourceGroupParameter;
+                    infrastructure.AspireResource.Scope = new(existingAnnotation.ResourceGroupParameter);
                 }
             }
             else

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -55,7 +55,7 @@ public class AzureBicepResource(string name, string? templateFile = null, string
     /// in the module definition for a given resource. It is
     /// only emitted for schema versions azure.bicep.v1.
     /// </remarks>
-    public ResourceScope? Scope { get; set; }
+    public AzureBicepResourceScope? Scope { get; set; }
 
     /// <summary>
     /// For testing purposes only.

--- a/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
@@ -7,7 +7,7 @@ namespace Aspire.Hosting.Azure;
 /// Represents the scope associated with the resource.
 /// </summary>
 /// <param name="resourceGroup">The name of the existing resource group.</param>
-public sealed class ResourceScope(object resourceGroup)
+public sealed class AzureBicepResourceScope(object resourceGroup)
 {
     /// <summary>
     /// Represents the resource group to encode in the scope.

--- a/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
@@ -30,7 +30,7 @@ public static class ExistingAzureResourceExtensions
     /// <typeparam name="T">The type of the resource.</typeparam>
     /// <param name="builder">The resource builder.</param>
     /// <param name="nameParameter">The name of the existing resource.</param>
-    /// <param name="resourceGroupParameter"></param>
+    /// <param name="resourceGroupParameter">The name of the existing resource group, or <see langword="null"/> to use the current resource group.</param>
     /// <returns>The resource builder with the existing resource annotation added.</returns>
     public static IResourceBuilder<T> RunAsExisting<T>(this IResourceBuilder<T> builder, IResourceBuilder<ParameterResource> nameParameter, IResourceBuilder<ParameterResource>? resourceGroupParameter = null)
         where T : IAzureResource

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -532,16 +532,13 @@ internal sealed class BicepProvisioner(
 
     internal static async Task SetScopeAsync(JsonObject scope, AzureBicepResource resource, CancellationToken cancellationToken = default)
     {
-        foreach (var item in resource.Scope)
+        scope["resourceGroup"] = resource.Scope?.ResourceGroup switch
         {
-            scope[item.Key] = item.Value switch
-            {
-                string s => s,
-                IValueProvider v => await v.GetValueAsync(cancellationToken).ConfigureAwait(false),
-                null => null,
-                _ => throw new NotSupportedException($"The scope value type {item.Value.GetType()} is not supported.")
-            };
-        }
+            string s => s,
+            IValueProvider v => await v.GetValueAsync(cancellationToken).ConfigureAwait(false),
+            null => null,
+            _ => throw new NotSupportedException($"The scope value type {resource.Scope.ResourceGroup.GetType()} is not supported.")
+        };
     }
 
     private static bool IsParameterWithGeneratedValue(object? value)

--- a/src/Aspire.Hosting.Azure/ResourceScope.cs
+++ b/src/Aspire.Hosting.Azure/ResourceScope.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents the scope associated with the resource.
+/// </summary>
+/// <param name="resourceGroup">The name of the existing resource group.</param>
+public sealed class ResourceScope(object resourceGroup)
+{
+    /// <summary>
+    /// Represents the resource group to encode in the scope.
+    /// </summary>
+    public object ResourceGroup { get; } = resourceGroup;
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -192,11 +192,11 @@ public class AzureBicepProvisionerTests
 
         var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
                        .WithParameter("key", "value");
+        bicep0.Resource.Scope = new("rg0");
 
         var bicep1 = builder.AddBicepTemplateString("bicep1", "param name string")
                        .WithParameter("key", "value");
-
-        bicep1.Resource.Scope["resourceGroup"] = "rg";
+        bicep1.Resource.Scope = new("rg1");
 
         var parameters0 = new JsonObject();
         var scope0 = new JsonObject();
@@ -220,13 +220,11 @@ public class AzureBicepProvisionerTests
 
         var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
                        .WithParameter("key", "value");
-
-        bicep0.Resource.Scope["resourceGroup"] = "rg";
+        bicep0.Resource.Scope = new("rg0");
 
         var bicep1 = builder.AddBicepTemplateString("bicep1", "param name string")
                        .WithParameter("key", "value");
-
-        bicep1.Resource.Scope["resourceGroup"] = "rg";
+        bicep1.Resource.Scope = new("rg0");
 
         var parameters0 = new JsonObject();
         var scope0 = new JsonObject();


### PR DESCRIPTION
Follow-up to #7249. Use strongly-typed resource scope for existing resources instead of Dictionary.