### PR TITLE
Add detailed container information to Docker info

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,6 +209,7 @@ jobs:
         if: always()
         run: |
           docker container ls --all
+          docker container ls --all --format json
           docker volume ls
           docker network ls
 


### PR DESCRIPTION
This includes information about networks the containers are attached to, which helps diagnose problems with leaking Docker networks.

(Keeping the previous `docker container ls --all` command as well because output of that one is easy for humans to read)
