### PR TITLE
Don't add relationship to parent with WaitFor

### DIFF
--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -692,12 +692,20 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
                                        .WaitFor(childResource);
 
         Assert.True(containerResource.Resource.TryGetAnnotationsOfType<WaitAnnotation>(out var waitAnnotations));
-
         Assert.Collection(
             waitAnnotations,
             a => Assert.Equal(a.Resource, parentResource.Resource),
             a => Assert.Equal(a.Resource, childResource.Resource)
             );
+
+        Assert.True(containerResource.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationshipAnnotations));
+        Assert.Collection(
+            relationshipAnnotations,
+            a =>
+            {
+                Assert.Equal(a.Resource, childResource.Resource);
+                Assert.Equal(a.Type, childResource.Resource);
+            });
     }
 
     private sealed class CustomChildResource(string name, CustomResource parent) : Resource(name), IResourceWithParent<CustomResource>, IResourceWithWaitSupport

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.Common.Tests;
+using Aspire.Dashboard.Model;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -699,13 +700,10 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
             );
 
         Assert.True(containerResource.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationshipAnnotations));
-        Assert.Collection(
-            relationshipAnnotations,
-            a =>
-            {
-                Assert.Equal(a.Resource, childResource.Resource);
-                Assert.Equal(a.Type, childResource.Resource);
-            });
+        var relationshipAnnotation = Assert.Single(relationshipAnnotations);
+
+        Assert.Equal(childResource.Resource, relationshipAnnotation.Resource);
+        Assert.Equal(KnownRelationshipTypes.WaitFor, relationshipAnnotation.Type);
     }
 
     private sealed class CustomChildResource(string name, CustomResource parent) : Resource(name), IResourceWithParent<CustomResource>, IResourceWithWaitSupport


### PR DESCRIPTION
## Description

WaitFor on a child resource automatically added a `WaitFor` relationship to the parent. This shows up in resource references/back references and is messy/confusing because the user didn't choose to do this.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
