### PR TITLE
Enable remaining tests in GitHub Actions & disable non-Helix tests in Azure DevOps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60 
+    timeout-minutes: 60
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -138,14 +138,14 @@ jobs:
 
           # These are failing due to globalization issues
           # Dashboard projects
-          # - project: tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
-          #   name: Dashboard.Components
-          # - project: tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
-          #   name: Dashboard
+          - project: tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
+            name: Dashboard.Components
+          - project: tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+            name: Dashboard
 
           # Playground project
-          # - project: tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
-          #   name: Playground
+          - project: tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+            name: Playground
           # Add more projects as needed
     steps:
       - name: Checkout code

--- a/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
+++ b/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
-    
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
     <PackageReference Include="bUnit" />
   </ItemGroup>
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -47,6 +47,7 @@ public class PlotlyChartTests : TestContext
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public async Task Render_HasInstrument_InitializeChartInvocation()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -17,6 +17,7 @@ public class FormatHelpersTests
     [InlineData("0.9", 0.9d)]
     [InlineData("12,345,678.9", 12345678.9d)]
     [InlineData("1.234568", 1.23456789d)]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatNumberWithOptionalDecimalPlaces_InvariantCulture(string expected, double value)
     {
         Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, maxDecimalPlaces: 6, CultureInfo.InvariantCulture));
@@ -28,6 +29,7 @@ public class FormatHelpersTests
     [InlineData("0,9", 0.9d)]
     [InlineData("12.345.678,9", 12345678.9d)]
     [InlineData("1,234568", 1.23456789d)]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatNumberWithOptionalDecimalPlaces_GermanCulture(string expected, double value)
     {
         Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, maxDecimalPlaces: 6, CultureInfo.GetCultureInfo("de-DE")));
@@ -39,6 +41,7 @@ public class FormatHelpersTests
     [InlineData("06/15/2009 13:45:30.1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
     [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
     [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatDateTime_WithMilliseconds_InvariantCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
@@ -63,6 +66,7 @@ public class FormatHelpersTests
     [InlineData("15.6.2009 13.45.30,1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
     [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
     [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatDateTime_WithMilliseconds_FinnishCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
@@ -75,6 +79,7 @@ public class FormatHelpersTests
     [InlineData("15/06/2009 1:45:30.1234567 pm", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
     [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
     [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -33,11 +33,9 @@ public class AppHostTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/6866")]
     public async Task TestEndpointsReturnOk(TestEndpoints testEndpoints)
     {
-        var appHostName = testEndpoints.AppHost!;
+        var appHostType = testEndpoints.AppHostType!;
         var resourceEndpoints = testEndpoints.ResourceEndpoints!;
-
-        var appHostPath = $"{appHostName}.dll";
-        var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostPath, _testOutput);
+        var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostType, _testOutput);
         var projects = appHost.Resources.OfType<ProjectResource>();
         await using var app = await appHost.BuildAsync();
 
@@ -78,7 +76,7 @@ public class AppHostTests
                 var timeout = TimeSpan.FromMinutes(5);
                 foreach (var (ResourceName, TargetState) in testEndpoints.WaitForResources)
                 {
-                    _testOutput.WriteLine($"Waiting for resource '{ResourceName}' to reach state '{TargetState}' in app '{Path.GetFileNameWithoutExtension(appHostPath)}'");
+                    _testOutput.WriteLine($"Waiting for resource '{ResourceName}' to reach state '{TargetState}' in app '{appHost.AppHostAssembly}'");
                     await app.WaitForResource(ResourceName, TargetState).WaitAsync(TimeSpan.FromMinutes(5));
                 }
             }
@@ -99,22 +97,18 @@ public class AppHostTests
 
             foreach (var path in endpoints)
             {
-                _testOutput.WriteLine($"Calling endpoint '{client.BaseAddress}{path.TrimStart('/')} for resource '{resource}' in app '{Path.GetFileNameWithoutExtension(appHostPath)}'");
+                _testOutput.WriteLine($"Calling endpoint '{client.BaseAddress}{path.TrimStart('/')} for resource '{resource}' in app '{appHost.AppHostAssembly}'");
                 try
                 {
                     response = await client.GetAsync(path);
                 }
                 catch (TimeoutRejectedException tre)
                 {
-                    throw new XunitException($"Endpoint '{client.BaseAddress}{path.TrimStart('/')}' for resource '{resource}' in app '{Path.GetFileNameWithoutExtension(appHostPath)}' timed out", tre);
+                    throw new XunitException($"Endpoint '{client.BaseAddress}{path.TrimStart('/')}' for resource '{resource}' in app '{appHost.AppHostAssembly}' timed out", tre);
                 }
 
-                Assert.True(HttpStatusCode.OK == response.StatusCode, $"Endpoint '{client.BaseAddress}{path.TrimStart('/')}' for resource '{resource}' in app '{Path.GetFileNameWithoutExtension(appHostPath)}' returned status code {response.StatusCode}");
+                Assert.True(HttpStatusCode.OK == response.StatusCode, $"Endpoint '{client.BaseAddress}{path.TrimStart('/')}' for resource '{resource}' in app '{appHost.AppHostAssembly}' returned status code {response.StatusCode}");
             }
-        }
-        if (testEndpoints.WhenReady != null)
-        {
-            await testEndpoints.WhenReady(app, appHostPath, _testOutput);
         }
 
         app.EnsureNoErrorsLogged();
@@ -140,7 +134,7 @@ public class AppHostTests
         IList<TestEndpoints> candidates =
         [
             // Disable due to https://github.com/dotnet/aspire/issues/5959
-            //new TestEndpoints("EventHubs.AppHost",
+            //new TestEndpoints(typeof(Projects.EventHubs.AppHost",
             //    resourceEndpoints: new() { { "api", ["/alive", "/health"] } },
             //    waitForTexts: [
             //        new ("eventhubns", "Emulator Service is Successfully Up"),
@@ -149,7 +143,7 @@ public class AppHostTests
             //        new ("consumer", "Completed retrieving properties for Event Hub")
             //    ],
             //    whenReady: TestEventHubsAppHost),
-            new TestEndpoints("Redis.AppHost",
+            new TestEndpoints(typeof(Projects.Redis_AppHost),
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/garnet/ping", "/garnet/get", "/garnet/set", "/redis/ping", "/redis/get", "/redis/set", "/valkey/ping", "/valkey/get", "/valkey/set"] } },
                 waitForTexts: [
                     new ("redis", "Ready to accept connections tcp"),
@@ -157,40 +151,40 @@ public class AppHostTests
                     new ("garnet", "Ready to accept connections"),
                     new ("apiservice", "Application started")
                 ]),
-            new TestEndpoints("AzureStorageEndToEnd.AppHost",
+            new TestEndpoints(typeof(Projects.AzureStorageEndToEnd_AppHost),
                 resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
                 waitForTexts: [
                     new ("storage", "Azurite Table service is successfully listening")
                 ]),
-            new TestEndpoints("MilvusPlayground.AppHost",
+            new TestEndpoints(typeof(Projects.MilvusPlayground_AppHost),
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/create", "/search"] } },
                 waitForTexts: [
                     new ("milvus", "Milvus Proxy successfully initialized and ready to serve"),
                 ]),
             // Cosmos emulator is extremely slow to start up and unreliable in CI
-            //new TestEndpoints("CosmosEndToEnd.AppHost",
+            //new TestEndpoints(typeof(Projects.CosmosEndToEnd_AppHost),
             //    resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
             //    // "/ef" - disabled due to https://github.com/dotnet/aspire/issues/5415
             //    waitForTexts: [
             //        new ("cosmos", "Started$"),
             //        new ("api", "Application started")
             //    ]),
-            new TestEndpoints("Keycloak.AppHost",
+            new TestEndpoints(typeof(Projects.Keycloak_AppHost),
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } }),
-            new TestEndpoints("Mongo.AppHost",
+            new TestEndpoints(typeof(Projects.Mongo_AppHost),
                 resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
                 waitForTexts: [
                     new ("mongo", "Waiting for connections"),
                     new ("mongo-mongoexpress", "Mongo Express server listening"),
                     new("api", "Application started.")
                 ]),
-            new TestEndpoints("MySqlDb.AppHost",
+            new TestEndpoints(typeof(Projects.MySqlDb_AppHost),
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/catalog"] } },
                 waitForTexts: [
                     new ("mysql", "ready for connections.* port: 33060"),
                     new ("apiservice", "Application started")
                 ]),
-            new TestEndpoints("Nats.AppHost",
+            new TestEndpoints(typeof(Projects.Nats_AppHost),
                 resourceEndpoints: new() {
                     { "api", ["/alive", "/health"] },
                     { "backend", ["/alive", "/health"] }
@@ -199,12 +193,12 @@ public class AppHostTests
                     new ("nats", "Server is ready"),
                     new("api", "Application started")
                 ]),
-            new TestEndpoints("ParameterEndToEnd.AppHost",
+            new TestEndpoints(typeof(Projects.ParameterEndToEnd_AppHost),
                 resourceEndpoints: new() { { "api", ["/", "/alive", "/health"] } },
                 waitForTexts: [
                     new ("sql", "SQL Server is now ready for client connections."),
                 ]),
-            new TestEndpoints("PostgresEndToEnd.AppHost",
+            new TestEndpoints(typeof(Projects.PostgresEndToEnd_AppHost),
                 resourceEndpoints: new() {
                     // Invoking "/" first as that *creates* the databases
                     { "api", ["/", "/alive", "/health"] }
@@ -218,33 +212,33 @@ public class AppHostTests
                     new ("pg6", "PostgreSQL init process complete; ready for start up"),
                     new ("pg10", "PostgreSQL init process complete; ready for start up"),
                 ]),
-            new TestEndpoints("ProxylessEndToEnd.AppHost",
+            new TestEndpoints(typeof(Projects.ProxylessEndToEnd_AppHost),
                 resourceEndpoints: new() { { "api", ["/alive", "/health", "/redis"] } },
                 waitForTexts: [
                     new ("redis", "Ready to accept connections"),
                     new("api", "Application started"),
                     new("api2", "Application started")
                 ]),
-            new TestEndpoints("Qdrant.AppHost",
+            new TestEndpoints(typeof(Projects.Qdrant_AppHost),
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } },
                 waitForTexts: [
                     new ("qdrant", "Qdrant HTTP listening"),
                     new ("apiservice", "Application started")
                 ]),
-            new TestEndpoints("Seq.AppHost",
+            new TestEndpoints(typeof(Projects.Seq_AppHost),
                 resourceEndpoints: new() { { "api", ["/alive", "/health"] } },
                 waitForTexts: [
                     new ("seq", "Seq listening"),
                     new ("api", "Application started")
                 ]),
             // Invoke "/" first to create the databases
-            new TestEndpoints("SqlServerEndToEnd.AppHost",
+            new TestEndpoints(typeof(Projects.SqlServerEndToEnd_AppHost),
                 resourceEndpoints: new() { { "api", ["/", "/alive", "/health"] } },
                 waitForTexts: [
                     new ("sql1", "SQL Server is now ready for client connections"),
                     new ("sql2", "SQL Server is now ready for client connections"),
                 ]),
-            new TestEndpoints("TestShop.AppHost",
+            new TestEndpoints(typeof(Projects.TestShop_AppHost),
                 resourceEndpoints: new() {
                     { "catalogdbapp", ["/alive", "/health"] },
                     { "frontend", ["/alive", "/health"] }
@@ -267,7 +261,7 @@ public class AppHostTests
         TheoryData<TestEndpoints> theoryData = new();
         foreach (var candidateTestEndpoint in GetAllTestEndpoints())
         {
-            if (string.IsNullOrEmpty(s_appHostNameFilter) || candidateTestEndpoint.AppHost?.Contains(s_appHostNameFilter, StringComparison.OrdinalIgnoreCase) == true)
+            if (string.IsNullOrEmpty(s_appHostNameFilter) || candidateTestEndpoint.AppHostType?.Name.Contains(s_appHostNameFilter, StringComparison.OrdinalIgnoreCase) == true)
             {
                 theoryData.Add(candidateTestEndpoint);
             }
@@ -284,18 +278,16 @@ public class AppHostTests
 
 public class TestEndpoints
 {
-    public TestEndpoints(string appHost,
+    public TestEndpoints(Type appHostType,
                          Dictionary<string, List<string>> resourceEndpoints,
-                         List<ReadyStateText>? waitForTexts = null,
-                         Func<DistributedApplication, string, ITestOutputHelper, Task>? whenReady = null)
+                         List<ReadyStateText>? waitForTexts = null)
     {
-        AppHost = appHost;
+        AppHostType = appHostType;
         ResourceEndpoints = resourceEndpoints;
         WaitForTexts = waitForTexts;
-        WhenReady = whenReady;
     }
 
-    public string AppHost { get; set; }
+    public Type AppHostType { get; set; }
 
     public List<ResourceWait>? WaitForResources { get; set; }
 
@@ -303,9 +295,7 @@ public class TestEndpoints
 
     public Dictionary<string, List<string>>? ResourceEndpoints { get; set; }
 
-    public Func<DistributedApplication, string, ITestOutputHelper, Task>? WhenReady { get; set; }
-
-    public override string? ToString() => $"{AppHost} ({ResourceEndpoints?.Count ?? 0} resources)";
+    public override string? ToString() => $"{AppHostType} ({ResourceEndpoints?.Count ?? 0} resources)";
 
     public class ResourceWait(string resourceName, string targetState)
     {

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -48,7 +48,7 @@
 
     <ProjectReference Include="$(PlaygroundSourceDir)AspireEventHub/EventHubs.AppHost/EventHubs.AppHost.csproj" />
     <ProjectReference Include="$(PlaygroundSourceDir)AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/AzureStorageEndToEnd.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj" Condition="'$(ContinuousIntegrationBuild)' != 'true'" />
+    <ProjectReference Include="$(PlaygroundSourceDir)AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj" />
     <ProjectReference Include="$(PlaygroundSourceDir)CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj" />
     <ProjectReference Include="$(PlaygroundSourceDir)ParameterEndToEnd/ParameterEndToEnd.AppHost/ParameterEndToEnd.AppHost.csproj" />
     <ProjectReference Include="$(PlaygroundSourceDir)PostgresEndToEnd/PostgresEndToEnd.AppHost/PostgresEndToEnd.AppHost.csproj" />

--- a/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
+++ b/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,16 +15,10 @@ internal static class DistributedApplicationTestFactory
     /// <summary>
     /// Creates an <see cref="IDistributedApplicationTestingBuilder"/> for the specified app host assembly.
     /// </summary>
-    public static async Task<IDistributedApplicationTestingBuilder> CreateAsync(string appHostAssemblyPath, ITestOutputHelper? testOutput)
+    public static async Task<IDistributedApplicationTestingBuilder> CreateAsync(Type appHostProgramType, ITestOutputHelper? testOutput)
     {
-        var appHostProjectName = Path.GetFileNameWithoutExtension(appHostAssemblyPath) ?? throw new InvalidOperationException("AppHost assembly was not found.");
+        var builder = await DistributedApplicationTestingBuilder.CreateAsync(appHostProgramType);
 
-        var appHostAssembly = Assembly.LoadFrom(Path.Combine(AppContext.BaseDirectory, appHostAssemblyPath));
-
-        var appHostType = appHostAssembly.GetTypes().FirstOrDefault(t => t.Name.EndsWith("_AppHost"))
-            ?? throw new InvalidOperationException("Generated AppHost type not found.");
-
-        var builder = await DistributedApplicationTestingBuilder.CreateAsync(appHostType);
         // Custom hook needed because we want to only override the registry when
         // the original is from `docker.io`, but the options.ContainerRegistryOverride will
         // always override.

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -16,8 +16,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     [Fact]
     public async Task WithDockerfileTest()
     {
-        var appHostPath = Directory.GetFiles(AppContext.BaseDirectory, "WithDockerfile.AppHost.dll").Single();
-        var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostPath, _testOutput);
+        var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.WithDockerfile_AppHost), _testOutput);
         await using var app = await appHost.BuildAsync();
 
         await app.StartAsync();
@@ -34,8 +33,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     [ActiveIssue("https://github.com/dotnet/aspire/issues/6867")]
     public async Task KafkaTest()
     {
-        var appHostPath = Directory.GetFiles(AppContext.BaseDirectory, "KafkaBasic.AppHost.dll").Single();
-        var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostPath, _testOutput);
+        var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.KafkaBasic_AppHost), _testOutput);
         await using var app = await appHost.BuildAsync();
 
         await app.StartAsync();
@@ -59,10 +57,10 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     [Fact]
     [RequiresDocker]
     [RequiresTools(["func"])]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/7437")]
     public async Task AzureFunctionsTest()
     {
-        var appHostPath = Directory.GetFiles(AppContext.BaseDirectory, "AzureFunctionsEndToEnd.AppHost.dll").Single();
-        var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostPath, _testOutput);
+        var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.AzureFunctionsEndToEnd_AppHost), _testOutput);
         await using var app = await appHost.BuildAsync();
 
         await app.StartAsync();


### PR DESCRIPTION
This PR disables the Non-Helix Tests job in Azure DevOps and enables the remaining tests in our GitHub Actions pipeline instead.
Some tests are failing and so they needed to be suppressed. I've opened https://github.com/dotnet/aspire/issues/7433 & https://github.com/dotnet/aspire/issues/7437 for those.