### PR TITLE
Convert ServiceBus Queue, Topic, and Subscriptions to Resources

### DIFF
--- a/playground/AspireEventHub/EventHubs.AppHost/aspire-manifest.json
+++ b/playground/AspireEventHub/EventHubs.AppHost/aspire-manifest.json
@@ -22,6 +22,10 @@
         "principalId": ""
       }
     },
+    "eventhub": {
+      "type": "value.v0",
+      "connectionString": "Endpoint={eventhubns.outputs.eventHubsEndpoint};EntityPath=eventhub"
+    },
     "consumer": {
       "type": "project.v0",
       "path": "../EventHubsConsumer/EventHubsConsumer.csproj",
@@ -29,7 +33,7 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
-        "ConnectionStrings__eventhubns": "{eventhubns.connectionString}",
+        "ConnectionStrings__eventhub": "{eventhub.connectionString}",
         "ConnectionStrings__checkpoints": "{checkpoints.connectionString}"
       }
     },
@@ -42,7 +46,7 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
         "HTTP_PORTS": "{api.bindings.http.targetPort}",
-        "ConnectionStrings__eventhubns": "{eventhubns.connectionString}"
+        "ConnectionStrings__eventhub": "{eventhub.connectionString}"
       },
       "bindings": {
         "http": {

--- a/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
+++ b/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
@@ -28,8 +28,8 @@ resource eventhubns_AzureEventHubsDataOwner 'Microsoft.Authorization/roleAssignm
   scope: eventhubns
 }
 
-resource hub 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
-  name: 'hub'
+resource eventhub 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
+  name: 'eventhub'
   parent: eventhubns
 }
 

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
@@ -7,7 +7,9 @@ var eventHub = builder.AddAzureEventHubs("eventhubs")
     .RunAsEmulator()
     .AddHub("myhub");
 #if !SKIP_UNSTABLE_EMULATORS
-var serviceBus = builder.AddAzureServiceBus("messaging").RunAsEmulator().WithQueue("myqueue");
+var serviceBus = builder.AddAzureServiceBus("messaging")
+    .RunAsEmulator();
+serviceBus.AddServiceBusQueue("myqueue");
 var cosmosDb = builder.AddAzureCosmosDB("cosmosdb")
     .RunAsEmulator();
 var database = cosmosDb.AddCosmosDatabase("mydatabase");

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/aspire-manifest.json
@@ -26,6 +26,10 @@
         "principalId": ""
       }
     },
+    "myhub": {
+      "type": "value.v0",
+      "connectionString": "Endpoint={eventhubs.outputs.eventHubsEndpoint};EntityPath=myhub"
+    },
     "messaging": {
       "type": "azure.bicep.v0",
       "connectionString": "{messaging.outputs.serviceBusEndpoint}",
@@ -34,6 +38,10 @@
         "principalType": "",
         "principalId": ""
       }
+    },
+    "myqueue": {
+      "type": "value.v0",
+      "connectionString": "{messaging.outputs.serviceBusEndpoint}"
     },
     "cosmosdb": {
       "type": "azure.bicep.v0",
@@ -75,12 +83,17 @@
         "AzureWebJobsStorage__queueServiceUri": "{funcstorage67c6c.outputs.queueEndpoint}",
         "Aspire__Azure__Storage__Blobs__AzureWebJobsStorage__ServiceUri": "{funcstorage67c6c.outputs.blobEndpoint}",
         "Aspire__Azure__Storage__Queues__AzureWebJobsStorage__ServiceUri": "{funcstorage67c6c.outputs.queueEndpoint}",
-        "eventhubs__fullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
-        "Aspire__Azure__Messaging__EventHubs__EventHubProducerClient__eventhubs__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
-        "Aspire__Azure__Messaging__EventHubs__EventHubConsumerClient__eventhubs__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
-        "Aspire__Azure__Messaging__EventHubs__EventProcessorClient__eventhubs__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
-        "Aspire__Azure__Messaging__EventHubs__PartitionReceiver__eventhubs__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
-        "Aspire__Azure__Messaging__EventHubs__EventHubBufferedProducerClient__eventhubs__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
+        "myhub__fullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
+        "Aspire__Azure__Messaging__EventHubs__EventHubProducerClient__myhub__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
+        "Aspire__Azure__Messaging__EventHubs__EventHubConsumerClient__myhub__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
+        "Aspire__Azure__Messaging__EventHubs__EventProcessorClient__myhub__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
+        "Aspire__Azure__Messaging__EventHubs__PartitionReceiver__myhub__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
+        "Aspire__Azure__Messaging__EventHubs__EventHubBufferedProducerClient__myhub__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
+        "Aspire__Azure__Messaging__EventHubs__EventHubProducerClient__myhub__EventHubName": "myhub",
+        "Aspire__Azure__Messaging__EventHubs__EventHubConsumerClient__myhub__EventHubName": "myhub",
+        "Aspire__Azure__Messaging__EventHubs__EventProcessorClient__myhub__EventHubName": "myhub",
+        "Aspire__Azure__Messaging__EventHubs__PartitionReceiver__myhub__EventHubName": "myhub",
+        "Aspire__Azure__Messaging__EventHubs__EventHubBufferedProducerClient__myhub__EventHubName": "myhub",
         "messaging__fullyQualifiedNamespace": "{messaging.outputs.serviceBusEndpoint}",
         "Aspire__Azure__Messaging__ServiceBus__messaging__FullyQualifiedNamespace": "{messaging.outputs.serviceBusEndpoint}",
         "cosmosdb__accountEndpoint": "{cosmosdb.outputs.connectionString}",
@@ -117,7 +130,7 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
         "HTTP_PORTS": "{apiservice.bindings.http.targetPort}",
-        "ConnectionStrings__eventhubs": "{eventhubs.connectionString}",
+        "ConnectionStrings__myhub": "{myhub.connectionString}",
         "ConnectionStrings__messaging": "{messaging.connectionString}",
         "ConnectionStrings__cosmosdb": "{cosmosdb.connectionString}",
         "ConnectionStrings__queue": "{queue.connectionString}",

--- a/playground/AzureServiceBus/ServiceBus.AppHost/Program.cs
+++ b/playground/AzureServiceBus/ServiceBus.AppHost/Program.cs
@@ -5,18 +5,14 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var serviceBus = builder.AddAzureServiceBus("sbemulator");
 
-serviceBus
-    .WithQueue("queue1", queue =>
+serviceBus.AddServiceBusQueue("queue1")
+    .WithProperties(queue => queue.DeadLetteringOnMessageExpiration = false);
+
+serviceBus.AddServiceBusTopic("topic1")
+    .AddServiceBusSubscription("sub1")
+    .WithProperties(subscription =>
     {
-        queue.DeadLetteringOnMessageExpiration = false;
-    })
-    .WithTopic("topic1", topic =>
-    {
-        var subscription = new AzureServiceBusSubscriptionResource("sub1")
-        {
-            MaxDeliveryCount = 10,
-        };
-        topic.Subscriptions.Add(subscription);
+        subscription.MaxDeliveryCount = 10;
 
         var rule = new AzureServiceBusRule("app-prop-filter-1")
         {
@@ -33,8 +29,7 @@ serviceBus
             }
         };
         subscription.Rules.Add(rule);
-    })
-    ;
+    });
 
 serviceBus.RunAsEmulator(configure => configure.WithConfiguration(document =>
 {

--- a/playground/AzureServiceBus/ServiceBus.AppHost/Program.cs
+++ b/playground/AzureServiceBus/ServiceBus.AppHost/Program.cs
@@ -1,5 +1,5 @@
 using System.Text.Json.Nodes;
-using Aspire.Hosting.Azure.ServiceBus;
+using Aspire.Hosting.Azure;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -12,13 +12,13 @@ serviceBus
     })
     .WithTopic("topic1", topic =>
     {
-        var subscription = new ServiceBusSubscription("sub1")
+        var subscription = new AzureServiceBusSubscriptionResource("sub1")
         {
             MaxDeliveryCount = 10,
         };
         topic.Subscriptions.Add(subscription);
 
-        var rule = new ServiceBusRule("app-prop-filter-1")
+        var rule = new AzureServiceBusRule("app-prop-filter-1")
         {
             CorrelationFilter = new()
             {

--- a/playground/AzureServiceBus/ServiceBus.AppHost/aspire-manifest.json
+++ b/playground/AzureServiceBus/ServiceBus.AppHost/aspire-manifest.json
@@ -10,6 +10,18 @@
         "principalId": ""
       }
     },
+    "queue1": {
+      "type": "value.v0",
+      "connectionString": "{sbemulator.outputs.serviceBusEndpoint}"
+    },
+    "topic1": {
+      "type": "value.v0",
+      "connectionString": "{sbemulator.outputs.serviceBusEndpoint}"
+    },
+    "sub1": {
+      "type": "value.v0",
+      "connectionString": "{sbemulator.outputs.serviceBusEndpoint}"
+    },
     "worker": {
       "type": "project.v0",
       "path": "../ServiceBusWorker/ServiceBusWorker.csproj",

--- a/playground/bicep/BicepSample.AppHost/Program.cs
+++ b/playground/bicep/BicepSample.AppHost/Program.cs
@@ -53,10 +53,16 @@ builder.AddAzureApplicationInsights("aiwithoutlaw");
 // Redis takes forever to spin up...
 var redis = builder.AddAzureRedis("redis");
 
-var serviceBus = builder.AddAzureServiceBus("sb")
-                        .WithQueue("queue1")
-                        .WithTopic("topic1", topic => topic.Subscriptions.AddRange([new("subscription1"), new("subscription2")]))
-                        .WithTopic("topic2", topic => topic.Subscriptions.Add(new("subscription1")));
+var serviceBus = builder.AddAzureServiceBus("sb");
+
+serviceBus.AddServiceBusQueue("queue1");
+
+var topic1 = serviceBus.AddServiceBusTopic("topic1");
+topic1.AddServiceBusSubscription("subscription1");
+topic1.AddServiceBusSubscription("subscription2");
+serviceBus.AddServiceBusTopic("topic2")
+    .AddServiceBusSubscription("topic2sub", "subscription1");
+
 var signalr = builder.AddAzureSignalR("signalr");
 var webpubsub = builder.AddAzureWebPubSub("wps");
 builder.AddProject<Projects.BicepSample_ApiService>("api")

--- a/playground/bicep/BicepSample.AppHost/aspire-manifest.json
+++ b/playground/bicep/BicepSample.AppHost/aspire-manifest.json
@@ -162,6 +162,30 @@
         "principalId": ""
       }
     },
+    "queue1": {
+      "type": "value.v0",
+      "connectionString": "{sb.outputs.serviceBusEndpoint}"
+    },
+    "topic1": {
+      "type": "value.v0",
+      "connectionString": "{sb.outputs.serviceBusEndpoint}"
+    },
+    "subscription1": {
+      "type": "value.v0",
+      "connectionString": "{sb.outputs.serviceBusEndpoint}"
+    },
+    "subscription2": {
+      "type": "value.v0",
+      "connectionString": "{sb.outputs.serviceBusEndpoint}"
+    },
+    "topic2": {
+      "type": "value.v0",
+      "connectionString": "{sb.outputs.serviceBusEndpoint}"
+    },
+    "topic2sub": {
+      "type": "value.v0",
+      "connectionString": "{sb.outputs.serviceBusEndpoint}"
+    },
     "signalr": {
       "type": "azure.bicep.v0",
       "connectionString": "Endpoint=https://{signalr.outputs.hostName};AuthType=azure",

--- a/playground/bicep/BicepSample.AppHost/sb.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/sb.module.bicep
@@ -56,7 +56,7 @@ resource topic2 'Microsoft.ServiceBus/namespaces/topics@2024-01-01' = {
   parent: sb
 }
 
-resource subscription1 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2024-01-01' = {
+resource topic2sub 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2024-01-01' = {
   name: 'subscription1'
   parent: topic2
 }

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -51,29 +51,36 @@ var pgsqldb = builder.AddAzurePostgresFlexibleServer("pgsql")
 var pgsql2 = builder.AddAzurePostgresFlexibleServer("pgsql2")
     .AddDatabase("pgsql2db");
 
-var sb = builder.AddAzureServiceBus("servicebus")
-    .WithQueue("queue1")
-    .ConfigureInfrastructure(infrastructure =>
-    {
-        var queue = infrastructure.GetProvisionableResources().OfType<ServiceBusQueue>().Single(q => q.BicepIdentifier == "queue1");
-        queue.MaxDeliveryCount = 5;
-        queue.LockDuration = TimeSpan.FromMinutes(5);
-    })
-    .WithTopic("topic1")
-    .ConfigureInfrastructure(infrastructure =>
-    {
-        var topic = infrastructure.GetProvisionableResources().OfType<ServiceBusTopic>().Single(q => q.BicepIdentifier == "topic1");
-        topic.EnablePartitioning = true;
-    })
-    .WithTopic("topic2", topic2 => topic2.Subscriptions.Add(new("subscription1")))
-    .ConfigureInfrastructure(infrastructure =>
-    {
-        var subscription = infrastructure.GetProvisionableResources().OfType<ServiceBusSubscription>().Single(q => q.BicepIdentifier == "subscription1");
-        subscription.LockDuration = TimeSpan.FromMinutes(5);
-        subscription.RequiresSession = true;
-    })
-    .WithTopic("topic1", topic2 => topic2.Subscriptions.Add(new("subscription2")))
-    .WithTopic("topic3", topic3 => topic3.Subscriptions.AddRange([new("sub1"), new("sub2")]));
+var sb = builder.AddAzureServiceBus("servicebus");
+
+sb.AddServiceBusQueue("queue1");
+sb.ConfigureInfrastructure(infrastructure =>
+ {
+     var queue = infrastructure.GetProvisionableResources().OfType<ServiceBusQueue>().Single(q => q.BicepIdentifier == "queue1");
+     queue.MaxDeliveryCount = 5;
+     queue.LockDuration = TimeSpan.FromMinutes(5);
+ });
+
+sb.AddServiceBusTopic("topic1")
+    .AddServiceBusSubscription("subscription2");
+sb.ConfigureInfrastructure(infrastructure =>
+{
+    var topic = infrastructure.GetProvisionableResources().OfType<ServiceBusTopic>().Single(q => q.BicepIdentifier == "topic1");
+    topic.EnablePartitioning = true;
+});
+
+sb.AddServiceBusTopic("topic2")
+    .AddServiceBusSubscription("subscription1");
+sb.ConfigureInfrastructure(infrastructure =>
+{
+    var subscription = infrastructure.GetProvisionableResources().OfType<ServiceBusSubscription>().Single(q => q.BicepIdentifier == "subscription1");
+    subscription.LockDuration = TimeSpan.FromMinutes(5);
+    subscription.RequiresSession = true;
+});
+
+var topic3 = sb.AddServiceBusTopic("topic3");
+topic3.AddServiceBusSubscription("sub1");
+topic3.AddServiceBusSubscription("sub2");
 
 var appConfig = builder.AddAzureAppConfiguration("appConfig");
 

--- a/playground/cdk/CdkSample.AppHost/aspire-manifest.json
+++ b/playground/cdk/CdkSample.AppHost/aspire-manifest.json
@@ -144,6 +144,38 @@
         "principalId": ""
       }
     },
+    "queue1": {
+      "type": "value.v0",
+      "connectionString": "{servicebus.outputs.serviceBusEndpoint}"
+    },
+    "topic1": {
+      "type": "value.v0",
+      "connectionString": "{servicebus.outputs.serviceBusEndpoint}"
+    },
+    "subscription2": {
+      "type": "value.v0",
+      "connectionString": "{servicebus.outputs.serviceBusEndpoint}"
+    },
+    "topic2": {
+      "type": "value.v0",
+      "connectionString": "{servicebus.outputs.serviceBusEndpoint}"
+    },
+    "subscription1": {
+      "type": "value.v0",
+      "connectionString": "{servicebus.outputs.serviceBusEndpoint}"
+    },
+    "topic3": {
+      "type": "value.v0",
+      "connectionString": "{servicebus.outputs.serviceBusEndpoint}"
+    },
+    "sub1": {
+      "type": "value.v0",
+      "connectionString": "{servicebus.outputs.serviceBusEndpoint}"
+    },
+    "sub2": {
+      "type": "value.v0",
+      "connectionString": "{servicebus.outputs.serviceBusEndpoint}"
+    },
     "appConfig": {
       "type": "azure.bicep.v0",
       "connectionString": "{appConfig.outputs.appConfigEndpoint}",

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusCorrelationFilter.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusCorrelationFilter.cs
@@ -1,17 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Hosting.Azure.ServiceBus;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents the correlation filter expression.
 /// </summary>
-public class ServiceBusCorrelationFilter
+public class AzureServiceBusCorrelationFilter
 {
     /// <summary>
     /// Represents the correlation filter expression.
     /// </summary>
-    public ServiceBusCorrelationFilter()
+    public AzureServiceBusCorrelationFilter()
     {
     }
 

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -109,30 +109,48 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The Azure Service Bus resource builder.</param>
     /// <param name="name">The name of the queue.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(WithQueue)} instead to add an Azure Service Bus Queue.")]
+    [Obsolete($"This method is obsolete because it has the wrong return type and will be removed in a future version. Use {nameof(AddServiceBusQueue)} instead to add an Azure Service Bus Queue.")]
     public static IResourceBuilder<AzureServiceBusResource> AddQueue(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name)
     {
-        return builder.WithQueue(name);
+        builder.AddServiceBusQueue(name);
+
+        return builder;
     }
 
     /// <summary>
-    /// Adds an Azure Service Bus Queue resource to the application model. This resource requires an <see cref="AzureServiceBusResource"/> to be added to the application model.
+    /// Adds an Azure Service Bus Queue resource to the application model.
     /// </summary>
     /// <param name="builder">The Azure Service Bus resource builder.</param>
-    /// <param name="name">The name of the queue.</param>
-    /// <param name="configure">An optional method that can be used for customizing the <see cref="AzureServiceBusQueueResource"/>.</param>
+    /// <param name="name">The name of the queue resource.</param>
+    /// <param name="queueName">The name of the Service Bus Queue. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<AzureServiceBusResource> WithQueue(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name, Action<AzureServiceBusQueueResource>? configure = null)
+    public static IResourceBuilder<AzureServiceBusQueueResource> AddServiceBusQueue(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name, string? queueName = null)
     {
-        var queue = builder.Resource.Queues.FirstOrDefault(x => x.Name == name);
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(name);
 
-        if (queue == null)
-        {
-            queue = new AzureServiceBusQueueResource(name);
-            builder.Resource.Queues.Add(queue);
-        }
+        // Use the resource name as the queue name if it's not provided
+        queueName ??= name;
 
-        configure?.Invoke(queue);
+        var queue = new AzureServiceBusQueueResource(name, queueName, builder.Resource);
+        builder.Resource.Queues.Add(queue);
+
+        return builder.ApplicationBuilder.AddResource(queue);
+    }
+
+    /// <summary>
+    /// Allows setting the properties of an Azure Service Bus Queue resource.
+    /// </summary>
+    /// <param name="builder">The Azure Service Bus Queue resource builder.</param>
+    /// <param name="configure">A method that can be used for customizing the <see cref="AzureServiceBusQueueResource"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureServiceBusQueueResource> WithProperties(this IResourceBuilder<AzureServiceBusQueueResource> builder, Action<AzureServiceBusQueueResource> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        configure(builder.Resource);
+
         return builder;
     }
 
@@ -141,10 +159,12 @@ public static class AzureServiceBusExtensions
     /// </summary>
     /// <param name="builder">The Azure Service Bus resource builder.</param>
     /// <param name="name">The name of the topic.</param>
-    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(WithTopic)} instead to add an Azure Service Bus Topic.")]
+    [Obsolete($"This method is obsolete because it has the wrong return type and will be removed in a future version. Use {nameof(AddServiceBusTopic)} instead to add an Azure Service Bus Topic.")]
     public static IResourceBuilder<AzureServiceBusResource> AddTopic(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name)
     {
-        return builder.WithTopic(name);
+        builder.AddServiceBusTopic(name);
+
+        return builder;
     }
 
     /// <summary>
@@ -153,39 +173,53 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The Azure Service Bus resource builder.</param>
     /// <param name="name">The name of the topic.</param>
     /// <param name="subscriptions">The name of the subscriptions.</param>
-    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(WithTopic)} instead to add an Azure Service Bus Topic and Subscriptions.")]
+    [Obsolete($"This method is obsolete because it has the wrong return type and will be removed in a future version. Use {nameof(AddServiceBusTopic)} and {nameof(AddServiceBusSubscription)} instead to add an Azure Service Bus Topic and Subscriptions.")]
     public static IResourceBuilder<AzureServiceBusResource> AddTopic(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name, string[] subscriptions)
     {
-        return builder.WithTopic(name, topic =>
+        var topic = builder.AddServiceBusTopic(name);
+
+        foreach (var subscription in subscriptions)
         {
-            foreach (var subscription in subscriptions)
-            {
-                if (!topic.Subscriptions.Any(x => x.Name == subscription))
-                {
-                    topic.Subscriptions.Add(new AzureServiceBusSubscriptionResource(subscription));
-                }
-            }
-        });
+            topic.AddServiceBusSubscription(subscription);
+        }
+
+        return builder;
     }
 
     /// <summary>
-    /// Adds an Azure Service Bus Topic resource to the application model. This resource requires an <see cref="AzureServiceBusResource"/> to be added to the application model.
+    /// Adds an Azure Service Bus Topic resource to the application model.
     /// </summary>
     /// <param name="builder">The Azure Service Bus resource builder.</param>
     /// <param name="name">The name of the topic.</param>
-    /// <param name="configure">An optional method that can be used for customizing the <see cref="AzureServiceBusTopicResource"/>.</param>
+    /// <param name="topicName">The name of the Service Bus Topic. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<AzureServiceBusResource> WithTopic(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name, Action<AzureServiceBusTopicResource>? configure = null)
+    public static IResourceBuilder<AzureServiceBusTopicResource> AddServiceBusTopic(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name, string? topicName = null)
     {
-        var topic = builder.Resource.Topics.FirstOrDefault(x => x.Name == name);
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(name);
 
-        if (topic == null)
-        {
-            topic = new AzureServiceBusTopicResource(name);
-            builder.Resource.Topics.Add(topic);
-        }
+        // Use the resource name as the topic name if it's not provided
+        topicName ??= name;
 
-        configure?.Invoke(topic);
+        var topic = new AzureServiceBusTopicResource(name, topicName, builder.Resource);
+        builder.Resource.Topics.Add(topic);
+
+        return builder.ApplicationBuilder.AddResource(topic);
+    }
+
+    /// <summary>
+    /// Allows setting the properties of an Azure Service Bus Topic resource.
+    /// </summary>
+    /// <param name="builder">The Azure Service Bus Topic resource builder.</param>
+    /// <param name="configure">A method that can be used for customizing the <see cref="AzureServiceBusTopicResource"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureServiceBusTopicResource> WithProperties(this IResourceBuilder<AzureServiceBusTopicResource> builder, Action<AzureServiceBusTopicResource> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        configure(builder.Resource);
+
         return builder;
     }
 
@@ -193,19 +227,60 @@ public static class AzureServiceBusExtensions
     /// Adds an Azure Service Bus Subscription resource to the application model. This resource requires an <see cref="AzureServiceBusResource"/> to be added to the application model.
     /// </summary>
     /// <param name="builder">The Azure Service Bus resource builder.</param>
-    /// <param name="topicName">The name of the topic.</param>
+    /// <param name="topicName">The name of the topic resource.</param>
     /// <param name="subscriptionName">The name of the subscription.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(WithTopic)} instead to add an Azure Service Bus Subscription to a Topic.")]
+    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(AddServiceBusSubscription)} instead to add an Azure Service Bus Subscription to a Topic.")]
     public static IResourceBuilder<AzureServiceBusResource> AddSubscription(this IResourceBuilder<AzureServiceBusResource> builder, string topicName, string subscriptionName)
     {
-        builder.WithTopic(topicName, topic =>
+        IResourceBuilder<AzureServiceBusTopicResource> topicBuilder;
+        if (builder.Resource.Topics.FirstOrDefault(x => x.Name == topicName) is { } existingResource)
         {
-            if (!topic.Subscriptions.Any(x => x.Name == subscriptionName))
-            {
-                topic.Subscriptions.Add(new AzureServiceBusSubscriptionResource(subscriptionName));
-            }
-        });
+            topicBuilder = builder.ApplicationBuilder.CreateResourceBuilder(existingResource);
+        }
+        else
+        {
+            topicBuilder = builder.AddServiceBusTopic(topicName);
+        }
+
+        topicBuilder.AddServiceBusSubscription(subscriptionName);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an Azure Service Bus Subscription resource to the application model.
+    /// </summary>
+    /// <param name="builder">The Azure Service Bus Topic resource builder.</param>
+    /// <param name="name">The name of the subscription.</param>
+    /// <param name="subscriptionName">The name of the Service Bus Subscription. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureServiceBusSubscriptionResource> AddServiceBusSubscription(this IResourceBuilder<AzureServiceBusTopicResource> builder, [ResourceName] string name, string? subscriptionName = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(name);
+
+        // Use the resource name as the subscription name if it's not provided
+        subscriptionName ??= name;
+
+        var subscription = new AzureServiceBusSubscriptionResource(name, subscriptionName, builder.Resource);
+        builder.Resource.Subscriptions.Add(subscription);
+
+        return builder.ApplicationBuilder.AddResource(subscription);
+    }
+
+    /// <summary>
+    /// Allows setting the properties of an Azure Service Bus Subscription resource.
+    /// </summary>
+    /// <param name="builder">The Azure Service Bus Subscription resource builder.</param>
+    /// <param name="configure">A method that can be used for customizing the <see cref="AzureServiceBusSubscriptionResource"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureServiceBusSubscriptionResource> WithProperties(this IResourceBuilder<AzureServiceBusSubscriptionResource> builder, Action<AzureServiceBusSubscriptionResource> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        configure(builder.Resource);
 
         return builder;
     }

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -120,15 +120,15 @@ public static class AzureServiceBusExtensions
     /// </summary>
     /// <param name="builder">The Azure Service Bus resource builder.</param>
     /// <param name="name">The name of the queue.</param>
-    /// <param name="configure">An optional method that can be used for customizing the <see cref="ServiceBusQueue"/>.</param>
+    /// <param name="configure">An optional method that can be used for customizing the <see cref="AzureServiceBusQueueResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<AzureServiceBusResource> WithQueue(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name, Action<ServiceBusQueue>? configure = null)
+    public static IResourceBuilder<AzureServiceBusResource> WithQueue(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name, Action<AzureServiceBusQueueResource>? configure = null)
     {
         var queue = builder.Resource.Queues.FirstOrDefault(x => x.Name == name);
 
         if (queue == null)
         {
-            queue = new ServiceBusQueue(name);
+            queue = new AzureServiceBusQueueResource(name);
             builder.Resource.Queues.Add(queue);
         }
 
@@ -162,7 +162,7 @@ public static class AzureServiceBusExtensions
             {
                 if (!topic.Subscriptions.Any(x => x.Name == subscription))
                 {
-                    topic.Subscriptions.Add(new ServiceBusSubscription(subscription));
+                    topic.Subscriptions.Add(new AzureServiceBusSubscriptionResource(subscription));
                 }
             }
         });
@@ -173,15 +173,15 @@ public static class AzureServiceBusExtensions
     /// </summary>
     /// <param name="builder">The Azure Service Bus resource builder.</param>
     /// <param name="name">The name of the topic.</param>
-    /// <param name="configure">An optional method that can be used for customizing the <see cref="ServiceBusTopic"/>.</param>
+    /// <param name="configure">An optional method that can be used for customizing the <see cref="AzureServiceBusTopicResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<AzureServiceBusResource> WithTopic(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name, Action<ServiceBusTopic>? configure = null)
+    public static IResourceBuilder<AzureServiceBusResource> WithTopic(this IResourceBuilder<AzureServiceBusResource> builder, [ResourceName] string name, Action<AzureServiceBusTopicResource>? configure = null)
     {
         var topic = builder.Resource.Topics.FirstOrDefault(x => x.Name == name);
 
         if (topic == null)
         {
-            topic = new ServiceBusTopic(name);
+            topic = new AzureServiceBusTopicResource(name);
             builder.Resource.Topics.Add(topic);
         }
 
@@ -203,7 +203,7 @@ public static class AzureServiceBusExtensions
         {
             if (!topic.Subscriptions.Any(x => x.Name == subscriptionName))
             {
-                topic.Subscriptions.Add(new ServiceBusSubscription(subscriptionName));
+                topic.Subscriptions.Add(new AzureServiceBusSubscriptionResource(subscriptionName));
             }
         });
 

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusFilterType.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusFilterType.cs
@@ -1,12 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Hosting.Azure.ServiceBus;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Rule filter types.
 /// </summary>
-public enum ServiceBusFilterType
+public enum AzureServiceBusFilterType
 {
     /// <summary>
     /// SqlFilter.

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 using System.Xml;
 using Azure.Provisioning;
 
-namespace Aspire.Hosting.Azure.ServiceBus;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents a Service Bus Queue.
@@ -13,12 +13,12 @@ namespace Aspire.Hosting.Azure.ServiceBus;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class ServiceBusQueue
+public class AzureServiceBusQueueResource
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ServiceBusQueue"/> class.
+    /// Initializes a new instance of the <see cref="AzureServiceBusQueueResource"/> class.
     /// </summary>
-    public ServiceBusQueue(string name)
+    public AzureServiceBusQueueResource(string name)
     {
         Name = name;
     }

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Azure.ServiceBus;
 
 namespace Aspire.Hosting.Azure;
 
@@ -14,8 +13,8 @@ namespace Aspire.Hosting.Azure;
 public class AzureServiceBusResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure)
     : AzureProvisioningResource(name, configureInfrastructure), IResourceWithConnectionString, IResourceWithAzureFunctionsConfig, IResourceWithEndpoints
 {
-    internal List<ServiceBusQueue> Queues { get; } = [];
-    internal List<ServiceBusTopic> Topics { get; } = [];
+    internal List<AzureServiceBusQueueResource> Queues { get; } = [];
+    internal List<AzureServiceBusTopicResource> Topics { get; } = [];
 
     /// <summary>
     /// Gets the "serviceBusEndpoint" output reference from the bicep template for the Azure Storage resource.

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusRule.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusRule.cs
@@ -4,7 +4,7 @@
 using System.Text.Json;
 using Azure.Provisioning;
 
-namespace Aspire.Hosting.Azure.ServiceBus;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents a Service Bus Rule.
@@ -12,12 +12,12 @@ namespace Aspire.Hosting.Azure.ServiceBus;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class ServiceBusRule
+public class AzureServiceBusRule
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ServiceBusRule"/> class.
+    /// Initializes a new instance of the <see cref="AzureServiceBusRule"/> class.
     /// </summary>
-    public ServiceBusRule(string name)
+    public AzureServiceBusRule(string name)
     {
         Name = name;
     }
@@ -30,12 +30,12 @@ public class ServiceBusRule
     /// <summary>
     /// Properties of correlation filter.
     /// </summary>
-    public ServiceBusCorrelationFilter CorrelationFilter { get; set; } = new();
+    public AzureServiceBusCorrelationFilter CorrelationFilter { get; set; } = new();
 
     /// <summary>
     /// Filter type that is evaluated against a BrokeredMessage.
     /// </summary>
-    public ServiceBusFilterType FilterType { get; set; } = ServiceBusFilterType.CorrelationFilter;
+    public AzureServiceBusFilterType FilterType { get; set; } = AzureServiceBusFilterType.CorrelationFilter;
 
     /// <summary>
     /// Converts the current instance to a provisioning entity.
@@ -98,8 +98,8 @@ public class ServiceBusRule
 
         rule.FilterType = FilterType switch
         {
-            ServiceBusFilterType.SqlFilter => global::Azure.Provisioning.ServiceBus.ServiceBusFilterType.SqlFilter,
-            ServiceBusFilterType.CorrelationFilter => global::Azure.Provisioning.ServiceBus.ServiceBusFilterType.CorrelationFilter,
+            AzureServiceBusFilterType.SqlFilter => global::Azure.Provisioning.ServiceBus.ServiceBusFilterType.SqlFilter,
+            AzureServiceBusFilterType.CorrelationFilter => global::Azure.Provisioning.ServiceBus.ServiceBusFilterType.CorrelationFilter,
             _ => throw new NotImplementedException()
         };
 
@@ -116,7 +116,7 @@ public class ServiceBusRule
 
         if (rule.Name != null)
         {
-            writer.WriteString(nameof(ServiceBusQueue.Name), rule.Name);
+            writer.WriteString(nameof(AzureServiceBusQueueResource.Name), rule.Name);
         }
 
         writer.WriteStartObject("Properties");
@@ -124,8 +124,8 @@ public class ServiceBusRule
         writer.WriteString(nameof(FilterType), rule.FilterType switch
         {
             // The Emulator uses "Sql/Correlation" instead of "SqlFilter/CorrelationFilter" in Azure.Provisioning (and Bicep template).
-            ServiceBusFilterType.SqlFilter => "Sql",
-            ServiceBusFilterType.CorrelationFilter => "Correlation",
+            AzureServiceBusFilterType.SqlFilter => "Sql",
+            AzureServiceBusFilterType.CorrelationFilter => "Correlation",
             _ => throw new NotImplementedException()
         });
 
@@ -139,11 +139,11 @@ public class ServiceBusRule
         }
         if (rule.CorrelationFilter.CorrelationId != null)
         {
-            writer.WriteString(nameof(ServiceBusCorrelationFilter.CorrelationId), rule.CorrelationFilter.CorrelationId);
+            writer.WriteString(nameof(AzureServiceBusCorrelationFilter.CorrelationId), rule.CorrelationFilter.CorrelationId);
         }
         if (rule.CorrelationFilter.MessageId != null)
         {
-            writer.WriteString(nameof(ServiceBusCorrelationFilter.MessageId), rule.CorrelationFilter.MessageId);
+            writer.WriteString(nameof(AzureServiceBusCorrelationFilter.MessageId), rule.CorrelationFilter.MessageId);
         }
         if (rule.CorrelationFilter.SendTo != null)
         {
@@ -152,7 +152,7 @@ public class ServiceBusRule
         }
         if (rule.CorrelationFilter.ReplyTo != null)
         {
-            writer.WriteString(nameof(ServiceBusCorrelationFilter.ReplyTo), rule.CorrelationFilter.ReplyTo);
+            writer.WriteString(nameof(AzureServiceBusCorrelationFilter.ReplyTo), rule.CorrelationFilter.ReplyTo);
         }
         if (rule.CorrelationFilter.Subject != null)
         {
@@ -161,19 +161,19 @@ public class ServiceBusRule
         }
         if (rule.CorrelationFilter.SessionId != null)
         {
-            writer.WriteString(nameof(ServiceBusCorrelationFilter.SessionId), rule.CorrelationFilter.SessionId);
+            writer.WriteString(nameof(AzureServiceBusCorrelationFilter.SessionId), rule.CorrelationFilter.SessionId);
         }
         if (rule.CorrelationFilter.ReplyToSessionId != null)
         {
-            writer.WriteString(nameof(ServiceBusCorrelationFilter.ReplyToSessionId), rule.CorrelationFilter.ReplyToSessionId);
+            writer.WriteString(nameof(AzureServiceBusCorrelationFilter.ReplyToSessionId), rule.CorrelationFilter.ReplyToSessionId);
         }
         if (rule.CorrelationFilter.ContentType != null)
         {
-            writer.WriteString(nameof(ServiceBusCorrelationFilter.ContentType), rule.CorrelationFilter.ContentType);
+            writer.WriteString(nameof(AzureServiceBusCorrelationFilter.ContentType), rule.CorrelationFilter.ContentType);
         }
         if (rule.CorrelationFilter.RequiresPreprocessing.HasValue)
         {
-            writer.WriteBoolean(nameof(ServiceBusCorrelationFilter.RequiresPreprocessing), rule.CorrelationFilter.RequiresPreprocessing.Value);
+            writer.WriteBoolean(nameof(AzureServiceBusCorrelationFilter.RequiresPreprocessing), rule.CorrelationFilter.RequiresPreprocessing.Value);
         }
 
         writer.WriteEndObject(); // CorrelationFilter

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusSubscriptionResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusSubscriptionResource.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 using System.Xml;
 using Azure.Provisioning;
 
-namespace Aspire.Hosting.Azure.ServiceBus;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents a Service Bus Subscription.
@@ -13,12 +13,12 @@ namespace Aspire.Hosting.Azure.ServiceBus;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class ServiceBusSubscription
+public class AzureServiceBusSubscriptionResource
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ServiceBusSubscription"/> class.
+    /// Initializes a new instance of the <see cref="AzureServiceBusSubscriptionResource"/> class.
     /// </summary>
-    public ServiceBusSubscription(string name)
+    public AzureServiceBusSubscriptionResource(string name)
     {
         Name = name;
     }
@@ -74,7 +74,7 @@ public class ServiceBusSubscription
     /// <summary>
     /// The rules for this subscription.
     /// </summary>
-    public List<ServiceBusRule> Rules { get; } = [];
+    public List<AzureServiceBusRule> Rules { get; } = [];
 
     /// <summary>
     /// Converts the current instance to a provisioning entity.
@@ -130,7 +130,7 @@ public class ServiceBusSubscription
 
         if (subscription.Name != null)
         {
-            writer.WriteString(nameof(ServiceBusQueue.Name), subscription.Name);
+            writer.WriteString(nameof(AzureServiceBusQueueResource.Name), subscription.Name);
         }
 
         writer.WriteStartObject("Properties");

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusTopicResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusTopicResource.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 using System.Xml;
 using Azure.Provisioning;
 
-namespace Aspire.Hosting.Azure.ServiceBus;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents a Service Bus Topic.
@@ -13,12 +13,12 @@ namespace Aspire.Hosting.Azure.ServiceBus;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-public class ServiceBusTopic
+public class AzureServiceBusTopicResource
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ServiceBusTopic"/> class.
+    /// Initializes a new instance of the <see cref="AzureServiceBusTopicResource"/> class.
     /// </summary>
-    public ServiceBusTopic(string name)
+    public AzureServiceBusTopicResource(string name)
     {
         Name = name;
     }
@@ -50,7 +50,7 @@ public class ServiceBusTopic
     /// <summary>
     /// The subscriptions for this topic.
     /// </summary>
-    public List<ServiceBusSubscription> Subscriptions { get; } = [];
+    public List<AzureServiceBusSubscriptionResource> Subscriptions { get; } = [];
 
     /// <summary>
     /// Converts the current instance to a provisioning entity.

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -1826,12 +1826,11 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         }
         else
         {
-            serviceBus
-                .WithQueue("queue1")
-                .WithQueue("queue2")
-                .WithTopic("t1")
-                .WithTopic("t2")
-                .WithTopic("t1", topic => topic.Subscriptions.Add(new("s3")));
+            serviceBus.AddServiceBusQueue("queue1");
+            serviceBus.AddServiceBusQueue("queue2");
+            serviceBus.AddServiceBusTopic("t1")
+                .AddServiceBusSubscription("s3");
+            serviceBus.AddServiceBusTopic("t2");
         }
 
         serviceBus.Resource.Outputs["serviceBusEndpoint"] = "mynamespaceEndpoint";

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -32,8 +32,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         serviceBus.WithTopic("topic1", topic =>
         {
             topic.DefaultMessageTimeToLive = TimeSpan.FromSeconds(1);
-            var subscription = new ServiceBusSubscription("subscription1");
-            subscription.Rules.Add(new ServiceBusRule("rule1"));
+            var subscription = new AzureServiceBusSubscriptionResource("subscription1");
+            subscription.Rules.Add(new AzureServiceBusRule("rule1"));
             topic.Subscriptions.Add(subscription);
         });
         serviceBus.AddSubscription("topic1", "subscription1");
@@ -334,7 +334,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 topic.DuplicateDetectionHistoryTimeWindow = TimeSpan.FromSeconds(20);
                 topic.RequiresDuplicateDetection = true;
 
-                var subscription = new ServiceBusSubscription("subscription1")
+                var subscription = new AzureServiceBusSubscriptionResource("subscription1")
                 {
                     DeadLetteringOnMessageExpiration = true,
                     DefaultMessageTimeToLive = TimeSpan.FromMinutes(1),
@@ -345,9 +345,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 };
                 topic.Subscriptions.Add(subscription);
 
-                var rule = new ServiceBusRule("rule1")
+                var rule = new AzureServiceBusRule("rule1")
                 {
-                    FilterType = ServiceBusFilterType.SqlFilter,
+                    FilterType = AzureServiceBusFilterType.SqlFilter,
                     CorrelationFilter = new()
                     {
                         ContentType = "application/text",
@@ -438,7 +438,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 topic.DuplicateDetectionHistoryTimeWindow = TimeSpan.FromSeconds(20);
                 topic.RequiresDuplicateDetection = true;
 
-                var subscription = new ServiceBusSubscription("subscription1")
+                var subscription = new AzureServiceBusSubscriptionResource("subscription1")
                 {
                     DeadLetteringOnMessageExpiration = true,
                     DefaultMessageTimeToLive = TimeSpan.FromMinutes(1),
@@ -449,9 +449,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 };
                 topic.Subscriptions.Add(subscription);
 
-                var rule = new ServiceBusRule("rule1")
+                var rule = new AzureServiceBusRule("rule1")
                 {
-                    FilterType = ServiceBusFilterType.SqlFilter,
+                    FilterType = AzureServiceBusFilterType.SqlFilter,
                     CorrelationFilter = new()
                     {
                         ContentType = "application/text",

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -18,27 +18,23 @@ namespace Aspire.Hosting.Azure.Tests;
 public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 {
     [Fact]
-    public async Task NameResourcesAreReused()
+    public async Task ResourceNamesCanBeDifferentThanAzureNames()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var serviceBus = builder.AddAzureServiceBus("sb");
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        serviceBus.AddQueue("queue1");
-        serviceBus.AddQueue("queue1");
-        serviceBus.WithQueue("queue1", queue => queue.DefaultMessageTimeToLive = TimeSpan.FromSeconds(1));
-        serviceBus.AddTopic("topic1");
-        serviceBus.AddTopic("topic1");
-        serviceBus.WithTopic("topic1", topic =>
-        {
-            topic.DefaultMessageTimeToLive = TimeSpan.FromSeconds(1);
-            var subscription = new AzureServiceBusSubscriptionResource("subscription1");
-            subscription.Rules.Add(new AzureServiceBusRule("rule1"));
-            topic.Subscriptions.Add(subscription);
-        });
-        serviceBus.AddSubscription("topic1", "subscription1");
-        serviceBus.AddSubscription("topic1", "subscription2");
-#pragma warning restore CS0618 // Type or member is obsolete
+        serviceBus.AddServiceBusQueue("queue1", "queueName")
+            .WithProperties(queue => queue.DefaultMessageTimeToLive = TimeSpan.FromSeconds(1));
+        var topic1 = serviceBus.AddServiceBusTopic("topic1", "topicName")
+            .WithProperties(topic =>
+            {
+                topic.DefaultMessageTimeToLive = TimeSpan.FromSeconds(1);
+            });
+        topic1.AddServiceBusSubscription("subscription1", "subscriptionName")
+            .WithProperties(sub =>
+            {
+                sub.Rules.Add(new AzureServiceBusRule("rule1"));
+            });
 
         var manifest = await ManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
@@ -77,7 +73,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             }
 
             resource queue1 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' = {
-              name: 'queue1'
+              name: 'queueName'
               properties: {
                 defaultMessageTimeToLive: 'PT1S'
               }
@@ -85,7 +81,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             }
 
             resource topic1 'Microsoft.ServiceBus/namespaces/topics@2024-01-01' = {
-              name: 'topic1'
+              name: 'topicName'
               properties: {
                 defaultMessageTimeToLive: 'PT1S'
               }
@@ -93,7 +89,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             }
 
             resource subscription1 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2024-01-01' = {
-              name: 'subscription1'
+              name: 'subscriptionName'
               parent: topic1
             }
 
@@ -103,11 +99,6 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 filterType: 'CorrelationFilter'
               }
               parent: subscription1
-            }
-            
-            resource subscription2 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2024-01-01' = {
-              name: 'subscription2'
-              parent: topic1
             }
 
             output serviceBusEndpoint string = sb.properties.serviceBusEndpoint
@@ -132,7 +123,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         }
         else
         {
-            serviceBus.WithTopic("device-connection-state-events1234567890-even-longer");
+            serviceBus.AddServiceBusTopic("device-connection-state-events1234567890-even-longer");
         }
 
         var manifest = await ManifestUtils.GetManifestWithBicep(serviceBus.Resource);
@@ -197,9 +188,10 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         });
 
         var resource = builder.AddAzureServiceBus("resource")
-                              .WithQueue("queue1")
                               .RunAsEmulator()
                               .WithHealthCheck("blocking_check");
+
+        resource.AddServiceBusQueue("queue1");
 
         var dependentResource = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
                                        .WaitFor(resource);
@@ -234,8 +226,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(output);
 
         var serviceBus = builder.AddAzureServiceBus("servicebusns")
-            .RunAsEmulator()
-            .WithQueue("queue123");
+            .RunAsEmulator();
+
+        serviceBus.AddServiceBusQueue("queue123");
 
         using var app = builder.Build();
         await app.StartAsync();
@@ -316,8 +309,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         global::Azure.Provisioning.ServiceBus.ServiceBusSubscription? subscription = null;
         global::Azure.Provisioning.ServiceBus.ServiceBusRule? rule = null;
 
-        var serviceBus = builder.AddAzureServiceBus("servicebusns")
-            .WithQueue("queue1", queue =>
+        var serviceBus = builder.AddAzureServiceBus("servicebusns");
+        serviceBus.AddServiceBusQueue("queue1")
+            .WithProperties(queue =>
             {
                 queue.DeadLetteringOnMessageExpiration = true;
                 queue.DefaultMessageTimeToLive = TimeSpan.FromMinutes(1);
@@ -327,23 +321,24 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 queue.MaxDeliveryCount = 10;
                 queue.RequiresDuplicateDetection = true;
                 queue.RequiresSession = true;
-            })
-            .WithTopic("topic1", topic =>
+            });
+
+        var topic1 = serviceBus.AddServiceBusTopic("topic1")
+            .WithProperties(topic =>
             {
                 topic.DefaultMessageTimeToLive = TimeSpan.FromMinutes(1);
                 topic.DuplicateDetectionHistoryTimeWindow = TimeSpan.FromSeconds(20);
                 topic.RequiresDuplicateDetection = true;
-
-                var subscription = new AzureServiceBusSubscriptionResource("subscription1")
-                {
-                    DeadLetteringOnMessageExpiration = true,
-                    DefaultMessageTimeToLive = TimeSpan.FromMinutes(1),
-                    LockDuration = TimeSpan.FromMinutes(5),
-                    MaxDeliveryCount = 10,
-                    ForwardDeadLetteredMessagesTo = "",
-                    RequiresSession = true,
-                };
-                topic.Subscriptions.Add(subscription);
+            });
+        topic1.AddServiceBusSubscription("subscription1")
+            .WithProperties(sub =>
+            { 
+                sub.DeadLetteringOnMessageExpiration = true;
+                sub.DefaultMessageTimeToLive = TimeSpan.FromMinutes(1);
+                sub.LockDuration = TimeSpan.FromMinutes(5);
+                sub.MaxDeliveryCount = 10;
+                sub.ForwardDeadLetteredMessagesTo = "";
+                sub.RequiresSession = true;
 
                 var rule = new AzureServiceBusRule("rule1")
                 {
@@ -360,8 +355,10 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                         SendTo = "xyz"
                     }
                 };
-                subscription.Rules.Add(rule);
-            })
+                sub.Rules.Add(rule);
+            });
+
+        serviceBus
             .ConfigureInfrastructure(infrastructure =>
             {
                 queue = infrastructure.GetProvisionableResources().OfType<global::Azure.Provisioning.ServiceBus.ServiceBusQueue>().Single();
@@ -420,8 +417,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var serviceBus = builder.AddAzureServiceBus("servicebusns")
-            .RunAsEmulator()
-            .WithQueue("queue1", queue =>
+            .RunAsEmulator();
+        serviceBus.AddServiceBusQueue("queue1")
+            .WithProperties(queue =>
             {
                 queue.DeadLetteringOnMessageExpiration = true;
                 queue.DefaultMessageTimeToLive = TimeSpan.FromMinutes(1);
@@ -431,23 +429,24 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 queue.MaxDeliveryCount = 10;
                 queue.RequiresDuplicateDetection = true;
                 queue.RequiresSession = true;
-            })
-            .WithTopic("topic1", topic =>
+            });
+
+        var topic1 = serviceBus.AddServiceBusTopic("topic1")
+            .WithProperties(topic =>
             {
                 topic.DefaultMessageTimeToLive = TimeSpan.FromMinutes(1);
                 topic.DuplicateDetectionHistoryTimeWindow = TimeSpan.FromSeconds(20);
                 topic.RequiresDuplicateDetection = true;
-
-                var subscription = new AzureServiceBusSubscriptionResource("subscription1")
-                {
-                    DeadLetteringOnMessageExpiration = true,
-                    DefaultMessageTimeToLive = TimeSpan.FromMinutes(1),
-                    LockDuration = TimeSpan.FromMinutes(5),
-                    MaxDeliveryCount = 10,
-                    ForwardDeadLetteredMessagesTo = "",
-                    RequiresSession = true,
-                };
-                topic.Subscriptions.Add(subscription);
+            });
+        topic1.AddServiceBusSubscription("subscription1")
+            .WithProperties(sub =>
+            {
+                sub.DeadLetteringOnMessageExpiration = true;
+                sub.DefaultMessageTimeToLive = TimeSpan.FromMinutes(1);
+                sub.LockDuration = TimeSpan.FromMinutes(5);
+                sub.MaxDeliveryCount = 10;
+                sub.ForwardDeadLetteredMessagesTo = "";
+                sub.RequiresSession = true;
 
                 var rule = new AzureServiceBusRule("rule1")
                 {
@@ -464,7 +463,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                         SendTo = "xyz"
                     }
                 };
-                subscription.Rules.Add(rule);
+                sub.Rules.Add(rule);
             });
 
         using var app = builder.Build();
@@ -556,8 +555,9 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var serviceBus = builder.AddAzureServiceBus("servicebusns")
-            .RunAsEmulator()
-            .WithQueue("queue1", queue =>
+            .RunAsEmulator();
+        serviceBus.AddServiceBusQueue("queue1")
+            .WithProperties(queue =>
             {
                 queue.DefaultMessageTimeToLive = TimeSpan.FromMinutes(1);
             });
@@ -734,5 +734,58 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var serviceBus = builder.AddAzureServiceBus("sb").RunAsEmulator();
 
         Assert.Throws<InvalidOperationException>(() => serviceBus.RunAsEmulator());
+    }
+
+    [Fact]
+    public void AzureServiceBusHasCorrectConnectionStrings()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var serviceBus = builder.AddAzureServiceBus("sb");
+        var queue = serviceBus.AddServiceBusQueue("queue");
+        var topic = serviceBus.AddServiceBusTopic("topic");
+        var subscription = topic.AddServiceBusSubscription("sub");
+
+        // queue, topic, and subscription should have the same connection string as the service bus account, for now.
+        // In the future, we can add the queue/topic/sub info to the connection string.
+        Assert.Equal("{sb.outputs.serviceBusEndpoint}", serviceBus.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{sb.outputs.serviceBusEndpoint}", queue.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{sb.outputs.serviceBusEndpoint}", topic.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{sb.outputs.serviceBusEndpoint}", subscription.Resource.ConnectionStringExpression.ValueExpression);
+    }
+
+    [Fact]
+    public void AzureServiceBusAppliesAzureFunctionsConfiguration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var serviceBus = builder.AddAzureServiceBus("sb");
+        var queue = serviceBus.AddServiceBusQueue("queue");
+        var topic = serviceBus.AddServiceBusTopic("topic");
+        var subscription = topic.AddServiceBusSubscription("sub");
+
+        var target = new Dictionary<string, object>();
+        ((IResourceWithAzureFunctionsConfig)serviceBus.Resource).ApplyAzureFunctionsConfiguration(target, "sb");
+        Assert.Collection(target.Keys.OrderBy(k => k),
+            k => Assert.Equal("Aspire__Azure__Messaging__ServiceBus__sb__FullyQualifiedNamespace", k),
+            k => Assert.Equal("sb__fullyQualifiedNamespace", k));
+
+        target.Clear();
+        ((IResourceWithAzureFunctionsConfig)queue.Resource).ApplyAzureFunctionsConfiguration(target, "queue");
+        Assert.Collection(target.Keys.OrderBy(k => k),
+            k => Assert.Equal("Aspire__Azure__Messaging__ServiceBus__queue__FullyQualifiedNamespace", k),
+            k => Assert.Equal("queue__fullyQualifiedNamespace", k));
+
+        target.Clear();
+        ((IResourceWithAzureFunctionsConfig)topic.Resource).ApplyAzureFunctionsConfiguration(target, "topic");
+        Assert.Collection(target.Keys.OrderBy(k => k),
+            k => Assert.Equal("Aspire__Azure__Messaging__ServiceBus__topic__FullyQualifiedNamespace", k),
+            k => Assert.Equal("topic__fullyQualifiedNamespace", k));
+
+        target.Clear();
+        ((IResourceWithAzureFunctionsConfig)subscription.Resource).ApplyAzureFunctionsConfiguration(target, "sub");
+        Assert.Collection(target.Keys.OrderBy(k => k),
+            k => Assert.Equal("Aspire__Azure__Messaging__ServiceBus__sub__FullyQualifiedNamespace", k),
+            k => Assert.Equal("sub__fullyQualifiedNamespace", k));
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -15,8 +15,8 @@ public class ExistingAzureResourceTests
 
         var existingResourceName = builder.AddParameter("existingResourceName");
         var serviceBus = builder.AddAzureServiceBus("messaging")
-            .RunAsExisting(existingResourceName)
-            .WithQueue("queue");
+            .RunAsExisting(existingResourceName);
+        serviceBus.AddServiceBusQueue("queue");
 
         var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
@@ -75,8 +75,8 @@ public class ExistingAzureResourceTests
 
         var existingResourceName = builder.AddParameter("existingResourceName");
         var serviceBus = builder.AddAzureServiceBus("messaging")
-            .RunAsExisting(existingResourceName)
-            .WithQueue("queue");
+            .RunAsExisting(existingResourceName);
+        serviceBus.AddServiceBusQueue("queue");
 
         var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
@@ -144,8 +144,8 @@ public class ExistingAzureResourceTests
 
         var existingResourceName = builder.AddParameter("existingResourceName");
         var serviceBus = builder.AddAzureServiceBus("messaging")
-            .PublishAsExisting(existingResourceName)
-            .WithQueue("queue");
+            .PublishAsExisting(existingResourceName);
+        serviceBus.AddServiceBusQueue("queue");
 
         var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
@@ -205,8 +205,8 @@ public class ExistingAzureResourceTests
         var existingResourceName = builder.AddParameter("existingResourceName");
         var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
         var serviceBus = builder.AddAzureServiceBus("messaging")
-            .PublishAsExisting(existingResourceName, existingResourceGroupName)
-            .WithQueue("queue");
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+        serviceBus.AddServiceBusQueue("queue");
 
         var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
@@ -269,8 +269,8 @@ public class ExistingAzureResourceTests
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var serviceBus = builder.AddAzureServiceBus("messaging")
-            .PublishAsExisting("existingResourceName", "existingResourceGroupName")
-            .WithQueue("queue");
+            .PublishAsExisting("existingResourceName", "existingResourceGroupName");
+        serviceBus.AddServiceBusQueue("queue");
 
         var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 


### PR DESCRIPTION
## Description

This allows them to be referenceable and waitable in the future.

Also rename the classes and put them in the appropriate namespace.

Probably easiest to review each commit separately.

Contributes to #7407

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No

