### PR TITLE
Don't use a shared session folder.

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -81,7 +81,6 @@ steps:
         DOTNET_ASPIRE_DEPENDENCY_CHECK_TIMEOUT: 180
         DCP_DIAGNOSTICS_LOG_LEVEL: debug
         DCP_DIAGNOSTICS_LOG_FOLDER: $(Build.ArtifactStagingDirectory)/artifacts/log/dcp
-        DCP_SESSION_FOLDER: $(Build.ArtifactStagingDirectory)/artifacts/log/dcp/session
         DCP_PRESERVE_EXECUTABLE_LOGS: 1
       displayName: Run non-helix tests
 

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -151,10 +151,9 @@
 
     <HelixPreCommand Condition="'$(OS)' == 'Windows_NT'" Include="dotnet dev-certs https --trust" />
 
-    <!-- Set the DCP_DIAGNOSTICS_LOG_LEVEL env -->
+    <!-- Set the DCP env -->
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_DIAGNOSTICS_LOG_LEVEL=debug" />
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_DIAGNOSTICS_LOG_FOLDER=$(_HelixLogsPath)" />
-    <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_SESSION_FOLDER=$(_HelixLogsPath)" />
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_PRESERVE_EXECUTABLE_LOGS=1" />
 
     <HelixPostCommand Include="$(_WaitForDcpCommand)" />


### PR DESCRIPTION
- Each session should have a different folder for maximum isolation. We'll need a different strategy here.

Saw this on a CI run:

```
[apphost]       System.IO.IOException: The process cannot access the file 'C:\h\w\AC440968\t\aspire.4tqrtr31.dfj\kubeconfig' because it is being used by another process.
[apphost]          at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
[apphost]          at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable1 unixCreateMode) [apphost]          at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable1 unixCreateMode)
[apphost]          at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable1 unixCreateMode) [apphost]          at System.IO.FileInfo.OpenRead() [apphost]          at k8s.KubernetesClientConfiguration.LoadKubeConfigAsync(FileInfo kubeconfig, Boolean useRelativePaths) [apphost]          at k8s.KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(FileInfo kubeconfig, String currentContext, String masterUrl, Boolean useRelativePaths) [apphost]          at Aspire.Hosting.Dcp.KubernetesService.<>c__DisplayClass30_0.<<EnsureKubernetesAsync>b__0>d.MoveNext() in /_/src/Aspire.Hosting/Dcp/KubernetesService.cs:line 482 [apphost]       --- End of stack trace from previous location --- [apphost]          at Polly.ResiliencePipeline.<>c__101.<<ExecuteAsync>b__10_0>d.MoveNext()
[apphost]       --- End of stack trace from previous location ---
[apphost]          at Polly.Outcome1.GetResultOrRethrow() [apphost]          at Polly.ResiliencePipeline.ExecuteAsync[TResult](Func2 callback, CancellationToken cancellationToken)
[apphost]          at Aspire.Hosting.Dcp.KubernetesService.EnsureKubernetesAsync(CancellationToken cancellationToken) in //src/Aspire.Hosting/Dcp/KubernetesService.cs:line 473
[apphost]          at Aspire.Hosting.Dcp.KubernetesService.ExecuteWithRetry[TResult](DcpApiOperationType operationType, String resourceType, Func2 operation, Func2 isRetryable, CancellationToken cancellationToken) in //src/Aspire.Hosting/Dcp/KubernetesService.cs:line 388
[apphost]          at Aspire.Hosting.Dcp.DcpExecutor.CreateResourcesAsync[RT](CancellationToken cancellationToken) in //src/Aspire.Hosting/Dcp/DcpExecutor.cs:line 1453
[apphost]          at Aspire.Hosting.Dcp.DcpExecutor.CreateServicesAsync(CancellationToken cancellationToken) in //src/Aspire.Hosting/Dcp/DcpExecutor.cs:line 585
[apphost]          at Aspire.Hosting.Dcp.DcpExecutor.RunApplicationAsync(CancellationToken cancellationToken) in //src/Aspire.Hosting/Dcp/DcpExecutor.cs:line 126
[apphost]          at Aspire.Hosting.Orchestrator.ApplicationOrchestrator.RunApplicationAsync(CancellationToken cancellationToken) in //src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs:line 170
[apphost]          at Aspire.Hosting.Orchestrator.OrchestratorHostService.StartAsync(CancellationToken cancellationToken) in //src/Aspire.Hosting/Orchestrator/OrchestratorHostService.cs:line 41
[apphost]          at Microsoft.Extensions.Hosting.Internal.Host.<StartAsync>b__14_1(IHostedService service, CancellationToken token)
[apphost]          at Microsoft.Extensions.Hosting.Internal.Host.ForeachService[T](IEnumerable1 services, CancellationToken token, Boolean concurrent, Boolean abortOnFirstException, List1 exceptions, Func3 operation) [apphost] [createdump] Writing full dump for process 840 to file C:\h\w\AC440968\t\86e8bb74-3544-4ffd-81be-60ad04eed6c4\aspire_starter_run_Release_ya3dkuw0_rq4.AppHost.exe_840_1738616051_crashdump.dmp [apphost] [createdump] Dump successfully written in 441ms [apphost] Unhandled exception. System.AggregateException: One or more errors occurred. (The process cannot access the file 'C:\h\w\AC440968\t\aspire.4tqrtr31.dfj\kubeconfig' because it is being used by another process.) [apphost]  ---> System.IO.IOException: The process cannot access the file 'C:\h\w\AC440968\t\aspire.4tqrtr31.dfj\kubeconfig' because it is being used by another process. [apphost]    at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options) [apphost]    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable1 unixCreateMode)
[apphost]    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable1 unixCreateMode) [apphost]    at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable1 unixCreateMode)
[apphost]    at System.IO.FileInfo.OpenRead()
[apphost]    at k8s.KubernetesClientConfiguration.LoadKubeConfigAsync(FileInfo kubeconfig, Boolean useRelativePaths)
[apphost]    at k8s.KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(FileInfo kubeconfig, String currentContext, String masterUrl, Boolean useRelativePaths)
[apphost]    at Aspire.Hosting.Dcp.KubernetesService.<>c__DisplayClass30_0.<<EnsureKubernetesAsync>b__0>d.MoveNext() in //src/Aspire.Hosting/Dcp/KubernetesService.cs:line 482
[apphost] --- End of stack trace from previous location ---
[apphost]    at Polly.ResiliencePipeline.<>c__101.<<ExecuteAsync>b__10_0>d.MoveNext() [apphost] --- End of stack trace from previous location --- [apphost]    at Polly.Outcome1.GetResultOrRethrow()
[apphost]    at Polly.ResiliencePipeline.ExecuteAsync[TResult](Func2 callback, CancellationToken cancellationToken) [apphost]    at Aspire.Hosting.Dcp.KubernetesService.EnsureKubernetesAsync(CancellationToken cancellationToken) in /_/src/Aspire.Hosting/Dcp/KubernetesService.cs:line 473 [apphost]    at Aspire.Hosting.Dcp.KubernetesService.ExecuteWithRetry[TResult](DcpApiOperationType operationType, String resourceType, Func2 operation, Func2 isRetryable, CancellationToken cancellationToken) in /_/src/Aspire.Hosting/Dcp/KubernetesService.cs:line 388 [apphost]    at Aspire.Hosting.Dcp.DcpExecutor.CreateResourcesAsync[RT](CancellationToken cancellationToken) in /_/src/Aspire.Hosting/Dcp/DcpExecutor.cs:line 1453 [apphost]    at Aspire.Hosting.Dcp.DcpExecutor.CreateServicesAsync(CancellationToken cancellationToken) in /_/src/Aspire.Hosting/Dcp/DcpExecutor.cs:line 585 [apphost]    at Aspire.Hosting.Dcp.DcpExecutor.RunApplicationAsync(CancellationToken cancellationToken) in /_/src/Aspire.Hosting/Dcp/DcpExecutor.cs:line 126 [apphost]    at Aspire.Hosting.Orchestrator.ApplicationOrchestrator.RunApplicationAsync(CancellationToken cancellationToken) in /_/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs:line 170 [apphost]    at Aspire.Hosting.Orchestrator.OrchestratorHostService.StartAsync(CancellationToken cancellationToken) in /_/src/Aspire.Hosting/Orchestrator/OrchestratorHostService.cs:line 41 [apphost]    at Microsoft.Extensions.Hosting.Internal.Host.<StartAsync>b__14_1(IHostedService service, CancellationToken token) [apphost]    at Microsoft.Extensions.Hosting.Internal.Host.ForeachService[T](IEnumerable1 services, CancellationToken token, Boolean concurrent, Boolean abortOnFirstException, List1 exceptions, Func3 operation)
[apphost]    at Microsoft.Extensions.Hosting.Internal.Host.StartAsync(CancellationToken cancellationToken)
[apphost]    at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
[apphost]    at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
[apphost]    at Aspire.Hosting.DistributedApplication.RunAsync(CancellationToken cancellationToken) in //src/Aspire.Hosting/DistributedApplication.cs:line 311
[apphost]    --- End of inner exception stack trace ---
[apphost]    at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
[apphost]    at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
[apphost]    at System.Threading.Tasks.Task.Wait()
[apphost]    at Aspire.Hosting.DistributedApplication.Run() in //src/Aspire.Hosting/DistributedApplication.cs:line 339
[apphost]    at Program.<Main>$(String[] args) in C:\h\w\AC440968\t\templates-testroot\aspire_starter_run_Release_ya3dkuw0_rq4\aspire_starter_run_Release_ya3dkuw0_rq4.AppHost\Program.cs:line 16
```