### PR TITLE
Add existing resource support to more Azure resources

### DIFF
--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -25,13 +25,19 @@ public static class AzureAppConfigurationExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var store = new AppConfigurationStore(infrastructure.AspireResource.GetBicepIdentifier())
-            {
-                SkuName = "standard",
-                DisableLocalAuth = true,
-                Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
-            };
-            infrastructure.Add(store);
+            var store = infrastructure.CreateExistingOrNewProvisionableResource(
+                (identifier, name) =>
+                {
+                    var resource = AppConfigurationStore.FromExisting(identifier);
+                    resource.Name = name;
+                    return resource;
+                },
+                (infrastructure) => new AppConfigurationStore(infrastructure.AspireResource.GetBicepIdentifier())
+                {
+                    SkuName = "standard",
+                    DisableLocalAuth = true,
+                    Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
+                });
 
             infrastructure.Add(new ProvisioningOutput("appConfigEndpoint", typeof(string)) { Value = store.Endpoint });
 

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -26,7 +26,14 @@ public static class AzureKeyVaultResourceExtensions
 
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
-            var keyVault = new KeyVaultService(infrastructure.AspireResource.GetBicepIdentifier())
+            var keyVault = infrastructure.CreateExistingOrNewProvisionableResource(
+            (identifier, name) =>
+            {
+                var resource = KeyVaultService.FromExisting(identifier);
+                resource.Name = name;
+                return resource;
+            },
+            (infrastructure) => new KeyVaultService(infrastructure.AspireResource.GetBicepIdentifier())
             {
                 Properties = new KeyVaultProperties()
                 {
@@ -38,8 +45,7 @@ public static class AzureKeyVaultResourceExtensions
                     },
                     EnableRbacAuthorization = true
                 }
-            };
-            infrastructure.Add(keyVault);
+            });
 
             infrastructure.Add(new ProvisioningOutput("vaultUri", typeof(string))
             {

--- a/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
@@ -25,15 +25,21 @@ public static class AzureLogAnalyticsWorkspaceExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var workspace = new OperationalInsightsWorkspace(infrastructure.AspireResource.GetBicepIdentifier())
-            {
-                Sku = new OperationalInsightsWorkspaceSku()
+            var workspace = infrastructure.CreateExistingOrNewProvisionableResource(
+                (identifier, name) =>
                 {
-                    Name = OperationalInsightsWorkspaceSkuName.PerGB2018
+                    var resource = OperationalInsightsWorkspace.FromExisting(identifier);
+                    resource.Name = name;
+                    return resource;
                 },
-                Tags = { { "aspire-resource-name", name } }
-            };
-            infrastructure.Add(workspace);
+                (infrastructure) => new OperationalInsightsWorkspace(infrastructure.AspireResource.GetBicepIdentifier())
+                {
+                    Sku = new OperationalInsightsWorkspaceSku()
+                    {
+                        Name = OperationalInsightsWorkspaceSkuName.PerGB2018
+                    },
+                    Tags = { { "aspire-resource-name", name } }
+                });
 
             infrastructure.Add(new ProvisioningOutput("logAnalyticsWorkspaceId", typeof(string))
             {

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -30,16 +30,22 @@ public static class AzureSearchExtensions
 
         void ConfigureSearch(AzureResourceInfrastructure infrastructure)
         {
-            var search = new SearchService(infrastructure.AspireResource.GetBicepIdentifier())
-            {
-                SearchSkuName = SearchServiceSkuName.Basic,
-                ReplicaCount = 1,
-                PartitionCount = 1,
-                HostingMode = SearchServiceHostingMode.Default,
-                IsLocalAuthDisabled = true,
-                Tags = { { "aspire-resource-name", name } }
-            };
-            infrastructure.Add(search);
+            var search = infrastructure.CreateExistingOrNewProvisionableResource(
+                (identifier, name) =>
+                {
+                    var resource = SearchService.FromExisting(identifier);
+                    resource.Name = name;
+                    return resource;
+                },
+                (infrastructure) => new SearchService(infrastructure.AspireResource.GetBicepIdentifier())
+                {
+                    SearchSkuName = SearchServiceSkuName.Basic,
+                    ReplicaCount = 1,
+                    PartitionCount = 1,
+                    HostingMode = SearchServiceHostingMode.Default,
+                    IsLocalAuthDisabled = true,
+                    Tags = { { "aspire-resource-name", name } }
+                });
 
             var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
             infrastructure.Add(principalTypeParameter);

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -33,35 +33,31 @@ public static class AzureServiceBusExtensions
 
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
-            AzureProvisioning.ServiceBusNamespace? serviceBusNamespace;
-            if (infrastructure.AspireResource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAnnotation))
-            {
-                var existingResourceName = existingAnnotation.NameParameter.AsProvisioningParameter(infrastructure, $"{infrastructure.AspireResource.GetBicepIdentifier()}Existing");
-                serviceBusNamespace = AzureProvisioning.ServiceBusNamespace.FromExisting(infrastructure.AspireResource.GetBicepIdentifier());
-                serviceBusNamespace.Name = existingResourceName;
-                if (existingAnnotation.ResourceGroupParameter is not null)
+            AzureProvisioning.ServiceBusNamespace serviceBusNamespace = infrastructure.CreateExistingOrNewProvisionableResource(
+                (identifier, name) =>
                 {
-                    infrastructure.AspireResource.Scope = new(existingAnnotation.ResourceGroupParameter);
-                }
-            }
-            else
-            {
-                var skuParameter = new ProvisioningParameter("sku", typeof(string))
+                    var resource = AzureProvisioning.ServiceBusNamespace.FromExisting(identifier);
+                    resource.Name = name;
+                    return resource;
+                },
+                (infrastructure) =>
                 {
-                    Value = "Standard"
-                };
-                infrastructure.Add(skuParameter);
-                serviceBusNamespace = new AzureProvisioning.ServiceBusNamespace(infrastructure.AspireResource.GetBicepIdentifier())
-                {
-                    Sku = new AzureProvisioning.ServiceBusSku()
+                    var skuParameter = new ProvisioningParameter("sku", typeof(string))
                     {
-                        Name = skuParameter
-                    },
-                    DisableLocalAuth = true,
-                    Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
-                };
-            }
-            infrastructure.Add(serviceBusNamespace);
+                        Value = "Standard"
+                    };
+                    infrastructure.Add(skuParameter);
+                    var resource = new AzureProvisioning.ServiceBusNamespace(infrastructure.AspireResource.GetBicepIdentifier())
+                    {
+                        Sku = new AzureProvisioning.ServiceBusSku()
+                        {
+                            Name = skuParameter
+                        },
+                        DisableLocalAuth = true,
+                        Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
+                    };
+                    return resource;
+                });
 
             var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
             infrastructure.Add(principalTypeParameter);

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -37,7 +37,14 @@ public static class AzureSignalRExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var service = new SignalRService(infrastructure.AspireResource.GetBicepIdentifier())
+            var service = infrastructure.CreateExistingOrNewProvisionableResource((identifier, name) =>
+            {
+                var resource = SignalRService.FromExisting(identifier);
+                resource.Name = name;
+                return resource;
+            },
+
+            (infrastructure) => new SignalRService(infrastructure.AspireResource.GetBicepIdentifier())
             {
                 Kind = SignalRServiceKind.SignalR,
                 Sku = new SignalRResourceSku()
@@ -55,8 +62,7 @@ public static class AzureSignalRExtensions
                 ],
                 CorsAllowedOrigins = ["*"],
                 Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
-            };
-            infrastructure.Add(service);
+            });
 
             infrastructure.Add(new ProvisioningOutput("hostName", typeof(string)) { Value = service.HostName });
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -32,27 +32,33 @@ public static class AzureStorageExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var storageAccount = new StorageAccount(infrastructure.AspireResource.GetBicepIdentifier())
-            {
-                Kind = StorageKind.StorageV2,
-                AccessTier = StorageAccountAccessTier.Hot,
-                Sku = new StorageSku() { Name = StorageSkuName.StandardGrs },
-                NetworkRuleSet = new StorageAccountNetworkRuleSet()
+            var storageAccount = infrastructure.CreateExistingOrNewProvisionableResource(
+                (identifier, name) =>
                 {
-                    // Unfortunately Azure Storage does not list ACA as one of the resource types in which
-                    // the AzureServices firewall policy works. This means that we need this Azure Storage
-                    // account to have its default action set to Allow.
-                    DefaultAction = StorageNetworkDefaultAction.Allow
+                    var resource = StorageAccount.FromExisting(identifier);
+                    resource.Name = name;
+                    return resource;
                 },
-                // Set the minimum TLS version to 1.2 to ensure resources provisioned are compliant
-                // with the pending deprecation of TLS 1.0 and 1.1.
-                MinimumTlsVersion = StorageMinimumTlsVersion.Tls1_2,
-                // Disable shared key access to the storage account as managed identity is configured
-                // to access the storage account by default.
-                AllowSharedKeyAccess = false,
-                Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
-            };
-            infrastructure.Add(storageAccount);
+                (infrastructure) => new StorageAccount(infrastructure.AspireResource.GetBicepIdentifier())
+                {
+                    Kind = StorageKind.StorageV2,
+                    AccessTier = StorageAccountAccessTier.Hot,
+                    Sku = new StorageSku() { Name = StorageSkuName.StandardGrs },
+                    NetworkRuleSet = new StorageAccountNetworkRuleSet()
+                    {
+                        // Unfortunately Azure Storage does not list ACA as one of the resource types in which
+                        // the AzureServices firewall policy works. This means that we need this Azure Storage
+                        // account to have its default action set to Allow.
+                        DefaultAction = StorageNetworkDefaultAction.Allow
+                    },
+                    // Set the minimum TLS version to 1.2 to ensure resources provisioned are compliant
+                    // with the pending deprecation of TLS 1.0 and 1.1.
+                    MinimumTlsVersion = StorageMinimumTlsVersion.Tls1_2,
+                    // Disable shared key access to the storage account as managed identity is configured
+                    // to access the storage account by default.
+                    AllowSharedKeyAccess = false,
+                    Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
+                });
 
             var blobs = new BlobService("blobs")
             {

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -28,30 +28,41 @@ public static class AzureWebPubSubExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            // Supported values are Free_F1 Standard_S1 Premium_P1
-            var skuParameter = new ProvisioningParameter("sku", typeof(string))
-            {
-                Value = "Free_F1"
-            };
-            infrastructure.Add(skuParameter);
-
-            // Supported values are 1 2 5 10 20 50 100
-            var capacityParameter = new ProvisioningParameter("capacity", typeof(int))
-            {
-                Value = new BicepValue<int>(1)
-            };
-            infrastructure.Add(capacityParameter);
-
-            var service = new WebPubSubService(infrastructure.AspireResource.GetBicepIdentifier())
-            {
-                Sku = new BillingInfoSku()
+            var service = infrastructure.CreateExistingOrNewProvisionableResource(
+                (identifier, name) =>
                 {
-                    Name = skuParameter,
-                    Capacity = capacityParameter
+                    var resource = WebPubSubService.FromExisting(identifier);
+                    resource.Name = name;
+                    return resource;
                 },
-                Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
-            };
-            infrastructure.Add(service);
+                (infrastructure) =>
+                {
+                    // Supported values are Free_F1 Standard_S1 Premium_P1
+                    var skuParameter = new ProvisioningParameter("sku", typeof(string))
+                    {
+                        Value = "Free_F1"
+                    };
+                    infrastructure.Add(skuParameter);
+
+                    // Supported values are 1 2 5 10 20 50 100
+                    var capacityParameter = new ProvisioningParameter("capacity", typeof(int))
+                    {
+                        Value = new BicepValue<int>(1)
+                    };
+                    infrastructure.Add(capacityParameter);
+
+                    var service = new WebPubSubService(infrastructure.AspireResource.GetBicepIdentifier())
+                    {
+                        Sku = new BillingInfoSku()
+                        {
+                            Name = skuParameter,
+                            Capacity = capacityParameter
+                        },
+                        Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
+                    };
+                    return service;
+                }
+            );
 
             infrastructure.Add(new ProvisioningOutput("endpoint", typeof(string)) { Value = BicepFunction.Interpolate($"https://{service.HostName}") });
 
@@ -66,7 +77,7 @@ public static class AzureWebPubSubExtensions
             foreach (var setting in resource.Hubs)
             {
                 var hubName = setting.Key;
-                
+
                 var hubBuilder = setting.Value;
                 var hubResource = hubBuilder;
                 var hub = new WebPubSubHub(Infrastructure.NormalizeBicepIdentifier(hubResource.Name))
@@ -179,7 +190,7 @@ public static class AzureWebPubSubExtensions
 
         if (systemEvents != null)
         {
-            handler.SystemEvents = [..systemEvents];
+            handler.SystemEvents = [.. systemEvents];
         }
 
         if (authSettings != null)

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -263,4 +263,590 @@ public class ExistingAzureResourceTests
         Assert.Equal(expectedBicep, BicepText);
 
     }
+
+    [Fact]
+    public async Task SupportsExistingStorageAccountWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var storageAccount = builder.AddAzureStorage("storage")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(storageAccount.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "path": "storage.module.bicep",
+              "params": {
+                "storageExisting": "{existingResourceName.value}",
+                "principalType": "",
+                "principalId": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param storageExisting string
+
+            param principalType string
+
+            param principalId string
+
+            resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+              name: storageExisting
+            }
+
+            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
+              name: 'default'
+              parent: storage
+            }
+
+            resource storage_StorageBlobDataContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(storage.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+                principalType: principalType
+              }
+              scope: storage
+            }
+
+            resource storage_StorageTableDataContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(storage.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3')
+                principalType: principalType
+              }
+              scope: storage
+            }
+
+            resource storage_StorageQueueDataContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(storage.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
+                principalType: principalType
+              }
+              scope: storage
+            }
+
+            output blobEndpoint string = storage.properties.primaryEndpoints.blob
+
+            output queueEndpoint string = storage.properties.primaryEndpoints.queue
+
+            output tableEndpoint string = storage.properties.primaryEndpoints.table
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+
+    }
+
+    [Fact]
+    public async Task SupportsExistingAppConfigurationWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var appConfiguration = builder.AddAzureAppConfiguration("appConfig")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(appConfiguration.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{appConfig.outputs.appConfigEndpoint}",
+              "path": "appConfig.module.bicep",
+              "params": {
+                "appConfigExisting": "{existingResourceName.value}",
+                "principalType": "",
+                "principalId": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param appConfigExisting string
+
+            param principalType string
+
+            param principalId string
+
+            resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' existing = {
+              name: appConfigExisting
+            }
+
+            resource appConfig_AppConfigurationDataOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(appConfig.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b')
+                principalType: principalType
+              }
+              scope: appConfig
+            }
+
+            output appConfigEndpoint string = appConfig.properties.endpoint
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingEventHubsWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var eventHubs = builder.AddAzureEventHubs("eventHubs")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(eventHubs.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{eventHubs.outputs.eventHubsEndpoint}",
+              "path": "eventHubs.module.bicep",
+              "params": {
+                "eventHubsExisting": "{existingResourceName.value}",
+                "principalType": "",
+                "principalId": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param eventHubsExisting string
+
+            param principalType string
+
+            param principalId string
+
+            resource eventHubs 'Microsoft.EventHub/namespaces@2024-01-01' existing = {
+              name: eventHubsExisting
+            }
+
+            resource eventHubs_AzureEventHubsDataOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(eventHubs.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f526a384-b230-433a-b45c-95f59c4a2dec'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f526a384-b230-433a-b45c-95f59c4a2dec')
+                principalType: principalType
+              }
+              scope: eventHubs
+            }
+
+            output eventHubsEndpoint string = eventHubs.properties.serviceBusEndpoint
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingKeyVaultWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var keyVault = builder.AddAzureKeyVault("keyVault")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(keyVault.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{keyVault.outputs.vaultUri}",
+              "path": "keyVault.module.bicep",
+              "params": {
+                "keyVaultExisting": "{existingResourceName.value}",
+                "principalType": "",
+                "principalId": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param keyVaultExisting string
+
+            param principalType string
+
+            param principalId string
+
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+              name: keyVaultExisting
+              tags: {
+                'aspire-resource-name': 'keyVault'
+              }
+            }
+
+            resource keyVault_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(keyVault.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+                principalType: principalType
+              }
+              scope: keyVault
+            }
+
+            output vaultUri string = keyVault.properties.vaultUri
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingLogAnalyticsWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var logAnalytics = builder.AddAzureLogAnalyticsWorkspace("logAnalytics")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(logAnalytics.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "path": "logAnalytics.module.bicep",
+              "params": {
+                "logAnalyticsExisting": "{existingResourceName.value}"
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param logAnalyticsExisting string
+
+            resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+              name: logAnalyticsExisting
+            }
+
+            output logAnalyticsWorkspaceId string = logAnalytics.id
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingPostgresSqlWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var postgresSql = builder.AddAzurePostgresFlexibleServer("postgresSql")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(postgresSql.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{postgresSql.outputs.connectionString}",
+              "path": "postgresSql.module.bicep",
+              "params": {
+                "postgresSqlExisting": "{existingResourceName.value}",
+                "principalId": "",
+                "principalType": "",
+                "principalName": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param postgresSqlExisting string
+
+            param principalId string
+
+            param principalType string
+
+            param principalName string
+
+            resource postgresSql 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' existing = {
+              name: postgresSqlExisting
+              properties: {
+                authConfig: {
+                  activeDirectoryAuth: 'Enabled'
+                  passwordAuth: 'Disabled'
+                }
+              }
+            }
+
+            resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
+              name: 'AllowAllAzureIps'
+              properties: {
+                endIpAddress: '0.0.0.0'
+                startIpAddress: '0.0.0.0'
+              }
+              parent: postgresSql
+            }
+
+            resource postgresSql_admin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2024-08-01' = {
+              name: principalId
+              properties: {
+                principalName: principalName
+                principalType: principalType
+              }
+              parent: postgresSql
+              dependsOn: [
+                postgresSql
+                postgreSqlFirewallRule_AllowAllAzureIps
+              ]
+            }
+
+            output connectionString string = 'Host=${postgresSql.properties.fullyQualifiedDomainName};Username=${principalName}'
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingAzureSearchWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var search = builder.AddAzureSearch("search")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(search.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{search.outputs.connectionString}",
+              "path": "search.module.bicep",
+              "params": {
+                "searchExisting": "{existingResourceName.value}",
+                "principalType": "",
+                "principalId": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param searchExisting string
+
+            param principalType string
+
+            param principalId string
+
+            resource search 'Microsoft.Search/searchServices@2023-11-01' existing = {
+              name: searchExisting
+            }
+
+            resource search_SearchIndexDataContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(search.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8ebe5a00-799e-43f5-93ac-243d3dce84a7'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8ebe5a00-799e-43f5-93ac-243d3dce84a7')
+                principalType: principalType
+              }
+              scope: search
+            }
+
+            resource search_SearchServiceContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(search.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7ca78c08-252a-4471-8644-bb5ff32d4ba0'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7ca78c08-252a-4471-8644-bb5ff32d4ba0')
+                principalType: principalType
+              }
+              scope: search
+            }
+
+            output connectionString string = 'Endpoint=https://${searchExisting}.search.windows.net'
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingAzureSignalRWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var signalR = builder.AddAzureSignalR("signalR")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(signalR.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "Endpoint=https://{signalR.outputs.hostName};AuthType=azure",
+              "path": "signalR.module.bicep",
+              "params": {
+                "signalRExisting": "{existingResourceName.value}",
+                "principalType": "",
+                "principalId": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param signalRExisting string
+
+            param principalType string
+
+            param principalId string
+
+            resource signalR 'Microsoft.SignalRService/signalR@2024-03-01' existing = {
+              name: signalRExisting
+            }
+
+            resource signalR_SignalRAppServer 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(signalR.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '420fcaa2-552c-430f-98ca-3264be4806c7'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '420fcaa2-552c-430f-98ca-3264be4806c7')
+                principalType: principalType
+              }
+              scope: signalR
+            }
+
+            output hostName string = signalR.properties.hostName
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingAzureWebPubSubWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var webPubSub = builder.AddAzureWebPubSub("webPubSub")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(webPubSub.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{webPubSub.outputs.endpoint}",
+              "path": "webPubSub.module.bicep",
+              "params": {
+                "webPubSubExisting": "{existingResourceName.value}",
+                "principalType": "",
+                "principalId": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param webPubSubExisting string
+
+            param principalType string
+
+            param principalId string
+
+            resource webPubSub 'Microsoft.SignalRService/webPubSub@2024-03-01' existing = {
+              name: webPubSubExisting
+            }
+
+            resource webPubSub_WebPubSubServiceOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(webPubSub.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12cf5a90-567b-43ae-8102-96cf46c7d9b4'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12cf5a90-567b-43ae-8102-96cf46c7d9b4')
+                principalType: principalType
+              }
+              scope: webPubSub
+            }
+
+            output endpoint string = 'https://${webPubSub.properties.hostName}'
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
 }


### PR DESCRIPTION
This PR adds support for the existing Azure resource feature introduced in #7249 to more resources.

We introduce a `CreateExistingOrNewProvisionableResource` existing method that encapsulates the logic for wiring up an existing or new resource definition based on the existence of the annotation.

Note: SQL Server and Azure Redis will be done in a separate PR since they have some unique interactions with role assignments/access perms.