### PR TITLE
Sign builds when building a release branch

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -138,8 +138,12 @@ extends:
           jobs:
 
           - job: Windows
-            # timeout accounts for wait times for helix agents up to 30mins
-            timeoutInMinutes: 90
+            ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+              # If the build is getting signed, then the timeout should be increased.
+              timeoutInMinutes: 120
+            ${{ else }}:
+              # timeout accounts for wait times for helix agents up to 30mins
+              timeoutInMinutes: 90
 
             pool:
               name: NetCore1ESPool-Internal
@@ -168,8 +172,12 @@ extends:
 
           - ${{ if eq(variables._RunAsPublic, True) }}:
             - job: Linux
-              # timeout accounts for wait times for helix agents up to 30mins
-              timeoutInMinutes: 90
+              ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+                # If the build is getting signed, then the timeout should be increased.
+                timeoutInMinutes: 120
+              ${{ else }}:
+                # timeout accounts for wait times for helix agents up to 30mins
+                timeoutInMinutes: 90
 
               pool:
                 name: NetCore1ESPool-Internal

--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -27,5 +27,9 @@ variables:
         /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-    - name: PostBuildSign
-      value: true
+    - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+      - name: PostBuildSign
+        value: false
+    - ${{ else }}:
+      - name: PostBuildSign
+        value: true


### PR DESCRIPTION
## Description

cc: @wtgodbe . This will make it such that builds from a release branch are automatically signed. Previously we would change these values each release after snap to enable signing, but this change makes it such that this just happens automatically. I've queued a build internally to validate that this works as expected and things seem to work well.


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
