### PR TITLE
[Testing] Cancel host start & stop when DistributedApplicationFactory is disposed

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
@@ -24,6 +25,8 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
     private readonly TaskCompletionSource _exitTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource<DistributedApplicationBuilder> _builderTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource<DistributedApplication> _appTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly CancellationTokenSource _disposingCts = new();
+    private TimeSpan _shutdownTimeout = TimeSpan.FromSeconds(10);
     private readonly object _lockObj = new();
     private bool _entryPointStarted;
     private IHostApplicationLifetime? _hostApplicationLifetime;
@@ -41,8 +44,10 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
     /// </summary>
     internal async Task<DistributedApplicationBuilder> ResolveBuilderAsync(CancellationToken cancellationToken = default)
     {
+        ObjectDisposedException.ThrowIf(_disposingCts.IsCancellationRequested, this);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposingCts.Token);
         EnsureEntryPointStarted();
-        return await _builderTcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return await _builderTcs.Task.WaitAsync(linkedCts.Token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -50,8 +55,9 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
     /// </summary>
     internal async Task<DistributedApplication> ResolveApplicationAsync(CancellationToken cancellationToken = default)
     {
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposingCts.Token);
         EnsureEntryPointStarted();
-        return await _appTcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return await _appTcs.Task.WaitAsync(linkedCts.Token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -61,8 +67,10 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
     /// <returns>A <see cref="Task"/> representing the completion of the operation.</returns>
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
+        ObjectDisposedException.ThrowIf(_disposingCts.IsCancellationRequested, this);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposingCts.Token);
         EnsureEntryPointStarted();
-        await _startedTcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _startedTcs.Task.WaitAsync(linkedCts.Token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -71,6 +79,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
     /// <returns>The <see cref="HttpClient"/>.</returns>
     public HttpClient CreateHttpClient(string resourceName, string? endpointName = default)
     {
+        ObjectDisposedException.ThrowIf(_disposingCts.IsCancellationRequested, this);
         return GetStartedApplication().CreateHttpClient(resourceName, endpointName);
     }
 
@@ -82,6 +91,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
     /// <exception cref="ArgumentException">The resource was not found or does not expose a connection string.</exception>
     public ValueTask<string?> GetConnectionString(string resourceName)
     {
+        ObjectDisposedException.ThrowIf(_disposingCts.IsCancellationRequested, this);
         return GetStartedApplication().GetConnectionStringAsync(resourceName);
     }
 
@@ -95,6 +105,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
     /// <exception cref="InvalidOperationException">The resource has no endpoints.</exception>
     public Uri GetEndpoint(string resourceName, string? endpointName = default)
     {
+        ObjectDisposedException.ThrowIf(_disposingCts.IsCancellationRequested, this);
         return GetStartedApplication().GetEndpoint(resourceName, endpointName);
     }
 
@@ -133,6 +144,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
 
     private void OnBuiltCore(DistributedApplication application)
     {
+        _shutdownTimeout = application.Services.GetService<IOptions<HostOptions>>()?.Value.ShutdownTimeout ?? _shutdownTimeout;
         _appTcs.TrySetResult(application);
         OnBuilt(application);
     }
@@ -432,26 +444,23 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
 
     private void OnDisposed()
     {
+        _disposingCts.Cancel();
         _builderTcs.TrySetCanceled();
         _startedTcs.TrySetCanceled();
     }
 
     /// <inheritdoc/>
-    public virtual void Dispose()
-    {
-        OnDisposed();
-        if (_hostApplicationLifetime is null || _appTcs.Task is not { IsCompletedSuccessfully: true } appTask)
-        {
-            return;
-        }
-
-        _hostApplicationLifetime?.StopApplication();
-        appTask.GetAwaiter().GetResult()?.Dispose();
-    }
+    public virtual void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
 
     /// <inheritdoc/>
     public virtual async ValueTask DisposeAsync()
     {
+        if (_disposingCts.IsCancellationRequested)
+        {
+            // Dispose already called.
+            return;
+        }
+
         OnDisposed();
         if (_appTcs.Task is not { IsCompletedSuccessfully: true } appTask)
         {
@@ -464,11 +473,37 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
             static state => (state as IHostApplicationLifetime)?.StopApplication(),
             _hostApplicationLifetime);
 
-        await _exitTcs.Task.ConfigureAwait(false);
-
-        if (appTask.GetAwaiter().GetResult() is { } appDisposable)
+        using var shutdownTimeoutCts = new CancellationTokenSource(_shutdownTimeout);
+        try
         {
-            await appDisposable.DisposeAsync().ConfigureAwait(false);
+            await _exitTcs.Task.WaitAsync(shutdownTimeoutCts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignore errors thrown from the app host thread.
+            // These should be caught and handled within the app host.
+        }
+
+        // We need to dispose so that the ResourceNotificationService will propagate cancellation.
+        if (appTask.GetAwaiter().GetResult() is { } app)
+        {
+            try
+            {
+                await app.StopAsync().WaitAsync(shutdownTimeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (_disposingCts.IsCancellationRequested)
+            {
+                // Ignore during disposal.
+            }
+
+            try
+            {
+                await app.DisposeAsync().AsTask().WaitAsync(shutdownTimeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (_disposingCts.IsCancellationRequested)
+            {
+                // Ignore during disposal.
+            }
         }
     }
 
@@ -521,7 +556,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
             _disposing = true;
             if (innerHost is IAsyncDisposable asyncDisposable)
             {
-                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                await asyncDisposable.DisposeAsync().AsTask().WaitAsync(appFactory._disposingCts.Token).ConfigureAwait(false);
             }
             else
             {
@@ -533,7 +568,8 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         {
             try
             {
-                await innerHost.StartAsync(cancellationToken).ConfigureAwait(false);
+                using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, appFactory._disposingCts.Token);
+                await innerHost.StartAsync(linkedToken.Token).ConfigureAwait(false);
                 appFactory._startedTcs.TrySetResult();
             }
             catch (Exception exception)
@@ -543,6 +579,10 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
             }
         }
 
-        public Task StopAsync(CancellationToken cancellationToken = default) => innerHost.StopAsync(cancellationToken);
+        public async Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, appFactory._disposingCts.Token);
+            await innerHost.StopAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -582,7 +582,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         public async Task StopAsync(CancellationToken cancellationToken = default)
         {
             using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, appFactory._disposingCts.Token);
-            await innerHost.StopAsync(cancellationToken).ConfigureAwait(false);
+            await innerHost.StopAsync(linkedToken.Token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
@@ -106,6 +106,10 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
                 _dcpInfo = dcpInfo;
                 return dcpInfo;
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex) when (ex is not DistributedApplicationException)
             {
                 throw new DistributedApplicationException(string.Format(

--- a/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
@@ -106,11 +106,9 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
                 _dcpInfo = dcpInfo;
                 return dcpInfo;
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex) when (ex is not DistributedApplicationException)
+            catch (Exception ex) when
+                (ex is not DistributedApplicationException
+                && !(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
             {
                 throw new DistributedApplicationException(string.Format(
                     CultureInfo.InvariantCulture,

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -32,7 +32,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
     private const string DebugSessionPortVar = "DEBUG_SESSION_PORT";
     private const string DefaultAspireNetworkName = "default-aspire-network";
 
-    // Disposal of te DcpExecutor means shutting down watches and log streams,
+    // Disposal of the DcpExecutor means shutting down watches and log streams,
     // and asking DCP to start the shutdown process. If we cannot complete these tasks within 10 seconds,
     // it probably means DCP crashed and there is no point trying further.
     private static readonly TimeSpan s_disposeTimeout = TimeSpan.FromSeconds(10);

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
@@ -20,12 +20,13 @@ public class TestingFactoryCrashTests
         var timeout = TimeSpan.FromMinutes(5);
         using var cts = new CancellationTokenSource(timeout);
 
-        using var factory = new DistributedApplicationFactory(typeof(Projects.TestingAppHost1_AppHost), [$"--crash-{crashArg}"]);
+        var factory = new DistributedApplicationFactory(typeof(Projects.TestingAppHost1_AppHost), [$"--crash-{crashArg}"]);
 
         if (crashArg is "before-build" or "after-build")
         {
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => factory.StartAsync().WaitAsync(cts.Token));
             Assert.Contains(crashArg, exception.Message);
+            await factory.DisposeAsync().AsTask().WaitAsync(cts.Token);
             return;
         }
         else
@@ -33,15 +34,6 @@ public class TestingFactoryCrashTests
             await factory.StartAsync().WaitAsync(cts.Token);
         }
 
-        if (crashArg is "after-start" or "after-shutdown")
-        {
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => factory.DisposeAsync().AsTask().WaitAsync(cts.Token));
-            Assert.Contains(crashArg, exception.Message);
-            return;
-        }
-        else
-        {
-            await factory.DisposeAsync().AsTask().WaitAsync(cts.Token);
-        }
+        await factory.DisposeAsync().AsTask().WaitAsync(cts.Token);
     }
 }

--- a/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
+++ b/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -23,6 +24,15 @@ builder.AddProject<Projects.TestingAppHost1_MyWorker>("myworker1")
     .WithEndpoint(name: "myendpoint1", env: "myendpoint1_port");
 builder.AddPostgres("postgres1");
 
+if (args.Contains("--add-unknown-container"))
+{
+    var failsToStart = builder.AddContainer("fails-to-start", $"{Guid.NewGuid()}/does/not/exist");
+    builder.AddExecutable("app", "cmd", ".")
+        .WaitFor(failsToStart)
+        .WithHttpEndpoint()
+        .WithHttpHealthCheck();
+}
+
 if (args.Contains("--crash-before-build"))
 {
     throw new InvalidOperationException("Crashing: before-build.");
@@ -36,6 +46,13 @@ if (args.Contains("--crash-after-build"))
 }
 
 await app.StartAsync();
+
+if (args.Contains("--wait-for-healthy"))
+{
+    // Wait indefinitely until redis becomes healthy.
+    var notifications = app.Services.GetRequiredService<ResourceNotificationService>();
+    await notifications.WaitForResourceHealthyAsync("redis1");
+}
 
 if (args.Contains("--crash-after-start"))
 {


### PR DESCRIPTION
## Description

When using *Aspire.Hosting.Testing* with an AppHost project, a background thread is created to execute the AppHost's entry point (Program.Main). This thread is intercepted at various points (creating, created, starting, etc) to pass control to the test suite, giving the developer opportunity to implement their test scenarios.

There are two threads which must be coordinated: the AppHost thread and the test scenario thread. Ideally, we want the test scenario thread to take precedence: when it calls `StartAsync()`, the app is started. When it calls `StopAsync()`, the app is stopped, and so on.

If the test scenario thread calls `Dispose()` or `DisposeAsync()`, we want to ensure that the AppHost thread is also stopped. In this PR, we add a `CancellationTokenSource` to the `DistributedApplicationFactory` to signal to the AppHost thread that it should stop because disposal has started. The AppHost observes the `CancellationToken` via the host's `StartAsync` and `StopAsync` methods.

We also add a timeout inside `DistributionApplicationFactory.DisposeAsync` as a catch-all, similar to `DcpExecutor`'s `DisposeAsync()` implementation.

Fixes #7139

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
