### PR TITLE
Convert AzureEventHub and ConsumerGroup to Resources

### DIFF
--- a/playground/AspireEventHub/EventHubs.AppHost/Program.cs
+++ b/playground/AspireEventHub/EventHubs.AppHost/Program.cs
@@ -6,8 +6,8 @@ var blob = builder.AddAzureStorage("ehstorage")
     .AddBlobs("checkpoints");
 
 var eventHub = builder.AddAzureEventHubs("eventhubns")
-    .RunAsEmulator()
-    .WithHub("hub");
+    .RunAsEmulator();
+eventHub.AddHub("hub");
 
 builder.AddProject<Projects.EventHubsConsumer>("consumer")
     .WithReference(eventHub).WaitFor(eventHub)

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
@@ -3,7 +3,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 var storage = builder.AddAzureStorage("storage").RunAsEmulator();
 var queue = storage.AddQueues("queue");
 var blob = storage.AddBlobs("blob");
-var eventHubs = builder.AddAzureEventHubs("eventhubs").RunAsEmulator().WithHub("myhub");
+var eventHubs = builder.AddAzureEventHubs("eventhubs").RunAsEmulator();
+eventHubs.AddHub("myhub");
 #if !SKIP_UNSTABLE_EMULATORS
 var serviceBus = builder.AddAzureServiceBus("messaging").RunAsEmulator().WithQueue("myqueue");
 var cosmosDb = builder.AddAzureCosmosDB("cosmosdb")

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
@@ -2,30 +2,42 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using Aspire.Hosting.ApplicationModel;
 using Azure.Provisioning;
 
 namespace Aspire.Hosting.Azure;
 
 /// <summary>
-/// Represents a Consumer Group.
+/// Represents an Azure Event Hub Consumer Group.
 /// </summary>
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class AzureEventHubConsumerGroupResource
+public class AzureEventHubConsumerGroupResource : Resource, IResourceWithParent<AzureEventHubResource>, IResourceWithConnectionString
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureEventHubConsumerGroupResource"/> class.
     /// </summary>
-    public AzureEventHubConsumerGroupResource(string name)
+    public AzureEventHubConsumerGroupResource(string name, string consumerGroupName, AzureEventHubResource parent) : base(name)
     {
-        Name = name;
+        ConsumerGroupName = consumerGroupName;
+        Parent = parent;
     }
 
     /// <summary>
-    /// The event hub name.
+    /// The event hub consumer group name.
     /// </summary>
-    public string Name { get; set; }
+    public string ConsumerGroupName { get; set; }
+
+    /// <summary>
+    /// Gets the parent Azure Event Hub resource.
+    /// </summary>
+    public AzureEventHubResource Parent { get; }
+
+    /// <summary>
+    /// Gets the connection string expression for the Azure Event Hub.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
 
     /// <summary>
     /// Converts the current instance to a provisioning entity.
@@ -35,7 +47,7 @@ public class AzureEventHubConsumerGroupResource
     {
         var consumerGroup = new global::Azure.Provisioning.EventHubs.EventHubsConsumerGroup(Infrastructure.NormalizeBicepIdentifier(Name));
 
-        consumerGroup.Name = Name;
+        consumerGroup.Name = ConsumerGroupName;
 
         return consumerGroup;
     }
@@ -46,6 +58,6 @@ public class AzureEventHubConsumerGroupResource
     /// <param name="writer">The Utf8JsonWriter to write the JSON object to.</param>
     internal void WriteJsonObjectProperties(Utf8JsonWriter writer)
     {
-        writer.WriteString(nameof(Name), Name);
+        writer.WriteString(nameof(Name), ConsumerGroupName);
     }
 }

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
@@ -4,7 +4,7 @@
 using System.Text.Json;
 using Azure.Provisioning;
 
-namespace Aspire.Hosting.Azure.EventHubs;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents a Consumer Group.
@@ -12,12 +12,12 @@ namespace Aspire.Hosting.Azure.EventHubs;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class EventHubConsumerGroup
+public class AzureEventHubConsumerGroupResource
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="EventHubConsumerGroup"/> class.
+    /// Initializes a new instance of the <see cref="AzureEventHubConsumerGroupResource"/> class.
     /// </summary>
-    public EventHubConsumerGroup(string name)
+    public AzureEventHubConsumerGroupResource(string name)
     {
         Name = name;
     }

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
@@ -4,7 +4,7 @@
 using System.Text.Json;
 using Azure.Provisioning;
 
-namespace Aspire.Hosting.Azure.EventHubs;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents an Event Hub.
@@ -12,12 +12,12 @@ namespace Aspire.Hosting.Azure.EventHubs;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class EventHub
+public class AzureEventHubResource
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="EventHub"/> class.
+    /// Initializes a new instance of the <see cref="AzureEventHubResource"/> class.
     /// </summary>
-    public EventHub(string name)
+    public AzureEventHubResource(string name)
     {
         Name = name;
     }
@@ -36,7 +36,7 @@ public class EventHub
     /// <summary>
     /// The consumer groups for this hub.
     /// </summary>
-    public List<EventHubConsumerGroup> ConsumerGroups { get; } = [];
+    public List<AzureEventHubConsumerGroupResource> ConsumerGroups { get; } = [];
 
     /// <summary>
     /// Converts the current instance to a provisioning entity.

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
@@ -2,30 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using Aspire.Hosting.ApplicationModel;
 using Azure.Provisioning;
 
 namespace Aspire.Hosting.Azure;
 
 /// <summary>
-/// Represents an Event Hub.
+/// Represents an Azure Event Hub.
 /// </summary>
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class AzureEventHubResource
+public class AzureEventHubResource : Resource, IResourceWithParent<AzureEventHubsResource>, IResourceWithConnectionString
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureEventHubResource"/> class.
     /// </summary>
-    public AzureEventHubResource(string name)
+    public AzureEventHubResource(string name, string hubName, AzureEventHubsResource parent) : base(name)
     {
-        Name = name;
+        HubName = hubName;
+        Parent = parent;
     }
 
     /// <summary>
     /// The event hub name.
     /// </summary>
-    public string Name { get; set; }
+    public string HubName { get; set; }
 
     /// <summary>
     /// Number of partitions created for the Event Hub, allowed values are from
@@ -34,9 +36,19 @@ public class AzureEventHubResource
     public long? PartitionCount { get; set; }
 
     /// <summary>
+    /// Gets the parent Azure Event Hubs resource.
+    /// </summary>
+    public AzureEventHubsResource Parent { get; }
+
+    /// <summary>
+    /// Gets the connection string expression for the Azure Event Hub.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
+
+    /// <summary>
     /// The consumer groups for this hub.
     /// </summary>
-    public List<AzureEventHubConsumerGroupResource> ConsumerGroups { get; } = [];
+    internal List<AzureEventHubConsumerGroupResource> ConsumerGroups { get; } = [];
 
     /// <summary>
     /// Converts the current instance to a provisioning entity.
@@ -46,7 +58,7 @@ public class AzureEventHubResource
     {
         var hub = new global::Azure.Provisioning.EventHubs.EventHub(Infrastructure.NormalizeBicepIdentifier(Name));
 
-        hub.Name = Name;
+        hub.Name = HubName;
 
         if (PartitionCount.HasValue)
         {
@@ -64,7 +76,7 @@ public class AzureEventHubResource
     {
         var hub = this;
 
-        writer.WriteString(nameof(Name), hub.Name);
+        writer.WriteString(nameof(Name), hub.HubName);
 
         if (hub.PartitionCount.HasValue)
         {

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -109,15 +109,15 @@ public static class AzureEventHubsExtensions
     /// </remarks>
     /// <param name="builder">The Azure Event Hubs resource builder.</param>
     /// <param name="name">The name of the Event Hub.</param>
-    /// <param name="configure">An optional method that can be used for customizing the <see cref="EventHub"/>.</param>
+    /// <param name="configure">An optional method that can be used for customizing the <see cref="AzureEventHubResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<AzureEventHubsResource> WithHub(this IResourceBuilder<AzureEventHubsResource> builder, [ResourceName] string name, Action<EventHub>? configure = null)
+    public static IResourceBuilder<AzureEventHubsResource> WithHub(this IResourceBuilder<AzureEventHubsResource> builder, [ResourceName] string name, Action<AzureEventHubResource>? configure = null)
     {
         var hub = builder.Resource.Hubs.FirstOrDefault(x => x.Name == name);
 
         if (hub == null)
         {
-            hub = new EventHub(name);
+            hub = new AzureEventHubResource(name);
             builder.Resource.Hubs.Add(hub);
         }
 

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -104,14 +104,13 @@ public static class AzureEventHubsExtensions
     }
 
     /// <summary>
-    /// Adds an Azure Event Hubs hub resource to the application model. This resource requires an <see cref="AzureEventHubsResource"/> to be added to the application model.
+    /// Adds an Azure Event Hubs hub resource to the application model.
     /// </summary>
     /// <param name="builder">The Azure Event Hubs resource builder.</param>
     /// <param name="name">The name of the Event Hub resource.</param>
     /// <param name="hubName">The name of the Event Hub. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
-    /// <param name="configure">An optional method that can be used for customizing the <see cref="AzureEventHubResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<AzureEventHubResource> AddHub(this IResourceBuilder<AzureEventHubsResource> builder, [ResourceName] string name, string? hubName = null, Action<AzureEventHubResource>? configure = null)
+    public static IResourceBuilder<AzureEventHubResource> AddHub(this IResourceBuilder<AzureEventHubsResource> builder, [ResourceName] string name, string? hubName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
@@ -120,10 +119,25 @@ public static class AzureEventHubsExtensions
         hubName ??= name;
 
         var hub = new AzureEventHubResource(name, hubName, builder.Resource);
-        configure?.Invoke(hub);
         builder.Resource.Hubs.Add(hub);
 
         return builder.ApplicationBuilder.AddResource(hub);
+    }
+
+    /// <summary>
+    /// Allows setting the properties of an Azure Event Hub resource.
+    /// </summary>
+    /// <param name="builder">The Azure Event Hub resource builder.</param>
+    /// <param name="configure">A method that can be used for customizing the <see cref="AzureEventHubResource"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureEventHubResource> WithProperties(this IResourceBuilder<AzureEventHubResource> builder, Action<AzureEventHubResource> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        configure(builder.Resource);
+
+        return builder;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -95,35 +95,56 @@ public static class AzureEventHubsExtensions
     /// <param name="builder">The Azure Event Hubs resource builder.</param>
     /// <param name="name">The name of the Event Hub.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(WithHub)} instead to add an Azure Event Hub.")]
+    [Obsolete($"This method is obsolete because it has the wrong return type and will be removed in a future version. Use {nameof(AddHub)} instead to add an Azure Event Hub.")]
     public static IResourceBuilder<AzureEventHubsResource> AddEventHub(this IResourceBuilder<AzureEventHubsResource> builder, [ResourceName] string name)
     {
-        return builder.WithHub(name);
+        builder.AddHub(name);
+
+        return builder;
     }
 
     /// <summary>
     /// Adds an Azure Event Hubs hub resource to the application model. This resource requires an <see cref="AzureEventHubsResource"/> to be added to the application model.
     /// </summary>
-    /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="EventHubsEmulatorContainerImageTags.Tag"/> tag of the <inheritdoc cref="EventHubsEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="EventHubsEmulatorContainerImageTags.Image"/> container image.
-    /// </remarks>
     /// <param name="builder">The Azure Event Hubs resource builder.</param>
-    /// <param name="name">The name of the Event Hub.</param>
+    /// <param name="name">The name of the Event Hub resource.</param>
+    /// <param name="hubName">The name of the Event Hub. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
     /// <param name="configure">An optional method that can be used for customizing the <see cref="AzureEventHubResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<AzureEventHubsResource> WithHub(this IResourceBuilder<AzureEventHubsResource> builder, [ResourceName] string name, Action<AzureEventHubResource>? configure = null)
+    public static IResourceBuilder<AzureEventHubResource> AddHub(this IResourceBuilder<AzureEventHubsResource> builder, [ResourceName] string name, string? hubName = null, Action<AzureEventHubResource>? configure = null)
     {
-        var hub = builder.Resource.Hubs.FirstOrDefault(x => x.Name == name);
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(name);
 
-        if (hub == null)
-        {
-            hub = new AzureEventHubResource(name);
-            builder.Resource.Hubs.Add(hub);
-        }
+        // Use the resource name as the hub name if it's not provided
+        hubName ??= name;
 
+        var hub = new AzureEventHubResource(name, hubName, builder.Resource);
         configure?.Invoke(hub);
+        builder.Resource.Hubs.Add(hub);
 
-        return builder;
+        return builder.ApplicationBuilder.AddResource(hub);
+    }
+
+    /// <summary>
+    /// Adds an Azure Event Hub Consumer Group resource to the application model.
+    /// </summary>
+    /// <param name="builder">The Azure Event Hub resource builder.</param>
+    /// <param name="name">The name of the Event Hub Consumer Group resource.</param>
+    /// <param name="groupName">The name of the Consumer Group. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureEventHubConsumerGroupResource> AddConsumerGroup(this IResourceBuilder<AzureEventHubResource> builder, [ResourceName] string name, string? groupName = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(name);
+
+        // Use the resource name as the group name if it's not provided
+        groupName ??= name;
+
+        var consumerGroup = new AzureEventHubConsumerGroupResource(name, groupName, builder.Resource);
+        builder.Resource.ConsumerGroups.Add(consumerGroup);
+
+        return builder.ApplicationBuilder.AddResource(consumerGroup);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsResource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Azure.EventHubs;
 
 namespace Aspire.Hosting.Azure;
 
@@ -28,7 +27,7 @@ public class AzureEventHubsResource(string name, Action<AzureResourceInfrastruct
 
     private const string ConnectionKeyPrefix = "Aspire__Azure__Messaging__EventHubs";
 
-    internal List<EventHub> Hubs { get; } = [];
+    internal List<AzureEventHubResource> Hubs { get; } = [];
 
     /// <summary>
     /// Gets the "eventHubsEndpoint" output reference from the bicep template for the Azure Event Hubs resource.

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -215,8 +215,9 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         var eventHubs = builder.AddAzureEventHubs("eh");
 
-        var hub = eventHubs.AddHub("hub-resource", "hub-name", hub => hub.PartitionCount = 3);
-        hub.AddConsumerGroup("cg1", "group-name");
+        eventHubs.AddHub("hub-resource", "hub-name")
+            .WithProperties(hub => hub.PartitionCount = 3)
+            .AddConsumerGroup("cg1", "group-name");
 
         var manifest = await ManifestUtils.GetManifestWithBicep(eventHubs.Resource);
 
@@ -285,8 +286,9 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
                 cg = infrastructure.GetProvisionableResources().OfType<global::Azure.Provisioning.EventHubs.EventHubsConsumerGroup>().Single();
             });
 
-        var hub1 = eventHubs.AddHub("hub1", configure: hub => hub.PartitionCount = 4);
-        hub1.AddConsumerGroup("cg1");
+        eventHubs.AddHub("hub1")
+            .WithProperties(hub => hub.PartitionCount = 4)
+            .AddConsumerGroup("cg1");
 
         using var app = builder.Build();
 
@@ -309,8 +311,9 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         var eventHubs = builder.AddAzureEventHubs("eh")
             .RunAsEmulator();
 
-        var hub1 = eventHubs.AddHub("hub1", configure: hub => hub.PartitionCount = 4);
-        hub1.AddConsumerGroup("cg1");
+        eventHubs.AddHub("hub1")
+            .WithProperties(hub => hub.PartitionCount = 4)
+            .AddConsumerGroup("cg1");
 
         using var app = builder.Build();
         await app.StartAsync();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -35,9 +35,9 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         });
 
         var resource = builder.AddAzureEventHubs("resource")
-                              .WithHub("hubx")
                               .RunAsEmulator()
                               .WithHealthCheck("blocking_check");
+        resource.AddHub("hubx");
 
         var dependentResource = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
                                        .WaitFor(resource);
@@ -70,8 +70,8 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
         var eventHub = builder.AddAzureEventHubs("eventhubns")
-            .RunAsEmulator()
-            .WithHub("hub");
+            .RunAsEmulator();
+        eventHub.AddHub("hub");
 
         using var app = builder.Build();
         await app.StartAsync();
@@ -210,15 +210,13 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task NamedResourcesAreReused()
+    public async Task CanSetHubAndConsumerGroupName()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var eventHubs = builder.AddAzureEventHubs("eh");
 
-        eventHubs.WithHub("hub1");
-        eventHubs.WithHub("hub1");
-        eventHubs.WithHub("hub1", hub => hub.PartitionCount = 3);
-        eventHubs.WithHub("hub1", hub => hub.ConsumerGroups.Add(new("cg1")));
+        var hub = eventHubs.AddHub("hub-resource", "hub-name", hub => hub.PartitionCount = 3);
+        hub.AddConsumerGroup("cg1", "group-name");
 
         var manifest = await ManifestUtils.GetManifestWithBicep(eventHubs.Resource);
 
@@ -253,8 +251,8 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
               scope: eh
             }
 
-            resource hub1 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
-              name: 'hub1'
+            resource hub_resource 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
+              name: 'hub-name'
               properties: {
                 partitionCount: 3
               }
@@ -262,8 +260,8 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
             }
 
             resource cg1 'Microsoft.EventHub/namespaces/eventhubs/consumergroups@2024-01-01' = {
-              name: 'cg1'
-              parent: hub1
+              name: 'group-name'
+              parent: hub_resource
             }
 
             output eventHubsEndpoint string = eh.properties.serviceBusEndpoint
@@ -281,16 +279,14 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         global::Azure.Provisioning.EventHubs.EventHubsConsumerGroup? cg = null;
 
         var eventHubs = builder.AddAzureEventHubs("eh")
-            .WithHub("hub1", hub =>
-            {
-                hub.PartitionCount = 4;
-                hub.ConsumerGroups.Add(new AzureEventHubConsumerGroupResource("cg1"));
-            })
             .ConfigureInfrastructure(infrastructure =>
             {
                 hub = infrastructure.GetProvisionableResources().OfType<global::Azure.Provisioning.EventHubs.EventHub>().Single();
                 cg = infrastructure.GetProvisionableResources().OfType<global::Azure.Provisioning.EventHubs.EventHubsConsumerGroup>().Single();
             });
+
+        var hub1 = eventHubs.AddHub("hub1", configure: hub => hub.PartitionCount = 4);
+        hub1.AddConsumerGroup("cg1");
 
         using var app = builder.Build();
 
@@ -311,12 +307,10 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var eventHubs = builder.AddAzureEventHubs("eh")
-            .RunAsEmulator()
-            .WithHub("hub1", hub =>
-            {
-                hub.PartitionCount = 4;
-                hub.ConsumerGroups.Add(new AzureEventHubConsumerGroupResource("cg1"));
-            });
+            .RunAsEmulator();
+
+        var hub1 = eventHubs.AddHub("hub1", configure: hub => hub.PartitionCount = 4);
+        hub1.AddConsumerGroup("cg1");
 
         using var app = builder.Build();
         await app.StartAsync();
@@ -364,11 +358,11 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
 
         var eventHubs = builder
             .AddAzureEventHubs("eh")
-            .WithHub("hub1")
             .RunAsEmulator(configure => configure.WithConfiguration(document =>
             {
                 document["UserConfig"]!["LoggingConfig"] = new JsonObject { ["Type"] = "Console" };
             }));
+        eventHubs.AddHub("hub1");
 
         using var app = builder.Build();
         await app.StartAsync();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -284,7 +284,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
             .WithHub("hub1", hub =>
             {
                 hub.PartitionCount = 4;
-                hub.ConsumerGroups.Add(new EventHubConsumerGroup("cg1"));
+                hub.ConsumerGroups.Add(new AzureEventHubConsumerGroupResource("cg1"));
             })
             .ConfigureInfrastructure(infrastructure =>
             {
@@ -315,7 +315,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
             .WithHub("hub1", hub =>
             {
                 hub.PartitionCount = 4;
-                hub.ConsumerGroups.Add(new EventHubConsumerGroup("cg1"));
+                hub.ConsumerGroups.Add(new AzureEventHubConsumerGroupResource("cg1"));
             });
 
         using var app = builder.Build();


### PR DESCRIPTION
## Description

This allows them to be referenceable and waitable in the future.

Also rename the classes and put them in the appropriate namespace.

Probably easiest to review each commit separately.

Contributes to #7407

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
