### PR TITLE
Follow-up fixes to RunAsExisting flow

### DIFF
--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -43,16 +43,15 @@ public static class AzureKeyVaultResourceExtensions
                         Family = KeyVaultSkuFamily.A,
                         Name = KeyVaultSkuName.Standard
                     },
-                    EnableRbacAuthorization = true
-                }
+                    EnableRbacAuthorization = true,
+                },
+                Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
             });
 
             infrastructure.Add(new ProvisioningOutput("vaultUri", typeof(string))
             {
                 Value = keyVault.Properties.VaultUri
             });
-
-            keyVault.Tags["aspire-resource-name"] = infrastructure.AspireResource.Name;
 
             var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
             infrastructure.Add(principalTypeParameter);

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureResourceProvisionerOfT.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureResourceProvisionerOfT.cs
@@ -10,7 +10,6 @@ using Azure.ResourceManager.Authorization.Models;
 using Azure.ResourceManager.Authorization;
 using Azure;
 using Aspire.Hosting.ApplicationModel;
-using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Azure.Provisioning;
 
@@ -36,20 +35,6 @@ internal sealed class ProvisioningContext(
     public AzureLocation Location => location;
     public UserPrincipal Principal => principal;
     public JsonObject UserSecrets => userSecrets;
-
-    public async Task<ResourceGroupResource> GetResourceGroup(string resourceGroupName, ILogger resourceLogger, CancellationToken cancellationToken)
-    {
-        var targetResourceGroup = ResourceGroup;
-        try
-        {
-            targetResourceGroup = await Subscription.GetResourceGroupAsync(resourceGroupName, cancellationToken).ConfigureAwait(false);
-        }
-        catch (RequestFailedException ex) when (ex.Status == 404)
-        {
-            resourceLogger.LogWarning("Resource group {ResourceGroupName} not found. Using default resource group.", resourceGroupName);
-        }
-        return targetResourceGroup;
-    }
 }
 
 internal interface IAzureResourceProvisioner

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -541,7 +541,7 @@ internal sealed class BicepProvisioner(
 
     internal static async Task SetScopeAsync(JsonObject scope, AzureBicepResource resource, CancellationToken cancellationToken = default)
     {
-        // Resole the scope from the AzureBicepResource if it has already been set
+        // Resolve the scope from the AzureBicepResource if it has already been set
         // via the ConfigureInfrastructure callback. If not, fallback to the ExistingAzureResourceAnnotation.
         var targetScope = resource.Scope;
         if (targetScope is null

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -114,9 +114,9 @@ internal sealed class BicepProvisioner(
             existingResource.ResourceGroup is { } existingResourceGroup)
         {
             var existingResourceGroupName = existingResourceGroup is ParameterResource parameterResource
-                ? parameterResource.Name
+                ? parameterResource.Value
                 : (string)existingResourceGroup;
-            resourceGroup = await context.GetResourceGroup(existingResourceGroupName, resourceLogger, cancellationToken).ConfigureAwait(false);
+            resourceGroup = await context.Subscription.GetResourceGroupAsync(existingResourceGroupName, cancellationToken).ConfigureAwait(false);
         }
 
         await notificationService.PublishUpdateAsync(resource, state => state with
@@ -310,6 +310,12 @@ internal sealed class BicepProvisioner(
         {
             // Same for outputs
             resourceConfig["Outputs"] = outputObj.ToJsonString();
+        }
+
+        // Write resource scope to config for consistent checksums
+        if (scope is not null)
+        {
+            resourceConfig["Scope"] = scope.ToJsonString();
         }
 
         // Save the checksum to the configuration
@@ -535,12 +541,22 @@ internal sealed class BicepProvisioner(
 
     internal static async Task SetScopeAsync(JsonObject scope, AzureBicepResource resource, CancellationToken cancellationToken = default)
     {
-        scope["resourceGroup"] = resource.Scope?.ResourceGroup switch
+        // Resole the scope from the AzureBicepResource if it has already been set
+        // via the ConfigureInfrastructure callback. If not, fallback to the ExistingAzureResourceAnnotation.
+        var targetScope = resource.Scope;
+        if (targetScope is null
+            && resource.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existingResource)
+            && existingResource.ResourceGroup is { } existingResourceGroup)
+        {
+            targetScope = new AzureBicepResourceScope(existingResourceGroup);
+        }
+
+        scope["resourceGroup"] = targetScope?.ResourceGroup switch
         {
             string s => s,
             IValueProvider v => await v.GetValueAsync(cancellationToken).ConfigureAwait(false),
             null => null,
-            _ => throw new NotSupportedException($"The scope value type {resource.Scope.ResourceGroup.GetType()} is not supported.")
+            _ => throw new NotSupportedException($"The scope value type {targetScope.ResourceGroup.GetType()} is not supported.")
         };
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -659,9 +659,6 @@ public class ExistingAzureResourceTests
 
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: existingResourceName
-              tags: {
-                'aspire-resource-name': 'keyVault'
-              }
             }
 
             resource keyVault_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {


### PR DESCRIPTION
- Inline Tags configuration for key vault
- Set resource scope in user-secrets config
- Remove fallback to default user group if existing resource group was not found
- Fix resolution of resource group name from parameter resource