### PR TITLE
Remove unnecessary condition from version option

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
@@ -87,7 +87,7 @@
       "description": "The version of .NET Aspire to use.",
       "displayName": ".NET Aspire version",
       "datatype": "choice",
-      "isEnabled": "(Framework == net8.0 || hostIdentifier == dotnetcli || hostIdentifier == \"dotnetcli-preview\")",
+      "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.1",

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -90,7 +90,7 @@
       "description": "The version of .NET Aspire to use.",
       "displayName": ".NET Aspire version",
       "datatype": "choice",
-      "isEnabled": "(Framework == net8.0 || hostIdentifier == dotnetcli || hostIdentifier == \"dotnetcli-preview\")",
+      "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.1",

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -90,7 +90,7 @@
       "description": "The version of .NET Aspire to use.",
       "displayName": ".NET Aspire version",
       "datatype": "choice",
-      "isEnabled": "(Framework == net8.0 || hostIdentifier == dotnetcli || hostIdentifier == \"dotnetcli-preview\")",
+      "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.1",

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
@@ -88,7 +88,7 @@
       "description": "The version of .NET Aspire to use.",
       "displayName": ".NET Aspire version",
       "datatype": "choice",
-      "isEnabled": "(Framework == net8.0 || hostIdentifier == dotnetcli || hostIdentifier == \"dotnetcli-preview\")",
+      "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.1",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -145,7 +145,7 @@
       "description": "The version of .NET Aspire to use.",
       "displayName": ".NET Aspire version",
       "datatype": "choice",
-      "isEnabled": "(Framework == net8.0 || hostIdentifier == dotnetcli || hostIdentifier == \"dotnetcli-preview\")",
+      "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.1",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -90,7 +90,7 @@
       "description": "The version of .NET Aspire to use.",
       "displayName": ".NET Aspire version",
       "datatype": "choice",
-      "isEnabled": "(Framework == net8.0 || hostIdentifier == dotnetcli || hostIdentifier == \"dotnetcli-preview\")",
+      "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.1",


### PR DESCRIPTION
## Description

Removes a condition on the AspireVersion option that isn't required as the CLI scenario is covered by a separate option.

Contributes to #7391

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected (in C# Dev Kit)
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
