### PR TITLE
Do not run non-helix tests in AzDO by default

### DIFF
--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -66,7 +66,7 @@ variables:
   # Use the build reason to decide whether to include helix_tests
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
     - name: testVariants
-      value: ',_helix_tests'
+      value: '_pipeline_tests,_helix_tests'
   - ${{ else }}:
     - name: testVariants
       value: ''
@@ -167,7 +167,8 @@ stages:
                 repoLogPath: $(Build.Arcade.LogsPath)
                 repoTestResultsPath: $(Build.Arcade.TestResultsPath)
                 isWindows: false
-                runHelixTests: ${{ contains(testVariant, 'helix') }}
+                runHelixTests: ${{ contains(testVariant, '_helix') }}
+                runPipelineTests: ${{ contains(testVariant, '_pipeline') }}
 
 # ----------------------------------------------------------------
 # This stage performs quality gates checks
@@ -188,7 +189,7 @@ stages:
         runAsPublic: false
         workspace:
           clean: all
-  
+
         # ----------------------------------------------------------------
         # This stage downloads the code coverage reports from the build jobs,
         # merges those and validates the combined test coverage.
@@ -196,20 +197,20 @@ stages:
         jobs:
         - job: CodeCoverageReport
           timeoutInMinutes: 10
-  
+
           pool:
             name: $(DncEngPublicBuildPool)
             demands: ImageOverride -equals build.ubuntu.2004.amd64.open
-  
+
           preSteps:
             - checkout: self
               fetchDepth: 1
               clean: true
-  
+
           steps:
           - script: $(Build.SourcesDirectory)/build.sh --ci --restore
             displayName: Init toolset
-  
+
           - template: /eng/pipelines/templates/VerifyCoverageReport.yml
             parameters:
               # matches what is used in the conditions for the build/test jobs

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -19,6 +19,9 @@ parameters:
   - name: runHelixTests
     type: boolean
     default: false
+  - name: runPipelineTests
+    type: boolean
+    default: false
 
 steps:
   # Internal pipeline: Build with pack+sign
@@ -46,7 +49,7 @@ steps:
       displayName: Build
 
   # Non-helix tests are run only on the public pipeline
-  - ${{ if and(eq(parameters.runAsPublic, 'true'), ne(parameters.runHelixTests, 'true')) }}:
+  - ${{ if and(eq(parameters.runAsPublic, 'true'), eq(parameters.runPipelineTests, 'true')) }}:
     # non-helix tests
     - ${{ if ne(parameters.isWindows, 'true') }}:
       - script: mkdir ${{ parameters.repoArtifactsPath }}/devcert-scripts &&
@@ -130,7 +133,7 @@ steps:
       condition: always()
 
   # Code coverage - only on public pipelines
-  - ${{ if eq(parameters.runAsPublic, 'true') }}:
+  - ${{ if and(eq(parameters.runAsPublic, 'true'), or(eq(parameters.runHelixTests, 'true'), eq(parameters.runPipelineTests, 'true'))) }}:
     - task: CopyFiles@2
       inputs:
         Contents: '${{ parameters.repoArtifactsPath }}/**/*.cobertura.xml'


### PR DESCRIPTION
We are running these in GitHub Actions now and therefore do not need to run them in Azure DevOps.