### PR TITLE
Pass EventHub and ConsumerGroup via EventHub connection strings

### DIFF
--- a/playground/AspireEventHub/EventHubs.AppHost/Program.cs
+++ b/playground/AspireEventHub/EventHubs.AppHost/Program.cs
@@ -6,8 +6,8 @@ var blob = builder.AddAzureStorage("ehstorage")
     .AddBlobs("checkpoints");
 
 var eventHub = builder.AddAzureEventHubs("eventhubns")
-    .RunAsEmulator();
-eventHub.AddHub("hub");
+    .RunAsEmulator()
+    .AddHub("eventhub");
 
 builder.AddProject<Projects.EventHubsConsumer>("consumer")
     .WithReference(eventHub).WaitFor(eventHub)

--- a/playground/AspireEventHub/EventHubsApi/Program.cs
+++ b/playground/AspireEventHub/EventHubsApi/Program.cs
@@ -5,10 +5,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
-builder.AddAzureEventHubProducerClient("eventhubns", settings =>
-{
-    settings.EventHubName = "hub";
-});
+builder.AddAzureEventHubProducerClient("eventhub");
 
 var app = builder.Build();
 

--- a/playground/AspireEventHub/EventHubsConsumer/Program.cs
+++ b/playground/AspireEventHub/EventHubsConsumer/Program.cs
@@ -10,11 +10,7 @@ bool useConsumer = Environment.GetEnvironmentVariable("USE_EVENTHUBCONSUMERCLIEN
 
 if (useConsumer)
 {
-    builder.AddAzureEventHubConsumerClient("eventhubns",
-        settings =>
-        {
-            settings.EventHubName = "hub";
-        });
+    builder.AddAzureEventHubConsumerClient("eventhub");
 
     builder.Services.AddHostedService<Consumer>();
     Console.WriteLine("Starting EventHubConsumerClient...");
@@ -24,11 +20,8 @@ else
     // required for checkpointing our position in the event stream
     builder.AddAzureBlobClient("checkpoints");
 
-    builder.AddAzureEventProcessorClient("eventhubns",
-        settings =>
-        {
-            settings.EventHubName = "hub";
-        });
+    builder.AddAzureEventProcessorClient("eventhub");
+
     builder.Services.AddHostedService<Processor>();
     Console.WriteLine("Starting EventProcessorClient...");
 }

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class AzureEventHubConsumerGroupResource : Resource, IResourceWithParent<AzureEventHubResource>, IResourceWithConnectionString
+public class AzureEventHubConsumerGroupResource : Resource, IResourceWithParent<AzureEventHubResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureEventHubConsumerGroupResource"/> class.
@@ -35,9 +35,14 @@ public class AzureEventHubConsumerGroupResource : Resource, IResourceWithParent<
     public AzureEventHubResource Parent { get; }
 
     /// <summary>
-    /// Gets the connection string expression for the Azure Event Hub.
+    /// Gets the connection string expression for the Azure Event Hub Consumer Group.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
+    public ReferenceExpression ConnectionStringExpression => Parent.Parent.GetConnectionString(Parent.HubName, ConsumerGroupName);
+
+    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
+    {
+        Parent.Parent.ApplyAzureFunctionsConfiguration(target, connectionName, Parent.HubName, ConsumerGroupName);
+    }
 
     /// <summary>
     /// Converts the current instance to a provisioning entity.

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class AzureEventHubResource : Resource, IResourceWithParent<AzureEventHubsResource>, IResourceWithConnectionString
+public class AzureEventHubResource : Resource, IResourceWithParent<AzureEventHubsResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureEventHubResource"/> class.
@@ -43,12 +43,17 @@ public class AzureEventHubResource : Resource, IResourceWithParent<AzureEventHub
     /// <summary>
     /// Gets the connection string expression for the Azure Event Hub.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
+    public ReferenceExpression ConnectionStringExpression => Parent.GetConnectionString(HubName);
 
     /// <summary>
     /// The consumer groups for this hub.
     /// </summary>
     internal List<AzureEventHubConsumerGroupResource> ConsumerGroups { get; } = [];
+
+    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
+    {
+        Parent.ApplyAzureFunctionsConfiguration(target, connectionName, HubName);
+    }
 
     /// <summary>
     /// Converts the current instance to a provisioning entity.

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsResource.cs
@@ -44,12 +44,46 @@ public class AzureEventHubsResource(string name, Action<AzureResourceInfrastruct
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Event Hubs endpoint.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression =>
-        IsEmulator
-        ? ReferenceExpression.Create($"Endpoint=sb://{EmulatorEndpoint.Property(EndpointProperty.Host)}:{EmulatorEndpoint.Property(EndpointProperty.Port)};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")
-        : ReferenceExpression.Create($"{EventHubsEndpoint}");
+    public ReferenceExpression ConnectionStringExpression => GetConnectionString();
 
-    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
+    internal ReferenceExpression GetConnectionString(string? eventHub = null, string? consumerGroup = null)
+    {
+        var builder = new ReferenceExpressionBuilder();
+
+        if (IsEmulator)
+        {
+            builder.Append($"Endpoint=sb://{EmulatorEndpoint.Property(EndpointProperty.Host)}:{EmulatorEndpoint.Property(EndpointProperty.Port)};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true");
+        }
+        else
+        {
+            if (eventHub is null && consumerGroup is null)
+            {
+                // for backwards compatibility - if there is no event hub or consumer group, return just the endpoint
+                builder.AppendFormatted(EventHubsEndpoint);
+            }
+            else
+            {
+                builder.Append($"Endpoint={EventHubsEndpoint}");
+            }
+        }
+
+        if (eventHub is not null)
+        {
+            builder.Append($";EntityPath={eventHub}");
+        }
+
+        if (consumerGroup is not null)
+        {
+            builder.Append($";ConsumerGroup={consumerGroup}");
+        }
+
+        return builder.Build();
+    }
+
+    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName) =>
+        ApplyAzureFunctionsConfiguration(target, connectionName);
+
+    internal void ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName, string? eventHub = null, string? consumerGroup = null)
     {
         if (IsEmulator)
         {
@@ -69,6 +103,19 @@ public class AzureEventHubsResource(string name, Action<AzureResourceInfrastruct
             foreach (var clientName in s_eventHubClientNames)
             {
                 target[$"{ConnectionKeyPrefix}__{clientName}__{connectionName}__FullyQualifiedNamespace"] = EventHubsEndpoint;
+            }
+        }
+
+        // Injected to support Aspire client integration for each EventHubs client in Azure Functions projects.
+        foreach (var clientName in s_eventHubClientNames)
+        {
+            if (eventHub is not null)
+            {
+                target[$"{ConnectionKeyPrefix}__{clientName}__{connectionName}__EventHubName"] = eventHub;
+            }
+            if (consumerGroup is not null)
+            {
+                target[$"{ConnectionKeyPrefix}__{clientName}__{connectionName}__ConsumerGroup"] = consumerGroup;
             }
         }
     }


### PR DESCRIPTION
## Description

This allows for developers to not have to hard code, or pass their own configuration, to get the name of the event hub in their applications.

Also, when using an Azure Function, specify the EventHub and ConsumerGroup in ApplyAzureFunctionsConfiguration.

Contributes to #7407

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
