### PR TITLE
Added WaitForBehavior

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -69,7 +69,7 @@ public class ResourceNotificationService : IDisposable
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceProvider = serviceProvider;
         _resourceLoggerService = resourceLoggerService ?? throw new ArgumentNullException(nameof(resourceLoggerService));
-        DefaultWaitBehavior = serviceProvider.GetRequiredService<IOptions<ResourceNotificationServiceOptions>>().Value.DefaultWaitBehavior;
+        DefaultWaitBehavior = serviceProvider.GetService<IOptions<ResourceNotificationServiceOptions>>()?.Value.DefaultWaitBehavior ?? WaitBehavior.StopOnDependencyFailure;
 
         // The IHostApplicationLifetime parameter is not used anymore, but we keep it for backwards compatibility.
         // Notification updates will be cancelled when the service is disposed.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -682,7 +682,7 @@ public class ResourceEvent(IResource resource, string resourceId, CustomResource
 /// <summary>
 /// Options for the <see cref="ResourceNotificationService"/>.
 /// </summary>
-public class ResourceNotificationServiceOptions
+public sealed class ResourceNotificationServiceOptions
 {
     /// <summary>
     /// The default behavior to use when waiting for dependencies.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -6,9 +6,11 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -25,6 +27,9 @@ public class ResourceNotificationService : IDisposable
     private readonly ResourceLoggerService _resourceLoggerService;
 
     private Action<ResourceEvent>? OnResourceUpdated { get; set; }
+
+    // This is for testing
+    internal WaitBehavior DefaultWaitBehavior { get; set; }
 
     /// <summary>
     /// Creates a new instance of <see cref="ResourceNotificationService"/>.
@@ -45,6 +50,7 @@ public class ResourceNotificationService : IDisposable
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceProvider = new NullServiceProvider();
         _resourceLoggerService = new ResourceLoggerService();
+        DefaultWaitBehavior = WaitBehavior.StopOnDependencyFailure;
     }
 
     /// <summary>
@@ -54,11 +60,16 @@ public class ResourceNotificationService : IDisposable
     /// <param name="hostApplicationLifetime">The host application lifetime.</param>
     /// <param name="resourceLoggerService">The resource logger service.</param>
     /// <param name="serviceProvider">The service provider.</param>
-    public ResourceNotificationService(ILogger<ResourceNotificationService> logger, IHostApplicationLifetime hostApplicationLifetime, IServiceProvider serviceProvider, ResourceLoggerService resourceLoggerService)
+    public ResourceNotificationService(
+        ILogger<ResourceNotificationService> logger,
+        IHostApplicationLifetime hostApplicationLifetime,
+        IServiceProvider serviceProvider,
+        ResourceLoggerService resourceLoggerService)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceProvider = serviceProvider;
         _resourceLoggerService = resourceLoggerService ?? throw new ArgumentNullException(nameof(resourceLoggerService));
+        DefaultWaitBehavior = serviceProvider.GetRequiredService<IOptions<ResourceNotificationServiceOptions>>().Value.DefaultWaitBehavior;
 
         // The IHostApplicationLifetime parameter is not used anymore, but we keep it for backwards compatibility.
         // Notification updates will be cancelled when the service is disposed.
@@ -128,7 +139,7 @@ public class ResourceNotificationService : IDisposable
         throw new OperationCanceledException($"The operation was cancelled before the resource reached one of the target states: [{string.Join(", ", targetStates)}]");
     }
 
-    private async Task WaitUntilHealthyAsync(IResource resource, IResource dependency, CancellationToken cancellationToken)
+    private async Task WaitUntilHealthyAsync(IResource resource, IResource dependency, WaitBehavior waitBehavior, CancellationToken cancellationToken)
     {
         var resourceLogger = _resourceLoggerService.GetLogger(resource);
         resourceLogger.LogInformation("Waiting for resource '{Name}' to enter the '{State}' state.", dependency.Name, KnownResourceStates.Running);
@@ -147,29 +158,34 @@ public class ResourceNotificationService : IDisposable
 
         async Task Core(string displayName, string resourceId)
         {
-            var resourceEvent = await WaitForResourceCoreAsync(dependency.Name, re => re.ResourceId == resourceId && IsContinuableState(re.Snapshot), cancellationToken: cancellationToken).ConfigureAwait(false);
+            var resourceEvent = await WaitForResourceCoreAsync(dependency.Name, re => re.ResourceId == resourceId && IsContinuableState(waitBehavior, re.Snapshot), cancellationToken: cancellationToken).ConfigureAwait(false);
             var snapshot = resourceEvent.Snapshot;
 
-            if (snapshot.State?.Text == KnownResourceStates.FailedToStart)
+            if (waitBehavior == WaitBehavior.StopOnDependencyFailure)
             {
-                resourceLogger.LogError(
-                    "Dependency resource '{ResourceName}' failed to start.",
-                    displayName
-                    );
+                if (snapshot.State?.Text == KnownResourceStates.FailedToStart)
+                {
+                    resourceLogger.LogError(
+                        "Dependency resource '{ResourceName}' failed to start.",
+                        displayName
+                        );
 
-                throw new DistributedApplicationException($"Dependency resource '{displayName}' failed to start.");
-            }
-            else if (snapshot.State!.Text == KnownResourceStates.Finished || snapshot.State!.Text == KnownResourceStates.Exited)
-            {
-                resourceLogger.LogError(
-                    "Resource '{ResourceName}' has entered the '{State}' state prematurely.",
-                    displayName,
-                    snapshot.State.Text
-                    );
+                    throw new DistributedApplicationException($"Dependency resource '{displayName}' failed to start.");
+                }
+                else if (snapshot.State!.Text == KnownResourceStates.Finished ||
+                         snapshot.State.Text == KnownResourceStates.Exited ||
+                         snapshot.State.Text == KnownResourceStates.RuntimeUnhealthy)
+                {
+                    resourceLogger.LogError(
+                        "Resource '{ResourceName}' has entered the '{State}' state prematurely.",
+                        displayName,
+                        snapshot.State.Text
+                        );
 
-                throw new DistributedApplicationException(
-                    $"Resource '{displayName}' has entered the '{snapshot.State.Text}' state prematurely."
-                    );
+                    throw new DistributedApplicationException(
+                        $"Resource '{displayName}' has entered the '{snapshot.State.Text}' state prematurely."
+                        );
+                }
             }
 
             // If our dependency resource has health check annotations we want to wait until they turn healthy
@@ -189,11 +205,17 @@ public class ResourceNotificationService : IDisposable
 
             resourceLogger.LogInformation("Finished waiting for resource '{Name}'.", displayName);
 
-            static bool IsContinuableState(CustomResourceSnapshot snapshot) =>
-                snapshot.State?.Text == KnownResourceStates.Running ||
-                snapshot.State?.Text == KnownResourceStates.Finished ||
-                snapshot.State?.Text == KnownResourceStates.Exited ||
-                snapshot.State?.Text == KnownResourceStates.FailedToStart;
+            static bool IsContinuableState(WaitBehavior waitBehavior, CustomResourceSnapshot snapshot) =>
+                waitBehavior switch
+                {
+                    WaitBehavior.WaitOnDependencyFailure => snapshot.State?.Text == KnownResourceStates.Running,
+                    WaitBehavior.StopOnDependencyFailure => snapshot.State?.Text == KnownResourceStates.Running ||
+                                                            snapshot.State?.Text == KnownResourceStates.Finished ||
+                                                            snapshot.State?.Text == KnownResourceStates.Exited ||
+                                                            snapshot.State?.Text == KnownResourceStates.FailedToStart ||
+                                                            snapshot.State?.Text == KnownResourceStates.RuntimeUnhealthy,
+                    _ => throw new DistributedApplicationException($"Unexpected wait behavior: {waitBehavior}")
+                };
         }
     }
 
@@ -298,7 +320,7 @@ public class ResourceNotificationService : IDisposable
 
             var pendingDependency = waitAnnotation.WaitType switch
             {
-                WaitType.WaitUntilHealthy => WaitUntilHealthyAsync(resource, waitAnnotation.Resource, cancellationToken),
+                WaitType.WaitUntilHealthy => WaitUntilHealthyAsync(resource, waitAnnotation.Resource, waitAnnotation.WaitBehavior ?? DefaultWaitBehavior, cancellationToken),
                 WaitType.WaitForCompletion => WaitUntilCompletionAsync(resource, waitAnnotation.Resource, waitAnnotation.ExitCode, cancellationToken),
                 _ => throw new DistributedApplicationException($"Unexpected wait type: {waitAnnotation.WaitType}")
             };
@@ -655,4 +677,15 @@ public class ResourceEvent(IResource resource, string resourceId, CustomResource
     /// The snapshot of the resource state.
     /// </summary>
     public CustomResourceSnapshot Snapshot { get; } = snapshot;
+}
+
+/// <summary>
+/// Options for the <see cref="ResourceNotificationService"/>.
+/// </summary>
+public class ResourceNotificationServiceOptions
+{
+    /// <summary>
+    /// The default behavior to use when waiting for dependencies.
+    /// </summary>
+    public WaitBehavior DefaultWaitBehavior { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
@@ -28,6 +28,11 @@ public sealed class WaitAnnotation(IResource resource, WaitType waitType, int ex
     public WaitType WaitType { get; } = waitType;
 
     /// <summary>
+    /// The behavior of the wait. Only applicable when <see cref="WaitType"/> is <see cref="WaitType.WaitUntilHealthy"/>.
+    /// </summary>
+    public WaitBehavior? WaitBehavior { get; init; }
+
+    /// <summary>
     /// The exit code that the resource must return for the wait to be satisfied.
     /// </summary>
     public int ExitCode { get; } = exitCode;
@@ -47,4 +52,20 @@ public enum WaitType
     /// Dependent resource will wait until resource completes.
     /// </summary>
     WaitForCompletion
+}
+
+/// <summary>
+/// Specifies the behavior of the wait.
+/// </summary>
+public enum WaitBehavior
+{
+    /// <summary>
+    /// If the dependency fails, ignore the failure and continue waiting.
+    /// </summary>
+    WaitOnDependencyFailure,
+
+    /// <summary>
+    /// If the dependency fails, stop waiting and fail the wait.
+    /// </summary>
+    StopOnDependencyFailure
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -202,6 +202,12 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddSingleton<ResourceLoggerService>();
         _innerBuilder.Services.AddSingleton<IDistributedApplicationEventing>(Eventing);
         _innerBuilder.Services.AddHealthChecks();
+        _innerBuilder.Services.Configure<ResourceNotificationServiceOptions>(o =>
+        {
+            // Default to stopping on dependency failure if the dashboard is disabled. As there's no way to see or easily recover
+            // from a failure in that case.
+            o.DefaultWaitBehavior = options.DisableDashboard ? WaitBehavior.StopOnDependencyFailure : WaitBehavior.WaitOnDependencyFailure;
+        });
 
         ConfigureHealthChecks();
 

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -734,6 +734,64 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Waits for the dependency resource to enter the Running state before starting the resource.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder for the resource that will be waiting.</param>
+    /// <param name="dependency">The resource builder for the dependency resource.</param>
+    /// <param name="waitBehavior">The wait behavior to use.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// <para>This method is useful when a resource should wait until another has started running. This can help
+    /// reduce errors in logs during local development where dependency resources.</para>
+    /// <para>Some resources automatically register health checks with the application host container. For these
+    /// resources, calling <see cref="WaitFor{T}(IResourceBuilder{T}, IResourceBuilder{IResource}, WaitBehavior)"/> also results
+    /// in the resource being blocked from starting until the health checks associated with the dependency resource
+    /// return <see cref="HealthStatus.Healthy"/>.</para>
+    /// <para>The <see cref="WithHealthCheck{T}(IResourceBuilder{T}, string)"/> method can be used to associate
+    /// additional health checks with a resource.</para>
+    /// <para>The <paramref name="waitBehavior"/> parameter can be used to control the behavior of the wait operation.</para>
+    /// </remarks>
+    /// <example>
+    /// Start message queue before starting the worker service.
+    /// <code lang="C#">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var messaging = builder.AddRabbitMQ("messaging");
+    /// builder.AddProject&lt;Projects.MyApp&gt;("myapp")
+    ///        .WithReference(messaging)
+    ///        .WaitFor(messaging, WaitBehavior.StopOnDependencyFailure);
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<T> WaitFor<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency, WaitBehavior waitBehavior) where T : IResourceWithWaitSupport
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(dependency);
+
+        if (builder.Resource as IResource == dependency.Resource)
+        {
+            throw new DistributedApplicationException($"The '{builder.Resource.Name}' resource cannot wait for itself.");
+        }
+
+        if (builder.Resource is IResourceWithParent resourceWithParent && resourceWithParent.Parent == dependency.Resource)
+        {
+            throw new DistributedApplicationException($"The '{builder.Resource.Name}' resource cannot wait for its parent '{dependency.Resource.Name}'.");
+        }
+
+        if (dependency.Resource is IResourceWithParent dependencyResourceWithParent)
+        {
+            // If the dependency resource is a child resource we automatically apply
+            // the WaitFor to the parent resource. This caters for situations where
+            // the child resource itself does not have any health checks setup.
+            var parentBuilder = builder.ApplicationBuilder.CreateResourceBuilder(dependencyResourceWithParent.Parent);
+            builder.WaitFor(parentBuilder, waitBehavior);
+        }
+
+        builder.WithRelationship(dependency.Resource, KnownRelationshipTypes.WaitFor);
+
+        return builder.WithAnnotation(new WaitAnnotation(dependency.Resource, WaitType.WaitUntilHealthy) { WaitBehavior = waitBehavior });
+    }
+
+    /// <summary>
     /// Adds a <see cref="ExplicitStartupAnnotation" /> annotation to the resource so it doesn't automatically start
     /// with the app host startup.
     /// </summary>


### PR DESCRIPTION
## Description

- This behavior determines what happens to the wait when dependencies are in a failure mode. The default behavior is determined by if the dashboard is enabled. If enabled the default behavior is to treat all failures are non terminal. If the dashboard is not enabled the default behavior is to treat all failures as terminal. This can be overridden by the on a per wait basis.
- Added tests to verify the behavior

Fixes #7186

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
