### PR TITLE
Support string or ParameterResource arguments for AsExisting APIs

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
@@ -203,14 +203,14 @@ public static class AzureProvisioningResourceExtensions
         T provisionedResource;
         if (infrastructure.AspireResource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAnnotation))
         {
-            var existingResourceName = existingAnnotation.Name is IResourceBuilder<ParameterResource> nameParameter
+            var existingResourceName = existingAnnotation.Name is ParameterResource nameParameter
                 ? nameParameter.AsProvisioningParameter(infrastructure)
                 : new BicepValue<string>((string)existingAnnotation.Name);
             provisionedResource = createExisting(infrastructure.AspireResource.GetBicepIdentifier(), existingResourceName);
             if (existingAnnotation.ResourceGroup is not null)
             {
-                var existingResourceGroup = existingAnnotation.ResourceGroup is IResourceBuilder<ParameterResource> resourceGroupParameter
-                    ? resourceGroupParameter.Resource
+                var existingResourceGroup = existingAnnotation.ResourceGroup is ParameterResource resourceGroupParameter
+                    ? resourceGroupParameter
                     : existingAnnotation.ResourceGroup;
                 infrastructure.AspireResource.Scope = new(existingResourceGroup);
             }

--- a/src/Aspire.Hosting.Azure/ExistingAzureResourceAnnotation.cs
+++ b/src/Aspire.Hosting.Azure/ExistingAzureResourceAnnotation.cs
@@ -9,16 +9,21 @@ namespace Aspire.Hosting.Azure;
 /// Represents a resource that is not managed by Aspire's provisioning or
 /// container management layer.
 /// </summary>
-public sealed class ExistingAzureResourceAnnotation(ParameterResource nameParameter,
-    ParameterResource? resourceGroupParameter = null) : IResourceAnnotation
+public sealed class ExistingAzureResourceAnnotation(object name, object? resourceGroup = null) : IResourceAnnotation
 {
     /// <summary>
     /// Gets the name of the existing resource.
     /// </summary>
-    public ParameterResource NameParameter { get; } = nameParameter;
+    /// <remarks>
+    /// Supports a <see cref="string"/> or a <see cref="ParameterResource"/> via runtime validation.
+    /// </remarks>
+    public object Name { get; } = name;
 
     /// <summary>
     /// Gets the name of the existing resource group. If <see langword="null"/>, use the current resource group.
     /// </summary>
-    public ParameterResource? ResourceGroupParameter { get; } = resourceGroupParameter;
+    /// <remarks>
+    /// Supports a <see cref="string"/> or a <see cref="ParameterResource"/> via runtime validation.
+    /// </remarks>
+    public object? ResourceGroup { get; } = resourceGroup;
 }

--- a/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
@@ -28,40 +28,57 @@ public static class ExistingAzureResourceExtensions
     /// </summary>
     /// <typeparam name="T">The type of the resource.</typeparam>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="nameParameter">The name of the existing resource.</param>
-    /// <param name="resourceGroupParameter">The name of the existing resource group, or <see langword="null"/> to use the current resource group.</param>
+    /// <param name="name">The name of the existing resource.</param>
+    /// <param name="resourceGroup">The name of the existing resource group, or <see langword="null"/> to use the current resource group.</param>
     /// <returns>The resource builder with the existing resource annotation added.</returns>
-    public static IResourceBuilder<T> RunAsExisting<T>(this IResourceBuilder<T> builder, IResourceBuilder<ParameterResource> nameParameter, IResourceBuilder<ParameterResource>? resourceGroupParameter = null)
+    public static IResourceBuilder<T> RunAsExisting<T>(this IResourceBuilder<T> builder, object name, object? resourceGroup = null)
         where T : IAzureResource
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ValidateExistingArguments(name, resourceGroup);
 
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
-            builder.WithAnnotation(new ExistingAzureResourceAnnotation(nameParameter.Resource, resourceGroupParameter?.Resource));
+            builder.WithAnnotation(new ExistingAzureResourceAnnotation(name, resourceGroup));
         }
 
         return builder;
     }
 
     /// <summary>
-    /// Marks the resource as an existing resource when the application is deployed.
+    /// Marks the resource as an existing resource when the application is published.
     /// </summary>
     /// <typeparam name="T">The type of the resource.</typeparam>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="nameParameter">The name of the existing resource.</param>
-    /// <param name="resourceGroupParameter">The name of the existing resource group, or <see langword="null"/> to use the current resource group.</param>
+    /// <param name="name">The name of the existing resource.</param>
+    /// <param name="resourceGroup">The name of the existing resource group, or <see langword="null"/> to use the current resource group.</param>
     /// <returns>The resource builder with the existing resource annotation added.</returns>
-    public static IResourceBuilder<T> PublishAsExisting<T>(this IResourceBuilder<T> builder, IResourceBuilder<ParameterResource> nameParameter, IResourceBuilder<ParameterResource>? resourceGroupParameter = null)
+    public static IResourceBuilder<T> PublishAsExisting<T>(this IResourceBuilder<T> builder, object name, object? resourceGroup = null)
         where T : IAzureResource
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ValidateExistingArguments(name, resourceGroup);
 
         if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
-            builder.WithAnnotation(new ExistingAzureResourceAnnotation(nameParameter.Resource, resourceGroupParameter?.Resource));
+            builder.WithAnnotation(new ExistingAzureResourceAnnotation(name, resourceGroup));
         }
 
         return builder;
+    }
+
+    private static void ValidateExistingArguments(object name, object? resourceGroup)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        if (name is not string && name is not IResourceBuilder<ParameterResource>)
+        {
+            throw new ArgumentException("The name must be a string or a ParameterResource.", nameof(name));
+        }
+
+        if (resourceGroup is not null && resourceGroup is not string && resourceGroup is not IResourceBuilder<ParameterResource>)
+        {
+            throw new ArgumentException("The resource group must be a string, a ParameterResource, or null.", nameof(resourceGroup));
+        }
     }
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -111,9 +111,12 @@ internal sealed class BicepProvisioner(
         var resourceLogger = loggerService.GetLogger(resource);
 
         if (resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingResource) &&
-            existingResource.ResourceGroupParameter is { } resourceGroupParameter)
+            existingResource.ResourceGroup is { } existingResourceGroup)
         {
-            resourceGroup = await context.GetResourceGroup(resourceGroupParameter.Name, resourceLogger, cancellationToken).ConfigureAwait(false);
+            var existingResourceGroupName = existingResourceGroup is IResourceBuilder<ParameterResource> parameterResource
+                ? parameterResource.Resource.Name
+                : (string)existingResourceGroup;
+            resourceGroup = await context.GetResourceGroup(existingResourceGroupName, resourceLogger, cancellationToken).ConfigureAwait(false);
         }
 
         await notificationService.PublishUpdateAsync(resource, state => state with

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -113,8 +113,8 @@ internal sealed class BicepProvisioner(
         if (resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingResource) &&
             existingResource.ResourceGroup is { } existingResourceGroup)
         {
-            var existingResourceGroupName = existingResourceGroup is IResourceBuilder<ParameterResource> parameterResource
-                ? parameterResource.Resource.Name
+            var existingResourceGroupName = existingResourceGroup is ParameterResource parameterResource
+                ? parameterResource.Name
                 : (string)existingResourceGroup;
             resourceGroup = await context.GetResourceGroup(existingResourceGroupName, resourceLogger, cancellationToken).ConfigureAwait(false);
         }

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
@@ -35,8 +35,10 @@ public class ExistingAzureExtensionsResourceTests
             .RunAsExisting(nameParameter, resourceGroupParameter);
 
         Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
-        Assert.Equal("name", existingAzureResourceAnnotation.NameParameter.Name);
-        Assert.Equal("resourceGroup", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
+        var existingNameParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.Name);
+        Assert.Equal("name", existingNameParameter.Resource.Name);
+        var existingResourceGroupParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.ResourceGroup);
+        Assert.Equal("resourceGroup", existingResourceGroupParameter.Resource.Name);
     }
 
     [Fact]
@@ -54,8 +56,10 @@ public class ExistingAzureExtensionsResourceTests
             .RunAsExisting(nameParameter1, resourceGroupParameter1);
 
         Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
-        Assert.Equal("name1", existingAzureResourceAnnotation.NameParameter.Name);
-        Assert.Equal("resourceGroup1", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
+        var existingNameParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.Name);
+        Assert.Equal("name1", existingNameParameter.Resource.Name);
+        var existingResourceGroupParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.ResourceGroup);
+        Assert.Equal("resourceGroup1", existingResourceGroupParameter.Resource.Name);
     }
 
     [Fact]
@@ -70,8 +74,10 @@ public class ExistingAzureExtensionsResourceTests
             .PublishAsExisting(nameParameter, resourceGroupParameter);
 
         Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
-        Assert.Equal("name", existingAzureResourceAnnotation.NameParameter.Name);
-        Assert.Equal("resourceGroup", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
+        var existingNameParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.Name);
+        Assert.Equal("name", existingNameParameter.Resource.Name);
+        var existingResourceGroupParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.ResourceGroup);
+        Assert.Equal("resourceGroup", existingResourceGroupParameter.Resource.Name);
     }
 
     [Fact]
@@ -89,7 +95,41 @@ public class ExistingAzureExtensionsResourceTests
             .PublishAsExisting(nameParameter1, resourceGroupParameter1);
 
         Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
-        Assert.Equal("name1", existingAzureResourceAnnotation.NameParameter.Name);
-        Assert.Equal("resourceGroup1", existingAzureResourceAnnotation.ResourceGroupParameter!.Name);
+        var existingNameParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.Name);
+        Assert.Equal("name1", existingNameParameter.Resource.Name);
+        var existingResourceGroupParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.ResourceGroup);
+        Assert.Equal("resourceGroup1", existingResourceGroupParameter.Resource.Name);
+    }
+
+    public static TheoryData<Func<string, string, string, IResourceBuilder<IAzureResource>>> AsExistingMethodsWithString =>
+        new()
+        {
+            { (name, resourceGroup, type) => TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run).AddAzureServiceBus(type).RunAsExisting(name, resourceGroup) },
+            { (name, resourceGroup, type) => TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish).AddAzureServiceBus(type).PublishAsExisting(name, resourceGroup) }
+        };
+
+    [Theory]
+    [MemberData(nameof(AsExistingMethodsWithString))]
+    public void CanCallAsExistingWithStringArguments(Func<string, string, string, IResourceBuilder<IAzureResource>> runAsExisting)
+    {
+        var serviceBus = runAsExisting("existingName", "existingResourceGroup", "sb");
+
+        Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
+        Assert.Equal("existingName", existingAzureResourceAnnotation.Name);
+        Assert.Equal("existingResourceGroup", existingAzureResourceAnnotation.ResourceGroup);
+    }
+
+    public static TheoryData<Func<IResourceBuilder<IAzureResource>>> AsExistingMethodsWithInvalidArguments =>
+        new()
+        {
+            { () => TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run).AddAzureServiceBus("sb").RunAsExisting(1, 2) },
+            { () => TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish).AddAzureServiceBus("sb").PublishAsExisting(1, 2) }
+        };
+
+    [Theory]
+    [MemberData(nameof(AsExistingMethodsWithInvalidArguments))]
+    public void ThrowsForAsExistingWithInvalidArgumentType(Func<IResourceBuilder<IAzureResource>> asExisting)
+    {
+        Assert.Throws<ArgumentException>(() => asExisting());
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
@@ -35,10 +35,10 @@ public class ExistingAzureExtensionsResourceTests
             .RunAsExisting(nameParameter, resourceGroupParameter);
 
         Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
-        var existingNameParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.Name);
-        Assert.Equal("name", existingNameParameter.Resource.Name);
-        var existingResourceGroupParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.ResourceGroup);
-        Assert.Equal("resourceGroup", existingResourceGroupParameter.Resource.Name);
+        var existingNameParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.Name);
+        Assert.Equal("name", existingNameParameter.Name);
+        var existingResourceGroupParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.ResourceGroup);
+        Assert.Equal("resourceGroup", existingResourceGroupParameter.Name);
     }
 
     [Fact]
@@ -56,10 +56,10 @@ public class ExistingAzureExtensionsResourceTests
             .RunAsExisting(nameParameter1, resourceGroupParameter1);
 
         Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
-        var existingNameParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.Name);
-        Assert.Equal("name1", existingNameParameter.Resource.Name);
-        var existingResourceGroupParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.ResourceGroup);
-        Assert.Equal("resourceGroup1", existingResourceGroupParameter.Resource.Name);
+        var existingNameParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.Name);
+        Assert.Equal("name1", existingNameParameter.Name);
+        var existingResourceGroupParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.ResourceGroup);
+        Assert.Equal("resourceGroup1", existingResourceGroupParameter.Name);
     }
 
     [Fact]
@@ -74,10 +74,10 @@ public class ExistingAzureExtensionsResourceTests
             .PublishAsExisting(nameParameter, resourceGroupParameter);
 
         Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
-        var existingNameParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.Name);
-        Assert.Equal("name", existingNameParameter.Resource.Name);
-        var existingResourceGroupParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.ResourceGroup);
-        Assert.Equal("resourceGroup", existingResourceGroupParameter.Resource.Name);
+        var existingNameParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.Name);
+        Assert.Equal("name", existingNameParameter.Name);
+        var existingResourceGroupParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.ResourceGroup);
+        Assert.Equal("resourceGroup", existingResourceGroupParameter.Name);
     }
 
     [Fact]
@@ -95,10 +95,10 @@ public class ExistingAzureExtensionsResourceTests
             .PublishAsExisting(nameParameter1, resourceGroupParameter1);
 
         Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
-        var existingNameParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.Name);
-        Assert.Equal("name1", existingNameParameter.Resource.Name);
-        var existingResourceGroupParameter = Assert.IsAssignableFrom<IResourceBuilder<ParameterResource>>(existingAzureResourceAnnotation.ResourceGroup);
-        Assert.Equal("resourceGroup1", existingResourceGroupParameter.Resource.Name);
+        var existingNameParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.Name);
+        Assert.Equal("name1", existingNameParameter.Name);
+        var existingResourceGroupParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.ResourceGroup);
+        Assert.Equal("resourceGroup1", existingResourceGroupParameter.Name);
     }
 
     public static TheoryData<Func<string, string, string, IResourceBuilder<IAzureResource>>> AsExistingMethodsWithString =>
@@ -117,19 +117,5 @@ public class ExistingAzureExtensionsResourceTests
         Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
         Assert.Equal("existingName", existingAzureResourceAnnotation.Name);
         Assert.Equal("existingResourceGroup", existingAzureResourceAnnotation.ResourceGroup);
-    }
-
-    public static TheoryData<Func<IResourceBuilder<IAzureResource>>> AsExistingMethodsWithInvalidArguments =>
-        new()
-        {
-            { () => TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run).AddAzureServiceBus("sb").RunAsExisting(1, 2) },
-            { () => TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish).AddAzureServiceBus("sb").PublishAsExisting(1, 2) }
-        };
-
-    [Theory]
-    [MemberData(nameof(AsExistingMethodsWithInvalidArguments))]
-    public void ThrowsForAsExistingWithInvalidArgumentType(Func<IResourceBuilder<IAzureResource>> asExisting)
-    {
-        Assert.Throws<ArgumentException>(() => asExisting());
     }
 }


### PR DESCRIPTION
Follow-up to #7249. Expand support for strings and parameter resoruces as argument types.