### PR TITLE
Hide project arguments in dashboard, show secrets as passwords in the source column

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -15,7 +15,17 @@
     <ContentAfterValue>
         @if (ContentAfterValue is not null)
         {
-            <span class="subtext">&nbsp;@ContentAfterValue</span>
+            foreach (var launchArgument in ContentAfterValue)
+            {
+                if (launchArgument.IsShown)
+                {
+                    <span class="subtext">&nbsp;@launchArgument.Value</span>
+                }
+                else
+                {
+                    <span class="subtext">&nbsp;●●●●●●</span>
+                }
+            }
         }
     </ContentAfterValue>
 </GridValue>
@@ -28,7 +38,7 @@
     public required string Value { get; set; }
 
     [Parameter]
-    public required string? ContentAfterValue { get; set; }
+    public required List<LaunchArgument>? ContentAfterValue { get; set; }
 
     [Parameter, EditorRequired]
     public required string ValueToVisualize { get; set; }

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -33,8 +33,8 @@ public class ResourceSourceViewModel(string value, string? contentAfterValue, st
                 var argumentsString = string.Join(" ", launchArguments);
                 if (resource.TryGetAppArgsFormatParams(out var formatParams))
                 {
-                    var hiddenArgs = string.Format(CultureInfo.InvariantCulture, argumentsString, formatParams.Select(_ => "***"));
-                    var shownArgs = string.Format(CultureInfo.InvariantCulture, argumentsString, formatParams);
+                    var hiddenArgs = string.Format(CultureInfo.InvariantCulture, argumentsString, formatParams.Select(_ => "***").ToArray<object?>());
+                    var shownArgs = string.Format(CultureInfo.InvariantCulture, argumentsString, formatParams.ToArray<object?>());
                     commandLineInfo = (ArgumentsString: hiddenArgs, programPath is null ? argumentsString : $"{programPath} {shownArgs}");
                 }
                 else

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-using System.Text.RegularExpressions;
-
 namespace Aspire.Dashboard.Model;
 
 public class ResourceSourceViewModel(string value, List<LaunchArgument>? contentAfterValue, string valueToVisualize, string tooltip)
@@ -28,13 +25,13 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
             else
             {
                 var argumentsString = string.Join(" ", launchArguments);
-                if (resource.TryGetAppArgsFormatParams(out var formatParams))
+                if (resource.TryGetAppArgsSensitivity(out var areArgumentsSensitive))
                 {
                     var arguments = launchArguments
-                        .Select(arg => new LaunchArgument(arg, !Regex.IsMatch(arg, "{\\d+}")))
+                        .Select((arg, i) => new LaunchArgument(arg, IsShown: !areArgumentsSensitive[i]))
                         .ToList();
-                    var launchArgsString = string.Format(CultureInfo.InvariantCulture, argumentsString, [.. formatParams]);
-                    commandLineInfo = (Arguments: arguments, launchArgsString);
+
+                    commandLineInfo = (Arguments: arguments, argumentsString);
                 }
                 else
                 {

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -12,7 +12,7 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
 
     internal static ResourceSourceViewModel? GetSourceViewModel(ResourceViewModel resource)
     {
-        (List<LaunchArgument>? Arguments, string? ArgumentsString)? commandLineInfo;
+        (List<LaunchArgument>? Arguments, string? ArgumentsString) commandLineInfo;
 
         // If the resource contains launch arguments, these project arguments should be shown in place of all executable arguments,
         // which include args added by the app host
@@ -58,19 +58,19 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
             }
 
             // default to project path if there is no executable path or executable arguments
-            return new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: commandLineInfo?.Arguments, valueToVisualize: projectPath, tooltip: projectPath);
+            return new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: commandLineInfo.Arguments, valueToVisualize: projectPath, tooltip: projectPath);
         }
 
         if (resource.TryGetExecutablePath(out var executablePath))
         {
-            var fullSource = commandLineInfo?.ArgumentsString is not null ? $"{executablePath} {commandLineInfo.Value.ArgumentsString}" : executablePath;
-            return new ResourceSourceViewModel(value: Path.GetFileName(executablePath), contentAfterValue: commandLineInfo?.Arguments, valueToVisualize: fullSource, tooltip: fullSource);
+            var fullSource = commandLineInfo.ArgumentsString is not null ? $"{executablePath} {commandLineInfo.ArgumentsString}" : executablePath;
+            return new ResourceSourceViewModel(value: Path.GetFileName(executablePath), contentAfterValue: commandLineInfo.Arguments, valueToVisualize: fullSource, tooltip: fullSource);
         }
 
         if (resource.TryGetContainerImage(out var containerImage))
         {
-            var fullSource = commandLineInfo?.ArgumentsString is null ? containerImage : $"{containerImage} {commandLineInfo.Value.ArgumentsString}";
-            return new ResourceSourceViewModel(value: containerImage, contentAfterValue: commandLineInfo?.Arguments, valueToVisualize: fullSource, tooltip: fullSource);
+            var fullSource = commandLineInfo.ArgumentsString is null ? containerImage : $"{containerImage} {commandLineInfo.ArgumentsString}";
+            return new ResourceSourceViewModel(value: containerImage, contentAfterValue: commandLineInfo.Arguments, valueToVisualize: fullSource, tooltip: fullSource);
         }
 
         if (resource.Properties.TryGetValue(KnownProperties.Resource.Source, out var property) && property.Value is { HasStringValue: true, StringValue: var value })

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -18,6 +18,12 @@ public class ResourceSourceViewModel(string value, string? contentAfterValue, st
 
         if (resource.TryGetExecutableArguments(out var arguments))
         {
+            if (resource.TryGetExecutableHostArguments(out var hostArgs))
+            {
+                var foundHostArgCount = arguments.TakeWhile((arg, i) => i < hostArgs.Length && string.Equals(arg, hostArgs[i], StringComparison.Ordinal)).Count();
+                arguments = [..arguments.Skip(foundHostArgCount)];
+            }
+
             var argumentsString = arguments.IsDefaultOrEmpty ? null : string.Join(" ", arguments);
             commandLineInfo = (ArgumentsString: argumentsString, $"{executablePath} {argumentsString}");
         }

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -18,9 +18,9 @@ public class ResourceSourceViewModel(string value, string? contentAfterValue, st
 
         if (resource.TryGetExecutableArguments(out var arguments))
         {
-            if (resource.TryGetExecutableHostArguments(out var hostArgs))
+            if (resource.TryGetProjectArguments(out var projectArgs))
             {
-                var foundHostArgCount = arguments.TakeWhile((arg, i) => i < hostArgs.Length && string.Equals(arg, hostArgs[i], StringComparison.Ordinal)).Count();
+                var foundHostArgCount = arguments.TakeWhile((arg, i) => i < projectArgs.Length && string.Equals(arg, projectArgs[i], StringComparison.Ordinal)).Count();
                 arguments = [..arguments.Skip(foundHostArgCount)];
             }
 

--- a/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
@@ -59,9 +59,14 @@ internal static class ResourceViewModelExtensions
         return resource.TryGetCustomDataStringArray(KnownProperties.Executable.Args, out arguments);
     }
 
-    public static bool TryGetProjectArguments(this ResourceViewModel resource, out ImmutableArray<string> arguments)
+    public static bool TryGetAppArgs(this ResourceViewModel resource, out ImmutableArray<string> arguments)
     {
-        return resource.TryGetCustomDataStringArray(KnownProperties.Project.Args, out arguments);
+        return resource.TryGetCustomDataStringArray(KnownProperties.Resource.AppArgs, out arguments);
+    }
+
+    public static bool TryGetAppArgsFormatParams(this ResourceViewModel resource, out ImmutableArray<string> argParams)
+    {
+        return resource.TryGetCustomDataStringArray(KnownProperties.Resource.AppArgsParams, out argParams);
     }
 
     private static bool TryGetCustomDataString(this ResourceViewModel resource, string key, [NotNullWhen(returnValue: true)] out string? s)

--- a/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
@@ -59,9 +59,9 @@ internal static class ResourceViewModelExtensions
         return resource.TryGetCustomDataStringArray(KnownProperties.Executable.Args, out arguments);
     }
 
-    public static bool TryGetExecutableHostArguments(this ResourceViewModel resource, out ImmutableArray<string> arguments)
+    public static bool TryGetProjectArguments(this ResourceViewModel resource, out ImmutableArray<string> arguments)
     {
-        return resource.TryGetCustomDataStringArray(KnownProperties.Executable.HostArgs, out arguments);
+        return resource.TryGetCustomDataStringArray(KnownProperties.Project.Args, out arguments);
     }
 
     private static bool TryGetCustomDataString(this ResourceViewModel resource, string key, [NotNullWhen(returnValue: true)] out string? s)

--- a/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
@@ -64,9 +64,9 @@ internal static class ResourceViewModelExtensions
         return resource.TryGetCustomDataStringArray(KnownProperties.Resource.AppArgs, out arguments);
     }
 
-    public static bool TryGetAppArgsFormatParams(this ResourceViewModel resource, out ImmutableArray<string> argParams)
+    public static bool TryGetAppArgsSensitivity(this ResourceViewModel resource, out ImmutableArray<bool> argParams)
     {
-        return resource.TryGetCustomDataStringArray(KnownProperties.Resource.AppArgsParams, out argParams);
+        return resource.TryGetCustomDataBoolArray(KnownProperties.Resource.AppArgsSensitivity, out argParams);
     }
 
     private static bool TryGetCustomDataString(this ResourceViewModel resource, string key, [NotNullWhen(returnValue: true)] out string? s)
@@ -103,6 +103,31 @@ internal static class ResourceViewModelExtensions
         }
 
         strings = default;
+        return false;
+    }
+
+    private static bool TryGetCustomDataBoolArray(this ResourceViewModel resource, string key, out ImmutableArray<bool> bools)
+    {
+        if (resource.Properties.TryGetValue(key, out var property) && property is { Value: { ListValue: not null } value })
+        {
+            var builder = ImmutableArray.CreateBuilder<bool>(value.ListValue.Values.Count);
+
+            foreach (var element in value.ListValue.Values)
+            {
+                if (!element.HasNumberValue)
+                {
+                    bools = default;
+                    return false;
+                }
+
+                builder.Add(Convert.ToBoolean(element.NumberValue));
+            }
+
+            bools = builder.MoveToImmutable();
+            return true;
+        }
+
+        bools = default;
         return false;
     }
 

--- a/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
@@ -59,6 +59,11 @@ internal static class ResourceViewModelExtensions
         return resource.TryGetCustomDataStringArray(KnownProperties.Executable.Args, out arguments);
     }
 
+    public static bool TryGetExecutableHostArguments(this ResourceViewModel resource, out ImmutableArray<string> arguments)
+    {
+        return resource.TryGetCustomDataStringArray(KnownProperties.Executable.HostArgs, out arguments);
+    }
+
     private static bool TryGetCustomDataString(this ResourceViewModel resource, string key, [NotNullWhen(returnValue: true)] out string? s)
     {
         if (resource.Properties.TryGetValue(key, out var property) && property.Value.TryConvertToString(out var valueString))

--- a/src/Aspire.Hosting/ApplicationModel/AppLaunchArgumentAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AppLaunchArgumentAnnotation.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a container or project application launch argument.
+/// </summary>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Argument = {Argument}, IsSensitive = {IsSensitive}")]
+internal sealed class AppLaunchArgumentAnnotation(string argument, bool isSensitive) : IResourceAnnotation
+{
+    /// <summary>
+    /// The evaluated launch argument.
+    /// </summary>
+    public string Argument { get; } = argument;
+
+    /// <summary>
+    /// Whether the argument contains a secret.
+    /// </summary>
+    public bool IsSensitive { get; } = isSensitive;
+}

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -101,13 +101,14 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
     {
         var value = await vp.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
+        if (vp is ParameterResource pr)
+        {
+            return new ResolvedValue(value, pr.Secret);
+        }
+
+        // No need to do extra work, since the below will only be valid for containers.
         if (!sourceIsContainer)
         {
-            if (vp is ParameterResource pr)
-            {
-                return new ResolvedValue(value, pr.Secret);
-            }
-
             return new ResolvedValue(value, false);
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 
 namespace Aspire.Hosting.ApplicationModel;
 
-internal class ExpressionResolver(string containerHostName, CancellationToken cancellationToken)
+internal class ExpressionResolver(string containerHostName, CancellationToken cancellationToken, bool sourceIsContainer)
 {
     class HostAndPortPresence
     {
@@ -77,23 +77,39 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
         };
     }
 
-    async Task<string?> EvalExpressionAsync(ReferenceExpression expr)
+    async Task<ResolvedValue> EvalExpressionAsync(ReferenceExpression expr)
     {
         // This logic is similar to ReferenceExpression.GetValueAsync, except that we recurse on
         // our own resolver method
         var args = new object?[expr.ValueProviders.Count];
+        var isSensitive = false;
 
         for (var i = 0; i < expr.ValueProviders.Count; i++)
         {
-            args[i] = await ResolveInternalAsync(expr.ValueProviders[i]).ConfigureAwait(false);
+            var result = await ResolveInternalAsync(expr.ValueProviders[i]).ConfigureAwait(false);
+            args[i] = result?.Value;
+            if (result?.IsSensitive is true)
+            {
+                isSensitive = true;
+            }
         }
 
-        return string.Format(CultureInfo.InvariantCulture, expr.Format, args);
+        return new(string.Format(CultureInfo.InvariantCulture, expr.Format, args), isSensitive);
     }
 
-    async Task<string?> EvalValueProvider(IValueProvider vp)
+    async Task<ResolvedValue> EvalValueProvider(IValueProvider vp)
     {
         var value = await vp.GetValueAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!sourceIsContainer)
+        {
+            if (vp is ParameterResource pr)
+            {
+                return new ResolvedValue(value, pr.Secret);
+            }
+
+            return new ResolvedValue(value, false);
+        }
 
         if (vp is HostUrl && value != null)
         {
@@ -128,30 +144,32 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
             }
         }
 
-        return value;
+        return new ResolvedValue(value, false);
     }
 
     /// <summary>
     /// Resolve an expression when it is being used from inside a container.
     /// So it's either a container-to-container or container-to-exe communication.
     /// </summary>
-    async ValueTask<string?> ResolveInternalAsync(object? value)
+    async ValueTask<ResolvedValue> ResolveInternalAsync(object? value)
     {
-        return value switch
+        return (value, sourceIsContainer) switch
         {
-            ConnectionStringReference cs => await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false),
-            IResourceWithConnectionString cs => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
-            ReferenceExpression ex => await EvalExpressionAsync(ex).ConfigureAwait(false),
-            EndpointReference endpointReference => await EvalEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false),
-            EndpointReferenceExpression ep => await EvalEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false),
-            IValueProvider vp => await EvalValueProvider(vp).ConfigureAwait(false),
+            (ConnectionStringReference cs, true) => await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false),
+            (IResourceWithConnectionString cs, true) => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
+            (ReferenceExpression ex, false) => await EvalExpressionAsync(ex).ConfigureAwait(false),
+            (ReferenceExpression ex, true) => await EvalExpressionAsync(ex).ConfigureAwait(false),
+            (EndpointReference endpointReference, true) => new(await EvalEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false), false),
+            (EndpointReferenceExpression ep, true) => new(await EvalEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false), false),
+            (IValueProvider vp, false) => await EvalValueProvider(vp).ConfigureAwait(false),
+            (IValueProvider vp, true) => await EvalValueProvider(vp).ConfigureAwait(false),
             _ => throw new NotImplementedException()
         };
     }
 
-    static async ValueTask<string?> ResolveWithContainerSourceAsync(IValueProvider valueProvider, string containerHostName, CancellationToken cancellationToken)
+    static async ValueTask<ResolvedValue> ResolveWithContainerSourceAsync(IValueProvider valueProvider, string containerHostName, bool sourceIsContainer, CancellationToken cancellationToken)
     {
-        var resolver = new ExpressionResolver(containerHostName, cancellationToken);
+        var resolver = new ExpressionResolver(containerHostName, cancellationToken, sourceIsContainer);
 
         // Run the processing phase to know if the host and port properties are both used for each endpoint.
         resolver.Preprocess = true;
@@ -161,14 +179,10 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
         return await resolver.ResolveInternalAsync(valueProvider).ConfigureAwait(false);
     }
 
-    internal static async ValueTask<string?> ResolveAsync(bool sourceIsContainer, IValueProvider valueProvider, string containerHostName, CancellationToken cancellationToken)
+    internal static async ValueTask<ResolvedValue> ResolveAsync(bool sourceIsContainer, IValueProvider valueProvider, string containerHostName, CancellationToken cancellationToken)
     {
-        return sourceIsContainer switch
-        {
-            // Exe -> Exe and Exe -> Container cases
-            false => await valueProvider.GetValueAsync(cancellationToken).ConfigureAwait(false),
-            // Container -> Exe and Container -> Container cases
-            true => await ResolveWithContainerSourceAsync(valueProvider, containerHostName, cancellationToken).ConfigureAwait(false)
-        };
+        return await ResolveWithContainerSourceAsync(valueProvider, containerHostName, sourceIsContainer, cancellationToken).ConfigureAwait(false);
     }
 }
+
+internal record ResolvedValue(string? Value, bool IsSensitive);

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -994,7 +994,6 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             }
             else if (value is { } argument)
             {
-                // TODO return after processing whether the argument contains a secret
                 er.DcpResource.AnnotateAsObjectList(CustomResource.ResourceAppArgsAnnotation, new AppLaunchArgumentAnnotation(argument, isSensitive: isSensitive));
                 spec.Args.Add(argument);
             }
@@ -1251,7 +1250,6 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             }
             else if (value is { } argument)
             {
-                // TODO return after processing whether the argument contains a secret
                 cr.DcpResource.AnnotateAsObjectList(CustomResource.ResourceAppArgsAnnotation, new AppLaunchArgumentAnnotation(argument, isSensitive: isSensitive));
                 spec.Args.Add(argument);
             }

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -854,7 +854,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
 
                     foreach (var arg in exeSpec.Spec.Args)
                     {
-                        exeSpec.AnnotateAsObjectList(CustomResource.ResourceHostArgsAnnotation, arg);
+                        exeSpec.AnnotateAsObjectList(CustomResource.ProjectArgsAnnotation, arg);
                     }
 
                     var launchProfile = project.GetEffectiveLaunchProfile()?.LaunchProfile;
@@ -865,7 +865,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
                         {
                             const string separator = "--";
                             exeSpec.Spec.Args.Add(separator);
-                            exeSpec.Annotate(CustomResource.ResourceHostArgsAnnotation, separator);
+                            exeSpec.Annotate(CustomResource.ProjectArgsAnnotation, separator);
 
                             exeSpec.Spec.Args.AddRange(cmdArgs);
                         }

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -852,13 +852,21 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
                     // and the environment variables/application URLs inside CreateExecutableAsync().
                     exeSpec.Spec.Args.Add("--no-launch-profile");
 
+                    foreach (var arg in exeSpec.Spec.Args)
+                    {
+                        exeSpec.AnnotateAsObjectList(CustomResource.ResourceHostArgsAnnotation, arg);
+                    }
+
                     var launchProfile = project.GetEffectiveLaunchProfile()?.LaunchProfile;
                     if (launchProfile is not null && !string.IsNullOrWhiteSpace(launchProfile.CommandLineArgs))
                     {
                         var cmdArgs = CommandLineArgsParser.Parse(launchProfile.CommandLineArgs);
                         if (cmdArgs.Count > 0)
                         {
-                            exeSpec.Spec.Args.Add("--");
+                            const string separator = "--";
+                            exeSpec.Spec.Args.Add(separator);
+                            exeSpec.Annotate(CustomResource.ResourceHostArgsAnnotation, separator);
+
                             exeSpec.Spec.Args.AddRange(cmdArgs);
                         }
                     }

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -983,7 +983,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
 
         spec.Args ??= [];
 
-        await er.ModelResource.ProcessArgumentValuesAsync(_executionContext, (unprocessed, value, ex) =>
+        await er.ModelResource.ProcessArgumentValuesAsync(_executionContext, (unprocessed, value, ex, isSensitive) =>
         {
             if (ex is not null)
             {
@@ -995,7 +995,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             else if (value is { } argument)
             {
                 // TODO return after processing whether the argument contains a secret
-                er.DcpResource.AnnotateAsObjectList(CustomResource.ResourceAppArgsAnnotation, new AppLaunchArgumentAnnotation(argument, isSensitive: false));
+                er.DcpResource.AnnotateAsObjectList(CustomResource.ResourceAppArgsAnnotation, new AppLaunchArgumentAnnotation(argument, isSensitive: isSensitive));
                 spec.Args.Add(argument);
             }
         },
@@ -1240,7 +1240,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
 
         spec.Args ??= [];
 
-        await cr.ModelResource.ProcessArgumentValuesAsync(_executionContext, (unprocessed, value, ex) =>
+        await cr.ModelResource.ProcessArgumentValuesAsync(_executionContext, (unprocessed, value, ex, isSensitive) =>
         {
             if (ex is not null)
             {
@@ -1252,7 +1252,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             else if (value is { } argument)
             {
                 // TODO return after processing whether the argument contains a secret
-                cr.DcpResource.AnnotateAsObjectList(CustomResource.ResourceAppArgsAnnotation, new AppLaunchArgumentAnnotation(argument, isSensitive: false));
+                cr.DcpResource.AnnotateAsObjectList(CustomResource.ResourceAppArgsAnnotation, new AppLaunchArgumentAnnotation(argument, isSensitive: isSensitive));
                 spec.Args.Add(argument);
             }
         },

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -25,9 +25,9 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
     public const string OtelServiceNameAnnotation = "otel-service-name";
     public const string OtelServiceInstanceIdAnnotation = "otel-service-instance-id";
     public const string ResourceStateAnnotation = "resource-state";
+    public const string ResourceAppArgsAnnotation = "resource-app-args";
     public const string ResourceReplicaCount = "resource-replica-count";
     public const string ResourceReplicaIndex = "resource-replica-index";
-    public const string ProjectArgsAnnotation = "project-args";
 
     public string? AppModelResourceName => Metadata.Annotations?.TryGetValue(ResourceNameAnnotation, out var value) is true ? value : null;
 

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -27,7 +27,7 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
     public const string ResourceStateAnnotation = "resource-state";
     public const string ResourceReplicaCount = "resource-replica-count";
     public const string ResourceReplicaIndex = "resource-replica-index";
-    public const string ResourceHostArgsAnnotation = "resource-host-args";
+    public const string ProjectArgsAnnotation = "project-args";
 
     public string? AppModelResourceName => Metadata.Annotations?.TryGetValue(ResourceNameAnnotation, out var value) is true ? value : null;
 

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -27,6 +27,7 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
     public const string ResourceStateAnnotation = "resource-state";
     public const string ResourceReplicaCount = "resource-replica-count";
     public const string ResourceReplicaIndex = "resource-replica-index";
+    public const string ResourceHostArgsAnnotation = "resource-host-args";
 
     public string? AppModelResourceName => Metadata.Annotations?.TryGetValue(ResourceNameAnnotation, out var value) is true ? value : null;
 
@@ -112,7 +113,7 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
             values = [value];
         }
 
-        var newAnnotationVal = JsonSerializer.Serialize(values);
+        var newAnnotationVal = JsonSerializer.Serialize<List<TValue>>(values);
         annotations[annotationName] = newAnnotationVal;
     }
 }

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -103,8 +103,6 @@ internal class ResourceSnapshotBuilder
             relationships = ApplicationModel.ResourceSnapshotBuilder.BuildRelationships(appModelResource);
         }
 
-        List<string>? hostArgs;
-
         if (projectPath is not null)
         {
             return previous with
@@ -116,9 +114,9 @@ internal class ResourceSnapshotBuilder
                     new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
                     new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
                     new(KnownProperties.Executable.Args, executable.Status?.EffectiveArgs ?? []) { IsSensitive = true },
-                    new(KnownProperties.Executable.HostArgs, executable.TryGetAnnotationAsObjectList(CustomResource.ResourceHostArgsAnnotation, out hostArgs) ? hostArgs : null),
                     new(KnownProperties.Executable.Pid, executable.Status?.ProcessId),
-                    new(KnownProperties.Project.Path, projectPath)
+                    new(KnownProperties.Project.Path, projectPath),
+                    new(KnownProperties.Project.Args, executable.TryGetAnnotationAsObjectList(CustomResource.ProjectArgsAnnotation, out List<string>? projectArgs) ? projectArgs : null)
                 ]),
                 EnvironmentVariables = environment,
                 CreationTimeStamp = executable.Metadata.CreationTimestamp?.ToUniversalTime(),
@@ -138,7 +136,6 @@ internal class ResourceSnapshotBuilder
                 new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
                 new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
                 new(KnownProperties.Executable.Args, executable.Status?.EffectiveArgs ?? []) { IsSensitive = true },
-                new(KnownProperties.Executable.HostArgs, executable.TryGetAnnotationAsObjectList(CustomResource.ResourceHostArgsAnnotation, out hostArgs) ? hostArgs : null),
                 new(KnownProperties.Executable.Pid, executable.Status?.ProcessId)
             ]),
             EnvironmentVariables = environment,

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
-using System.Data;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Model;
@@ -104,6 +103,8 @@ internal class ResourceSnapshotBuilder
             relationships = ApplicationModel.ResourceSnapshotBuilder.BuildRelationships(appModelResource);
         }
 
+        List<string>? hostArgs;
+
         if (projectPath is not null)
         {
             return previous with
@@ -115,6 +116,7 @@ internal class ResourceSnapshotBuilder
                     new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
                     new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
                     new(KnownProperties.Executable.Args, executable.Status?.EffectiveArgs ?? []) { IsSensitive = true },
+                    new(KnownProperties.Executable.HostArgs, executable.TryGetAnnotationAsObjectList(CustomResource.ResourceHostArgsAnnotation, out hostArgs) ? hostArgs : null),
                     new(KnownProperties.Executable.Pid, executable.Status?.ProcessId),
                     new(KnownProperties.Project.Path, projectPath)
                 ]),
@@ -136,6 +138,7 @@ internal class ResourceSnapshotBuilder
                 new(KnownProperties.Executable.Path, executable.Spec.ExecutablePath),
                 new(KnownProperties.Executable.WorkDir, executable.Spec.WorkingDirectory),
                 new(KnownProperties.Executable.Args, executable.Status?.EffectiveArgs ?? []) { IsSensitive = true },
+                new(KnownProperties.Executable.HostArgs, executable.TryGetAnnotationAsObjectList(CustomResource.ResourceHostArgsAnnotation, out hostArgs) ? hostArgs : null),
                 new(KnownProperties.Executable.Pid, executable.Status?.ProcessId)
             ]),
             EnvironmentVariables = environment,

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -175,7 +175,7 @@ internal class ResourceSnapshotBuilder
         {
             if (annotation.IsSensitive)
             {
-                launchArgsBuilder.Add(sensitiveArgCount.ToString(CultureInfo.InvariantCulture));
+                launchArgsBuilder.Add("{" + sensitiveArgCount.ToString(CultureInfo.InvariantCulture) + "}");
                 formatArgsBuilder.Add(annotation.Argument);
                 sensitiveArgCount++;
             }

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -529,7 +529,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
 
         await resource.ProcessArgumentValuesAsync(
             ExecutionContext,
-            (unprocessed, expression, ex) =>
+            (unprocessed, expression, ex, _) =>
             {
                 if (ex is not null)
                 {

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -27,6 +27,8 @@ internal static class KnownProperties
         public const string HealthState = "resource.healthState";
         public const string ConnectionString = "resource.connectionString";
         public const string ParentName = "resource.parentName";
+        public const string AppArgs = "resource.appArgs";
+        public const string AppArgsParams = "resource.appArgsParams";
     }
 
     public static class Container
@@ -50,6 +52,5 @@ internal static class KnownProperties
     public static class Project
     {
         public const string Path = "project.path";
-        public const string Args = "project.args";
     }
 }

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -45,11 +45,11 @@ internal static class KnownProperties
         public const string Pid = "executable.pid";
         public const string WorkDir = "executable.workDir";
         public const string Args = "executable.args";
-        public const string HostArgs = "executable.hostArgs";
     }
 
     public static class Project
     {
         public const string Path = "project.path";
+        public const string Args = "project.args";
     }
 }

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -28,7 +28,7 @@ internal static class KnownProperties
         public const string ConnectionString = "resource.connectionString";
         public const string ParentName = "resource.parentName";
         public const string AppArgs = "resource.appArgs";
-        public const string AppArgsParams = "resource.appArgsParams";
+        public const string AppArgsSensitivity = "resource.appArgsSensitivity";
     }
 
     public static class Container

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -45,6 +45,7 @@ internal static class KnownProperties
         public const string Pid = "executable.pid";
         public const string WorkDir = "executable.workDir";
         public const string Args = "executable.args";
+        public const string HostArgs = "executable.hostArgs";
     }
 
     public static class Project

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -26,9 +26,9 @@ public class ResourceSourceViewModelTests
             properties.TryAdd(KnownProperties.Executable.Args, new ResourcePropertyViewModel(KnownProperties.Executable.Args, Value.ForList(testData.ExecutableArguments.Select(Value.ForString).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
         }
 
-        if (testData.HostArguments is not null)
+        if (testData.HostArguments is not null && testData.ResourceType == "Project")
         {
-            properties.TryAdd(KnownProperties.Executable.HostArgs, new ResourcePropertyViewModel(KnownProperties.Executable.HostArgs, Value.ForList(testData.HostArguments.Select(Value.ForString).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
+            properties.TryAdd(KnownProperties.Project.Args, new ResourcePropertyViewModel(KnownProperties.Project.Args, Value.ForList(testData.HostArguments.Select(Value.ForString).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
         }
 
         var resource = ModelTestHelpers.CreateResource(

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -31,9 +31,9 @@ public class ResourceSourceViewModelTests
             properties.TryAdd(KnownProperties.Resource.AppArgs, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgs, Value.ForList(testData.AppArgs.Select(Value.ForString).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
         }
 
-        if (testData.AppArgsFormatArgs is not null)
+        if (testData.AppArgsSensitivity is not null)
         {
-            properties.TryAdd(KnownProperties.Resource.AppArgsParams, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgsParams, Value.ForList(testData.AppArgsFormatArgs.Select(Value.ForString).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
+            properties.TryAdd(KnownProperties.Resource.AppArgsSensitivity, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgsSensitivity, Value.ForList(testData.AppArgsSensitivity.Select(b => Value.ForNumber(Convert.ToInt32(b))).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
         }
 
         var resource = ModelTestHelpers.CreateResource(
@@ -70,7 +70,7 @@ public class ResourceSourceViewModelTests
                 ExecutablePath: "path/to/executable",
                 ExecutableArguments: ["arg1", "arg2"],
                 AppArgs: ["arg2"],
-                AppArgsFormatArgs: null,
+                AppArgsSensitivity: [false],
                 ProjectPath: "path/to/project",
                 ContainerImage: null,
                 SourceProperty: null),
@@ -85,14 +85,14 @@ public class ResourceSourceViewModelTests
                 ResourceType: "Project",
                 ExecutablePath: "path/to/executable",
                 ExecutableArguments: ["arg1", "arg2"],
-                AppArgs: ["arg2", "--key", "{0}"],
-                AppArgsFormatArgs: ["secret"],
+                AppArgs: ["arg2", "--key", "secret"],
+                AppArgsSensitivity: [false, false, true],
                 ProjectPath: "path/to/project",
                 ContainerImage: null,
                 SourceProperty: null),
             new ResourceSourceViewModel(
                 value: "project",
-                contentAfterValue: [new LaunchArgument("arg2", true), new LaunchArgument("--key", true), new LaunchArgument("{0}", false)],
+                contentAfterValue: [new LaunchArgument("arg2", true), new LaunchArgument("--key", true), new LaunchArgument("secret", false)],
                 valueToVisualize: "path/to/project arg2 --key secret",
                 tooltip: "path/to/project arg2 --key secret"));
 
@@ -102,7 +102,7 @@ public class ResourceSourceViewModelTests
                 ExecutablePath: null,
                 ExecutableArguments: null,
                 AppArgs: null,
-                AppArgsFormatArgs: null,
+                AppArgsSensitivity: null,
                 ProjectPath: "path/to/project",
                 ContainerImage: null,
                 SourceProperty: null),
@@ -118,7 +118,7 @@ public class ResourceSourceViewModelTests
                 ExecutablePath: "path/to/executable",
                 ExecutableArguments: ["arg1", "arg2"],
                 AppArgs: null,
-                AppArgsFormatArgs: null,
+                AppArgsSensitivity: null,
                 ProjectPath: null,
                 ContainerImage: null,
                 SourceProperty: null),
@@ -134,7 +134,7 @@ public class ResourceSourceViewModelTests
                 ExecutablePath: null,
                 ExecutableArguments: null,
                 AppArgs: null,
-                AppArgsFormatArgs: null,
+                AppArgsSensitivity: null,
                 ProjectPath: null,
                 ContainerImage: "my-container-image",
                 SourceProperty: null),
@@ -150,7 +150,7 @@ public class ResourceSourceViewModelTests
                 ExecutablePath: null,
                 ExecutableArguments: null,
                 AppArgs: null,
-                AppArgsFormatArgs: null,
+                AppArgsSensitivity: null,
                 ProjectPath: null,
                 ContainerImage: null,
                 SourceProperty: "source-value"),
@@ -166,7 +166,7 @@ public class ResourceSourceViewModelTests
                 ExecutablePath: "path/to/executable",
                 ExecutableArguments: null,
                 AppArgs: null,
-                AppArgsFormatArgs: null,
+                AppArgsSensitivity: null,
                 ProjectPath: null,
                 ContainerImage: null,
                 SourceProperty: null),
@@ -184,7 +184,7 @@ public class ResourceSourceViewModelTests
         string? ExecutablePath,
         string[]? ExecutableArguments,
         string[]? AppArgs,
-        string[]? AppArgsFormatArgs,
+        bool[]? AppArgsSensitivity,
         string? ProjectPath,
         string? ContainerImage,
         string? SourceProperty);

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -26,6 +26,11 @@ public class ResourceSourceViewModelTests
             properties.TryAdd(KnownProperties.Executable.Args, new ResourcePropertyViewModel(KnownProperties.Executable.Args, Value.ForList(testData.ExecutableArguments.Select(Value.ForString).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
         }
 
+        if (testData.HostArguments is not null)
+        {
+            properties.TryAdd(KnownProperties.Executable.HostArgs, new ResourcePropertyViewModel(KnownProperties.Executable.HostArgs, Value.ForList(testData.HostArguments.Select(Value.ForString).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
+        }
+
         var resource = ModelTestHelpers.CreateResource(
             resourceType: testData.ResourceType,
             properties: properties);
@@ -59,20 +64,22 @@ public class ResourceSourceViewModelTests
                 ResourceType: "Project",
                 ExecutablePath: "path/to/executable",
                 ExecutableArguments: ["arg1", "arg2"],
+                HostArguments: ["arg1"],
                 ProjectPath: "path/to/project",
                 ContainerImage: null,
                 SourceProperty: null),
             new ResourceSourceViewModel(
                 value: "project",
-                contentAfterValue: "arg1 arg2",
-                valueToVisualize: "path/to/executable arg1 arg2",
-                tooltip: "path/to/executable arg1 arg2"));
+                contentAfterValue: "arg2",
+                valueToVisualize: "path/to/executable arg2",
+                tooltip: "path/to/executable arg2"));
 
         // Project without executable arguments
         data.Add(new TestData(
                 ResourceType: "Project",
                 ExecutablePath: null,
                 ExecutableArguments: null,
+                HostArguments: null,
                 ProjectPath: "path/to/project",
                 ContainerImage: null,
                 SourceProperty: null),
@@ -87,6 +94,7 @@ public class ResourceSourceViewModelTests
                 ResourceType: "Executable",
                 ExecutablePath: "path/to/executable",
                 ExecutableArguments: ["arg1", "arg2"],
+                HostArguments: null,
                 ProjectPath: null,
                 ContainerImage: null,
                 SourceProperty: null),
@@ -101,6 +109,7 @@ public class ResourceSourceViewModelTests
                 ResourceType: "Container",
                 ExecutablePath: null,
                 ExecutableArguments: null,
+                HostArguments: null,
                 ProjectPath: null,
                 ContainerImage: "my-container-image",
                 SourceProperty: null),
@@ -115,6 +124,7 @@ public class ResourceSourceViewModelTests
                 ResourceType: "CustomResourceType",
                 ExecutablePath: null,
                 ExecutableArguments: null,
+                HostArguments: null,
                 ProjectPath: null,
                 ContainerImage: null,
                 SourceProperty: "source-value"),
@@ -129,6 +139,7 @@ public class ResourceSourceViewModelTests
                 ResourceType: "Executable",
                 ExecutablePath: "path/to/executable",
                 ExecutableArguments: null,
+                HostArguments: null,
                 ProjectPath: null,
                 ContainerImage: null,
                 SourceProperty: null),
@@ -145,6 +156,7 @@ public class ResourceSourceViewModelTests
         string ResourceType,
         string? ExecutablePath,
         string[]? ExecutableArguments,
+        string[]? HostArguments,
         string? ProjectPath,
         string? ContainerImage,
         string? SourceProperty);

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -52,7 +52,7 @@ public class ExpressionResolverTests
         // First test ExpressionResolver directly
         var csRef = new ConnectionStringReference(target.Resource, false);
         var connectionString = await ExpressionResolver.ResolveAsync(sourceIsContainer, csRef, "ContainerHostName", CancellationToken.None).DefaultTimeout();
-        Assert.Equal(expectedConnectionString, connectionString);
+        Assert.Equal(expectedConnectionString, connectionString.Value);
 
         // Then test it indirectly with a resource reference, which exercises a more complete code path
         var source = builder.AddResource(new ContainerResource("testSource"))

--- a/tests/Aspire.Hosting.Tests/Utils/ArgumentEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/ArgumentEvaluator.cs
@@ -11,7 +11,7 @@ public sealed class ArgumentEvaluator
     {
         var args = new List<string>();
 
-        await resource.ProcessArgumentValuesAsync(new(DistributedApplicationOperation.Run), (unprocessed, processed, ex) =>
+        await resource.ProcessArgumentValuesAsync(new(DistributedApplicationOperation.Run), (_, processed, ex, _) =>
         {
             if (ex is not null)
             {


### PR DESCRIPTION
## Description

Based on Karol and Drew's comments, I inverted the logic and added two properties, `resource.appArgs` and `resource.AppArgsParams`. The first contains launch args not added by DCP, and the second contains secrets that can be inserted into `resource.appArgs`. `resource.appArgs` will contain placeholders for all secrets. example:

The properties passed from AppHost to dashboard will be marked as sensitive if there is any secret in them. Processing in the dashboard turns placeholders into "passwords" in the source column - users can see all arguments by opening the text visualizer.

I extended the `ExpressionResolver` to return a type containing the resolved value as well as whether the expression contained a sensitive value, in the case of parameters appearing in the expressions.

Before:
![image](https://github.com/user-attachments/assets/023f0249-1fdb-461a-9bbf-241df6c454f8)

After:
![image](https://github.com/user-attachments/assets/6d7f6e09-47e8-423e-af0e-e7c4fdd3a755)

You can see that secrets do actually appear in the text visualizer
![image](https://github.com/user-attachments/assets/babd61d2-c73d-4d17-b077-311d7ea1837f)

Fixes #6835 and fixes #6459

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
