### PR TITLE
Clean up trace

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -507,7 +507,7 @@ public class ResourceNotificationService : IDisposable
                     newState.ResourceReadyEvent is not null,
                     newState.ExitCode,
                     string.Join(", ", newState.Urls.Select(u => $"{u.Name} = {u.Url}")),
-                    JoinIndentLines(newState.EnvironmentVariables.Select(e => $"{e.Name} = {e.Value}")),
+                    JoinIndentLines(newState.EnvironmentVariables.Where(e => e.IsFromSpec).Select(e => $"{e.Name} = {e.Value}")),
                     JoinIndentLines(newState.Properties.Select(p => $"{p.Name} = {Stringify(p.Value)}")),
                     JoinIndentLines(newState.HealthReports.Select(p => $"{p.Name} = {Stringify(p.Status)}")));
 


### PR DESCRIPTION
- Only show specified environment variables in the trace

This should significantly reduce the output as environment variables are inherited by the machine and this leads to lots of spew in CI scenarios.
