### PR TITLE
Ensure parameter value from config is used when a ParameterDefault is passed

### DIFF
--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -86,7 +86,7 @@ public static class ParameterResourceBuilderExtensions
         return builder.AddParameter(
                 new ParameterResource(
                     name,
-                    parameterDefault => parameterDefault?.GetDefaultValue() ?? valueGetter(),
+                    parameterDefault => parameterDefault is not null ? parameterDefault.GetDefaultValue() : valueGetter(),
                     secret)
                 {
                     Default = publishValueAsDefault ? new ConstantParameterDefault(valueGetter) : null

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -86,7 +86,7 @@ public static class ParameterResourceBuilderExtensions
         return builder.AddParameter(
                 new ParameterResource(
                     name,
-                    parameterDefault => parameterDefault != null ? parameterDefault.GetDefaultValue() : valueGetter(),
+                    parameterDefault => parameterDefault?.GetDefaultValue() ?? valueGetter(),
                     secret)
                 {
                     Default = publishValueAsDefault ? new ConstantParameterDefault(valueGetter) : null
@@ -116,11 +116,11 @@ public static class ParameterResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a parameter resource to the application, with a value coming from a ParameterDefault.
+    /// Adds a parameter resource to the application, with a value coming from a <see cref="ParameterDefault"/> if not supplied from configuration.
     /// </summary>
     /// <param name="builder">Distributed application builder</param>
     /// <param name="name">Name of parameter resource</param>
-    /// <param name="value">A <see cref="ParameterDefault"/> that is used to provide the parameter value</param>
+    /// <param name="value">A <see cref="ParameterDefault"/> that is used to provide the parameter value if a value is not present in configuration</param>
     /// <param name="secret">Optional flag indicating whether the parameter should be regarded as secret.</param>
     /// <param name="persist">Persist the value to the app host project's user secrets store. This is typically
     /// done when the value is generated, so that it stays stable across runs. This is only relevant when
@@ -142,13 +142,13 @@ public static class ParameterResourceBuilderExtensions
         }
 
         return builder.AddParameter(
-            new ParameterResource(name, p => p!.GetDefaultValue(), secret)
+            new ParameterResource(name, p => GetParameterValue(builder.Configuration, name, value), secret)
             {
                 Default = value
             });
     }
 
-    private static string GetParameterValue(IConfiguration configuration, string name, ParameterDefault? parameterDefault, string? configurationKey = null)
+    private static string GetParameterValue(ConfigurationManager configuration, string name, ParameterDefault? parameterDefault, string? configurationKey = null)
     {
         configurationKey ??= $"Parameters:{name}";
         return configuration[configurationKey]


### PR DESCRIPTION
## Description

This updates the `public static IResourceBuilder<ParameterResource> AddParameter(this IDistributedApplicationBuilder builder, [ResourceName] string name, ParameterDefault value, bool secret = false, bool persist = false)` method to ensure that the parameter value from configuration is used when present. The passed `ParameterDefault` should only be asked for a value if one wasn't otherwise provided.

Fixes #7417

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
