### PR TITLE
Embed Aspire version as project capability via AppHost targets

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -4,11 +4,11 @@
 
 | Diagnostic ID | Severity | Description | Location |
 | ------------- | -------- | ----------- | -------- |
-| `ASPIRE001` | Warning | The '\[ProjectLanguage\]' language isn't fully supported by Aspire - some code generation targets will not run, so will require manual authoring. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.targets](src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.targets) |
+| `ASPIRE001` | Warning | The '\[ProjectLanguage\]' language isn't fully supported by Aspire - some code generation targets will not run, so will require manual authoring. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
 | `ASPIRE002` | Warning | '\[ProjectName\]' is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting.AppHost PackageReference? | [src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets](src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets) |
 | `ASPIRE003` | Warning | '\[ProjectName\]' is a .NET Aspire AppHost project that requires Visual Studio version 17.10 or above to work correctly. You are using version $(MSBuildVersion). | [src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets](src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets) |
-| `ASPIRE004` | Warning | '\[ProjectName\]' is referenced by an Aspire Host project, but it is not an executable. Did you mean to set IsAspireProjectResource=&quot;false&quot;? | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.targets](src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.targets) |
-| `ASPIRE005` | Error | '\[ProjectName\]' project requires a newer version of the .NET Aspire Workload to work correctly. Please run `dotnet workload update`. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.targets](src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.targets) |
+| `ASPIRE004` | Warning | '\[ProjectName\]' is referenced by an Aspire Host project, but it is not an executable. Did you mean to set IsAspireProjectResource=&quot;false&quot;? | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
+| `ASPIRE005` | Error | '\[ProjectName\]' project requires a newer version of the .NET Aspire Workload to work correctly. Please run `dotnet workload update`. | [src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets](src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets) |
 
 ## Analyzer Warnings
 

--- a/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
+++ b/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(RepoRoot)eng/ReplaceText.targets" />
+
   <PropertyGroup>
     <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
     <IsPackable>true</IsPackable>
@@ -16,6 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <TextReplacementValue Include="VERSION" NewValue="$(PackageVersion)" />
+
     <None Include="**/*.props;**/*.targets;AspireAppHostConfiguration.json" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
     <None Update="build\Aspire.Hosting.AppHost.in.targets" Pack="true" PerformTextReplacement="True" PackagePath="build\Aspire.Hosting.AppHost.targets" />
   </ItemGroup>

--- a/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
+++ b/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <None Include="**/*.props;**/*.targets;AspireAppHostConfiguration.json" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
+    <None Update="build\Aspire.Hosting.AppHost.in.targets" Pack="true" PerformTextReplacement="True" PackagePath="build\Aspire.Hosting.AppHost.targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectCapability Include="Aspire" Condition=" '$(IsAspireHost)' == 'true' " />
+    <ProjectCapability Include="Aspire_@VERSION@" Condition=" '$(IsAspireHost)' == 'true' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.AppHost/buildMultiTargeting/Aspire.Hosting.AppHost.targets
+++ b/src/Aspire.Hosting.AppHost/buildMultiTargeting/Aspire.Hosting.AppHost.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\build\Aspire.Hosting.AppHost.in.targets" />
+  <Import Project="..\build\Aspire.Hosting.AppHost.targets" />
 </Project>

--- a/src/Aspire.Hosting.AppHost/buildMultiTargeting/Aspire.Hosting.AppHost.targets
+++ b/src/Aspire.Hosting.AppHost/buildMultiTargeting/Aspire.Hosting.AppHost.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\build\Aspire.Hosting.AppHost.targets" />
+  <Import Project="..\build\Aspire.Hosting.AppHost.in.targets" />
 </Project>

--- a/tests/Aspire.Hosting.Testing.Tests/Directory.Build.targets
+++ b/tests/Aspire.Hosting.Testing.Tests/Directory.Build.targets
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
   <!-- NOTE: These lines are only required because we are using P2P references, not NuGet. They will not exist in real apps. -->
-  <Import Project="..\..\src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.targets" />
+  <Import Project="..\..\src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.in.targets" />
   <Import Project="..\..\src\Aspire.AppHost.Sdk\SDK\Sdk.in.targets" />
 
   <PropertyGroup>

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -86,7 +86,7 @@ builder.Build().Run();
 """);
             File.WriteAllText(Path.Combine(appHostDirectory, "Directory.Build.targets"), $"""
 <Project>
-  <Import Project="{repoRoot}\src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.targets" />
+  <Import Project="{repoRoot}\src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.in.targets" />
   <Import Project="{repoRoot}\src\Aspire.AppHost.Sdk\SDK\Sdk.in.targets" />
 </Project>
 """);

--- a/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
@@ -16,7 +16,7 @@ public partial class WorkloadTestsBase
     [GeneratedRegex(@"^\s*//")]
     private static partial Regex CommentLineRegex();
 
-    // Regex is from src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.targets - _GeneratedClassNameFixupRegex
+    // Regex is from src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets - _GeneratedClassNameFixupRegex
     [GeneratedRegex(@"(((?<=\.)|^)(?=\d)|\W)")]
     private static partial Regex GeneratedClassNameFixupRegex();
     private static Lazy<IBrowser> Browser => new(CreateBrowser);

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -141,7 +141,7 @@
   </Target>
 
   <ImportGroup Condition="'$(RepoRoot)' != 'null' and '$(TestsRunningOutsideOfRepo)' != 'true' and '$(IsAspireHost)' == 'true'">
-    <Import Project="$(RepoRoot)src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.targets" Condition="Exists('$(RepoRoot)src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.targets')" />
+    <Import Project="$(RepoRoot)src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.in.targets" Condition="Exists('$(RepoRoot)src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.in.targets')" />
     <Import Project="$(RepoRoot)src\Aspire.AppHost.Sdk\SDK\Sdk.in.targets" Condition="Exists('$(RepoRoot)src\Aspire.AppHost.Sdk\SDK\Sdk.in.targets')" />
   </ImportGroup>
 


### PR DESCRIPTION
## Description

Updates the Aspire.Hosting.AppHost targets so that the Aspire version is embedded as a project capability.

Fixes #7405

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
