### PR TITLE
Add ability to clean up DCP resources synchronously

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -165,6 +165,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         var additionalConfig = new Dictionary<string, string?>();
         SetDefault("DcpPublisher:ContainerRuntimeInitializationTimeout", "00:00:30");
         SetDefault("DcpPublisher:RandomizePorts", "true");
+        SetDefault("DcpPublisher:WaitForResourceCleanup", "true");
 
         // Make sure we have a dashboard URL and OTLP endpoint URL.
         SetDefault("ASPNETCORE_URLS", "http://localhost:8080");

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -175,6 +175,11 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
 
         try
         {
+            if (_options.Value.WaitForResourceCleanup)
+            {
+                await _kubernetesService.CleanupResourcesAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             // The app orchestrator (represented by kubernetesService here) will perform a resource cleanup
             // (if not done already) when the app host process exits.
             // This is just a perf optimization, so we do not care that much if this call fails.

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -81,6 +81,13 @@ internal sealed class DcpOptions
     public TimeSpan ContainerRuntimeInitializationTimeout { get; set; }
 
     public TimeSpan ServiceStartupWatchTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Whether to wait for resource cleanup to end when stopping DcpExecutor.
+    /// This guarantees that application resources (programs, transient containers etc.) are stopped
+    /// before DcpExecutor.StopAsync() returns. Default is false (resources are cleaned up asynchronously).
+    /// </summary>
+    public bool WaitForResourceCleanup { get; set; }
 }
 
 internal class ValidateDcpOptions : IValidateOptions<DcpOptions>
@@ -180,6 +187,7 @@ internal class ConfigureDefaultDcpOptions(
         }
 
         options.RandomizePorts = dcpPublisherConfiguration.GetValue(nameof(options.RandomizePorts), options.RandomizePorts);
+        options.WaitForResourceCleanup = dcpPublisherConfiguration.GetValue(nameof(options.WaitForResourceCleanup), options.WaitForResourceCleanup);
         options.ServiceStartupWatchTimeout = configuration.GetValue("DOTNET_ASPIRE_SERVICE_STARTUP_WATCH_TIMEOUT", options.ServiceStartupWatchTimeout);
         options.ContainerRuntimeInitializationTimeout = dcpPublisherConfiguration.GetValue(nameof(options.ContainerRuntimeInitializationTimeout), options.ContainerRuntimeInitializationTimeout);
     }

--- a/src/Aspire.Hosting/Dcp/DcpVersion.cs
+++ b/src/Aspire.Hosting/Dcp/DcpVersion.cs
@@ -5,7 +5,7 @@ namespace Aspire.Hosting.Dcp;
 
 internal static class DcpVersion
 {
-    public static Version MinimumVersionInclusive = new Version(0, 10, 0); // Aspire 9.1 release
+    public static Version MinimumVersionInclusive = new Version(0, 11, 0); // Aspire 9.1 release
 
     /// <summary>
     /// Development build version proxy, considered always "current" and supporting latest features. 

--- a/src/Aspire.Hosting/Dcp/Model/Admin.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Admin.cs
@@ -12,8 +12,15 @@ internal sealed class ApiServerExecution
     [JsonPropertyName("status")]
     public string? ApiServerStatus { get; set; }
 
+    // Requested resource cleanup type.
     [JsonPropertyName("shutdownResourceCleanup")]
     public string? ShutdownResourceCleanup { get; set; } = ResourceCleanup.Full;
+
+    // Indicates whether the resources have been cleaned up.
+    public bool ResourcesCleanedUp =>
+        ApiServerStatus is not null && (
+        ApiServerStatus == Model.ApiServerStatus.CleanupComplete ||
+        ApiServerStatus == Model.ApiServerStatus.Stopping);
 }
 
 internal static class ApiServerStatus
@@ -21,11 +28,16 @@ internal static class ApiServerStatus
     // The server is running (default state).
     public const string Running = "Running";
 
-    // The server is stopping (also used for programmatic server stoppage).
+    // The server is stopping/shutting down (also used for programmatic server stoppage).
+    // This includes resource cleanup if it was not initiated previously.
     public const string Stopping = "Stopping";
 
-    // The server has stopped (final state).
-    public const string Stopped = "Stopped";
+    // The server is in te process of cleaning up resources
+    // (also used for triggering the resource cleanup without stopping the server).
+    public const string CleaningResources = "CleaningResources";
+
+    // The server completed resource cleanup.
+    public const string CleanupComplete = "CleanupComplete";
 }
 
 internal static class ResourceCleanup

--- a/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationHttpClientExtensionsForTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationHttpClientExtensionsForTests.cs
@@ -2,16 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
 
 namespace Aspire.Hosting.Testing.Tests;
 
 internal static class DistributedApplicationHttpClientExtensionsForTests
 {
     private static readonly Lazy<IHttpClientFactory> s_httpClientFactory = new(CreateHttpClientFactoryWithResilience);
-    public static HttpClient CreateHttpClientWithResilience(this DistributedApplication app, string resourceName, string? endpointName = default)
+    public static HttpClient CreateHttpClientWithResilience(this DistributedApplication app, string resourceName, string? endpointName = default, Action<HttpStandardResilienceOptions>? configure = default)
     {
         var baseUri = app.GetEndpoint(resourceName, endpointName);
-        var client = s_httpClientFactory.Value.CreateClient();
+        HttpClient client;
+        if (configure is not null)
+        {
+            var factory = CreateHttpClientFactoryWithResilience(configure);
+            client = factory.CreateClient();
+        }
+        else
+        {
+            client = s_httpClientFactory.Value.CreateClient();
+        }
         client.BaseAddress = baseUri;
         return client;
     }
@@ -23,6 +33,18 @@ internal static class DistributedApplicationHttpClientExtensionsForTests
             .ConfigureHttpClientDefaults(b =>
             {
                 b.AddStandardResilienceHandler();
+            });
+
+        return services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();
+    }
+
+    private static IHttpClientFactory CreateHttpClientFactoryWithResilience(Action<HttpStandardResilienceOptions> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddHttpClient()
+            .ConfigureHttpClientDefaults(b =>
+            {
+                b.AddStandardResilienceHandler(configure);
             });
 
         return services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -388,7 +388,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
         await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
         // Explicitly get the HTTPS endpoint - this is only available on the "https" launch profile.
-        var httpClient = app.CreateHttpClient("mywebapp1", "https");
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1", "https");
         var result = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast");
         Assert.NotNull(result);
         Assert.True(result.Length > 0);
@@ -409,7 +409,6 @@ public class TestingBuilderTests(ITestOutputHelper output)
     {
         var timeout = TimeSpan.FromMinutes(5);
         using var cts = new CancellationTokenSource(timeout);
-        DistributedApplication? app = null;
 
         IDistributedApplicationTestingBuilder builder;
         if (crashArg == "before-build")
@@ -429,7 +428,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
 
         cts.CancelAfter(timeout);
         builder.WithTestAndResourceLogging(output);
-        app = await builder.BuildAsync().WaitAsync(cts.Token);
+        using var app = await builder.BuildAsync().WaitAsync(cts.Token);
 
         cts.CancelAfter(timeout);
         if (crashArg == "after-build")

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -18,6 +18,8 @@ namespace Aspire.Hosting.Testing.Tests;
 
 public class TestingBuilderTests(ITestOutputHelper output)
 {
+    private static readonly TimeSpan s_appAliveCheckTimeout = TimeSpan.FromMinutes(1);
+
     [Fact]
     public void TestingBuilderHasAllPropertiesFromRealBuilder()
     {
@@ -164,7 +166,10 @@ public class TestingBuilderTests(ITestOutputHelper output)
         // Wait for the application to be ready
         await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
-        var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
+        {
+            opts.TotalRequestTimeout.Timeout = s_appAliveCheckTimeout;
+        });
         var result1 = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast");
         Assert.NotNull(result1);
         Assert.True(result1.Length > 0);
@@ -198,7 +203,8 @@ public class TestingBuilderTests(ITestOutputHelper output)
         string[] args = directArgs ? ["APP_HOST_ARG=42"] : [];
         Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder = directArgs switch
         {
-            true => (_, _) => { },
+            true => (_, _) => { }
+            ,
             false => (dao, habs) => habs.Args = ["APP_HOST_ARG=42"]
         };
 
@@ -219,7 +225,10 @@ public class TestingBuilderTests(ITestOutputHelper output)
         // Wait for the application to be ready
         await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
-        var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
+        {
+            opts.TotalRequestTimeout.Timeout = s_appAliveCheckTimeout;
+        });
         var appHostArg = await httpClient.GetStringAsync("/get-app-host-arg");
         Assert.NotNull(appHostArg);
         Assert.Equal("42", appHostArg);
@@ -254,7 +263,10 @@ public class TestingBuilderTests(ITestOutputHelper output)
         // Wait for the application to be ready
         await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
-        var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
+        {
+            opts.TotalRequestTimeout.Timeout = s_appAliveCheckTimeout;
+        });
         var appHostArg = await httpClient.GetStringAsync("/get-app-host-arg");
         Assert.NotNull(appHostArg);
         Assert.Equal("42", appHostArg);
@@ -294,7 +306,10 @@ public class TestingBuilderTests(ITestOutputHelper output)
         // Wait for the application to be ready
         await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
-        var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
+        {
+            opts.TotalRequestTimeout.Timeout = s_appAliveCheckTimeout;
+        });
         var appHostArg = await httpClient.GetStringAsync("/get-launch-profile-var");
         Assert.NotNull(appHostArg);
         Assert.Equal($"it-is-{launchProfileName}", appHostArg);
@@ -341,7 +356,10 @@ public class TestingBuilderTests(ITestOutputHelper output)
         // Wait for the application to be ready
         await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
-        var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
+        {
+            opts.TotalRequestTimeout.Timeout = s_appAliveCheckTimeout;
+        });
         var appHostArg = await httpClient.GetStringAsync("/get-launch-profile-var");
         Assert.NotNull(appHostArg);
         Assert.Equal($"it-is-{launchProfileName}", appHostArg);
@@ -388,7 +406,10 @@ public class TestingBuilderTests(ITestOutputHelper output)
         await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
         // Explicitly get the HTTPS endpoint - this is only available on the "https" launch profile.
-        var httpClient = app.CreateHttpClientWithResilience("mywebapp1", "https");
+        var httpClient = app.CreateHttpClientWithResilience("mywebapp1", "https", opts =>
+        {
+            opts.TotalRequestTimeout.Timeout = s_appAliveCheckTimeout;
+        });
         var result = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast");
         Assert.NotNull(result);
         Assert.True(result.Length > 0);

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
@@ -20,7 +20,7 @@ public class TestingFactoryCrashTests
         var timeout = TimeSpan.FromMinutes(5);
         using var cts = new CancellationTokenSource(timeout);
 
-        var factory = new DistributedApplicationFactory(typeof(Projects.TestingAppHost1_AppHost), [$"--crash-{crashArg}"]);
+        using var factory = new DistributedApplicationFactory(typeof(Projects.TestingAppHost1_AppHost), [$"--crash-{crashArg}"]);
 
         if (crashArg is "before-build" or "after-build")
         {

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -158,4 +158,9 @@ internal sealed class TestKubernetesService : IKubernetesService
 
         return Task.CompletedTask;
     }
+
+    public Task CleanupResourcesAsync(CancellationToken cancellationToken = default)
+    {
+        return StopServerAsync("Full", cancellationToken);
+    }
 }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -348,7 +348,7 @@ public class DistributedApplicationTests
                 Assert.Equal(["--add-host", "testlocalhost:127.0.0.1"], item.Spec.RunArgs);
             });
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]
@@ -402,7 +402,7 @@ public class DistributedApplicationTests
         redisContainer = await KubernetesHelper.GetResourceByNameMatchAsync<Container>(kubernetes, containerPattern, r => r.Status?.State == ContainerState.Running, token);
         Assert.NotNull(redisContainer);
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]
@@ -436,7 +436,7 @@ public class DistributedApplicationTests
         serviceA = await KubernetesHelper.GetResourceByNameMatchAsync<Executable>(kubernetes, executablePattern, r => r.Status?.State == ExecutableState.Running).DefaultTimeout(TestConstants.LongTimeoutDuration);
         Assert.NotNull(serviceA);
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]
@@ -488,7 +488,7 @@ public class DistributedApplicationTests
         Assert.False(string.IsNullOrEmpty(nodeAppPortValue));
         Assert.NotEqual(0, int.Parse(nodeAppPortValue, CultureInfo.InvariantCulture));
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         static string? GetEnv(IEnumerable<EnvVar>? envVars, string name)
         {
@@ -529,7 +529,7 @@ public class DistributedApplicationTests
         var keyBytes = Convert.FromHexString(GetEnv(aspireDashboard.Spec.Env, "DASHBOARD__OTLP__PRIMARYAPIKEY")!);
         Assert.Equal(16, keyBytes.Length);
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         static string? GetEnv(IEnumerable<EnvVar>? envVars, string name)
         {
@@ -565,7 +565,7 @@ public class DistributedApplicationTests
         Assert.Equal("Unsecured", GetEnv(aspireDashboard.Spec.Env, "DASHBOARD__FRONTEND__AUTHMODE"));
         Assert.Equal("Unsecured", GetEnv(aspireDashboard.Spec.Env, "DASHBOARD__OTLP__AUTHMODE"));
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         static string? GetEnv(IEnumerable<EnvVar>? envVars, string name)
         {
@@ -600,7 +600,7 @@ public class DistributedApplicationTests
         Assert.Equal("redis:latest", redisContainer.Spec.Image);
         Assert.Equal("bob", redisContainer.Spec.Command);
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]
@@ -631,7 +631,7 @@ public class DistributedApplicationTests
         Assert.NotEmpty(redisContainer.Spec.VolumeMounts);
         Assert.Equal(sourcePath, redisContainer.Spec.VolumeMounts[0].Source);
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]
@@ -662,7 +662,7 @@ public class DistributedApplicationTests
         Assert.NotEqual("etc/path-here", redisContainer.Spec.VolumeMounts[0].Source);
         Assert.True(Path.IsPathRooted(redisContainer.Spec.VolumeMounts[0].Source));
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]
@@ -692,7 +692,7 @@ public class DistributedApplicationTests
         Assert.NotEmpty(redisContainer.Spec.VolumeMounts);
         Assert.Equal($"{testName}-volume", redisContainer.Spec.VolumeMounts[0].Source);
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]
@@ -936,7 +936,7 @@ public class DistributedApplicationTests
         Assert.Equal($"localhost:1234,password={redis.Resource.PasswordParameter?.Value}", env.Value);
 
         var list = await s.ListAsync<Container>().DefaultTimeout();
-        var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(),$"{testName}-redis-{ReplicaIdRegex}"))) ;
+        var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redis-{ReplicaIdRegex}")));
         Assert.Equal(1234, Assert.Single(redisContainer.Spec.Ports!).HostPort);
 
         var otherRedisEnv = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redisNoPort"));
@@ -945,7 +945,7 @@ public class DistributedApplicationTests
         var otherRedisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redisNoPort-{ReplicaIdRegex}")));
         Assert.Equal(6379, Assert.Single(otherRedisContainer.Spec.Ports!).HostPort);
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]
@@ -990,7 +990,7 @@ public class DistributedApplicationTests
         Assert.Equal($"localhost:1234,password={redis.Resource.PasswordParameter!.Value}", env.Value);
 
         var list = await s.ListAsync<Container>().DefaultTimeout();
-        var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(),$"{testName}-redis-{ReplicaIdRegex}"))) ;
+        var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redis-{ReplicaIdRegex}")));
         Assert.Equal(1234, Assert.Single(redisContainer.Spec.Ports!).HostPort);
 
         var otherRedisEnv = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redisNoPort"));
@@ -999,7 +999,7 @@ public class DistributedApplicationTests
         var otherRedisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redisNoPort-{ReplicaIdRegex}")));
         Assert.Equal(6379, Assert.Single(otherRedisContainer.Spec.Ports!).HostPort);
 
-        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
+++ b/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
@@ -188,11 +188,11 @@ public class DistributedApplicationBuilderEventingTests
         });
 
         using var app = builder.Build();
-        await app.StartAsync().DefaultTimeout();
+        await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
         await beforeResourceStartedTcs.Task.DefaultTimeout();
 
-        await app.StopAsync().DefaultTimeout();
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]
@@ -215,12 +215,12 @@ public class DistributedApplicationBuilderEventingTests
         });
 
         using var app = builder.Build();
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
         var fired = countdownEvent.Wait(TimeSpan.FromSeconds(10));
 
         Assert.True(fired);
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
 
     [Fact]

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -53,6 +53,7 @@ public class TestProgram : IDisposable
 
         builder.Configuration["DcpPublisher:ResourceNameSuffix"] = $"{Random.Shared.Next():x}";
         builder.Configuration["DcpPublisher:RandomizePorts"] = randomizePorts.ToString(CultureInfo.InvariantCulture);
+        builder.Configuration["DcpPublisher:WaitForResourceCleanup"] = "true";
 
         AppBuilder = builder;
 


### PR DESCRIPTION
## Description

Synchronous resource cleanup is useful for tests (and enabled by default). This helps ensure that tests do not put too much stress on container orchestrator (Docker/Podman).

Included are some tweaks to existing test to make them dispose of DCP in more timely fashion. Timeout for app shutdown is extended in several places because the shutdown does synchronous resource cleanup.

Fixes # (issue)
https://github.com/dotnet/aspire/issues/4878

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
