### PR TITLE
Add AsExisting API for both run/publish modes

### DIFF
--- a/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/ExistingAzureResourceExtensions.cs
@@ -106,4 +106,22 @@ public static class ExistingAzureResourceExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Marks the resource as an existing resource in both run and publish modes.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="nameParameter">The name of the existing resource.</param>
+    /// <param name="resourceGroupParameter">The name of the existing resource group, or <see langword="null"/> to use the current resource group.</param>
+    /// <returns>The resource builder with the existing resource annotation added.</returns>
+    public static IResourceBuilder<T> AsExisting<T>(this IResourceBuilder<T> builder, IResourceBuilder<ParameterResource> nameParameter, IResourceBuilder<ParameterResource>? resourceGroupParameter = null)
+        where T : IAzureResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.WithAnnotation(new ExistingAzureResourceAnnotation(nameParameter.Resource, resourceGroupParameter?.Resource));
+
+        return builder;
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
@@ -118,4 +118,24 @@ public class ExistingAzureExtensionsResourceTests
         Assert.Equal("existingName", existingAzureResourceAnnotation.Name);
         Assert.Equal("existingResourceGroup", existingAzureResourceAnnotation.ResourceGroup);
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AsExistingInBothModesWorks(bool isPublishMode)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(isPublishMode ? DistributedApplicationOperation.Publish : DistributedApplicationOperation.Run);
+
+        var nameParameter = builder.AddParameter("name", "existingName");
+        var resourceGroupParameter = builder.AddParameter("resourceGroup", "existingResourceGroup");
+
+        var serviceBus = builder.AddAzureServiceBus("sb")
+            .AsExisting(nameParameter, resourceGroupParameter);
+
+        Assert.True(serviceBus.Resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingAzureResourceAnnotation));
+        var existingNameParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.Name);
+        Assert.Equal("name", existingNameParameter.Name);
+        var existingResourceGroupParameter = Assert.IsType<ParameterResource>(existingAzureResourceAnnotation.ResourceGroup);
+        Assert.Equal("resourceGroup", existingResourceGroupParameter.Name);
+    }
 }


### PR DESCRIPTION
`AsExisting` method without execution mode checks.