### PR TITLE
Ensure AspireStore base path is absolute

### DIFF
--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -247,7 +247,7 @@ namespace Projects%3B
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
         <_Parameter1>apphostprojectbaseintermediateoutputpath</_Parameter1>
         <_Parameter2>$(BaseIntermediateOutputPath)</_Parameter2>
-        <_Parameter2 Condition="'$([System.IO.Path]::IsPathRooted($(BaseIntermediateOutputPath)))' == 'false'">$(MSBuildProjectDirectory)\$(BaseIntermediateOutputPath)</_Parameter2>
+        <_Parameter2 Condition="'$([System.IO.Path]::IsPathRooted($(BaseIntermediateOutputPath)))' == 'false'">$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(BaseIntermediateOutputPath)')</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -247,6 +247,7 @@ namespace Projects%3B
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
         <_Parameter1>apphostprojectbaseintermediateoutputpath</_Parameter1>
         <_Parameter2>$(BaseIntermediateOutputPath)</_Parameter2>
+        <_Parameter2 Condition="'$([System.IO.Path]::IsPathRooted($(BaseIntermediateOutputPath)))' == 'false'">$(MSBuildProjectDirectory)\$(BaseIntermediateOutputPath)</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -247,7 +247,7 @@ namespace Projects%3B
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
         <_Parameter1>apphostprojectbaseintermediateoutputpath</_Parameter1>
         <_Parameter2>$(BaseIntermediateOutputPath)</_Parameter2>
-        <_Parameter2 Condition="'$([System.IO.Path]::IsPathRooted($(BaseIntermediateOutputPath)))' == 'false'">$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(BaseIntermediateOutputPath)')</_Parameter2>
+        <_Parameter2 Condition="'$([System.IO.Path]::IsPathRooted($(BaseIntermediateOutputPath)))' == 'false'">$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(BaseIntermediateOutputPath)'))</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/Aspire.Hosting/ApplicationModel/AspireStore.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AspireStore.cs
@@ -18,6 +18,11 @@ internal sealed class AspireStore : IAspireStore
     {
         ArgumentNullException.ThrowIfNull(basePath);
 
+        if (!Path.IsPathRooted(basePath))
+        {
+            throw new ArgumentException($"An absolute path is required: '${basePath}'", nameof(basePath));
+        }
+
         _basePath = basePath;
         EnsureDirectory();
     }

--- a/tests/Aspire.Hosting.Tests/AspireStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/AspireStoreTests.cs
@@ -109,6 +109,8 @@ public class AspireStoreTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("./folder")]
+    [InlineData("folder")]
+    [InlineData("obj/")]
     public void AspireStoreConstructor_ShouldThrow_IfNotAbsolutePath(string? basePath)
     {
         Assert.ThrowsAny<Exception>(() => new AspireStore(basePath!));

--- a/tests/Aspire.Hosting.Tests/AspireStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/AspireStoreTests.cs
@@ -105,6 +105,15 @@ public class AspireStoreTests
         Assert.Equal("updated", content2);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("./folder")]
+    public void AspireStoreConstructor_ShouldThrow_IfNotAbsolutePath(string? basePath)
+    {
+        Assert.ThrowsAny<Exception>(() => new AspireStore(basePath!));
+    }
+
     private static IAspireStore CreateStore()
     {
         var builder = TestDistributedApplicationBuilder.Create();


### PR DESCRIPTION
## Description

Add better error message when the AspireStore base path is invalid
c.f. #7511

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
