### PR TITLE
Expose `ResourceNotificationService` through `DistributedApplication`

### DIFF
--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -49,6 +49,7 @@ namespace Aspire.Hosting;
 public class DistributedApplication : IHost, IAsyncDisposable
 {
     private readonly IHost _host;
+    private ResourceNotificationService? _resourceNotifications;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DistributedApplication"/> class.
@@ -203,6 +204,57 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// </para>
     /// </remarks>
     public IServiceProvider Services => _host.Services;
+
+    /// <summary>
+    /// Gets the service for monitoring and responding to resource state changes in the distributed application.
+    /// </summary>
+    /// <remarks>
+    /// Two common use cases for the <see cref="ResourceNotificationService"/> are:
+    /// <list type="bullet">
+    /// <item>Database seeding.</item>
+    /// <item>Integration test readiness checks.</item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// Wait for resource readiness:
+    /// <code>
+    /// await app.ResourceNotifications.WaitForResourceHealthyAsync("postgres");
+    /// </code>
+    /// </example>
+    /// <example>
+    /// Monitor state changes:
+    /// <code>
+    /// await foreach (var update in app.ResourceNotifications.WatchAsync(cancellationToken))
+    /// {
+    ///     Console.WriteLine($"Resource {update.Resource.Name} state: {update.Snapshot.State?.Text}");
+    /// }
+    /// </code>
+    /// </example>
+    /// <example>
+    /// Wait for a specific state:
+    /// <code>
+    /// await app.ResourceNotifications.WaitForResourceAsync("worker", KnownResourceStates.Running);
+    /// </code>
+    /// </example>
+    /// <example>
+    /// Seed a database once it becomes available:
+    /// <code>
+    /// // Wait for the database to be healthy before seeding
+    /// await app.ResourceNotifications.WaitForResourceHealthyAsync("postgres");
+    /// using var scope = app.Services.CreateScope();
+    /// var dbContext = scope.ServiceProvider.GetRequiredService&lt;ApplicationDbContext&gt;();
+    /// await dbContext.Database.EnsureCreatedAsync();
+    /// if (!dbContext.Products.Any())
+    /// {
+    ///     await dbContext.Products.AddRangeAsync(new[] {
+    ///         new Product { Name = "Product 1", Price = 10.99m },
+    ///         new Product { Name = "Product 2", Price = 20.99m }
+    ///     });
+    ///     await dbContext.SaveChangesAsync();
+    /// }
+    /// </code>
+    /// </example>
+    public ResourceNotificationService ResourceNotifications => _resourceNotifications ??= _host.Services.GetRequiredService<ResourceNotificationService>();
 
     /// <summary>
     /// Disposes the distributed application by disposing the <see cref="IHost"/>.

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
@@ -46,17 +46,15 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 
@@ -94,8 +92,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
 
         await app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceHealthyAsync(db.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(db.Resource.Name, cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
         hb.Configuration[$"ConnectionStrings:{db.Resource.Name}"] = await cosmos.Resource.ConnectionStringExpression.GetValueAsync(default);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -208,17 +208,15 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSignalREmulatorFunctionalTest.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSignalREmulatorFunctionalTest.cs
@@ -59,15 +59,14 @@ public class AzureSignalREmulatorFunctionalTest(ITestOutputHelper testOutputHelp
         using var app = builder.Build();
 
         var pendingStart = app.StartAsync(cts.Token);
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(signalR.Resource.Name, KnownResourceStates.Running, cts.Token);
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(signalR.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(signalR.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(signalR.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 

--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -750,8 +750,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
 
     private static async Task WaitForResourceAsync(DistributedApplication app, string resourceName, string resourceState, TimeSpan? timeout = null)
     {
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(resourceName, resourceState).WaitAsync(timeout ?? TimeSpan.FromMinutes(3));
+        await app.ResourceNotifications.WaitForResourceAsync(resourceName, resourceState).WaitAsync(timeout ?? TimeSpan.FromMinutes(3));
     }
 
     private const string DefaultMessage = "aspire!";

--- a/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
@@ -107,8 +107,7 @@ public class ElasticsearchFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 await app.StartAsync(cts.Token);
 
-                var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-                await rns.WaitForResourceHealthyAsync(elasticsearch1.Resource.Name, cts.Token);
+                await app.ResourceNotifications.WaitForResourceHealthyAsync(elasticsearch1.Resource.Name, cts.Token);
 
                 try
                 {
@@ -165,8 +164,7 @@ public class ElasticsearchFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 await app.StartAsync();
 
-                var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-                await rns.WaitForResourceHealthyAsync(elasticsearch2.Resource.Name, cts.Token);
+                await app.ResourceNotifications.WaitForResourceHealthyAsync(elasticsearch2.Resource.Name, cts.Token);
 
                 try
                 {
@@ -256,17 +254,15 @@ public class ElasticsearchFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -39,17 +39,15 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -40,17 +40,15 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         await pendingStart;
 

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -51,17 +51,15 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
         await app.StopAsync();

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -47,17 +47,15 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 

--- a/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
@@ -340,17 +340,15 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -369,17 +369,15 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -50,22 +50,20 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync();
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-
         // What for the postgres server to start.
-        await rns.WaitForResourceAsync(postgres.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceAsync(postgres.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         // Wait for the dependent resource to be in the Waiting state.
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         // Now unblock the health check.
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
         // ... and wait for the resource as a whole to move into the health state.
-        await rns.WaitForResourceHealthyAsync(postgres.Resource.Name).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(postgres.Resource.Name).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         // ... then the dependent resource should be able to move into a running state.
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         await pendingStart.DefaultTimeout(TestConstants.LongTimeoutTimeSpan); // Startup should now complete.
 
@@ -162,13 +160,11 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
         using var app = builder.Build();
 
-        var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
-
         await app.StartAsync();
 
         var client = app.CreateHttpClient(pgWebBuilder.Resource.Name, "http");
 
-        await resourceNotificationService.WaitForResourceHealthyAsync(pgWebBuilder.Resource.Name).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(pgWebBuilder.Resource.Name).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         var httpContent = new MultipartFormDataContent
         {
@@ -231,11 +227,9 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using (var app = builder1.Build())
             {
-                var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-
                 await app.StartAsync();
 
-                await rns.WaitForResourceHealthyAsync(db1.Resource.Name, cts.Token);
+                await app.ResourceNotifications.WaitForResourceHealthyAsync(db1.Resource.Name, cts.Token);
 
                 try
                 {
@@ -295,11 +289,9 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using (var app = builder2.Build())
             {
-                var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-
                 await app.StartAsync();
 
-                await rns.WaitForResourceHealthyAsync(db2.Resource.Name, cts.Token);
+                await app.ResourceNotifications.WaitForResourceHealthyAsync(db2.Resource.Name, cts.Token);
 
                 try
                 {

--- a/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
@@ -99,9 +99,7 @@ public class AddPythonAppTests(ITestOutputHelper outputHelper)
 
         await app.StartAsync();
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-
-        await rns.WaitForResourceAsync("pyproj", "Finished").WaitAsync(TimeSpan.FromSeconds(30));
+        await app.ResourceNotifications.WaitForResourceAsync("pyproj", "Finished").WaitAsync(TimeSpan.FromSeconds(30));
 
         await app.StopAsync();
 

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -242,17 +242,15 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, (re => re.Snapshot.HealthStatus == HealthStatus.Healthy), cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, (re => re.Snapshot.HealthStatus == HealthStatus.Healthy), cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -41,17 +41,15 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync();
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
         await pendingStart.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -41,17 +41,15 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 
@@ -174,11 +172,9 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using var app1 = builder1.Build();
 
-            var rns = app1.Services.GetRequiredService<ResourceNotificationService>();
-
             await app1.StartAsync();
 
-            await rns.WaitForResourceHealthyAsync(masterdb1.Resource.Name, cts.Token);
+            await app1.ResourceNotifications.WaitForResourceHealthyAsync(masterdb1.Resource.Name, cts.Token);
 
             try
             {
@@ -259,11 +255,9 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using (var app2 = builder2.Build())
             {
-                rns = app2.Services.GetRequiredService<ResourceNotificationService>();
-
                 await app2.StartAsync();
 
-                await rns.WaitForResourceHealthyAsync(masterdb2.Resource.Name, cts.Token);
+                await app2.ResourceNotifications.WaitForResourceHealthyAsync(masterdb2.Resource.Name, cts.Token);
 
                 try
                 {

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -81,8 +81,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
         Assert.Equal("https", profileName);
 
         // Wait for resource to start.
-        var rns = _app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync("mywebapp1").WaitAsync(TimeSpan.FromSeconds(60));
+        await _app.ResourceNotifications.WaitForResourceAsync("mywebapp1").WaitAsync(TimeSpan.FromSeconds(60));
 
         // Explicitly get the HTTPS endpoint - this is only available on the "https" launch profile.
         var httpClient = _app.CreateHttpClientWithResilience("mywebapp1", "https");

--- a/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
@@ -30,7 +30,6 @@ public class CodespacesUrlRewriterTests(ITestOutputHelper testOutputHelper)
         var abortToken = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
         using var app = builder.Build();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
         await app.StartAsync(abortToken.Token);
 
@@ -68,20 +67,19 @@ public class CodespacesUrlRewriterTests(ITestOutputHelper testOutputHelper)
         var abortToken = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
         using var app = builder.Build();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
         await app.StartAsync(abortToken.Token);
 
         // Push the URL to the resource state.
         var localhostUrlSnapshot = new UrlSnapshot("Test", "http://localhost:1234", false);
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = KnownResourceStates.Running,
             Urls = [localhostUrlSnapshot]
         });
 
         // Wait until
-        var resourceEvent = await rns.WaitForResourceAsync(
+        var resourceEvent = await app.ResourceNotifications.WaitForResourceAsync(
             resource.Resource.Name,
             (re) => {
                 var match = re.Snapshot.Urls.Length > 0 && re.Snapshot.Urls[0].Url.Contains("app.github.dev");

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -28,24 +28,23 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var resource = builder.AddResource(new ParentResource("resource"));
 
         await using var app = await builder.BuildAsync().DefaultTimeout();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
         await app.StartAsync().DefaultTimeout();
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Starting, null)
         }).DefaultTimeout();
 
-        var startingEvent = await rns.WaitForResourceAsync("resource", e => e.Snapshot.State?.Text == KnownResourceStates.Starting).DefaultTimeout();
+        var startingEvent = await app.ResourceNotifications.WaitForResourceAsync("resource", e => e.Snapshot.State?.Text == KnownResourceStates.Starting).DefaultTimeout();
         Assert.Null(startingEvent.Snapshot.HealthStatus);
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null)
         });
 
-        var healthyEvent = await rns.WaitForResourceHealthyAsync("resource").DefaultTimeout();
+        var healthyEvent = await app.ResourceNotifications.WaitForResourceHealthyAsync("resource").DefaultTimeout();
         Assert.Equal(HealthStatus.Healthy, healthyEvent.Snapshot.HealthStatus);
 
         await app.StopAsync().DefaultTimeout();
@@ -69,31 +68,30 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
             .WithHealthCheck("healthcheck_a");
 
         await using var app = await builder.BuildAsync().DefaultTimeout();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
         await app.StartAsync().DefaultTimeout();
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Starting, null)
         }).DefaultTimeout();
 
-        var startingEvent = await rns.WaitForResourceAsync("resource", e => e.Snapshot.State?.Text == KnownResourceStates.Starting).DefaultTimeout();
+        var startingEvent = await app.ResourceNotifications.WaitForResourceAsync("resource", e => e.Snapshot.State?.Text == KnownResourceStates.Starting).DefaultTimeout();
         Assert.Null(startingEvent.Snapshot.HealthStatus);
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null)
         });
 
-        var runningEvent = await rns.WaitForResourceAsync("resource", e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout();
+        var runningEvent = await app.ResourceNotifications.WaitForResourceAsync("resource", e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout();
         // Resource is unhealthy because it has health reports that haven't run yet.
         Assert.Equal(HealthStatus.Unhealthy, runningEvent.Snapshot.HealthStatus);
 
         // Allow health check to report success.
         tcs.SetResult();
 
-        await rns.WaitForResourceHealthyAsync("resource").DefaultTimeout();
+        await app.ResourceNotifications.WaitForResourceHealthyAsync("resource").DefaultTimeout();
 
         await app.StopAsync().DefaultTimeout();
     }
@@ -120,17 +118,16 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
 
         await using var app = await builder.BuildAsync().DefaultTimeout();
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
         var healthService = app.Services.GetRequiredService<ResourceHealthCheckService>();
 
         await app.StartAsync().DefaultTimeout();
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null)
         });
 
-        await rns.WaitForResourceHealthyAsync("resource").DefaultTimeout();
+        await app.ResourceNotifications.WaitForResourceHealthyAsync("resource").DefaultTimeout();
 
         // Verify resource ready event called.
         var e1 = await channel.Reader.ReadAsync().DefaultTimeout();
@@ -140,7 +137,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var monitorStoppedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         monitor1.CancellationToken.Register(monitorStoppedTcs.SetResult);
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Exited, null)
         });
@@ -148,13 +145,13 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         // Wait for the health monitor to be stopped.
         await monitorStoppedTcs.Task.DefaultTimeout();
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null),
             HealthReports = [new HealthReportSnapshot("healthcheck_a", Status: null, Description: null, ExceptionText: null)]
         });
 
-        await rns.WaitForResourceHealthyAsync("resource").DefaultTimeout();
+        await app.ResourceNotifications.WaitForResourceHealthyAsync("resource").DefaultTimeout();
 
         var monitor2 = healthService.GetResourceMonitorState("resource")!;
         Assert.NotEqual(monitor1, monitor2);
@@ -186,17 +183,16 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         using var app = builder.Build();
         var logger = app.Services.GetRequiredService<ILogger<ResourceHealthCheckServiceTests>>();
         var rhcs = app.Services.GetRequiredService<ResourceHealthCheckService>();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
         var abortTokenSource = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
         await app.StartAsync(abortTokenSource.Token).DefaultTimeout();
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = KnownResourceStates.Running
         }).DefaultTimeout();
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, abortTokenSource.Token).DefaultTimeout();
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, abortTokenSource.Token).DefaultTimeout();
 
         await AsyncTestHelpers.AssertIsTrueRetryAsync(
             () =>
@@ -229,13 +225,11 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var rhcs = app.Services.GetRequiredService<ResourceHealthCheckService>();
         rhcs.NonHealthyHealthCheckStepInterval = TimeSpan.FromMilliseconds(10);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-
         var abortTokenSource = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
         await app.StartAsync(abortTokenSource.Token).DefaultTimeout();
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = KnownResourceStates.Running
         }).DefaultTimeout();
@@ -273,17 +267,16 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
                               .WithHealthCheck("resource_check");
 
         using var app = builder.Build();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
         var abortTokenSource = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
         await app.StartAsync(abortTokenSource.Token).DefaultTimeout();
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = KnownResourceStates.Running
         }).DefaultTimeout();
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, abortTokenSource.Token).DefaultTimeout();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, abortTokenSource.Token).DefaultTimeout();
 
         var firstCheck = await channel.Reader.ReadAsync(abortTokenSource.Token).DefaultTimeout();
         timeProvider.Advance(TimeSpan.FromSeconds(5));
@@ -313,10 +306,9 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         });
 
         using var app = builder.Build();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
         var pendingStart = app.StartAsync();
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null)
         }).DefaultTimeout();
@@ -344,11 +336,10 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
                               .WithHealthCheck("resource_check");
 
         using var app = builder.Build();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
         var pendingStart = app.StartAsync().DefaultTimeout();
 
-        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(resource.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null)
         }).DefaultTimeout();
@@ -394,7 +385,6 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
 
         using var app = builder.Build();
         var pendingStart = app.StartAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
         // Verify that the health check does not get run before we move the resource into the
         // the running state. There isn't a great way to do this using a completition source
@@ -412,7 +402,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
             }
         }
 
-        await rns.PublishUpdateAsync(parent.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(parent.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null)
         }).DefaultTimeout();
@@ -457,10 +447,8 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var rhcs = app.Services.GetRequiredService<ResourceHealthCheckService>();
         rhcs.HealthyHealthCheckInterval = TimeSpan.FromSeconds(1);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-
         // Get the custom resource to a running state.
-        await rns.PublishUpdateAsync(parent.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(parent.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null)
         }).DefaultTimeout();
@@ -510,10 +498,9 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
 
         using var app = builder.Build();
         var pendingStart = app.StartAsync();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
         // Get the custom resource to a running state.
-        await rns.PublishUpdateAsync(parent.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(parent.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null)
         }).DefaultTimeout();
@@ -521,7 +508,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         // ... only need to do this with custom resources, for containers this
         // is handled by app executor. When we get operators we won't need to do
         // this at all.
-        await rns.PublishUpdateAsync(child.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(child.Resource, s => s with
         {
             State = new ResourceStateSnapshot(KnownResourceStates.Running, null)
         }).DefaultTimeout();

--- a/tests/Aspire.Hosting.Tests/Utils/LoggerNotificationExtensions.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/LoggerNotificationExtensions.cs
@@ -111,7 +111,6 @@ public static class LoggerNotificationExtensions
 
     private static async Task WatchNotifications(DistributedApplication app, string? resourceName, Predicate<string> predicate, TaskCompletionSource tcs, CancellationTokenSource cancellationTokenSource)
     {
-        var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
         var resourceLoggerService = app.Services.GetRequiredService<ResourceLoggerService>();
         var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(LoggerNotificationExtensions));
 
@@ -120,7 +119,7 @@ public static class LoggerNotificationExtensions
 
         try
         {
-            await foreach (var resourceEvent in resourceNotificationService.WatchAsync(cancellationTokenSource.Token).ConfigureAwait(false))
+            await foreach (var resourceEvent in app.ResourceNotifications.WatchAsync(cancellationTokenSource.Token).ConfigureAwait(false))
             {
                 if (resourceName != null && !string.Equals(resourceEvent.Resource.Name, resourceName, StringComparison.OrdinalIgnoreCase))
                 {

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -30,10 +30,9 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         using var app = builder.Build();
         await app.StartAsync(abortCts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(throwingResource.Resource.Name, KnownResourceStates.FailedToStart, abortCts.Token);
-        await rns.WaitForResourceAsync(dependingContainerResource.Resource.Name, KnownResourceStates.FailedToStart, abortCts.Token);
-        await rns.WaitForResourceAsync(dependingExecutableResource.Resource.Name, KnownResourceStates.FailedToStart, abortCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(throwingResource.Resource.Name, KnownResourceStates.FailedToStart, abortCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependingContainerResource.Resource.Name, KnownResourceStates.FailedToStart, abortCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependingExecutableResource.Resource.Name, KnownResourceStates.FailedToStart, abortCts.Token);
 
         await app.StopAsync(abortCts.Token);
     }
@@ -102,15 +101,13 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
 
         using var app = builder.Build();
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-
         using var startupCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
         var startTask = app.StartAsync(startupCts.Token);
 
         using var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = KnownResourceStates.Running
         });
@@ -146,13 +143,12 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // CI machine is chugging (also useful when collecting code coverage).
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Now that we know we successfully entered the Waiting state, we can swap
         // the dependency into a running state which will unblock startup and
         // we can continue executing.
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = KnownResourceStates.Running
         });
@@ -187,16 +183,15 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         var startTask = app.StartAsync(startupCts.Token);
 
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = status
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, waitingStateCts.Token);
 
         await startTask;
     }
@@ -222,16 +217,15 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         var startTask = app.StartAsync(startupCts.Token);
 
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = status
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, waitingStateCts.Token);
 
         await startTask;
     }
@@ -257,24 +251,23 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         var startTask = app.StartAsync(startupCts.Token);
 
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = status
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Fake a restart of the dependency
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = KnownResourceStates.Running
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
 
         await startTask;
     }
@@ -305,24 +298,23 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         var startTask = app.StartAsync(startupCts.Token);
 
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = status
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Fake a restart of the dependency
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = KnownResourceStates.Running
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
 
         await startTask;
     }
@@ -352,13 +344,12 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // CI machine is chugging (also useful when collecting code coverage).
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Now that we know we successfully entered the Waiting state, we can swap
         // the dependency into a running state which will unblock startup and
         // we can continue executing.
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = KnownResourceStates.Finished,
             ExitCode = 0
@@ -368,7 +359,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // it successfully started after we moved the dependency resource into the Finished, but
         // we need to give it more time since we have to download the image in CI.
         var runningStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, runningStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, runningStateCts.Token);
 
         await startTask;
 
@@ -400,13 +391,12 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // CI machine is chugging (also useful when collecting code coverage).
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(nginx.Resource.Name, "Waiting", waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, "Waiting", waitingStateCts.Token);
 
         // Now that we know we successfully entered the Waiting state, we can swap
         // the dependency into a running state which will unblock startup and
         // we can continue executing.
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = KnownResourceStates.Finished,
             ExitCode = 0
@@ -416,7 +406,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // it successfully started after we moved the dependency resource into the Finished, but
         // we need to give it more time since we have to download the image in CI.
         var runningStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, runningStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, runningStateCts.Token);
 
         await startTask;
 
@@ -456,13 +446,12 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // CI machine is chugging (also useful when collecting code coverage).
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(nginx.Resource.Name, "Waiting", waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, "Waiting", waitingStateCts.Token);
 
         // Now that we know we successfully entered the Waiting state, we can swap
         // the dependency into a running state which will unblock startup and
         // we can continue executing.
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = KnownResourceStates.Running
         });
@@ -473,7 +462,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // it successfully started after we moved the dependency resource into the Finished, but
         // we need to give it more time since we have to download the image in CI.
         var runningStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, runningStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, runningStateCts.Token);
 
         await startTask;
 
@@ -511,13 +500,12 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // CI machine is chugging (also useful when collecting code coverage).
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Now that we know we successfully entered the Waiting state, we can swap
         // the dependency into a finished state which will unblock startup and
         // we can continue executing.
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = KnownResourceStates.Finished,
             ExitCode = 3 // Exit code does not match expected exit code above intentionally.
@@ -526,7 +514,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // This time we want to wait for Nginx to move into a FailedToStart state to verify that
         // it didn't start if the dependency resource didn't finish with the correct exit code.
         var runningStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, runningStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.FailedToStart, runningStateCts.Token);
 
         await startTask;
 
@@ -563,24 +551,23 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // CI machine is chugging (also useful when collecting code coverage).
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Publish the first replica as finished
-        await rns.PublishUpdateAsync(dependency.Resource, "test0", s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, "test0", s => s with
         {
             State = KnownResourceStates.Running,
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Publish the second replica as finished
-        await rns.PublishUpdateAsync(dependency.Resource, "test1", s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, "test1", s => s with
         {
             State = KnownResourceStates.Running,
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
 
         await startTask;
 
@@ -617,24 +604,23 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // CI machine is chugging (also useful when collecting code coverage).
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Publish the first replica as finished
-        await rns.PublishUpdateAsync(dependency.Resource, "test0", s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, "test0", s => s with
         {
             State = KnownResourceStates.Finished,
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Publish the second replica as finished
-        await rns.PublishUpdateAsync(dependency.Resource, "test1", s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, "test1", s => s with
         {
             State = KnownResourceStates.Finished,
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
 
         await startTask;
 
@@ -667,16 +653,15 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         // CI machine is chugging (also useful when collecting code coverage).
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Now that we know we successfully entered the Waiting state, we can end the dependency
-        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
         {
             State = KnownResourceStates.Finished
         });
 
-        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Running, waitingStateCts.Token);
 
         await startTask;
 

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -216,17 +216,15 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var pendingStart = app.StartAsync(cts.Token);
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await app.ResourceNotifications.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
 
         healthCheckTcs.SetResult(HealthCheckResult.Healthy());
 
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
 
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
 
         await pendingStart;
 

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -66,7 +66,6 @@ public class AppHostTests
         else
         {
             var applicationModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-            var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
 
             await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(5));
 

--- a/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationExtensions.cs
@@ -85,9 +85,8 @@ public static partial class DistributedApplicationExtensions
     public static Task WaitForResource(this DistributedApplication app, string resourceName, string? targetState = null, CancellationToken cancellationToken = default)
     {
         targetState ??= KnownResourceStates.Running;
-        var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
 
-        return resourceNotificationService.WaitForResourceAsync(resourceName, targetState, cancellationToken);
+        return app.ResourceNotifications.WaitForResourceAsync(resourceName, targetState, cancellationToken);
     }
 
     /// <summary>
@@ -100,9 +99,8 @@ public static partial class DistributedApplicationExtensions
     {
         targetStates ??= [KnownResourceStates.Running, KnownResourceStates.Hidden];
         var applicationModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
 
-        return Task.WhenAll(applicationModel.Resources.Select(r => resourceNotificationService.WaitForResourceAsync(r.Name, targetStates, cancellationToken)));
+        return Task.WhenAll(applicationModel.Resources.Select(r => app.ResourceNotifications.WaitForResourceAsync(r.Name, targetStates, cancellationToken)));
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

Adds a `ResourceNotification` property of type `ResourceNotificationService` to `DistributedApplication` and updates internal usage to consume it.

Fixes #6795

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [x] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)): https://github.com/dotnet/docs-aspire/issues/2563
  - [ ] No
