### PR TITLE
Clear button on ConsoleLogs page

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -39,7 +39,7 @@
                 { "title", item.Tooltip ?? string.Empty }
             };
 
-            <FluentMenuItem OnClick="() => HandleItemClicked(item)" Disabled="@item.IsDisabled" AdditionalAttributes="@additionalMenuItemAttributes">
+            <FluentMenuItem Id="@item.Id" OnClick="() => HandleItemClicked(item)" Disabled="@item.IsDisabled" AdditionalAttributes="@additionalMenuItemAttributes">
                 @item.Text
                 @if (item.Icon != null)
                 {

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -40,7 +40,8 @@ public partial class AspireMenuButton : FluentComponentBase
     [Parameter]
     public string? Title { get; set; }
 
-    public string MenuButtonId { get; } = Identifier.NewId();
+    [Parameter]
+    public string MenuButtonId { get; set; } = Identifier.NewId();
 
     protected override void OnParametersSet()
     {

--- a/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor.cs
@@ -35,6 +35,7 @@ public partial class ClearSignalsButton : ComponentBase
 
         _clearMenuItems.Add(new()
         {
+            Id = "clear-menu-all",
             Icon = s_clearAllResourcesIcon,
             OnClick = () => HandleClearSignal(null),
             Text = ControlsStringsLoc[name: nameof(ControlsStrings.ClearAllResources)],
@@ -42,6 +43,7 @@ public partial class ClearSignalsButton : ComponentBase
 
         _clearMenuItems.Add(new()
         {
+            Id = "clear-menu-resource",
             Icon = s_clearSelectedResourceIcon,
             OnClick = () => HandleClearSignal(SelectedResource.Id?.GetApplicationKey()),
             IsDisabled = SelectedResource.Id == null,

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -27,6 +27,8 @@
                             @bind-SelectedResource:after="HandleSelectedOptionChangedAsync"
                             LabelClass="toolbar-left" />
 
+            <ClearSignalsButton SelectedResource="PageViewModel.SelectedOption" HandleClearSignal="ClearConsoleLogs" />
+
             @foreach (var command in _highlightedCommands)
             {
                 <FluentButton Appearance="Appearance.Lightweight"

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -221,35 +221,35 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             Logger.LogDebug("New resource {ResourceName} selected.", selectedResourceName);
 
             ConsoleLogsSubscription? newConsoleLogsSubscription = null;
-        if (selectedResourceName is not null)
-        {
-            newConsoleLogsSubscription = new ConsoleLogsSubscription { Name = selectedResourceName };
-            Logger.LogDebug("Creating new subscription {SubscriptionId}.", newConsoleLogsSubscription.SubscriptionId);
-
-            if (Logger.IsEnabled(LogLevel.Debug))
+            if (selectedResourceName is not null)
             {
-                newConsoleLogsSubscription.CancellationToken.Register(state =>
+                newConsoleLogsSubscription = new ConsoleLogsSubscription { Name = selectedResourceName };
+                Logger.LogDebug("Creating new subscription {SubscriptionId}.", newConsoleLogsSubscription.SubscriptionId);
+
+                if (Logger.IsEnabled(LogLevel.Debug))
                 {
-                    var s = (ConsoleLogsSubscription)state!;
-                    Logger.LogDebug("Canceling subscription {SubscriptionId} to {ResourceName}.", s.SubscriptionId, s.Name);
-                }, newConsoleLogsSubscription);
+                    newConsoleLogsSubscription.CancellationToken.Register(state =>
+                    {
+                        var s = (ConsoleLogsSubscription)state!;
+                        Logger.LogDebug("Canceling subscription {SubscriptionId} to {ResourceName}.", s.SubscriptionId, s.Name);
+                    }, newConsoleLogsSubscription);
+                }
             }
-        }
 
-        if (_consoleLogsSubscription is { } currentSubscription)
-        {
-            currentSubscription.Cancel();
-            _consoleLogsSubscription = newConsoleLogsSubscription;
+            if (_consoleLogsSubscription is { } currentSubscription)
+            {
+                currentSubscription.Cancel();
+                _consoleLogsSubscription = newConsoleLogsSubscription;
 
-            await TaskHelpers.WaitIgnoreCancelAsync(currentSubscription.SubscriptionTask);
-        }
-        else
-        {
-            _consoleLogsSubscription = newConsoleLogsSubscription;
-        }
+                await TaskHelpers.WaitIgnoreCancelAsync(currentSubscription.SubscriptionTask);
+            }
+            else
+            {
+                _consoleLogsSubscription = newConsoleLogsSubscription;
+            }
 
-        Logger.LogDebug("Creating new log entries collection.");
-        _logEntries = new(Options.Value.Frontend.MaxConsoleLogCount);
+            Logger.LogDebug("Creating new log entries collection.");
+            _logEntries = new(Options.Value.Frontend.MaxConsoleLogCount);
 
             if (newConsoleLogsSubscription is not null)
             {

--- a/src/Aspire.Dashboard/Model/MenuButtonItem.cs
+++ b/src/Aspire.Dashboard/Model/MenuButtonItem.cs
@@ -13,6 +13,6 @@ public class MenuButtonItem
     public Icon? Icon { get; set; }
     public Func<Task>? OnClick { get; set; }
     public bool IsDisabled { get; set; }
-    public string? Id { get; set; }
+    public string Id { get; set; } = Identifier.NewId();
     public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
 }

--- a/src/Aspire.Dashboard/Model/MenuButtonItem.cs
+++ b/src/Aspire.Dashboard/Model/MenuButtonItem.cs
@@ -13,5 +13,6 @@ public class MenuButtonItem
     public Icon? Icon { get; set; }
     public Func<Task>? OnClick { get; set; }
     public bool IsDisabled { get; set; }
+    public string? Id { get; set; }
     public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
@@ -53,4 +53,14 @@ public readonly record struct ApplicationKey(string Name, string? InstanceId) : 
 
         return true;
     }
+
+    public override string ToString()
+    {
+        if (InstanceId == null)
+        {
+            return Name;
+        }
+
+        return $"{Name}-{InstanceId}";
+    }
 }

--- a/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
+++ b/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
@@ -13,7 +13,8 @@ internal static class BrowserStorageKeys
     public const string StructuredLogsPageState = "Aspire_PageState_StructuredLogs";
     public const string MetricsPageState = "Aspire_PageState_Metrics";
     public const string ConsoleLogsPageState = "Aspire_PageState_ConsoleLogs";
-    public const string ConsoleLogConsoleSettings  = "Aspire_ConsoleLog_ConsoleSettings";
+    public const string ConsoleLogConsoleSettings = "Aspire_ConsoleLog_ConsoleSettings";
+    public const string ConsoleLogFilters = "Aspire_ConsoleLog_Filters";
 
     public static string SplitterOrientationKey(string viewKey)
     {

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -135,7 +135,62 @@ public partial class ConsoleLogsTests : TestContext
         cut.WaitForState(() => instance._logEntries.EntriesCount > 0);
     }
 
-    private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null)
+    [Fact]
+    public void ClearLogEntries_AllResources_LogsFilteredOut()
+    {
+        // Arrange
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var testResource = ModelTestHelpers.CreateResource(appName: "test-resource", state: KnownResourceState.Running);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: name => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [ testResource ]);
+        var timeProvider = new TestTimeProvider();
+
+        SetupConsoleLogsServices(dashboardClient, timeProvider: timeProvider);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        // Act
+        var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "test-resource");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var instance = cut.Instance;
+        var logger = Services.GetRequiredService<ILogger<ConsoleLogsTests>>();
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
+
+        // Assert
+        logger.LogInformation("Waiting for selected resource.");
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource == testResource);
+        cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsWatchingLogs)]);
+
+        logger.LogInformation("Log results are added to log viewer.");
+        consoleLogsChannel.Writer.TryWrite([new ResourceLogLine(1, "2025-02-08T10:16:08Z Hello world", IsErrorMessage: false)]);
+        cut.WaitForState(() => instance._logEntries.EntriesCount > 0);
+
+        // Set current time to the date of the first entry so all entries are cleared.
+        var earliestEntry = instance._logEntries.GetEntries()[0];
+        timeProvider.UtcNow = earliestEntry.Timestamp!.Value;
+
+        logger.LogInformation("Clear current entries.");
+        cut.Find(".clear-button").Click();
+        cut.Find("#clear-menu-all").Click();
+
+        cut.WaitForState(() => instance._logEntries.EntriesCount == 0);
+
+        logger.LogInformation("New log results are added to log viewer.");
+        consoleLogsChannel.Writer.TryWrite([new ResourceLogLine(2, "2025-03-08T10:16:08Z Hello world", IsErrorMessage: false)]);
+        cut.WaitForState(() => instance._logEntries.EntriesCount > 0);
+    }
+
+    private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null, TestTimeProvider? timeProvider = null)
     {
         var version = typeof(FluentMain).Assembly.GetName().Version!;
 
@@ -153,6 +208,9 @@ public partial class ConsoleLogsTests : TestContext
         var keycodeModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/KeyCode/FluentKeyCode.razor.js", version));
         keycodeModule.Setup<string>("RegisterKeyCode", _ => true);
 
+        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Anchor/FluentAnchor.razor.js", version));
+        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js", version));
+
         JSInterop.SetupVoid("initializeContinuousScroll");
         JSInterop.SetupVoid("resetContinuousScrollPosition");
 
@@ -160,7 +218,7 @@ public partial class ConsoleLogsTests : TestContext
 
         Services.AddLocalization();
         Services.AddSingleton<ILoggerFactory>(loggerFactory);
-        Services.AddSingleton<BrowserTimeProvider, TestTimeProvider>();
+        Services.AddSingleton<BrowserTimeProvider>(timeProvider ?? new TestTimeProvider());
         Services.AddSingleton<IMessageService, MessageService>();
         Services.AddSingleton<IToastService, ToastService>();
         Services.AddSingleton<IOptions<DashboardOptions>>(Options.Create(new DashboardOptions()));

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestTimeProvider.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestTimeProvider.cs
@@ -10,13 +10,16 @@ public sealed class TestTimeProvider : BrowserTimeProvider
 {
     private TimeZoneInfo? _localTimeZone;
 
+    public DateTimeOffset UtcNow { get; set; }
+
     public TestTimeProvider() : base(NullLoggerFactory.Instance)
     {
+        UtcNow = new DateTimeOffset(2025, 12, 20, 23, 59, 59, TimeSpan.Zero);
     }
 
     public override DateTimeOffset GetUtcNow()
     {
-        return new DateTimeOffset(2025, 12, 20, 23, 59, 59, TimeSpan.Zero);
+        return UtcNow;
     }
 
     public override TimeZoneInfo LocalTimeZone => _localTimeZone ??= TimeZoneInfo.CreateCustomTimeZone(nameof(TestTimeProvider), TimeSpan.FromHours(1), nameof(TestTimeProvider), nameof(TestTimeProvider));


### PR DESCRIPTION
## Description

Adds a button to the console logs pages to clear logs, similar to what has been done in: https://github.com/dotnet/aspire/pull/6898. I followed the idea of simply filtering logs based on when the remove button was pressed.

![Clear-consolelogs (1)](https://github.com/user-attachments/assets/37427530-59d3-4dd0-8385-a3f3c28a0624)

Fixes https://github.com/dotnet/aspire/issues/5458

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
