### PR TITLE
Make CosmosDB resource names consistent.

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -3,7 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 
-namespace Aspire.Hosting.Azure.CosmosDB;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents an Azure Cosmos DB Database Container.
@@ -11,12 +11,12 @@ namespace Aspire.Hosting.Azure.CosmosDB;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class CosmosDBContainer : Resource, IResourceWithParent<CosmosDBDatabase>, IResourceWithConnectionString
+public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<AzureCosmosDBDatabaseResource>, IResourceWithConnectionString
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="CosmosDBContainer"/> class.
+    /// Initializes a new instance of the <see cref="AzureCosmosDBContainerResource"/> class.
     /// </summary>
-    public CosmosDBContainer(string name, string containerName, string partitionKeyPath, CosmosDBDatabase parent) : base(name)
+    public AzureCosmosDBContainerResource(string name, string containerName, string partitionKeyPath, AzureCosmosDBDatabaseResource parent) : base(name)
     {
         ContainerName = containerName;
         PartitionKeyPath = partitionKeyPath;
@@ -36,7 +36,7 @@ public class CosmosDBContainer : Resource, IResourceWithParent<CosmosDBDatabase>
     /// <summary>
     /// Gets the parent Azure Cosmos DB database resource.
     /// </summary>
-    public CosmosDBDatabase Parent { get; }
+    public AzureCosmosDBDatabaseResource Parent { get; }
 
     /// <summary>
     /// Gets the connection string expression for the Azure Cosmos DB Database Container.

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -3,7 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 
-namespace Aspire.Hosting.Azure.CosmosDB;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents an Azure Cosmos DB Database.
@@ -11,12 +11,12 @@ namespace Aspire.Hosting.Azure.CosmosDB;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class CosmosDBDatabase : Resource, IResourceWithParent<AzureCosmosDBResource>, IResourceWithConnectionString
+public class AzureCosmosDBDatabaseResource : Resource, IResourceWithParent<AzureCosmosDBResource>, IResourceWithConnectionString
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="CosmosDBDatabase"/> class.
+    /// Initializes a new instance of the <see cref="AzureCosmosDBDatabaseResource"/> class.
     /// </summary>
-    public CosmosDBDatabase(string name, string databaseName, AzureCosmosDBResource parent) : base(name)
+    public AzureCosmosDBDatabaseResource(string name, string databaseName, AzureCosmosDBResource parent) : base(name)
     {
         DatabaseName = databaseName;
         Parent = parent;
@@ -30,7 +30,7 @@ public class CosmosDBDatabase : Resource, IResourceWithParent<AzureCosmosDBResou
     /// <summary>
     /// The containers for this database.
     /// </summary>
-    internal List<CosmosDBContainer> Containers { get; } = [];
+    internal List<AzureCosmosDBContainerResource> Containers { get; } = [];
 
     /// <summary>
     /// Gets the parent Azure Cosmos DB account resource.

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -229,7 +229,7 @@ public static class AzureCosmosExtensions
     /// <param name="name">The name of the database resource.</param>
     /// <param name="databaseName">The name of the database. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<CosmosDBDatabase> AddCosmosDatabase(this IResourceBuilder<AzureCosmosDBResource> builder, [ResourceName] string name, string? databaseName = null)
+    public static IResourceBuilder<AzureCosmosDBDatabaseResource> AddCosmosDatabase(this IResourceBuilder<AzureCosmosDBResource> builder, [ResourceName] string name, string? databaseName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -237,7 +237,7 @@ public static class AzureCosmosExtensions
         // Use the resource name as the database name if it's not provided
         databaseName ??= name;
 
-        var database = new CosmosDBDatabase(name, databaseName, builder.Resource);
+        var database = new AzureCosmosDBDatabaseResource(name, databaseName, builder.Resource);
         builder.Resource.Databases.Add(database);
 
         return builder.ApplicationBuilder.AddResource(database);
@@ -251,7 +251,7 @@ public static class AzureCosmosExtensions
     /// <param name="partitionKeyPath">Partition key path for the container.</param>
     /// <param name="containerName">The name of the container. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<CosmosDBContainer> AddContainer(this IResourceBuilder<CosmosDBDatabase> builder, [ResourceName] string name, string partitionKeyPath, string? containerName = null)
+    public static IResourceBuilder<AzureCosmosDBContainerResource> AddContainer(this IResourceBuilder<AzureCosmosDBDatabaseResource> builder, [ResourceName] string name, string partitionKeyPath, string? containerName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -260,7 +260,7 @@ public static class AzureCosmosExtensions
         // Use the resource name as the container name if it's not provided
         containerName ??= name;
 
-        var container = new CosmosDBContainer(name, containerName, partitionKeyPath, builder.Resource);
+        var container = new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, builder.Resource);
         builder.Resource.Containers.Add(container);
 
         return builder.ApplicationBuilder.AddResource(container);

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -17,7 +17,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     IResourceWithEndpoints,
     IResourceWithAzureFunctionsConfig
 {
-    internal List<CosmosDBDatabase> Databases { get; } = [];
+    internal List<AzureCosmosDBDatabaseResource> Databases { get; } = [];
 
     internal EndpointReference EmulatorEndpoint => new(this, "emulator");
 


### PR DESCRIPTION
Also move the new resources into the same namespace as the emulator. Unfortunately the top level CosmosDBResource is in the top-level Aspire.Hosting namespace.