### PR TITLE
Indenting in notification service logging

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -501,9 +501,9 @@ public class ResourceNotificationService : IDisposable
                 {
                     const int spaces = 2;
                     var indent = new string(' ', spaces);
-                    var seperator = Environment.NewLine + indent;
+                    var separator = Environment.NewLine + indent;
 
-                    var result = string.Join(seperator, values);
+                    var result = string.Join(separator, values);
                     if (string.IsNullOrEmpty(result))
                     {
                         return result;

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -485,9 +485,9 @@ public class ResourceNotificationService : IDisposable
                     newState.ResourceReadyEvent is not null,
                     newState.ExitCode,
                     string.Join(", ", newState.Urls.Select(u => $"{u.Name} = {u.Url}")),
-                    string.Join(Environment.NewLine, newState.EnvironmentVariables.Select(e => $"{e.Name} = {e.Value}")),
-                    string.Join(Environment.NewLine, newState.Properties.Select(p => $"{p.Name} = {Stringify(p.Value)}")),
-                    string.Join(Environment.NewLine, newState.HealthReports.Select(p => $"{p.Name} = {Stringify(p.Status)}")));
+                    JoinIndentLines(newState.EnvironmentVariables.Select(e => $"{e.Name} = {e.Value}")),
+                    JoinIndentLines(newState.Properties.Select(p => $"{p.Name} = {Stringify(p.Value)}")),
+                    JoinIndentLines(newState.HealthReports.Select(p => $"{p.Name} = {Stringify(p.Status)}")));
 
                 static string Stringify(object? o) => o switch
                 {
@@ -496,6 +496,22 @@ public class ResourceNotificationService : IDisposable
                     null => "(null)",
                     _ => o.ToString()!
                 };
+
+                static string JoinIndentLines(IEnumerable<string> values)
+                {
+                    const int spaces = 2;
+                    var indent = new string(' ', spaces);
+                    var seperator = Environment.NewLine + indent;
+
+                    var result = string.Join(seperator, values);
+                    if (string.IsNullOrEmpty(result))
+                    {
+                        return result;
+                    }
+
+                    // Indent first line.
+                    return indent + result;
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Make resource notification logs easier to read.

After:

```
Version: 9
Resource dependentresource/dependentresource-fjjytbyn update published:
ResourceType = Container,
CreationTimeStamp = 2025-02-07T01:23:24,
State = { Text = Running, Style = (null) },
HeathStatus = Unhealthy,
ResourceReady = False,
ExitCode = (null),
Urls = {  },
EnvironmentVariables = {
  DIR = 
  PATH = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
  QDRANT__SERVICE__API_KEY = HnY0XayDT1be2qDQDQvnvD
  RUN_MODE = production
  TZ = Etc/UTC
},
Properties = {
  container.image = netaspireci.azurecr.io/qdrant/qdrant:v1.12.1
  container.id = 38432920bc1ddece9b223d8159c90cf629607db2240af7ce47b778aac83e3385
  container.command = (null)
  container.args = ./entrypoint.sh
  container.ports = 6334, 6333
  container.lifetime = Session
  resource.appArgs = (null)
  resource.appArgsSensitivity = (null)
},
HealthReports = {
  dependentresource_check = (null)
}
```