### PR TITLE
Re-execute envvar and arg callbacks when restarting resources V2

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -189,14 +189,16 @@ public static class ResourceExtensions
     {
         var env = new Dictionary<string, string>();
         var executionContext = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(applicationOperation));
-        await resource.ProcessEnvironmentVariableValuesAsync(executionContext,
-                        (key, unprocessed, value, ex) =>
-                        {
-                            if (value is string s)
-                            {
-                                env[key] = s;
-                            }
-                        }).ConfigureAwait(false);
+        await resource.ProcessEnvironmentVariableValuesAsync(
+            executionContext,
+            (key, unprocessed, value, ex) =>
+            {
+                if (value is string s)
+                {
+                    env[key] = s;
+                }
+            },
+            NullLogger.Instance).ConfigureAwait(false);
 
         return env;
     }
@@ -240,15 +242,17 @@ public static class ResourceExtensions
         var args = new List<string>();
 
         var executionContext = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(applicationOperation));
-        await resource.ProcessArgumentValuesAsync(executionContext,
-                        (unprocessed, value, ex, _) =>
-                        {
-                            if (value is string s)
-                            {
-                                args.Add(s);
-                            }
+        await resource.ProcessArgumentValuesAsync(
+            executionContext,
+            (unprocessed, value, ex, _) =>
+            {
+                if (value is string s)
+                {
+                    args.Add(s);
+                }
 
-                        }).ConfigureAwait(false);
+            },
+            NullLogger.Instance).ConfigureAwait(false);
 
         return [.. args];
     }
@@ -258,14 +262,12 @@ public static class ResourceExtensions
         DistributedApplicationExecutionContext executionContext,
         // (unprocessed, processed, exception, isSensitive)
         Action<object?, string?, Exception?, bool> processValue,
-        ILogger? logger = null,
+        ILogger logger,
         string? containerHostName = null,
         CancellationToken cancellationToken = default)
     {
         if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var callbacks))
         {
-            logger ??= NullLogger.Instance;
-
             var args = new List<object>();
             var context = new CommandLineArgsCallbackContext(args, cancellationToken)
             {
@@ -309,14 +311,12 @@ public static class ResourceExtensions
         this IResource resource,
         DistributedApplicationExecutionContext executionContext,
         Action<string, object?, string?, Exception?> processValue,
-        ILogger? logger = null,
+        ILogger logger,
         string? containerHostName = null,
         CancellationToken cancellationToken = default)
     {
         if (resource.TryGetEnvironmentVariables(out var callbacks))
         {
-            logger ??= NullLogger.Instance;
-
             var config = new Dictionary<string, object>();
             var context = new EnvironmentCallbackContext(executionContext, config, cancellationToken)
             {
@@ -357,6 +357,7 @@ public static class ResourceExtensions
     internal static async ValueTask ProcessContainerRuntimeArgValues(
         this IResource resource,
         Action<string?, Exception?> processValue,
+        ILogger logger,
         string? containerHostName = null,
         CancellationToken cancellationToken = default)
     {
@@ -379,7 +380,7 @@ public static class ResourceExtensions
                     var value = arg switch
                     {
                         string s => s,
-                        IValueProvider valueProvider => (await GetValue(key: null, valueProvider, NullLogger.Instance, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false))?.Value,
+                        IValueProvider valueProvider => (await GetValue(key: null, valueProvider, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false))?.Value,
                         { } obj => obj.ToString(),
                         null => null
                     };

--- a/src/Aspire.Hosting/Dcp/AppResource.cs
+++ b/src/Aspire.Hosting/Dcp/AppResource.cs
@@ -16,8 +16,6 @@ internal class AppResource : IResourceReference
     public virtual List<ServiceAppResource> ServicesProduced { get; } = [];
     public virtual List<ServiceAppResource> ServicesConsumed { get; } = [];
 
-    public bool IsInitialized { get; set; }
-
     public AppResource(IResource modelResource, CustomResource dcpResource)
     {
         ModelResource = modelResource;

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1547,6 +1547,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
                     runArgs.Add(s);
                 }
             },
+            resourceLogger,
             DefaultContainerHostName,
             cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1569,9 +1569,11 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             switch (sp.EndpointAnnotation.Protocol)
             {
                 case ProtocolType.Tcp:
-                    portSpec.Protocol = PortProtocol.TCP; break;
+                    portSpec.Protocol = PortProtocol.TCP;
+                    break;
                 case ProtocolType.Udp:
-                    portSpec.Protocol = PortProtocol.UDP; break;
+                    portSpec.Protocol = PortProtocol.UDP;
+                    break;
             }
 
             ports.Add(portSpec);

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -963,8 +963,6 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
 
     private async Task CreateExecutableAsync(AppResource er, ILogger resourceLogger, CancellationToken cancellationToken)
     {
-        er.IsInitialized = true;
-
         ExecutableSpec spec;
         Func<Task<CustomResource>> createResource;
 
@@ -978,48 +976,8 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
                 throw new InvalidOperationException($"Expected an Executable resource, but got {er.DcpResource.Kind} instead");
         }
 
-        var failedToApplyArgs = false;
-        var failedToApplyConfiguration = false;
-
-        spec.Args ??= [];
-
-        await er.ModelResource.ProcessArgumentValuesAsync(_executionContext, (unprocessed, value, ex, isSensitive) =>
-        {
-            if (ex is not null)
-            {
-                failedToApplyArgs = true;
-
-                resourceLogger.LogCritical(ex, "Failed to apply argument value '{ArgKey}'. A dependency may have failed to start.", ex.Data["ArgKey"]);
-                _logger.LogDebug(ex, "Failed to apply argument value '{ArgKey}' to '{ResourceName}'. A dependency may have failed to start.", ex.Data["ArgKey"], er.ModelResource.Name);
-            }
-            else if (value is { } argument)
-            {
-                er.DcpResource.AnnotateAsObjectList(CustomResource.ResourceAppArgsAnnotation, new AppLaunchArgumentAnnotation(argument, isSensitive: isSensitive));
-                spec.Args.Add(argument);
-            }
-        },
-        resourceLogger,
-        DefaultContainerHostName,
-        cancellationToken).ConfigureAwait(false);
-
-        spec.Env = [];
-
-        await er.ModelResource.ProcessEnvironmentVariableValuesAsync(_executionContext, (key, unprocessed, value, ex) =>
-        {
-            if (ex is not null)
-            {
-                failedToApplyConfiguration = true;
-                resourceLogger.LogCritical(ex, "Failed to apply environment variable '{Name}'. A dependency may have failed to start.", key);
-                _logger.LogDebug(ex, "Failed to apply environment variable '{Name}' to '{ResourceName}'. A dependency may have failed to start.", key, er.ModelResource.Name);
-            }
-            else if (value is string s)
-            {
-                spec.Env.Add(new EnvVar { Name = key, Value = s });
-            }
-        },
-        resourceLogger,
-        DefaultContainerHostName,
-        cancellationToken).ConfigureAwait(false);
+        (spec.Args, var failedToApplyArgs) = await BuildArgsAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
+        (spec.Env, var failedToApplyConfiguration) = await BuildEnvVarsAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
 
         if (failedToApplyConfiguration || failedToApplyArgs)
         {
@@ -1122,8 +1080,6 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
 
             async Task CreateContainerAsyncCore(AppResource cr, CancellationToken cancellationToken)
             {
-                cr.IsInitialized = true;
-
                 var logger = _loggerService.GetLogger(cr.ModelResource);
 
                 try
@@ -1181,108 +1137,25 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
 
         await ApplyBuildArgumentsAsync(dcpContainerResource, modelContainerResource, cancellationToken).ConfigureAwait(false);
 
-        var config = new Dictionary<string, object>();
-
-        dcpContainerResource.Spec.Env = [];
+        var spec = dcpContainerResource.Spec;
 
         if (cr.ServicesProduced.Count > 0)
         {
-            dcpContainerResource.Spec.Ports = new();
-
-            foreach (var sp in cr.ServicesProduced)
-            {
-                var ea = sp.EndpointAnnotation;
-
-                var portSpec = new ContainerPortSpec()
-                {
-                    ContainerPort = ea.TargetPort,
-                };
-
-                if (!ea.IsProxied && ea.Port is int)
-                {
-                    portSpec.HostPort = ea.Port;
-                }
-
-                switch (sp.EndpointAnnotation.Protocol)
-                {
-                    case ProtocolType.Tcp:
-                        portSpec.Protocol = PortProtocol.TCP; break;
-                    case ProtocolType.Udp:
-                        portSpec.Protocol = PortProtocol.UDP; break;
-                }
-
-                dcpContainerResource.Spec.Ports.Add(portSpec);
-            }
+            spec.Ports = BuildContainerPorts(cr);
         }
 
-        var failedToApplyConfiguration = false;
-        var failedToApplyArgs = false;
+        (spec.RunArgs, var failedToApplyRunArgs) = await BuildRunArgsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
 
-        var spec = dcpContainerResource.Spec;
+        (spec.Args, var failedToApplyArgs) = await BuildArgsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
 
-        spec.RunArgs = [];
-        await cr.ModelResource.ProcessContainerRuntimeArgValues((a, ex) =>
-        {
-            if (ex is not null)
-            {
-                failedToApplyArgs = true;
-                resourceLogger.LogCritical(ex, "Failed to apply argument value '{ArgKey}'. A dependency may have failed to start.", a);
-                _logger.LogDebug(ex, "Failed to apply argument value '{ArgKey}' to '{ResourceName}'. A dependency may have failed to start.", a, cr.ModelResource.Name);
-            }
-            else if (a is string s)
-            {
-                spec.RunArgs.Add(s);
-            }
-        },
-        DefaultContainerHostName,
-        cancellationToken).ConfigureAwait(false);
-
-        spec.Args ??= [];
-
-        await cr.ModelResource.ProcessArgumentValuesAsync(_executionContext, (unprocessed, value, ex, isSensitive) =>
-        {
-            if (ex is not null)
-            {
-                failedToApplyArgs = true;
-
-                resourceLogger.LogCritical(ex, "Failed to apply argument value '{ArgKey}'. A dependency may have failed to start.", value);
-                _logger.LogDebug(ex, "Failed to apply argument value '{ArgKey}' to '{ResourceName}'. A dependency may have failed to start.", value, cr.ModelResource.Name);
-            }
-            else if (value is { } argument)
-            {
-                cr.DcpResource.AnnotateAsObjectList(CustomResource.ResourceAppArgsAnnotation, new AppLaunchArgumentAnnotation(argument, isSensitive: isSensitive));
-                spec.Args.Add(argument);
-            }
-        },
-        resourceLogger,
-        DefaultContainerHostName,
-        cancellationToken).ConfigureAwait(false);
-
-        spec.Env = [];
-
-        await cr.ModelResource.ProcessEnvironmentVariableValuesAsync(_executionContext, (key, unprocessed, value, ex) =>
-        {
-            if (ex is not null)
-            {
-                failedToApplyConfiguration = true;
-                resourceLogger.LogCritical(ex, "Failed to apply environment variable '{Name}'. A dependency may have failed to start.", key);
-                _logger.LogDebug(ex, "Failed to apply environment variable '{Name}' to '{ResourceName}'. A dependency may have failed to start.", key, cr.ModelResource.Name);
-            }
-            else if (value is string s)
-            {
-                spec.Env.Add(new EnvVar { Name = key, Value = s });
-            }
-        },
-        resourceLogger,
-        DefaultContainerHostName,
-        cancellationToken).ConfigureAwait(false);
+        (spec.Env, var failedToApplyConfiguration) = await BuildEnvVarsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
 
         if (modelContainerResource is ContainerResource containerResource)
         {
-            dcpContainerResource.Spec.Command = containerResource.Entrypoint;
+            spec.Command = containerResource.Entrypoint;
         }
 
-        if (failedToApplyArgs || failedToApplyConfiguration)
+        if (failedToApplyRunArgs || failedToApplyArgs || failedToApplyConfiguration)
         {
             throw new FailedToApplyEnvironmentException();
         }
@@ -1519,47 +1392,48 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
     {
         var appResource = (AppResource)resourceReference;
         var resourceType = GetResourceType(appResource.DcpResource, appResource.ModelResource);
+        var resourceLogger = _loggerService.GetLogger(appResource.DcpResourceName);
 
         try
         {
+            _logger.LogDebug("Starting {ResourceType} '{ResourceName}'.", resourceType, appResource.DcpResourceName);
+
+            // Raise event after resource has been deleted. This is required because the event sets the status to "Starting" and resources being
+            // deleted will temporarily override the status to a terminal state, such as "Exited".
             switch (appResource.DcpResource)
             {
                 case Container c:
-                    if (appResource.IsInitialized)
-                    {
-                        await StartExecutableOrContainerAsync(c).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await CreateContainerAsync(appResource, _loggerService.GetLogger(appResource.ModelResource), cancellationToken).ConfigureAwait(false);
-                    }
+                    await EnsureResourceDeletedAsync<Container>(appResource.DcpResourceName).ConfigureAwait(false);
+
+                    await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, appResource.ModelResource, appResource.DcpResourceName)).ConfigureAwait(false);
+                    await CreateContainerAsync(appResource, resourceLogger, cancellationToken).ConfigureAwait(false);
                     break;
                 case Executable e:
-                    if (appResource.IsInitialized)
-                    {
-                        await StartExecutableOrContainerAsync(e).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await CreateExecutableAsync(appResource, _loggerService.GetLogger(appResource.ModelResource), cancellationToken).ConfigureAwait(false);
-                    }
+                    await EnsureResourceDeletedAsync<Executable>(appResource.DcpResourceName).ConfigureAwait(false);
+
+                    await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, appResource.ModelResource, appResource.DcpResourceName)).ConfigureAwait(false);
+                    await CreateExecutableAsync(appResource, resourceLogger, cancellationToken).ConfigureAwait(false);
                     break;
                 default:
                     throw new InvalidOperationException($"Unexpected resource type: {appResource.DcpResource.GetType().FullName}");
             }
         }
+        catch (FailedToApplyEnvironmentException)
+        {
+            // For this exception we don't want the noise of the stack trace, we've already
+            // provided more detail where we detected the issue (e.g. envvar name). To get
+            // more diagnostic information reduce logging level for DCP log category to Debug.
+            await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, appResource.ModelResource, appResource.DcpResourceName)).ConfigureAwait(false);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to start resource {ResourceName}", appResource.ModelResource.Name);
-            await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, appResource.ModelResource, appResource.DcpResource.Metadata.Name)).ConfigureAwait(false);
+            await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, appResource.ModelResource, appResource.DcpResourceName)).ConfigureAwait(false);
             throw;
         }
 
-        async Task StartExecutableOrContainerAsync<T>(T resource) where T : CustomResource
+        async Task EnsureResourceDeletedAsync<T>(string resourceName) where T : CustomResource
         {
-            var resourceName = resource.Metadata.Name;
-            _logger.LogDebug("Starting {ResourceType} '{ResourceName}'.", typeof(T).Name, resourceName);
-
             var resourceNotFound = false;
             try
             {
@@ -1589,14 +1463,120 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
                     {
                         // Success.
                     }
-                }, resource.Metadata.Name, cancellationToken).ConfigureAwait(false);
+                }, resourceName, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task<(List<string>, bool)> BuildArgsAsync(ILogger resourceLogger, IResource modelResource, CancellationToken cancellationToken)
+    {
+        var failedToApplyArgs = false;
+        var args = new List<string>();
+
+        await modelResource.ProcessArgumentValuesAsync(
+            _executionContext,
+            (unprocessed, value, ex) =>
+            {
+                if (ex is not null)
+                {
+                    failedToApplyArgs = true;
+
+                    resourceLogger.LogCritical(ex, "Failed to apply argument value '{ArgKey}'. A dependency may have failed to start.", ex.Data["ArgKey"]);
+                    _logger.LogDebug(ex, "Failed to apply argument value '{ArgKey}' to '{ResourceName}'. A dependency may have failed to start.", ex.Data["ArgKey"], modelResource.Name);
+                }
+                else if (value is string a)
+                {
+                    args.Add(a);
+                }
+            },
+            resourceLogger,
+            DefaultContainerHostName,
+            cancellationToken).ConfigureAwait(false);
+
+        return (args, failedToApplyArgs);
+    }
+
+    private async Task<(List<EnvVar>, bool)> BuildEnvVarsAsync(ILogger resourceLogger, IResource modelResource, CancellationToken cancellationToken)
+    {
+        var failedToApplyConfiguration = false;
+        var env = new List<EnvVar>();
+
+        await modelResource.ProcessEnvironmentVariableValuesAsync(
+            _executionContext,
+            (key, unprocessed, value, ex) =>
+            {
+                if (ex is not null)
+                {
+                    failedToApplyConfiguration = true;
+                    resourceLogger.LogCritical(ex, "Failed to apply environment variable '{Name}'. A dependency may have failed to start.", key);
+                    _logger.LogDebug(ex, "Failed to apply environment variable '{Name}' to '{ResourceName}'. A dependency may have failed to start.", key, modelResource.Name);
+                }
+                else if (value is string s)
+                {
+                    env.Add(new EnvVar { Name = key, Value = s });
+                }
+            },
+            resourceLogger,
+            DefaultContainerHostName,
+            cancellationToken).ConfigureAwait(false);
+
+        return (env, failedToApplyConfiguration);
+    }
+
+    private async Task<(List<string>, bool)> BuildRunArgsAsync(ILogger resourceLogger, IResource modelResource, CancellationToken cancellationToken)
+    {
+        var failedToApplyArgs = false;
+        var runArgs = new List<string>();
+
+        await modelResource.ProcessContainerRuntimeArgValues(
+            (a, ex) =>
+            {
+                if (ex is not null)
+                {
+                    failedToApplyArgs = true;
+                    resourceLogger.LogCritical(ex, "Failed to apply argument value '{ArgKey}'. A dependency may have failed to start.", a);
+                    _logger.LogDebug(ex, "Failed to apply argument value '{ArgKey}' to '{ResourceName}'. A dependency may have failed to start.", a, modelResource.Name);
+                }
+                else if (a is string s)
+                {
+                    runArgs.Add(s);
+                }
+            },
+            DefaultContainerHostName,
+            cancellationToken).ConfigureAwait(false);
+
+        return (runArgs, failedToApplyArgs);
+    }
+
+    private static List<ContainerPortSpec> BuildContainerPorts(AppResource cr)
+    {
+        var ports = new List<ContainerPortSpec>();
+
+        foreach (var sp in cr.ServicesProduced)
+        {
+            var ea = sp.EndpointAnnotation;
+
+            var portSpec = new ContainerPortSpec()
+            {
+                ContainerPort = ea.TargetPort,
+            };
+
+            if (!ea.IsProxied && ea.Port is int)
+            {
+                portSpec.HostPort = ea.Port;
             }
 
-            // Raise event after resource has been deleted. This is required because the event sets the status to "Starting" and resources being
-            // deleted will temporarily override the status to a terminal state, such as "Exited".
-            await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, appResource.ModelResource, appResource.DcpResource.Metadata.Name)).ConfigureAwait(false);
+            switch (sp.EndpointAnnotation.Protocol)
+            {
+                case ProtocolType.Tcp:
+                    portSpec.Protocol = PortProtocol.TCP; break;
+                case ProtocolType.Udp:
+                    portSpec.Protocol = PortProtocol.UDP; break;
+            }
 
-            await _kubernetesService.CreateAsync(resource, cancellationToken).ConfigureAwait(false);
+            ports.Add(portSpec);
         }
+
+        return ports;
     }
 }

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -56,6 +56,16 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
         AnnotateAsObjectList<TValue>(Metadata.Annotations, annotationName, value);
     }
 
+    public void SetAnnotationAsObjectList<TValue>(string annotationName, IEnumerable<TValue> list)
+    {
+        if (Metadata.Annotations is null)
+        {
+            Metadata.Annotations = new Dictionary<string, string>();
+        }
+
+        Metadata.Annotations[annotationName] = JsonSerializer.Serialize<List<TValue>>(list.ToList());
+    }
+
     public bool TryGetAnnotationAsObjectList<TValue>(string annotationName, [NotNullWhen(true)] out List<TValue>? list)
     {
         return TryGetAnnotationAsObjectList<TValue>(Metadata.Annotations, annotationName, out list);

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -26,6 +26,7 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
     public const string OtelServiceInstanceIdAnnotation = "otel-service-instance-id";
     public const string ResourceStateAnnotation = "resource-state";
     public const string ResourceAppArgsAnnotation = "resource-app-args";
+    public const string ResourceProjectArgsAnnotation = "resource-project-args";
     public const string ResourceReplicaCount = "resource-replica-count";
     public const string ResourceReplicaIndex = "resource-replica-index";
 

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -6,6 +6,7 @@ using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Publishing;
 
@@ -485,21 +486,22 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
     {
         var env = new Dictionary<string, (object, string)>();
 
-        await resource.ProcessEnvironmentVariableValuesAsync(ExecutionContext,
-                     (key, unprocessed, processed, ex) =>
-                     {
-                         if (ex is not null)
-                         {
-                             ExceptionDispatchInfo.Throw(ex);
-                         }
+        await resource.ProcessEnvironmentVariableValuesAsync(
+            ExecutionContext,
+            (key, unprocessed, processed, ex) =>
+            {
+                if (ex is not null)
+                {
+                    ExceptionDispatchInfo.Throw(ex);
+                }
 
-                         if (unprocessed is not null && processed is not null)
-                         {
-                             env[key] = (unprocessed, processed);
-                         }
-                     },
-                     cancellationToken: CancellationToken)
-                     .ConfigureAwait(false);
+                if (unprocessed is not null && processed is not null)
+                {
+                    env[key] = (unprocessed, processed);
+                }
+            },
+            NullLogger.Instance,
+            cancellationToken: CancellationToken).ConfigureAwait(false);
 
         if (env.Count > 0)
         {
@@ -541,8 +543,8 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                     args.Add((unprocessed, expression));
                 }
             },
-           cancellationToken: CancellationToken)
-          .ConfigureAwait(false);
+            NullLogger.Instance,
+            cancellationToken: CancellationToken).ConfigureAwait(false);
 
         if (args.Count > 0)
         {

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -141,6 +141,7 @@ public class DcpExecutorTests
         var callCount1 = exe1.Spec.Env!.Single(e => e.Name == "CALL_COUNT");
         Assert.Equal("1", callCount1.Value);
 
+        Assert.Single(exe1.Spec.Args!.Where(a => a == "--no-build"));
         Assert.Single(exe1.Spec.Args!.Where(a => a == "--test"));
         Assert.True(exe1.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations1));
         Assert.Single(argAnnotations1.Where(a => a.Argument == "--test"));
@@ -158,8 +159,9 @@ public class DcpExecutorTests
         var callCount2 = exe2.Spec.Env!.Single(e => e.Name == "CALL_COUNT");
         Assert.Equal("2", callCount2.Value);
 
-        Assert.Single(exe1.Spec.Args!.Where(a => a == "--test"));
-        Assert.True(exe1.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations2));
+        Assert.Single(exe2.Spec.Args!.Where(a => a == "--no-build"));
+        Assert.Single(exe2.Spec.Args!.Where(a => a == "--test"));
+        Assert.True(exe2.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations2));
         Assert.Single(argAnnotations2.Where(a => a.Argument == "--test"));
     }
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -105,6 +105,53 @@ public class DcpExecutorTests
     }
 
     [Fact]
+    public async Task ResourceRestarted_EnvironmentCallbacksApplied()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        var callCount = 0;
+        var resource = builder.AddProject<Projects.ServiceA>("ServiceA")
+            .WithEnvironment(c =>
+            {
+                Interlocked.Increment(ref callCount);
+                c.EnvironmentVariables["CALL_COUNT"] = callCount.ToString();
+            }).Resource;
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var dcpOptions = new DcpOptions { DashboardPath = "./dashboard", ResourceNameSuffix = "suffix" };
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions, events: events);
+        await appExecutor.RunApplicationAsync();
+
+        var executables = kubernetesService.CreatedResources.OfType<Executable>().ToList();
+
+        var exe1 = Assert.Single(executables);
+        var callCount1 = exe1.Spec.Env!.Single(e => e.Name == "CALL_COUNT");
+        Assert.Equal("1", callCount1.Value);
+
+        var reference = appExecutor.GetResource(exe1.Metadata.Name);
+
+        await appExecutor.StopResourceAsync(reference, CancellationToken.None);
+
+        await appExecutor.StartResourceAsync(reference, CancellationToken.None);
+
+        executables = kubernetesService.CreatedResources.OfType<Executable>().ToList();
+        Assert.Equal(2, executables.Count);
+
+        var exe2 = executables[1];
+        var callCount2 = exe2.Spec.Env!.Single(e => e.Name == "CALL_COUNT");
+        Assert.Equal("2", callCount2.Value);
+    }
+
+    [Fact]
     public async Task EndpointPortsExecutableNotReplicatedProxiedNoPortNoTargetPort()
     {
         var builder = DistributedApplication.CreateBuilder();
@@ -961,7 +1008,7 @@ public class DcpExecutorTests
         var builder = DistributedApplication.CreateBuilder();
         builder.AddContainer("database", "image");
 
-        var kubernetesService = new TestKubernetesService();
+        var kubernetesService = new TestKubernetesService(ignoreDeletes: true);
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
         var dcpEvents = new DcpExecutorEvents();

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -114,6 +114,10 @@ public class DcpExecutorTests
 
         var callCount = 0;
         var resource = builder.AddProject<Projects.ServiceA>("ServiceA")
+            .WithArgs(c =>
+            {
+                c.Args.Add("--test");
+            })
             .WithEnvironment(c =>
             {
                 Interlocked.Increment(ref callCount);
@@ -137,6 +141,10 @@ public class DcpExecutorTests
         var callCount1 = exe1.Spec.Env!.Single(e => e.Name == "CALL_COUNT");
         Assert.Equal("1", callCount1.Value);
 
+        Assert.Single(exe1.Spec.Args!.Where(a => a == "--test"));
+        Assert.True(exe1.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations1));
+        Assert.Single(argAnnotations1.Where(a => a.Argument == "--test"));
+
         var reference = appExecutor.GetResource(exe1.Metadata.Name);
 
         await appExecutor.StopResourceAsync(reference, CancellationToken.None);
@@ -149,6 +157,10 @@ public class DcpExecutorTests
         var exe2 = executables[1];
         var callCount2 = exe2.Spec.Env!.Single(e => e.Name == "CALL_COUNT");
         Assert.Equal("2", callCount2.Value);
+
+        Assert.Single(exe1.Spec.Args!.Where(a => a == "--test"));
+        Assert.True(exe1.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations2));
+        Assert.Single(argAnnotations2.Where(a => a.Argument == "--test"));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text;
 using k8s.Models;
+using k8s.Autorest;
 
 namespace Aspire.Hosting.Tests.Dcp;
 
@@ -20,18 +21,29 @@ internal sealed class TestKubernetesService : IKubernetesService
     public const int StartOfAutoPortRange = 52000;
 
     public ConcurrentQueue<CustomResource> CreatedResources { get; } = [];
+    public ConcurrentQueue<string> DeletedResources { get; } = [];
 
     private readonly List<Channel<(WatchEventType, CustomResource)>> _watchChannels = [];
     private readonly Func<CustomResource, string, Stream> _startStream;
+    private readonly bool _ignoreDeletes;
     private int _nextPort = StartOfAutoPortRange;
 
-    public TestKubernetesService(Func<CustomResource, string, Stream>? startStream = null)
+    public TestKubernetesService(Func<CustomResource, string, Stream>? startStream = null, bool ignoreDeletes = false)
     {
         _startStream = startStream ?? ((obj, logStreamType) => new MemoryStream(Encoding.UTF8.GetBytes($"Logs for {obj.Metadata.Name} ({logStreamType})")));
+        _ignoreDeletes = ignoreDeletes;
     }
 
     public Task<T> GetAsync<T>(string name, string? namespaceParameter = null, CancellationToken _ = default) where T : CustomResource
     {
+        if (DeletedResources.Contains(name))
+        {
+            throw new HttpOperationException("Not found")
+            {
+                Response = new HttpResponseMessageWrapper(new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.NotFound }, "Not found")
+            };
+        }
+
         var res = CreatedResources.OfType<T>().FirstOrDefault(r =>
             r.Metadata.Name == name &&
             string.Equals(r.Metadata.NamespaceProperty ?? string.Empty, namespaceParameter ?? string.Empty)
@@ -88,9 +100,24 @@ internal sealed class TestKubernetesService : IKubernetesService
         }
     }
 
-    public Task<T> DeleteAsync<T>(string name, string? namespaceParameter = null, CancellationToken cancellationToken = default) where T : CustomResource
+    public async Task<T> DeleteAsync<T>(string name, string? namespaceParameter = null, CancellationToken cancellationToken = default) where T : CustomResource
     {
-        return GetAsync<T>(name, namespaceParameter, cancellationToken);
+        try
+        {
+            var resource = await GetAsync<T>(name, namespaceParameter, cancellationToken);
+            if (!_ignoreDeletes)
+            {
+                DeletedResources.Enqueue(name);
+            }
+            return resource;
+        }
+        catch (Exception ex)
+        {
+            throw new HttpOperationException(ex.Message)
+            {
+                Response = new HttpResponseMessageWrapper(new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.NotFound }, ex.Message)
+            };
+        }
     }
 
     public Task<List<T>> ListAsync<T>(string? namespaceParameter = null, CancellationToken cancellationToken = default) where T : CustomResource

--- a/tests/Aspire.Hosting.Tests/Utils/ArgumentEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/ArgumentEvaluator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.ExceptionServices;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Tests.Utils;
 
@@ -11,18 +12,21 @@ public sealed class ArgumentEvaluator
     {
         var args = new List<string>();
 
-        await resource.ProcessArgumentValuesAsync(new(DistributedApplicationOperation.Run), (_, processed, ex, _) =>
-        {
-            if (ex is not null)
+        await resource.ProcessArgumentValuesAsync(
+            new(DistributedApplicationOperation.Run),
+            (_, processed, ex, _) =>
             {
-                ExceptionDispatchInfo.Throw(ex);
-            }
+                if (ex is not null)
+                {
+                    ExceptionDispatchInfo.Throw(ex);
+                }
 
-            if (processed is string s)
-            {
-                args.Add(s);
-            }
-        });
+                if (processed is string s)
+                {
+                    args.Add(s);
+                }
+            },
+            NullLogger.Instance);
 
         return args;
     }

--- a/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.ExceptionServices;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Tests.Utils;
 
@@ -17,20 +18,22 @@ public static class EnvironmentVariableEvaluator
         });
 
         var environmentVariables = new Dictionary<string, string>();
-        await resource.ProcessEnvironmentVariableValuesAsync(executionContext,
-                        (key, unprocessed, value, ex) =>
-                        {
-                            if (ex is not null)
-                            {
-                                ExceptionDispatchInfo.Throw(ex);
-                            }
+        await resource.ProcessEnvironmentVariableValuesAsync(
+            executionContext,
+            (key, unprocessed, value, ex) =>
+            {
+                if (ex is not null)
+                {
+                    ExceptionDispatchInfo.Throw(ex);
+                }
 
-                            if (value is string s)
-                            {
-                                environmentVariables[key] = s;
-                            }
-                        },
-                        containerHostName: containerHostName);
+                if (value is string s)
+                {
+                    environmentVariables[key] = s;
+                }
+            },
+            NullLogger.Instance,
+            containerHostName: containerHostName);
 
         return environmentVariables;
     }


### PR DESCRIPTION
## Description

Retry of https://github.com/dotnet/aspire/pull/7329

The bug was .NET project args were overwritten on exe resources. The fix is to store them in a custom annotation when preparing the exe resource, and reapply them when the exe is restarted.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
