### PR TITLE
Fix regression with AddConnectionSting

### DIFF
--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -110,13 +110,13 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
         {
             await WriteResourceObjectAsync(executable, () => WriteExecutableAsync(executable)).ConfigureAwait(false);
         }
-        else if (resource is IResourceWithConnectionString resourceWithConnectionString)
-        {
-            await WriteResourceObjectAsync(resource, () => WriteConnectionStringAsync(resourceWithConnectionString)).ConfigureAwait(false);
-        }
         else if (resource is ParameterResource parameter)
         {
             await WriteResourceObjectAsync(parameter, () => WriteParameterAsync(parameter)).ConfigureAwait(false);
+        }
+        else if (resource is IResourceWithConnectionString resourceWithConnectionString)
+        {
+            await WriteResourceObjectAsync(resource, () => WriteConnectionStringAsync(resourceWithConnectionString)).ConfigureAwait(false);
         }
         else
         {


### PR DESCRIPTION
## Description
- After #7327, AddConnectionString was generating a value.v0 resource instead of a parameter.v0. This fixes the order of evaluation so that parameters are preferred over IResourceWithConnectionString.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
