### PR TITLE
Update default container image name & tag generation

### DIFF
--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -40,7 +40,7 @@ public static class ContainerResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     public static IResourceBuilder<ContainerResource> AddContainer(this IDistributedApplicationBuilder builder, [ResourceName] string name, string image, string tag)
     {
-       return AddContainer(builder, name, image)
+        return AddContainer(builder, name, image)
            .WithImageTag(tag);
     }
 
@@ -180,7 +180,7 @@ public static class ContainerResourceBuilderExtensions
         }
 
         // For continuity with 9.0 and earlier behaviour, keep the registry and image combined.
-        var parsedRegistryAndImage = parsedReference.Registry is {} 
+        var parsedRegistryAndImage = parsedReference.Registry is { }
             ? $"{parsedReference.Registry}/{parsedReference.Image}"
             : parsedReference.Image;
 
@@ -202,10 +202,11 @@ public static class ContainerResourceBuilderExtensions
                 throw new ArgumentOutOfRangeException(nameof(image), parsedReference.Digest, "invalid digest format");
             }
 
-            var digest = parsedReference.Digest.Substring(prefix.Length);
+            var digest = parsedReference.Digest[prefix.Length..];
             imageAnnotation.SHA256 = digest;
         }
-        else {
+        else
+        {
             imageAnnotation.Tag = parsedReference.Tag ?? tag ?? "latest";
         }
 
@@ -381,12 +382,14 @@ public static class ContainerResourceBuilderExtensions
 
         var fullyQualifiedDockerfilePath = Path.GetFullPath(dockerfilePath, fullyQualifiedContextPath);
 
-        var imageName = builder.GenerateImageName();
+        var imageName = ImageNameGenerator.GenerateImageName(builder);
+        var imageTag = ImageNameGenerator.GenerateImageTag(builder);
         var annotation = new DockerfileBuildAnnotation(fullyQualifiedContextPath, fullyQualifiedDockerfilePath, stage);
+
         return builder.WithAnnotation(annotation, ResourceAnnotationMutationBehavior.Replace)
                       .WithImageRegistry(registry: null)
                       .WithImage(imageName)
-                      .WithImageTag("latest");
+                      .WithImageTag(imageTag);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Utils/ImageNameGenerator.cs
+++ b/src/Aspire.Hosting/Utils/ImageNameGenerator.cs
@@ -9,11 +9,18 @@ namespace Aspire.Hosting.Utils;
 
 internal static class ImageNameGenerator
 {
-    public static string GenerateImageName<T>(this IResourceBuilder<T> builder) where T: IResource
+    public static string GenerateImageName<T>(this IResourceBuilder<T> builder) where T : IResource
     {
-        var bytes = Encoding.UTF8.GetBytes(builder.ApplicationBuilder.AppHostDirectory);
+        // Resource names are already constrained to [a-zA-Z0-9-_] by the resource name validation
+        // so we just have to lowercase it and return it.
+        return builder.Resource.Name.ToLowerInvariant();
+    }
+
+    public static string GenerateImageTag<T>(this IResourceBuilder<T> builder) where T : IResource
+    {
+        var bytes = Encoding.UTF8.GetBytes($"{builder.ApplicationBuilder.AppHostDirectory}{DateTime.UtcNow.Ticks}");
         var hash = SHA1.HashData(bytes);
-        var hex = Convert.ToHexString(hash).ToLower();
-        return $"{builder.Resource.Name}-image-{hex}";
+        var hex = Convert.ToHexString(hash).ToLowerInvariant();
+        return hex;
     }
 }

--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -83,6 +83,85 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         await app.StopAsync();
     }
 
+    [Theory]
+    [InlineData("testcontainer")]
+    [InlineData("TestContainer")]
+    [InlineData("test-Container")]
+    [InlineData("TEST-234-CONTAINER")]
+    public async Task AddDockerfileUsesLowercaseResourceNameAsImageName(string resourceName)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
+
+        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+
+        var dockerFile = builder.AddDockerfile(resourceName, tempContextPath, tempDockerfilePath);
+
+        Assert.True(dockerFile.Resource.TryGetLastAnnotation<ContainerImageAnnotation>(out var containerImageAnnotation));
+        Assert.Equal(resourceName.ToLowerInvariant(), containerImageAnnotation.Image);
+    }
+
+    [Theory]
+    [InlineData("testcontainer")]
+    [InlineData("TestContainer")]
+    [InlineData("test-Container")]
+    [InlineData("TEST-234-CONTAINER")]
+    public async Task WithDockerfileUsesLowercaseResourceNameAsImageName(string resourceName)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
+
+        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+
+        var dockerFile = builder.AddContainer(resourceName, "someimagename")
+            .WithDockerfile(tempContextPath, tempDockerfilePath);
+
+        Assert.True(dockerFile.Resource.TryGetLastAnnotation<ContainerImageAnnotation>(out var containerImageAnnotation));
+        Assert.Equal(resourceName.ToLowerInvariant(), containerImageAnnotation.Image);
+    }
+
+    [Fact]
+    public async Task WithDockerfileUsesGeneratesDifferentHashForImageTagOnEachCall()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
+
+        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+
+        var dockerFile = builder.AddContainer("testcontainer", "someimagename")
+            .WithDockerfile(tempContextPath, tempDockerfilePath);
+        Assert.True(dockerFile.Resource.TryGetLastAnnotation<ContainerImageAnnotation>(out var containerImageAnnotation1));
+        var tag1 = containerImageAnnotation1.Tag;
+
+        dockerFile.WithDockerfile(tempContextPath, tempDockerfilePath);
+        Assert.True(dockerFile.Resource.TryGetLastAnnotation<ContainerImageAnnotation>(out var containerImageAnnotation2));
+        var tag2 = containerImageAnnotation2.Tag;
+
+        Assert.NotEqual(tag1, tag2);
+    }
+
+    [Fact]
+    public async Task WithDockerfileGeneratedImageTagCanBeOverridden()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
+
+        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+
+        var dockerFile = builder.AddContainer("testcontainer", "someimagename")
+            .WithDockerfile(tempContextPath, tempDockerfilePath);
+
+        Assert.True(dockerFile.Resource.TryGetLastAnnotation<ContainerImageAnnotation>(out var containerImageAnnotation1));
+        var generatedTag = containerImageAnnotation1.Tag;
+
+        dockerFile.WithImageTag("latest");
+        Assert.True(dockerFile.Resource.TryGetLastAnnotation<ContainerImageAnnotation>(out var containerImageAnnotation2));
+        var overriddenTag = containerImageAnnotation2.Tag;
+
+        Assert.NotEqual(generatedTag, overriddenTag);
+        Assert.Equal("latest", overriddenTag);
+    }
+
     [Fact]
     [RequiresDocker]
     public async Task WithDockerfileLaunchesContainerSuccessfully()
@@ -110,7 +189,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         var kubernetes = app.Services.GetRequiredService<IKubernetesService>();
         var containers = await kubernetes.ListAsync<Container>();
 
-        var container = Assert.Single<Container>(containers);
+        var container = Assert.Single(containers);
         Assert.Equal(tempContextPath, container!.Spec!.Build!.Context);
         Assert.Equal(tempDockerfilePath, container!.Spec!.Build!.Dockerfile);
 


### PR DESCRIPTION
## Description

Changes the generated container image name and tag used when calling `AddDockerfile` or `WithDockerfile`. Name will now just be the resource name lowercased, and the tag will be a hash generated from the app host directory path and current timestamp.

Fixes #7462

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Ye
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] Yes
        - Link to aspire-docs issue: https://github.com/dotnet/docs-aspire/issues/2557
