### PR TITLE
Allow CosmosDB connection strings to work with Database and Container keys

### DIFF
--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
@@ -73,13 +73,15 @@ public static class AspireMicrosoftAzureCosmosExtensions
 
         if (builder.Configuration.GetConnectionString(connectionName) is string connectionString)
         {
-            if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
+            var cosmosConnectionInfo = CosmosUtils.ParseConnectionString(connectionString);
+
+            if (cosmosConnectionInfo.AccountEndpoint is not null)
             {
-                settings.AccountEndpoint = uri;
+                settings.AccountEndpoint = cosmosConnectionInfo.AccountEndpoint;
             }
             else
             {
-                settings.ConnectionString = connectionString;
+                settings.ConnectionString = cosmosConnectionInfo.ConnectionString;
             }
         }
 

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
@@ -53,13 +53,15 @@ public static class AspireAzureEFCoreCosmosExtensions
 
         if (builder.Configuration.GetConnectionString(connectionName) is string connectionString)
         {
-            if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
+            var cosmosConnectionInfo = CosmosUtils.ParseConnectionString(connectionString);
+
+            if (cosmosConnectionInfo.AccountEndpoint is not null)
             {
-                settings.AccountEndpoint = uri;
+                settings.AccountEndpoint = cosmosConnectionInfo.AccountEndpoint;
             }
             else
             {
-                settings.ConnectionString = connectionString;
+                settings.ConnectionString = cosmosConnectionInfo.ConnectionString;
             }
         }
 

--- a/src/Shared/Cosmos/CosmosUtils.cs
+++ b/src/Shared/Cosmos/CosmosUtils.cs
@@ -47,7 +47,8 @@ internal static class CosmosUtils
             ConnectionString = connectionString
         };
 
-        // Strip out the database and container from the connection string to
+        // Strip out the database and container from the connection string in order
+        // to tell if we are left with just AccountEndpoint.
         if (connectionBuilder.TryGetValue("Database", out var _))
         {
             connectionBuilder["Database"] = null;

--- a/src/Shared/Cosmos/CosmosUtils.cs
+++ b/src/Shared/Cosmos/CosmosUtils.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data.Common;
+using System.Diagnostics;
 
 namespace Aspire.Hosting.Azure.CosmosDB;
 
@@ -23,4 +24,63 @@ internal static class CosmosUtils
         var accountKeyFromConnectionString = v.ToString();
         return accountKeyFromConnectionString == CosmosConstants.EmulatorAccountKey;
     }
+
+    /// <summary>
+    /// Parses the connection string to extract the account endpoint and connection string.
+    /// </summary>
+    /// <remarks>
+    /// The connection string can be in the following formats:
+    /// A valid Uri
+    /// AccountEndpoint={valid Uri} - optionally with [;Database={databaseName}[;Container={containerName}]]
+    /// {valid CosmosDB ConnectionString} - optionally with [;Database={databaseName}[;Container={containerName}]]
+    /// </remarks>
+    internal static CosmosConnectionInfo ParseConnectionString(string connectionString)
+    {
+        Uri? accountEndpoint;
+        if (Uri.TryCreate(connectionString, UriKind.Absolute, out accountEndpoint))
+        {
+            return new CosmosConnectionInfo(accountEndpoint, null);
+        }
+
+        var connectionBuilder = new DbConnectionStringBuilder()
+        {
+            ConnectionString = connectionString
+        };
+
+        // Strip out the database and container from the connection string to
+        if (connectionBuilder.TryGetValue("Database", out var _))
+        {
+            connectionBuilder["Database"] = null;
+        }
+
+        if (connectionBuilder.TryGetValue("Container", out var _))
+        {
+            connectionBuilder["Container"] = null;
+        }
+
+        // if we are only left with the AccountEndpoint, then we set the AccountEndpoint and
+        // not the connection string.
+        if (connectionBuilder.Count == 1 &&
+            connectionBuilder.TryGetValue("AccountEndpoint", out var accountEndpointValue) &&
+            Uri.TryCreate(accountEndpointValue.ToString(), UriKind.Absolute, out accountEndpoint))
+        {
+            return new CosmosConnectionInfo(accountEndpoint, null);
+        }
+
+        return new CosmosConnectionInfo(null, connectionBuilder.ConnectionString);
+    }
+}
+
+internal readonly struct CosmosConnectionInfo
+{
+    public CosmosConnectionInfo(Uri? accountEndpoint, string? connectionString)
+    {
+        Debug.Assert(accountEndpoint is not null ^ connectionString is not null, "only one should be set.");
+
+        AccountEndpoint = accountEndpoint;
+        ConnectionString = connectionString;
+    }
+
+    public Uri? AccountEndpoint { get; }
+    public string? ConnectionString { get; }
 }

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/AspireMicrosoftAzureCosmosExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/AspireMicrosoftAzureCosmosExtensionsTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Microsoft.Azure.Cosmos.Tests;
+
+public class AspireMicrosoftAzureCosmosExtensionsTests
+{
+    [Theory]
+    [InlineData("AccountEndpoint=https://localhost:8081;AccountKey=fake;", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;Database=db;", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;Database=db;Container=mycontainer;", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;AccountKey=fake;Database=db", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;AccountKey=fake;Database=db;DisableServerCertificateValidation=True", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;AccountKey=fake;Database=db;Container=mycontainer", "https://localhost:8081/")]
+    [InlineData("https://example1.documents.azure.com:443", "https://example1.documents.azure.com/")]
+    public void AddAzureCosmosClient_EnsuresConnectionStringIsCorrect(string connectionString, string expectedEndpoint)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        PopulateConfiguration(builder.Configuration, connectionString);
+
+        builder.AddAzureCosmosClient("cosmos");
+
+        using var host = builder.Build();
+        var client = host.Services.GetRequiredService<CosmosClient>();
+
+        Assert.Equal(expectedEndpoint, client.Endpoint.ToString());
+    }
+
+    [Fact]
+    public void AddAzureCosmosClient_FailsWithError()
+    {
+        var e = Assert.Throws<ArgumentException>(() =>
+            AddAzureCosmosClient_EnsuresConnectionStringIsCorrect("this=isnt;a=valid;cosmos=connectionstring", string.Empty));
+
+        Assert.Contains("missing", e.Message);
+        Assert.Contains("AccountEndpoint", e.Message);
+    }
+
+    private static void PopulateConfiguration(ConfigurationManager configuration, string connectionString) =>
+        configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:cosmos", connectionString)
+        ]);
+}

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
@@ -212,4 +212,42 @@ public class AspireAzureEfCoreCosmosDBExtensionsTests
             public string Name { get; set; } = default!;
         }
     }
+
+    [Theory]
+    [InlineData("AccountEndpoint=https://localhost:8081;AccountKey=fake;", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;Database=db;", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;Database=db;Container=mycontainer;", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;AccountKey=fake;Database=db", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;AccountKey=fake;Database=db;DisableServerCertificateValidation=True", "https://localhost:8081/")]
+    [InlineData("AccountEndpoint=https://localhost:8081;AccountKey=fake;Database=db;Container=mycontainer", "https://localhost:8081/")]
+    [InlineData("https://example1.documents.azure.com:443", "https://example1.documents.azure.com/")]
+    public void AddAzureCosmosClient_EnsuresConnectionStringIsCorrect(string connectionString, string expectedEndpoint)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        PopulateConfiguration(builder.Configuration, connectionString);
+
+        builder.AddCosmosDbContext<TestDbContext>("cosmos", "databaseName");
+
+        using var host = builder.Build();
+        var context = host.Services.GetRequiredService<TestDbContext>();
+        var client = context.Database.GetCosmosClient();
+
+        Assert.Equal(expectedEndpoint, client.Endpoint.ToString());
+    }
+
+    [Fact]
+    public void AddAzureCosmosClient_FailsWithError()
+    {
+        var e = Assert.Throws<ArgumentException>(() =>
+            AddAzureCosmosClient_EnsuresConnectionStringIsCorrect("this=isnt;a=valid;cosmos=connectionstring", string.Empty));
+
+        Assert.Contains("missing", e.Message);
+        Assert.Contains("AccountEndpoint", e.Message);
+    }
+
+    private static void PopulateConfiguration(ConfigurationManager configuration, string connectionString) =>
+        configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:cosmos", connectionString)
+        ]);
 }


### PR DESCRIPTION
## Description

With #7408, Cosmos Database and Containers are Aspire Resources now, which means they can be referenced via WithReference.

In the future, the Cosmos Host integration will append these values to the connection string. This will allow the database and container names to be specified outside of the application. (Today they are hard-coded in both, or specified separately in config.) We can also add new client APIs to register a Database or Container object in DI.

This is a stop-gap to support these values in .NET Aspire 9.1 client integration so it doesn't break applications when we start adding these values in the future.

Contributes to #7407

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
