### PR TITLE
Support existing resource functionality on Azure Redis

### DIFF
--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -25,7 +25,7 @@ public static class AzureAppConfigurationExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var store = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+            var store = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = AppConfigurationStore.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -25,7 +25,7 @@ public static class AzureAppConfigurationExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var store = infrastructure.CreateExistingOrNewProvisionableResource(
+            var store = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = AppConfigurationStore.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -32,7 +32,7 @@ public static class AzureEventHubsExtensions
 
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
-            var eventHubsNamespace = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+            var eventHubsNamespace = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = AzureProvisioning.EventHubsNamespace.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -32,7 +32,7 @@ public static class AzureEventHubsExtensions
 
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
-            var eventHubsNamespace = infrastructure.CreateExistingOrNewProvisionableResource(
+            var eventHubsNamespace = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = AzureProvisioning.EventHubsNamespace.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -26,7 +26,7 @@ public static class AzureKeyVaultResourceExtensions
 
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
-            var keyVault = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+            var keyVault = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
             (identifier, name) =>
             {
                 var resource = KeyVaultService.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -26,7 +26,7 @@ public static class AzureKeyVaultResourceExtensions
 
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
-            var keyVault = infrastructure.CreateExistingOrNewProvisionableResource(
+            var keyVault = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
             (identifier, name) =>
             {
                 var resource = KeyVaultService.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
@@ -25,7 +25,7 @@ public static class AzureLogAnalyticsWorkspaceExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var workspace = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+            var workspace = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = OperationalInsightsWorkspace.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
@@ -25,7 +25,7 @@ public static class AzureLogAnalyticsWorkspaceExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var workspace = infrastructure.CreateExistingOrNewProvisionableResource(
+            var workspace = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = OperationalInsightsWorkspace.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -309,7 +309,7 @@ public static class AzurePostgresExtensions
 
     private static PostgreSqlFlexibleServer CreatePostgreSqlFlexibleServer(AzureResourceInfrastructure infrastructure, IDistributedApplicationBuilder distributedApplicationBuilder, IReadOnlyDictionary<string, string> databases)
     {
-        var postgres = infrastructure.CreateExistingOrNewProvisionableResource(
+        var postgres = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
             (identifier, name) =>
             {
                 var resource = PostgreSqlFlexibleServer.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -309,7 +309,7 @@ public static class AzurePostgresExtensions
 
     private static PostgreSqlFlexibleServer CreatePostgreSqlFlexibleServer(AzureResourceInfrastructure infrastructure, IDistributedApplicationBuilder distributedApplicationBuilder, IReadOnlyDictionary<string, string> databases)
     {
-        var postgres = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+        var postgres = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
             (identifier, name) =>
             {
                 var resource = PostgreSqlFlexibleServer.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -198,7 +198,7 @@ public static class AzureRedisExtensions
 
     private static CdkRedisResource CreateRedisResource(AzureResourceInfrastructure infrastructure)
     {
-        return AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+        return AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
         (identifier, name) =>
         {
             var redisResource = (AzureRedisCacheResource)infrastructure.AspireResource;

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -30,7 +30,7 @@ public static class AzureSearchExtensions
 
         void ConfigureSearch(AzureResourceInfrastructure infrastructure)
         {
-            var search = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+            var search = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = SearchService.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -30,7 +30,7 @@ public static class AzureSearchExtensions
 
         void ConfigureSearch(AzureResourceInfrastructure infrastructure)
         {
-            var search = infrastructure.CreateExistingOrNewProvisionableResource(
+            var search = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = SearchService.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -32,7 +32,7 @@ public static class AzureServiceBusExtensions
 
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
-            AzureProvisioning.ServiceBusNamespace serviceBusNamespace = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+            AzureProvisioning.ServiceBusNamespace serviceBusNamespace = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = AzureProvisioning.ServiceBusNamespace.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -32,7 +32,7 @@ public static class AzureServiceBusExtensions
 
         var configureInfrastructure = static (AzureResourceInfrastructure infrastructure) =>
         {
-            AzureProvisioning.ServiceBusNamespace serviceBusNamespace = infrastructure.CreateExistingOrNewProvisionableResource(
+            AzureProvisioning.ServiceBusNamespace serviceBusNamespace = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = AzureProvisioning.ServiceBusNamespace.FromExisting(identifier);
@@ -439,7 +439,7 @@ public static class AzureServiceBusExtensions
     /// Here is an example of how to configure the emulator to use a different logging mechanism:
     /// <code language="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
-    /// 
+    ///
     /// builder.AddAzureServiceBus("servicebusns")
     ///        .RunAsEmulator(configure => configure
     ///            .WithConfiguration(document =>

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -37,7 +37,7 @@ public static class AzureSignalRExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var service = infrastructure.CreateExistingOrNewProvisionableResource((identifier, name) =>
+            var service = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,(identifier, name) =>
             {
                 var resource = SignalRService.FromExisting(identifier);
                 resource.Name = name;

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -37,7 +37,7 @@ public static class AzureSignalRExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var service = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,(identifier, name) =>
+            var service = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,(identifier, name) =>
             {
                 var resource = SignalRService.FromExisting(identifier);
                 resource.Name = name;

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -32,7 +32,7 @@ public static class AzureStorageExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var storageAccount = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+            var storageAccount = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = StorageAccount.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -32,7 +32,7 @@ public static class AzureStorageExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var storageAccount = infrastructure.CreateExistingOrNewProvisionableResource(
+            var storageAccount = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = StorageAccount.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -28,7 +28,7 @@ public static class AzureWebPubSubExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var service = infrastructure.CreateExistingOrNewProvisionableResource(
+            var service = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = WebPubSubService.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -28,7 +28,7 @@ public static class AzureWebPubSubExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var service = AzureProvisioningResourceExtensions.CreateExistingOrNewProvisionableResource(infrastructure,
+            var service = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
                 (identifier, name) =>
                 {
                     var resource = WebPubSubService.FromExisting(identifier);

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
@@ -193,7 +193,7 @@ public static class AzureProvisioningResourceExtensions
     /// <param name="createExisting">A callback to create the existing resource.</param>
     /// <param name="createNew">A callback to create the new resource.</param>
     /// <returns>The provisioned resource.</returns>
-    public static T CreateExistingOrNewProvisionableResource<T>(this AzureResourceInfrastructure infrastructure, Func<string, BicepValue<string>, T> createExisting, Func<AzureResourceInfrastructure, T> createNew)
+    public static T CreateExistingOrNewProvisionableResource<T>(AzureResourceInfrastructure infrastructure, Func<string, BicepValue<string>, T> createExisting, Func<AzureResourceInfrastructure, T> createNew)
         where T : ProvisionableResource
     {
         ArgumentNullException.ThrowIfNull(infrastructure);

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning;
-using Azure.Provisioning.Primitives;
 
 namespace Aspire.Hosting;
 
@@ -182,45 +181,6 @@ public static class AzureProvisioningResourceExtensions
         infrastructure.AspireResource.Parameters[parameterName] = expression;
 
         return GetOrAddParameter(infrastructure, parameterName);
-    }
-
-    /// <summary>
-    /// Encapsulates the logic for creating an existing or new <see cref="ProvisionableResource"/>
-    /// based on whether or not the <see cref="ExistingAzureResourceAnnotation" /> exists on the resource.
-    /// </summary>
-    /// <typeparam name="T">The type of <see cref="ProvisionableResource"/> to produce.</typeparam>
-    /// <param name="infrastructure">The <see cref="AzureResourceInfrastructure"/> that will contain the <see cref="ProvisionableResource"/>.</param>
-    /// <param name="createExisting">A callback to create the existing resource.</param>
-    /// <param name="createNew">A callback to create the new resource.</param>
-    /// <returns>The provisioned resource.</returns>
-    public static T CreateExistingOrNewProvisionableResource<T>(AzureResourceInfrastructure infrastructure, Func<string, BicepValue<string>, T> createExisting, Func<AzureResourceInfrastructure, T> createNew)
-        where T : ProvisionableResource
-    {
-        ArgumentNullException.ThrowIfNull(infrastructure);
-        ArgumentNullException.ThrowIfNull(createExisting);
-        ArgumentNullException.ThrowIfNull(createNew);
-
-        T provisionedResource;
-        if (infrastructure.AspireResource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAnnotation))
-        {
-            var existingResourceName = existingAnnotation.Name is ParameterResource nameParameter
-                ? nameParameter.AsProvisioningParameter(infrastructure)
-                : new BicepValue<string>((string)existingAnnotation.Name);
-            provisionedResource = createExisting(infrastructure.AspireResource.GetBicepIdentifier(), existingResourceName);
-            if (existingAnnotation.ResourceGroup is not null)
-            {
-                var existingResourceGroup = existingAnnotation.ResourceGroup is ParameterResource resourceGroupParameter
-                    ? resourceGroupParameter
-                    : existingAnnotation.ResourceGroup;
-                infrastructure.AspireResource.Scope = new(existingResourceGroup);
-            }
-        }
-        else
-        {
-            provisionedResource = createNew(infrastructure);
-        }
-        infrastructure.Add(provisionedResource);
-        return provisionedResource;
     }
 
     private static ProvisioningParameter GetOrAddParameter(AzureResourceInfrastructure infrastructure, string parameterName, bool? isSecure = null)

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1199,7 +1199,7 @@ public class ExistingAzureResourceTests
     }
 
     [Fact]
-    public async Task SupportsExistingAzureRedisWithResouceGroupAndAccessKeyAuth()
+    public async Task SupportsExistingAzureRedisWithResourceGroupAndAccessKeyAuth()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1171,9 +1171,13 @@ public class ExistingAzureResourceTests
         var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
+
             param existingResourceName string
+
             param principalId string
+
             param principalName string
+
             resource redis 'Microsoft.Cache/redis@2024-03-01' existing = {
               name: existingResourceName
               properties: {
@@ -1183,6 +1187,7 @@ public class ExistingAzureResourceTests
                 }
               }
             }
+
             resource redis_contributor 'Microsoft.Cache/redis/accessPolicyAssignments@2024-03-01' = {
               name: take('rediscontributor${uniqueString(resourceGroup().id)}', 24)
               properties: {
@@ -1192,6 +1197,7 @@ public class ExistingAzureResourceTests
               }
               parent: redis
             }
+
             output connectionString string = '${redis.properties.hostName},ssl=true'
             """;
 
@@ -1199,7 +1205,7 @@ public class ExistingAzureResourceTests
     }
 
     [Fact]
-    public async Task SupportsExistingAzureRedisWithResourceGroupAndAccessKeyAuth()
+    public async Task SupportsExistingAzureRedisWithResouceGroupAndAccessKeyAuth()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
@@ -1228,16 +1234,20 @@ public class ExistingAzureResourceTests
         var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
+
             param keyVaultName string
+
             resource redis 'Microsoft.Cache/redis@2024-03-01' existing = {
               name: 'existingResourceName'
               properties: {
                 disableAccessKeyAuthentication: false
               }
             }
+
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
+
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -993,4 +993,126 @@ public class ExistingAzureResourceTests
 
         Assert.Equal(expectedBicep, BicepText);
     }
+
+    [Fact]
+    public async Task SupportsExistingAzureRedisWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var redis = builder.AddAzureRedis("redis")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(redis.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{redis.outputs.connectionString}",
+              "path": "redis.module.bicep",
+              "params": {
+                "existingResourceName": "{existingResourceName.value}",
+                "principalId": "",
+                "principalName": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param existingResourceName string
+
+            param principalId string
+
+            param principalName string
+
+            resource redis 'Microsoft.Cache/redis@2024-03-01' existing = {
+              name: existingResourceName
+              properties: {
+                disableAccessKeyAuthentication: true
+                redisConfiguration: {
+                  'aad-enabled': 'true'
+                }
+              }
+            }
+
+            resource redis_contributor 'Microsoft.Cache/redis/accessPolicyAssignments@2024-03-01' = {
+              name: take('rediscontributor${uniqueString(resourceGroup().id)}', 24)
+              properties: {
+                accessPolicyName: 'Data Contributor'
+                objectId: principalId
+                objectIdAlias: principalName
+              }
+              parent: redis
+            }
+
+            output connectionString string = '${redis.properties.hostName},ssl=true'
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingAzureRedisWithResouceGroupAndAccessKeyAuth()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var redis = builder.AddAzureRedis("redis")
+            .PublishAsExisting("existingResourceName", "existingResourceGroupName")
+            .WithAccessKeyAuthentication();
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(redis.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{redis.secretOutputs.connectionString}",
+              "path": "redis.module.bicep",
+              "params": {
+                "keyVaultName": ""
+              },
+              "scope": {
+                "resourceGroup": "existingResourceGroupName"
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param keyVaultName string
+
+            resource redis 'Microsoft.Cache/redis@2024-03-01' existing = {
+              name: 'existingResourceName'
+              properties: {
+                disableAccessKeyAuthentication: false
+              }
+            }
+
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+              name: keyVaultName
+            }
+
+            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+              name: 'connectionString'
+              properties: {
+                value: '${redis.properties.hostName},ssl=true,password=${redis.listKeys().primaryKey}'
+              }
+              parent: keyVault
+            }
+            """;
+
+        Assert.Equal(expectedBicep, BicepText);
+    }
 }


### PR DESCRIPTION
- Make `CreateExistingOrNewProvisionableResource` a non-extension method to reduce discoverability for users outside core framework
- Add existing resource support to Azure Redis resource
  - Note: I needed to create a workaround here since setting `IsExistingResource` freezes the access key configuration property. 