### PR TITLE
Use last-one-wins conventions for ExistingResourceAnnotation

### DIFF
--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -34,7 +34,7 @@ public static class AzureServiceBusExtensions
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
             AzureProvisioning.ServiceBusNamespace? serviceBusNamespace;
-            if (infrastructure.AspireResource.TryGetExistingAzureResourceAnnotation(out var existingAnnotation))
+            if (infrastructure.AspireResource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAnnotation))
             {
                 var existingResourceName = existingAnnotation.NameParameter.AsProvisioningParameter(infrastructure, $"{infrastructure.AspireResource.GetBicepIdentifier()}Existing");
                 serviceBusNamespace = AzureProvisioning.ServiceBusNamespace.FromExisting(infrastructure.AspireResource.GetBicepIdentifier());

--- a/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
@@ -21,7 +21,7 @@ public static class ExistingAzureResourceExtensions
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        return resource.Annotations.OfType<ExistingAzureResourceAnnotation>().SingleOrDefault() is not null;
+        return resource.Annotations.OfType<ExistingAzureResourceAnnotation>().LastOrDefault() is not null;
     }
 
     /// <summary>
@@ -36,12 +36,6 @@ public static class ExistingAzureResourceExtensions
         where T : IAzureResource
     {
         ArgumentNullException.ThrowIfNull(builder);
-
-        // Throw if ExistingResourceAnnotation already exists on resource
-        if (builder.Resource.IsExisting())
-        {
-            throw new InvalidOperationException($"Resource {builder.Resource.Name} is already marked as an existing resource.");
-        }
 
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
@@ -64,11 +58,6 @@ public static class ExistingAzureResourceExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        if (builder.Resource.IsExisting())
-        {
-            throw new InvalidOperationException($"Resource {builder.Resource.Name} is already marked as an existing resource.");
-        }
-
         if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
             builder.Resource.Annotations.Add(new ExistingAzureResourceAnnotation(nameParameter.Resource, resourceGroupParameter?.Resource));
@@ -87,7 +76,7 @@ public static class ExistingAzureResourceExtensions
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        existingAzureResourceAnnotation = resource.Annotations.OfType<ExistingAzureResourceAnnotation>().SingleOrDefault();
+        existingAzureResourceAnnotation = resource.Annotations.OfType<ExistingAzureResourceAnnotation>().LastOrDefault();
         return existingAzureResourceAnnotation is not null;
     }
 }

--- a/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Azure;
@@ -39,7 +38,7 @@ public static class ExistingAzureResourceExtensions
 
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
-            builder.Resource.Annotations.Add(new ExistingAzureResourceAnnotation(nameParameter.Resource, resourceGroupParameter?.Resource));
+            builder.WithAnnotation(new ExistingAzureResourceAnnotation(nameParameter.Resource, resourceGroupParameter?.Resource));
         }
 
         return builder;
@@ -60,23 +59,9 @@ public static class ExistingAzureResourceExtensions
 
         if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
-            builder.Resource.Annotations.Add(new ExistingAzureResourceAnnotation(nameParameter.Resource, resourceGroupParameter?.Resource));
+            builder.WithAnnotation(new ExistingAzureResourceAnnotation(nameParameter.Resource, resourceGroupParameter?.Resource));
         }
 
         return builder;
-    }
-
-    /// <summary>
-    /// Gets the <see cref="ExistingAzureResourceAnnotation" /> if the resource is an existing resource.
-    /// </summary>
-    /// <param name="resource">The resource to check.</param>
-    /// <param name="existingAzureResourceAnnotation">The existing resource annotation if the resource is an existing resource.</param>
-    /// <returns>True if the resource is an existing resource, otherwise false.</returns>
-    public static bool TryGetExistingAzureResourceAnnotation(this IResource resource, [NotNullWhen(true)] out ExistingAzureResourceAnnotation? existingAzureResourceAnnotation)
-    {
-        ArgumentNullException.ThrowIfNull(resource);
-
-        existingAzureResourceAnnotation = resource.Annotations.OfType<ExistingAzureResourceAnnotation>().LastOrDefault();
-        return existingAzureResourceAnnotation is not null;
     }
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -110,7 +110,7 @@ internal sealed class BicepProvisioner(
         var resourceGroup = context.ResourceGroup;
         var resourceLogger = loggerService.GetLogger(resource);
 
-        if (resource.TryGetExistingAzureResourceAnnotation(out var existingResource) &&
+        if (resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingResource) &&
             existingResource.ResourceGroupParameter is { } resourceGroupParameter)
         {
             resourceGroup = await context.GetResourceGroup(resourceGroupParameter.Name, resourceLogger, cancellationToken).ConfigureAwait(false);

--- a/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppContainers\Aspire.Hosting.Azure.AppContainers.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Redis\Aspire.Hosting.Azure.Redis.csproj" />

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Xunit;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class ExistingAzureExtensionsResourceTests
+{
+    [Fact]
+    public void RunAsExistingInPublishModeNoOps()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var nameParameter = builder.AddParameter("name", "existingName");
+        var resourceGroupParameter = builder.AddParameter("resourceGroup", "existingResourceGroup");
+
+        var serviceBus = builder.AddAzureServiceBus("sb")
+            .RunAsExisting(nameParameter, resourceGroupParameter);
+
+        Assert.False(serviceBus.Resource.IsExisting());
+    }
+
+    [Fact]
+    public void RunAsExistingInRunModeWorks()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var nameParameter = builder.AddParameter("name", "existingName");
+        var resourceGroupParameter = builder.AddParameter("resourceGroup", "existingResourceGroup");
+
+        var serviceBus = builder.AddAzureServiceBus("sb")
+            .RunAsExisting(nameParameter, resourceGroupParameter);
+
+        Assert.True(serviceBus.Resource.TryGetExistingAzureResourceAnnotation(out var existingAzureResourceAnnotation));
+        Assert.Equal("name", existingAzureResourceAnnotation.NameParameter.Name);
+        Assert.Equal("resourceGroup", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
+    }
+
+    [Fact]
+    public void MultipleRunAsExistingInRunModeUsesLast()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var nameParameter = builder.AddParameter("name", "existingName");
+        var resourceGroupParameter = builder.AddParameter("resourceGroup", "existingResourceGroup");
+        var nameParameter1 = builder.AddParameter("name1", "existingName");
+        var resourceGroupParameter1 = builder.AddParameter("resourceGroup1", "existingResourceGroup");
+
+        var serviceBus = builder.AddAzureServiceBus("sb")
+            .RunAsExisting(nameParameter, resourceGroupParameter)
+            .RunAsExisting(nameParameter1, resourceGroupParameter1);
+
+        Assert.True(serviceBus.Resource.TryGetExistingAzureResourceAnnotation(out var existingAzureResourceAnnotation));
+        Assert.Equal("name1", existingAzureResourceAnnotation.NameParameter.Name);
+        Assert.Equal("resourceGroup1", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
+    }
+
+    [Fact]
+    public void PublishAsExistingInPublishModeWorks()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var nameParameter = builder.AddParameter("name", "existingName");
+        var resourceGroupParameter = builder.AddParameter("resourceGroup", "existingResourceGroup");
+
+        var serviceBus = builder.AddAzureServiceBus("sb")
+            .PublishAsExisting(nameParameter, resourceGroupParameter);
+
+        Assert.True(serviceBus.Resource.TryGetExistingAzureResourceAnnotation(out var existingAzureResourceAnnotation));
+        Assert.Equal("name", existingAzureResourceAnnotation.NameParameter.Name);
+        Assert.Equal("resourceGroup", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
+    }
+
+    [Fact]
+    public void MultiplePublishAsExistingInRunModeUsesLast()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var nameParameter = builder.AddParameter("name", "existingName");
+        var resourceGroupParameter = builder.AddParameter("resourceGroup", "existingResourceGroup");
+        var nameParameter1 = builder.AddParameter("name1", "existingName");
+        var resourceGroupParameter1 = builder.AddParameter("resourceGroup1", "existingResourceGroup");
+
+        var serviceBus = builder.AddAzureServiceBus("sb")
+            .PublishAsExisting(nameParameter, resourceGroupParameter)
+            .PublishAsExisting(nameParameter1, resourceGroupParameter1);
+
+        Assert.True(serviceBus.Resource.TryGetExistingAzureResourceAnnotation(out var existingAzureResourceAnnotation));
+        Assert.Equal("name1", existingAzureResourceAnnotation.NameParameter.Name);
+        Assert.Equal("resourceGroup1", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
+using Aspire.Hosting.ApplicationModel;
 using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -33,7 +34,7 @@ public class ExistingAzureExtensionsResourceTests
         var serviceBus = builder.AddAzureServiceBus("sb")
             .RunAsExisting(nameParameter, resourceGroupParameter);
 
-        Assert.True(serviceBus.Resource.TryGetExistingAzureResourceAnnotation(out var existingAzureResourceAnnotation));
+        Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
         Assert.Equal("name", existingAzureResourceAnnotation.NameParameter.Name);
         Assert.Equal("resourceGroup", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
     }
@@ -52,7 +53,7 @@ public class ExistingAzureExtensionsResourceTests
             .RunAsExisting(nameParameter, resourceGroupParameter)
             .RunAsExisting(nameParameter1, resourceGroupParameter1);
 
-        Assert.True(serviceBus.Resource.TryGetExistingAzureResourceAnnotation(out var existingAzureResourceAnnotation));
+        Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
         Assert.Equal("name1", existingAzureResourceAnnotation.NameParameter.Name);
         Assert.Equal("resourceGroup1", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
     }
@@ -68,7 +69,7 @@ public class ExistingAzureExtensionsResourceTests
         var serviceBus = builder.AddAzureServiceBus("sb")
             .PublishAsExisting(nameParameter, resourceGroupParameter);
 
-        Assert.True(serviceBus.Resource.TryGetExistingAzureResourceAnnotation(out var existingAzureResourceAnnotation));
+        Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
         Assert.Equal("name", existingAzureResourceAnnotation.NameParameter.Name);
         Assert.Equal("resourceGroup", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
     }
@@ -87,7 +88,7 @@ public class ExistingAzureExtensionsResourceTests
             .PublishAsExisting(nameParameter, resourceGroupParameter)
             .PublishAsExisting(nameParameter1, resourceGroupParameter1);
 
-        Assert.True(serviceBus.Resource.TryGetExistingAzureResourceAnnotation(out var existingAzureResourceAnnotation));
+        Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
         Assert.Equal("name1", existingAzureResourceAnnotation.NameParameter.Name);
         Assert.Equal("resourceGroup1", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
     }

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -66,7 +66,7 @@ public class ExistingAzureResourceTests
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
             """;
         Assert.Equal(expectedBicep, BicepText);
-
+    }
 
     [Fact]
     public async Task RequiresPublishAsExistingInPublishMode()

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -66,31 +66,7 @@ public class ExistingAzureResourceTests
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
             """;
         Assert.Equal(expectedBicep, BicepText);
-    }
 
-    [Fact]
-    public void ThrowsIfRunAsExistingCalledTwiceOnSameResource()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create();
-
-        var existingResourceName = builder.AddParameter("existingResourceName");
-        var serviceBus = builder.AddAzureServiceBus("messaging")
-            .RunAsExisting(existingResourceName);
-
-        Assert.Throws<InvalidOperationException>(() => serviceBus.RunAsExisting(existingResourceName));
-    }
-
-    [Fact]
-    public void ThrowsIfPublishAsExistingCalledTwiceOnSameResource()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-
-        var existingResourceName = builder.AddParameter("existingResourceName");
-        var serviceBus = builder.AddAzureServiceBus("messaging")
-            .PublishAsExisting(existingResourceName);
-
-        Assert.Throws<InvalidOperationException>(() => serviceBus.PublishAsExisting(existingResourceName));
-    }
 
     [Fact]
     public async Task RequiresPublishAsExistingInPublishMode()


### PR DESCRIPTION
Follow-up to #7249.