### PR TITLE
Convert CosmosDBDatabase and CosmosDBContainer to Resources

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/Program.cs
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/Program.cs
@@ -18,8 +18,8 @@ var redis = builder.AddRedis("cache")
 
 // Testing secret outputs
 var cosmosDb = builder.AddAzureCosmosDB("account")
-                      .RunAsEmulator(c => c.WithLifetime(ContainerLifetime.Persistent))
-                      .WithDatabase("db");
+                      .RunAsEmulator(c => c.WithLifetime(ContainerLifetime.Persistent));
+cosmosDb.AddCosmosDatabase("db");
 
 // Testing a connection string
 var blobs = builder.AddAzureStorage("storage")

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
@@ -76,6 +76,10 @@
         "principalId": ""
       }
     },
+    "db": {
+      "type": "value.v0",
+      "connectionString": "{account.outputs.connectionString}"
+    },
     "storage": {
       "type": "azure.bicep.v0",
       "path": "storage.module.bicep",

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
@@ -7,9 +7,10 @@ var eventHubs = builder.AddAzureEventHubs("eventhubs").RunAsEmulator().WithHub("
 #if !SKIP_UNSTABLE_EMULATORS
 var serviceBus = builder.AddAzureServiceBus("messaging").RunAsEmulator().WithQueue("myqueue");
 var cosmosDb = builder.AddAzureCosmosDB("cosmosdb")
-    .RunAsEmulator()
-    .WithDatabase("mydatabase", (database)
-        => database.Containers.AddRange([new("mycontainer", "/id")]));
+    .RunAsEmulator();
+var database = cosmosDb.AddCosmosDatabase("mydatabase");
+database.AddContainer("mycontainer", "/id");
+
 #endif
 
 var funcApp = builder.AddAzureFunctionsProject<Projects.AzureFunctionsEndToEnd_Functions>("funcapp")

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/aspire-manifest.json
@@ -44,6 +44,14 @@
         "principalId": ""
       }
     },
+    "mydatabase": {
+      "type": "value.v0",
+      "connectionString": "{cosmosdb.outputs.connectionString}"
+    },
+    "mycontainer": {
+      "type": "value.v0",
+      "connectionString": "{cosmosdb.outputs.connectionString}"
+    },
     "funcstorage67c6c": {
       "type": "azure.bicep.v0",
       "path": "funcstorage67c6c.module.bicep",

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -4,14 +4,15 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 #pragma warning disable ASPIRECOSMOS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-var db = builder.AddAzureCosmosDB("cosmos")
-                .WithDatabase("db", database => database.Containers.Add(new("entries", "/id")))
+var cosmos = builder.AddAzureCosmosDB("cosmos")
                 .RunAsPreviewEmulator(e => e.WithDataExplorer());
 #pragma warning restore ASPIRECOSMOS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+var db = cosmos.AddCosmosDatabase("db");
+db.AddContainer("entries", "/id");
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()
-       .WithReference(db).WaitFor(db);
+       .WithReference(cosmos).WaitFor(cosmos);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/aspire-manifest.json
@@ -10,6 +10,14 @@
         "principalId": ""
       }
     },
+    "db": {
+      "type": "value.v0",
+      "connectionString": "{cosmos.outputs.connectionString}"
+    },
+    "entries": {
+      "type": "value.v0",
+      "connectionString": "{cosmos.outputs.connectionString}"
+    },
     "api": {
       "type": "project.v0",
       "path": "../CosmosEndToEnd.ApiService/CosmosEndToEnd.ApiService.csproj",

--- a/playground/bicep/BicepSample.AppHost/Program.cs
+++ b/playground/bicep/BicepSample.AppHost/Program.cs
@@ -41,8 +41,8 @@ var pg = builder.AddAzurePostgresFlexibleServer("postgres2")
                 .WithPasswordAuthentication(administratorLogin, administratorLoginPassword)
                 .AddDatabase("db2");
 
-var cosmosDb = builder.AddAzureCosmosDB("cosmos")
-                      .WithDatabase("db3");
+var cosmosDb = builder.AddAzureCosmosDB("cosmos");
+cosmosDb.AddCosmosDatabase("db3");
 
 var logAnalytics = builder.AddAzureLogAnalyticsWorkspace("lawkspc");
 var appInsights = builder.AddAzureApplicationInsights("ai", logAnalytics);

--- a/playground/bicep/BicepSample.AppHost/aspire-manifest.json
+++ b/playground/bicep/BicepSample.AppHost/aspire-manifest.json
@@ -120,6 +120,10 @@
         "principalId": ""
       }
     },
+    "db3": {
+      "type": "value.v0",
+      "connectionString": "{cosmos.outputs.connectionString}"
+    },
     "lawkspc": {
       "type": "azure.bicep.v0",
       "path": "lawkspc.module.bicep"

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -9,7 +9,8 @@ using Azure.Provisioning.Storage;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var cosmosdb = builder.AddAzureCosmosDB("cosmos").WithDatabase("cosmosdb");
+var cosmosdb = builder.AddAzureCosmosDB("cosmos");
+cosmosdb.AddCosmosDatabase("cosmosdb");
 
 var sku = builder.AddParameter("storagesku");
 var locationOverride = builder.AddParameter("locationOverride");

--- a/playground/cdk/CdkSample.AppHost/aspire-manifest.json
+++ b/playground/cdk/CdkSample.AppHost/aspire-manifest.json
@@ -10,6 +10,10 @@
         "principalId": ""
       }
     },
+    "cosmosdb": {
+      "type": "value.v0",
+      "connectionString": "{cosmos.outputs.connectionString}"
+    },
     "storagesku": {
       "type": "parameter.v0",
       "value": "{storagesku.inputs.value}",

--- a/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBContainer.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBContainer.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
+
 namespace Aspire.Hosting.Azure.CosmosDB;
 
 /// <summary>
@@ -9,24 +11,24 @@ namespace Aspire.Hosting.Azure.CosmosDB;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class CosmosDBContainer
+public class CosmosDBContainer : Resource, IResourceWithParent<CosmosDBDatabase>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosDBContainer"/> class.
     /// </summary>
-    public CosmosDBContainer(string name, string partitionKeyPath)
+    public CosmosDBContainer(string name, string partitionKeyPath, CosmosDBDatabase parent) : base(name)
     {
-        Name = name;
         PartitionKeyPath = partitionKeyPath;
+        Parent = parent;
     }
-
-    /// <summary>
-    /// The container name.
-    /// </summary>
-    public string Name { get; set; }
 
     /// <summary>
     /// The partition key path.
     /// </summary>
     public string PartitionKeyPath { get; set; }
+
+    /// <summary>
+    /// Gets the parent Azure Cosmos DB database resource.
+    /// </summary>
+    public CosmosDBDatabase Parent { get; }
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBContainer.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBContainer.cs
@@ -16,14 +16,20 @@ public class CosmosDBContainer : Resource, IResourceWithParent<CosmosDBDatabase>
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosDBContainer"/> class.
     /// </summary>
-    public CosmosDBContainer(string name, string partitionKeyPath, CosmosDBDatabase parent) : base(name)
+    public CosmosDBContainer(string name, string containerName, string partitionKeyPath, CosmosDBDatabase parent) : base(name)
     {
+        ContainerName = containerName;
         PartitionKeyPath = partitionKeyPath;
         Parent = parent;
     }
 
     /// <summary>
-    /// The partition key path.
+    /// Gets or sets the container name.
+    /// </summary>
+    public string ContainerName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the partition key path.
     /// </summary>
     public string PartitionKeyPath { get; set; }
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBContainer.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBContainer.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Azure.CosmosDB;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class CosmosDBContainer : Resource, IResourceWithParent<CosmosDBDatabase>
+public class CosmosDBContainer : Resource, IResourceWithParent<CosmosDBDatabase>, IResourceWithConnectionString
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosDBContainer"/> class.
@@ -37,4 +37,9 @@ public class CosmosDBContainer : Resource, IResourceWithParent<CosmosDBDatabase>
     /// Gets the parent Azure Cosmos DB database resource.
     /// </summary>
     public CosmosDBDatabase Parent { get; }
+
+    /// <summary>
+    /// Gets the connection string expression for the Azure Cosmos DB Database Container.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBDatabase.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBDatabase.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
+
 namespace Aspire.Hosting.Azure.CosmosDB;
 
 /// <summary>
@@ -9,23 +11,23 @@ namespace Aspire.Hosting.Azure.CosmosDB;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class CosmosDBDatabase
+public class CosmosDBDatabase : Resource, IResourceWithParent<AzureCosmosDBResource>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosDBDatabase"/> class.
     /// </summary>
-    public CosmosDBDatabase(string name)
+    public CosmosDBDatabase(string name, AzureCosmosDBResource parent) : base(name)
     {
-        Name = name;
+        Parent = parent;
     }
-
-    /// <summary>
-    /// The database name.
-    /// </summary>
-    public string Name { get; set; }
 
     /// <summary>
     /// The containers for this database.
     /// </summary>
     public List<CosmosDBContainer> Containers { get; } = [];
+
+    /// <summary>
+    /// Gets the parent Azure Cosmos DB account resource.
+    /// </summary>
+    public AzureCosmosDBResource Parent { get; }
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBDatabase.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBDatabase.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Azure.CosmosDB;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class CosmosDBDatabase : Resource, IResourceWithParent<AzureCosmosDBResource>
+public class CosmosDBDatabase : Resource, IResourceWithParent<AzureCosmosDBResource>, IResourceWithConnectionString
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosDBDatabase"/> class.
@@ -36,4 +36,9 @@ public class CosmosDBDatabase : Resource, IResourceWithParent<AzureCosmosDBResou
     /// Gets the parent Azure Cosmos DB account resource.
     /// </summary>
     public AzureCosmosDBResource Parent { get; }
+
+    /// <summary>
+    /// Gets the connection string expression for the Azure Cosmos DB database.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBDatabase.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBDatabase.cs
@@ -16,15 +16,21 @@ public class CosmosDBDatabase : Resource, IResourceWithParent<AzureCosmosDBResou
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosDBDatabase"/> class.
     /// </summary>
-    public CosmosDBDatabase(string name, AzureCosmosDBResource parent) : base(name)
+    public CosmosDBDatabase(string name, string databaseName, AzureCosmosDBResource parent) : base(name)
     {
+        DatabaseName = databaseName;
         Parent = parent;
     }
 
     /// <summary>
+    /// Gets or sets the database name.
+    /// </summary>
+    public string DatabaseName { get; set; }
+
+    /// <summary>
     /// The containers for this database.
     /// </summary>
-    public List<CosmosDBContainer> Containers { get; } = [];
+    internal List<CosmosDBContainer> Containers { get; } = [];
 
     /// <summary>
     /// Gets the parent Azure Cosmos DB account resource.

--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -41,7 +41,7 @@ automatically.
 Then, in the _Program.cs_ file of `AppHost`, add a Cosmos DB connection and consume the connection using the following methods:
 
 ```csharp
-var cosmosdb = builder.AddAzureCosmosDB("cdb").AddDatabase("cosmosdb");
+var cosmosdb = builder.AddAzureCosmosDB("cdb").AddCosmosDatabase("cosmosdb");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(cosmosdb);

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -120,7 +120,7 @@ Then, in the _Program.cs_ file of `AppHost`, add a Cosmos DB connection and cons
 
 ```csharp
 var cosmosdb = builder.ExecutionContext.IsPublishMode
-    ? builder.AddAzureCosmosDB("cdb").AddDatabase("cosmosdb")
+    ? builder.AddAzureCosmosDB("cdb").AddCosmosDatabase("cosmosdb")
     : builder.AddConnectionString("cosmosdb");
 
 var myService = builder.AddProject<Projects.MyService>()

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
@@ -112,7 +112,7 @@ dotnet add package Aspire.Hosting.Azure.CosmosDB
 Then, in the _Program.cs_ file of `AppHost`, add a Cosmos DB connection and consume the connection using the following methods:
 
 ```csharp
-var cosmosdb = builder.AddAzureCosmosDB("cdb").AddDatabase("cosmosdb");
+var cosmosdb = builder.AddAzureCosmosDB("cdb").AddCosmosDatabase("cosmosdb");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(cosmosdb);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -248,7 +248,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             {
                 callbackDatabases = infrastructure.GetProvisionableResources().OfType<CosmosDBSqlDatabase>();
             }).WithAccessKeyAuthentication();
-        cosmos.WithDatabase("mydatabase", db => db.Containers.Add(new("mycontainer", "mypartitionkeypath")));
+        var db = cosmos.AddCosmosDatabase("mydatabase");
+        db.AddContainer("mycontainer", "mypartitionkeypath");
 
         cosmos.Resource.SecretOutputs["connectionString"] = "mycosmosconnectionstring";
 
@@ -359,7 +360,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             {
                 callbackDatabases = infrastructure.GetProvisionableResources().OfType<CosmosDBSqlDatabase>();
             });
-        cosmos.WithDatabase("mydatabase", db => db.Containers.Add(new("mycontainer", "mypartitionkeypath")));
+        var db = cosmos.AddCosmosDatabase("mydatabase");
+        db.AddContainer("mycontainer", "mypartitionkeypath");
 
         cosmos.Resource.Outputs["connectionString"] = "mycosmosconnectionstring";
 
@@ -480,7 +482,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             {
                 callbackDatabases = infrastructure.GetProvisionableResources().OfType<CosmosDBSqlDatabase>();
             }).WithAccessKeyAuthentication();
-        cosmos.WithDatabase("mydatabase", db => db.Containers.Add(new("mycontainer", "mypartitionkeypath")));
+        var db = cosmos.AddCosmosDatabase("mydatabase");
+        db.AddContainer("mycontainer", "mypartitionkeypath");
 
         cosmos.Resource.SecretOutputs["connectionString"] = "mycosmosconnectionstring";
 
@@ -591,7 +594,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             {
                 callbackDatabases = infrastructure.GetProvisionableResources().OfType<CosmosDBSqlDatabase>();
             });
-        cosmos.WithDatabase("mydatabase", db => db.Containers.Add(new("mycontainer", "mypartitionkeypath")));
+        var db = cosmos.AddCosmosDatabase("mydatabase");
+        db.AddContainer("mycontainer", "mypartitionkeypath");
 
         cosmos.Resource.Outputs["connectionString"] = "mycosmosconnectionstring";
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -248,8 +248,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             {
                 callbackDatabases = infrastructure.GetProvisionableResources().OfType<CosmosDBSqlDatabase>();
             }).WithAccessKeyAuthentication();
-        var db = cosmos.AddCosmosDatabase("mydatabase");
-        db.AddContainer("mycontainer", "mypartitionkeypath");
+        var db = cosmos.AddCosmosDatabase("db", databaseName: "mydatabase");
+        db.AddContainer("container", "mypartitionkeypath", containerName: "mycontainer");
 
         cosmos.Resource.SecretOutputs["connectionString"] = "mycosmosconnectionstring";
 
@@ -295,7 +295,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource mydatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
+            resource db 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
               name: 'mydatabase'
               location: location
               properties: {
@@ -306,7 +306,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: cosmos
             }
 
-            resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
+            resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
               name: 'mycontainer'
               location: location
               properties: {
@@ -319,7 +319,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                   }
                 }
               }
-              parent: mydatabase
+              parent: db
             }
 
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -696,7 +696,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         builder.AddAzureContainerAppsInfrastructure();
 
         // CosmosDB uses secret outputs
-        var db = builder.AddAzureCosmosDB("mydb").WithDatabase("db");
+        var db = builder.AddAzureCosmosDB("mydb");
+        db.AddCosmosDatabase("db");
 
         // Postgres uses secret outputs + a literal connection string
         var pgdb = builder.AddAzurePostgresFlexibleServer("pg").WithPasswordAuthentication().AddDatabase("db");
@@ -1316,7 +1317,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
 
         builder.AddAzureContainerAppsInfrastructure();
 
-        var db = builder.AddAzureCosmosDB("mydb").WithAccessKeyAuthentication().WithDatabase("db");
+        var db = builder.AddAzureCosmosDB("mydb").WithAccessKeyAuthentication();
+        db.AddCosmosDatabase("db");
 
         builder.AddContainer("api", "image")
             .WithReference(db)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -697,7 +697,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
 
         // CosmosDB uses secret outputs
         var db = builder.AddAzureCosmosDB("mydb");
-        db.AddCosmosDatabase("db");
+        db.AddCosmosDatabase("cosmosdb", databaseName: "db");
 
         // Postgres uses secret outputs + a literal connection string
         var pgdb = builder.AddAzurePostgresFlexibleServer("pg").WithPasswordAuthentication().AddDatabase("db");


### PR DESCRIPTION
## Description

This allows them to be referenceable and waitable in the future.

Contributes to #7407

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
