### PR TITLE
Disable helix test runs in CI

### DIFF
--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -63,6 +63,14 @@ variables:
   - name: _InternalBuildArgs
     value: ''
 
+  # Use the build reason to decide whether to include helix_tests
+  - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - name: testVariants
+      value: ',_helix_tests'
+  - ${{ else }}:
+    - name: testVariants
+      value: ''
+
 resources:
   containers:
   - container: LinuxContainer
@@ -95,7 +103,8 @@ stages:
 
       jobs:
 
-      - ${{ each testVariant in split(',_helix_tests', ',') }}:
+      # Windows jobs
+      - ${{ each testVariant in split( variables.testVariants, ',' ) }}:
         - job: Windows${{ testVariant }}
 
           # timeout accounts for wait times for helix agents up to 30mins
@@ -127,7 +136,8 @@ stages:
                 isWindows: true
                 runHelixTests: ${{ contains(testVariant, 'helix') }}
 
-      - ${{ each testVariant in split(',_helix_tests', ',') }}:
+      # Linux jobs
+      - ${{ each testVariant in split( variables.testVariants, ',' ) }}:
         - job: Linux${{ testVariant }}
 
           # timeout accounts for wait times for helix agents up to 30mins

--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -172,44 +172,45 @@ stages:
 # ----------------------------------------------------------------
 # This stage performs quality gates checks
 # ----------------------------------------------------------------
-- stage: codecoverage
-  displayName: CodeCoverage
-  dependsOn:
-    - build
-  condition: succeeded('build')
-  variables:
-  - template: /eng/common/templates/variables/pool-providers.yml
-  jobs:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enableMicrobuild: true
-      enableTelemetry: true
-      runAsPublic: false
-      workspace:
-        clean: all
-
-      # ----------------------------------------------------------------
-      # This stage downloads the code coverage reports from the build jobs,
-      # merges those and validates the combined test coverage.
-      # ----------------------------------------------------------------
-      jobs:
-      - job: CodeCoverageReport
-        timeoutInMinutes: 10
-
-        pool:
-          name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals build.ubuntu.2004.amd64.open
-
-        preSteps:
-          - checkout: self
-            fetchDepth: 1
-            clean: true
-
-        steps:
-        - script: $(Build.SourcesDirectory)/build.sh --ci --restore
-          displayName: Init toolset
-
-        - template: /eng/pipelines/templates/VerifyCoverageReport.yml
-          parameters:
-            # matches what is used in the conditions for the build/test jobs
-            testVariants: ',_helix_tests'
+- ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+  - stage: codecoverage
+    displayName: CodeCoverage
+    dependsOn:
+      - build
+    condition: succeeded('build')
+    variables:
+    - template: /eng/common/templates/variables/pool-providers.yml
+    jobs:
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        enableMicrobuild: true
+        enableTelemetry: true
+        runAsPublic: false
+        workspace:
+          clean: all
+  
+        # ----------------------------------------------------------------
+        # This stage downloads the code coverage reports from the build jobs,
+        # merges those and validates the combined test coverage.
+        # ----------------------------------------------------------------
+        jobs:
+        - job: CodeCoverageReport
+          timeoutInMinutes: 10
+  
+          pool:
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals build.ubuntu.2004.amd64.open
+  
+          preSteps:
+            - checkout: self
+              fetchDepth: 1
+              clean: true
+  
+          steps:
+          - script: $(Build.SourcesDirectory)/build.sh --ci --restore
+            displayName: Init toolset
+  
+          - template: /eng/pipelines/templates/VerifyCoverageReport.yml
+            parameters:
+              # matches what is used in the conditions for the build/test jobs
+              testVariants: ',_helix_tests'


### PR DESCRIPTION
## Description

To help reduce our load in our ACR, we want to disable helix test runs in PRs now that we have GHA running our tests as well.


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
