### PR TITLE
Allow Azure Functions to reference CosmosDB databases and containers

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<AzureCosmosDBDatabaseResource>, IResourceWithConnectionString
+public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<AzureCosmosDBDatabaseResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureCosmosDBContainerResource"/> class.
@@ -42,4 +42,8 @@ public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<Azur
     /// Gets the connection string expression for the Azure Cosmos DB Database Container.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
+
+    // ensure Azure Functions projects can WithReference a CosmosDB database container
+    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName) =>
+        ((IResourceWithAzureFunctionsConfig)Parent).ApplyAzureFunctionsConfiguration(target, connectionName);
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class AzureCosmosDBDatabaseResource : Resource, IResourceWithParent<AzureCosmosDBResource>, IResourceWithConnectionString
+public class AzureCosmosDBDatabaseResource : Resource, IResourceWithParent<AzureCosmosDBResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureCosmosDBDatabaseResource"/> class.
@@ -41,4 +41,8 @@ public class AzureCosmosDBDatabaseResource : Resource, IResourceWithParent<Azure
     /// Gets the connection string expression for the Azure Cosmos DB database.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
+
+    // ensure Azure Functions projects can WithReference a CosmosDB database
+    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName) =>
+        ((IResourceWithAzureFunctionsConfig)Parent).ApplyAzureFunctionsConfiguration(target, connectionName);
 }


### PR DESCRIPTION
Resources that participate in Azure Functions need to implement IResourceWithAzureFunctionsConfig. Add this to the child resources in CosmosDB.

For now, only the top-level account information is passed via connection string and config properties.

Contributes to #7407