### PR TITLE
Obsolete DockerBuildArg and related APIs

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/DockerBuildArg.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DockerBuildArg.cs
@@ -9,6 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The required name of the arg.</param>
 /// <param name="value">The optional value of the arg, when omitted the value is populated from the corresponding environment variable.</param>
+[Obsolete("Use DockerfileBuildAnnotation to define docker build arguments.")]
 public sealed class DockerBuildArg(string name, object? value = null)
 {
     /// <summary>

--- a/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
@@ -79,6 +79,7 @@ public static class ExecutableResourceBuilderExtensions
     /// <param name="builder">Resource builder</param>
     /// <param name="buildArgs">The optional build arguments, used with <c>docker build --build-args</c>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [Obsolete("Use builder.PublishAsDockerFile(c => c.WithBuildArg(name, value)) instead.")]
     public static IResourceBuilder<T> PublishAsDockerFile<T>(this IResourceBuilder<T> builder, IEnumerable<DockerBuildArg>? buildArgs) where T : ExecutableResource
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -560,35 +560,6 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
             Writer.WriteEndArray();
         }
     }
-
-    internal void WriteDockerBuildArgs(IEnumerable<DockerBuildArg>? buildArgs)
-    {
-        if (buildArgs?.ToArray() is { Length: > 0 } args)
-        {
-            Writer.WriteStartObject("buildArgs");
-
-            for (var i = 0; i < args.Length; i++)
-            {
-                var buildArg = args[i];
-
-                var valueString = buildArg.Value switch
-                {
-                    string stringValue => stringValue,
-                    IManifestExpressionProvider manifestExpression => manifestExpression.ValueExpression,
-                    bool boolValue => boolValue ? "true" : "false",
-                    null => null, // null means let docker build pull from env var.
-                    _ => buildArg.Value.ToString()
-                };
-
-                Writer.WriteString(buildArg.Name, valueString);
-
-                TryAddDependentResources(buildArg.Value);
-            }
-
-            Writer.WriteEndObject();
-        }
-    }
-
     private void WriteContainerMounts(ContainerResource container)
     {
         if (container.TryGetAnnotationsOfType<ContainerMountAnnotation>(out var mounts))

--- a/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
@@ -56,6 +56,7 @@ public class PublishAsDockerfileTests
 
         var path = tempDir.Directory.FullName;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var frontend = builder.AddNpmApp("frontend", path, "watch")
             .PublishAsDockerFile(buildArgs: [
                 new DockerBuildArg("SOME_STRING", "Test"),
@@ -64,6 +65,7 @@ public class PublishAsDockerfileTests
                 new DockerBuildArg("SOME_NUMBER", 7),
                 new DockerBuildArg("SOME_NONVALUE"),
             ]);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         // There should be an equivalent container resource with the same name
         // as the npm app resource.
@@ -107,10 +109,12 @@ public class PublishAsDockerfileTests
 
         var path = tempDir.Directory.FullName;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var frontend = builder.AddNpmApp("frontend", path, "watch")
             .PublishAsDockerFile(buildArgs: [
                 new DockerBuildArg("SOME_ARG")
             ]);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         // There should be an equivalent container resource with the same name
         // as the npm app resource.


### PR DESCRIPTION
## Description

- Obsolete DockerBuildArg and PublishAsDockerFile overload that takes it.
- We no longer produce dockerfile.v0 resources. We favor container.v1 in all cases.

From https://github.com/dotnet/aspire/pull/7374/files#r1938826837

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
