### PR TITLE
Display launchSettings.json args in dashboard

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -964,7 +964,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
         {
             throw new InvalidOperationException($"Expected an Executable resource, but got {er.DcpResource.Kind} instead");
         }
-        ExecutableSpec spec = exe.Spec;
+        var spec = exe.Spec;
 
         // An executable can be restarted so args must be reset to an empty state.
         // After resetting, first apply any dotnet project related args, e.g. configuration, and then add args from the model resource.

--- a/src/Shared/LaunchProfiles/LaunchProfileExtensions.cs
+++ b/src/Shared/LaunchProfiles/LaunchProfileExtensions.cs
@@ -36,6 +36,17 @@ internal static class LaunchProfileExtensions
             return null;
         }
 
+        var launchProfile = projectResource.GetLaunchProfile(launchProfileName, throwIfNotFound);
+        if (launchProfile == null)
+        {
+            return null;
+        }
+
+        return new NamedLaunchProfile(launchProfileName, launchProfile);
+    }
+
+    internal static LaunchProfile? GetLaunchProfile(this ProjectResource projectResource, string launchProfileName, bool throwIfNotFound = false)
+    {
         var profiles = projectResource.GetLaunchSettings()?.Profiles;
         if (profiles is null)
         {
@@ -49,7 +60,7 @@ internal static class LaunchProfileExtensions
             throw new DistributedApplicationException(message);
         }
 
-        return launchProfile is not null ? new (launchProfileName, launchProfile) : default;
+        return launchProfile;
     }
 
     private static LaunchSettings? GetLaunchSettings(this IProjectMetadata projectMetadata, string resourceName)

--- a/tests/testproject/TestProject.ServiceA/Properties/launchSettings.json
+++ b/tests/testproject/TestProject.ServiceA/Properties/launchSettings.json
@@ -16,7 +16,8 @@
       "applicationUrl": "http://localhost:5156",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "commandLineArgs": "--test1 --test2"
     },
     "https": {
       "commandName": "Project",


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/7475

Before (no args in dashboard):

![image](https://github.com/user-attachments/assets/5f53dcc6-4313-425c-a525-c5f16bc1a598)

After:

![image](https://github.com/user-attachments/assets/c3c166f9-c2d9-498a-b73e-d3a2bc6f18a1)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
