### PR TITLE
Revert redis password change

### DIFF
--- a/playground/AspireEventHub/EventHubs.AppHost/aspire-manifest.json
+++ b/playground/AspireEventHub/EventHubs.AppHost/aspire-manifest.json
@@ -22,6 +22,10 @@
         "principalId": ""
       }
     },
+    "eventhub": {
+      "type": "value.v0",
+      "connectionString": "Endpoint={eventhubns.outputs.eventHubsEndpoint};EntityPath=eventhub"
+    },
     "consumer": {
       "type": "project.v0",
       "path": "../EventHubsConsumer/EventHubsConsumer.csproj",
@@ -29,7 +33,7 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
-        "ConnectionStrings__eventhubns": "{eventhubns.connectionString}",
+        "ConnectionStrings__eventhub": "{eventhub.connectionString}",
         "ConnectionStrings__checkpoints": "{checkpoints.connectionString}"
       }
     },
@@ -42,7 +46,7 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
         "HTTP_PORTS": "{api.bindings.http.targetPort}",
-        "ConnectionStrings__eventhubns": "{eventhubns.connectionString}"
+        "ConnectionStrings__eventhub": "{eventhub.connectionString}"
       },
       "bindings": {
         "http": {

--- a/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
+++ b/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
@@ -28,8 +28,8 @@ resource eventhubns_AzureEventHubsDataOwner 'Microsoft.Authorization/roleAssignm
   scope: eventhubns
 }
 
-resource hub 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
-  name: 'hub'
+resource eventhub 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
+  name: 'eventhub'
   parent: eventhubns
 }
 

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
@@ -5,9 +5,6 @@ param api_containerport string
 
 param storage_outputs_blobendpoint string
 
-@secure()
-param cache_password_value string
-
 param account_outputs_connectionstring string
 
 @secure()
@@ -33,10 +30,6 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     configuration: {
       secrets: [
-        {
-          name: 'connectionstrings--cache'
-          value: 'cache:6379,password=${cache_password_value}'
-        }
         {
           name: 'value'
           value: secretparam_value
@@ -95,7 +88,7 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'ConnectionStrings__cache'
-              secretRef: 'connectionstrings--cache'
+              value: 'cache:6379'
             }
             {
               name: 'ConnectionStrings__account'

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
@@ -31,7 +31,7 @@
     },
     "cache": {
       "type": "container.v1",
-      "connectionString": "{cache.bindings.tcp.host}:{cache.bindings.tcp.port},password={cache-password.value}",
+      "connectionString": "{cache.bindings.tcp.host}:{cache.bindings.tcp.port}",
       "image": "docker.io/library/redis:7.4",
       "deployment": {
         "type": "azure.bicep.v0",
@@ -40,13 +40,10 @@
           "cache_volumes_0_storage": "{cache.volumes.0.storage}",
           "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
           "outputs_managed_identity_client_id": "{.outputs.MANAGED_IDENTITY_CLIENT_ID}",
-          "cache_password_value": "{cache-password.value}",
           "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
         }
       },
       "args": [
-        "--requirepass",
-        "{cache-password.value}",
         "--save",
         "60",
         "1"
@@ -119,7 +116,6 @@
         "params": {
           "api_containerport": "{api.containerPort}",
           "storage_outputs_blobendpoint": "{storage.outputs.blobEndpoint}",
-          "cache_password_value": "{cache-password.value}",
           "account_outputs_connectionstring": "{account.outputs.connectionString}",
           "secretparam_value": "{secretparam.value}",
           "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -154,21 +150,6 @@
           "protocol": "tcp",
           "transport": "http",
           "external": true
-        }
-      }
-    },
-    "cache-password": {
-      "type": "parameter.v0",
-      "value": "{cache-password.inputs.value}",
-      "inputs": {
-        "value": {
-          "type": "string",
-          "secret": true,
-          "default": {
-            "generate": {
-              "minLength": 22
-            }
-          }
         }
       }
     }

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/cache.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/cache.module.bicep
@@ -7,9 +7,6 @@ param outputs_azure_container_registry_managed_identity_id string
 
 param outputs_managed_identity_client_id string
 
-@secure()
-param cache_password_value string
-
 param outputs_azure_container_apps_environment_id string
 
 resource cache 'Microsoft.App/containerApps@2024-03-01' = {
@@ -31,8 +28,6 @@ resource cache 'Microsoft.App/containerApps@2024-03-01' = {
           image: 'docker.io/library/redis:7.4'
           name: 'cache'
           args: [
-            '--requirepass'
-            cache_password_value
             '--save'
             '60'
             '1'

--- a/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/aspire-manifest.json
@@ -3,12 +3,8 @@
   "resources": {
     "redis": {
       "type": "container.v0",
-      "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={redis-password.value}",
+      "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port}",
       "image": "docker.io/library/redis:7.4",
-      "args": [
-        "--requirepass",
-        "{redis-password.value}"
-      ],
       "bindings": {
         "tcp": {
           "scheme": "tcp",
@@ -61,21 +57,6 @@
           "protocol": "tcp",
           "transport": "http",
           "port": 13456
-        }
-      }
-    },
-    "redis-password": {
-      "type": "parameter.v0",
-      "value": "{redis-password.inputs.value}",
-      "inputs": {
-        "value": {
-          "type": "string",
-          "secret": true,
-          "default": {
-            "generate": {
-              "minLength": 22
-            }
-          }
         }
       }
     }

--- a/playground/Redis/Redis.AppHost/Redis.AppHost.csproj
+++ b/playground/Redis/Redis.AppHost/Redis.AppHost.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>dfbd0a65-25cf-4318-b377-813f4f6efeea</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/playground/Redis/Redis.AppHost/Redis.AppHost.csproj
+++ b/playground/Redis/Redis.AppHost/Redis.AppHost.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
-    <UserSecretsId>dfbd0a65-25cf-4318-b377-813f4f6efeea</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/playground/Redis/Redis.AppHost/aspire-manifest.json
+++ b/playground/Redis/Redis.AppHost/aspire-manifest.json
@@ -12,7 +12,7 @@
       ],
       "volumes": [
         {
-          "name": "redis.apphost-468a945e22-redis-data",
+          "name": "redis.apphost-7855b85e05-redis-data",
           "target": "/data",
           "readOnly": false
         }
@@ -40,7 +40,7 @@
       ],
       "volumes": [
         {
-          "name": "redis.apphost-468a945e22-garnet-data",
+          "name": "redis.apphost-7855b85e05-garnet-data",
           "target": "/data",
           "readOnly": false
         }

--- a/playground/Redis/Redis.AppHost/aspire-manifest.json
+++ b/playground/Redis/Redis.AppHost/aspire-manifest.json
@@ -3,18 +3,16 @@
   "resources": {
     "redis": {
       "type": "container.v0",
-      "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={redis-password.value}",
+      "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port}",
       "image": "docker.io/library/redis:7.4",
       "args": [
-        "--requirepass",
-        "{redis-password.value}",
         "--save",
         "60",
         "1"
       ],
       "volumes": [
         {
-          "name": "redis.apphost-7855b85e05-redis-data",
+          "name": "redis.apphost-468a945e22-redis-data",
           "target": "/data",
           "readOnly": false
         }
@@ -42,7 +40,7 @@
       ],
       "volumes": [
         {
-          "name": "redis.apphost-7855b85e05-garnet-data",
+          "name": "redis.apphost-468a945e22-garnet-data",
           "target": "/data",
           "readOnly": false
         }
@@ -104,21 +102,6 @@
           "scheme": "https",
           "protocol": "tcp",
           "transport": "http"
-        }
-      }
-    },
-    "redis-password": {
-      "type": "parameter.v0",
-      "value": "{redis-password.inputs.value}",
-      "inputs": {
-        "value": {
-          "type": "string",
-          "secret": true,
-          "default": {
-            "generate": {
-              "minLength": 22
-            }
-          }
         }
       }
     }

--- a/playground/TestShop/TestShop.AppHost/aspire-manifest.json
+++ b/playground/TestShop/TestShop.AppHost/aspire-manifest.json
@@ -4,10 +4,10 @@
     "postgres": {
       "type": "container.v0",
       "connectionString": "Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres-password.value}",
-      "image": "docker.io/library/postgres:17.2",
+      "image": "docker.io/library/postgres:17.0",
       "volumes": [
         {
-          "name": "testshop.apphost-48e1ce2b9b-postgres-data",
+          "name": "testshop.apphost-a23213a1a9-postgres-data",
           "target": "/var/lib/postgresql/data",
           "readOnly": false
         }
@@ -33,18 +33,16 @@
     },
     "basketcache": {
       "type": "container.v0",
-      "connectionString": "{basketcache.bindings.tcp.host}:{basketcache.bindings.tcp.port},password={basketcache-password.value}",
+      "connectionString": "{basketcache.bindings.tcp.host}:{basketcache.bindings.tcp.port}",
       "image": "docker.io/library/redis:7.4",
       "args": [
-        "--requirepass",
-        "{basketcache-password.value}",
         "--save",
         "60",
         "1"
       ],
       "volumes": [
         {
-          "name": "testshop.apphost-48e1ce2b9b-basketcache-data",
+          "name": "testshop.apphost-a23213a1a9-basketcache-data",
           "target": "/data",
           "readOnly": false
         }
@@ -112,7 +110,7 @@
       "image": "docker.io/library/rabbitmq:4.0-management",
       "volumes": [
         {
-          "name": "testshop.apphost-48e1ce2b9b-messaging-data",
+          "name": "testshop.apphost-a23213a1a9-messaging-data",
           "target": "/var/lib/rabbitmq",
           "readOnly": false
         }
@@ -230,21 +228,6 @@
     "postgres-password": {
       "type": "parameter.v0",
       "value": "{postgres-password.inputs.value}",
-      "inputs": {
-        "value": {
-          "type": "string",
-          "secret": true,
-          "default": {
-            "generate": {
-              "minLength": 22
-            }
-          }
-        }
-      }
-    },
-    "basketcache-password": {
-      "type": "parameter.v0",
-      "value": "{basketcache-password.inputs.value}",
       "inputs": {
         "value": {
           "type": "string",

--- a/playground/TestShop/TestShop.AppHost/aspire-manifest.json
+++ b/playground/TestShop/TestShop.AppHost/aspire-manifest.json
@@ -4,10 +4,10 @@
     "postgres": {
       "type": "container.v0",
       "connectionString": "Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres-password.value}",
-      "image": "docker.io/library/postgres:17.0",
+      "image": "docker.io/library/postgres:17.2",
       "volumes": [
         {
-          "name": "testshop.apphost-a23213a1a9-postgres-data",
+          "name": "testshop.apphost-48e1ce2b9b-postgres-data",
           "target": "/var/lib/postgresql/data",
           "readOnly": false
         }
@@ -42,7 +42,7 @@
       ],
       "volumes": [
         {
-          "name": "testshop.apphost-a23213a1a9-basketcache-data",
+          "name": "testshop.apphost-48e1ce2b9b-basketcache-data",
           "target": "/data",
           "readOnly": false
         }
@@ -110,7 +110,7 @@
       "image": "docker.io/library/rabbitmq:4.0-management",
       "volumes": [
         {
-          "name": "testshop.apphost-a23213a1a9-messaging-data",
+          "name": "testshop.apphost-48e1ce2b9b-messaging-data",
           "target": "/var/lib/rabbitmq",
           "readOnly": false
         }

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
@@ -37,40 +36,11 @@ public static class RedisBuilderExtensions
     /// </para>
     /// This version of the package defaults to the <inheritdoc cref="RedisContainerImageTags.Tag"/> tag of the <inheritdoc cref="RedisContainerImageTags.Image"/> container image.
     /// </remarks>
-    public static IResourceBuilder<RedisResource> AddRedis(this IDistributedApplicationBuilder builder, [ResourceName] string name, int? port)
-    {
-        return builder.AddRedis(name, port, null);
-    }
-
-    /// <summary>
-    /// Adds a Redis container to the application model.
-    /// </summary>
-    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
-    /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
-    /// <param name="port">The host port to bind the underlying container to.</param>
-    /// <param name="password">The parameter used to provide the password for the Redis resource. If <see langword="null"/> a random password will be generated.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <remarks>
-    /// <para>
-    /// This resource includes built-in health checks. When this resource is referenced as a dependency
-    /// using the <see cref="ResourceBuilderExtensions.WaitFor{T}(IResourceBuilder{T}, IResourceBuilder{IResource})"/>
-    /// extension method then the dependent resource will wait until the Redis resource is able to service
-    /// requests.
-    /// </para>
-    /// This version of the package defaults to the <inheritdoc cref="RedisContainerImageTags.Tag"/> tag of the <inheritdoc cref="RedisContainerImageTags.Image"/> container image.
-    /// </remarks>
-    public static IResourceBuilder<RedisResource> AddRedis(
-        this IDistributedApplicationBuilder builder,
-        [ResourceName] string name,
-        int? port = null,
-        IResourceBuilder<ParameterResource>? password = null)
+    public static IResourceBuilder<RedisResource> AddRedis(this IDistributedApplicationBuilder builder, [ResourceName] string name, int? port = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(name);
 
-        var passwordParameter = password?.Resource ?? ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, $"{name}-password");
-
-        var redis = new RedisResource(name, passwordParameter);
+        var redis = new RedisResource(name);
 
         string? connectionString = null;
 
@@ -91,35 +61,7 @@ public static class RedisBuilderExtensions
                       .WithEndpoint(port: port, targetPort: 6379, name: RedisResource.PrimaryEndpointName)
                       .WithImage(RedisContainerImageTags.Image, RedisContainerImageTags.Tag)
                       .WithImageRegistry(RedisContainerImageTags.Registry)
-                      .WithHealthCheck(healthCheckKey)
-                      .EnsureCommandLineCallback();
-    }
-
-    private static IResourceBuilder<RedisResource> EnsureCommandLineCallback(this IResourceBuilder<RedisResource> builder)
-    {
-        if (!builder.Resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out _))
-        {
-            builder.WithAnnotation(new CommandLineArgsCallbackAnnotation(context =>
-            {
-                if (builder.Resource.PasswordParameter is { } password)
-                {
-                    context.Args.Add("--requirepass");
-                    context.Args.Add(password);
-                }
-
-                if (builder.Resource.TryGetAnnotationsOfType<PersistenceAnnotation>(out var annotations))
-                {
-                    var persistenceAnnotation = annotations.Single();
-                    context.Args.Add("--save");
-                    context.Args.Add(
-                        (persistenceAnnotation.Interval ?? TimeSpan.FromSeconds(60)).TotalSeconds.ToString(CultureInfo.InvariantCulture));
-                    context.Args.Add(persistenceAnnotation.KeysChangedThreshold.ToString(CultureInfo.InvariantCulture));
-                }
-
-                return Task.CompletedTask;
-            }));
-        }
-        return builder;
+                      .WithHealthCheck(healthCheckKey);
     }
 
     /// <summary>
@@ -172,10 +114,6 @@ public static class RedisBuilderExtensions
                         // Redis Commander assumes Redis is being accessed over a default Aspire container network and hardcodes the resource address
                         // This will need to be refactored once updated service discovery APIs are available
                         var hostString = $"{(hostsVariableBuilder.Length > 0 ? "," : string.Empty)}{redisInstance.Name}:{redisInstance.Name}:{redisInstance.PrimaryEndpoint.TargetPort}:0";
-                        if (redisInstance.PasswordParameter is not null)
-                        {
-                            hostString += $":{redisInstance.PasswordParameter.Value}";
-                        }
                         hostsVariableBuilder.Append(hostString);
                     }
                 }
@@ -273,11 +211,6 @@ public static class RedisBuilderExtensions
                 MaxRetryAttempts = 5,
             }).Build();
 
-            await pipeline.ExecuteAsync(async (ctx) =>
-            {
-                await InitializeRedisInsightSettings(client, resourceLogger, ctx).ConfigureAwait(false);
-            }, cancellationToken).ConfigureAwait(false);
-
             using (var stream = new MemoryStream())
             {
                 // As part of configuring RedisInsight we need to factor in the possibility that the
@@ -316,15 +249,9 @@ public static class RedisBuilderExtensions
                         writer.WriteNumber("port", endpoint.TargetPort!.Value);
                         writer.WriteString("name", redisResource.Name);
                         writer.WriteNumber("db", 0);
+                        //todo: provide username and password when https://github.com/dotnet/aspire/pull/4642 merged.
                         writer.WriteNull("username");
-                        if (redisResource.PasswordParameter is { } passwordParam)
-                        {
-                            writer.WriteString("password", passwordParam.Value);
-                        }
-                        else
-                        {
-                            writer.WriteNull("password");
-                        }
+                        writer.WriteNull("password");
                         writer.WriteString("connectionType", "STANDALONE");
                         writer.WriteEndObject();
                     }
@@ -378,53 +305,8 @@ public static class RedisBuilderExtensions
                 {
                     resourceLogger.LogError("Could not import Redis databases into RedisInsight. Reason: {reason}", ex.Message);
                 }
-            }
+            };
         }
-    }
-
-    /// <summary>
-    /// Initializes the Redis Insight settings to work around https://github.com/RedisInsight/RedisInsight/issues/3452.
-    /// Redis Insight requires the encryption property to be set if the Redis database connection contains a password.
-    /// </summary>
-    private static async Task InitializeRedisInsightSettings(HttpClient client, ILogger resourceLogger, CancellationToken ct)
-    {
-        if (await AreSettingsInitialized(client, ct).ConfigureAwait(false))
-        {
-            return;
-        }
-
-        var jsonContent = JsonContent.Create(new
-        {
-            agreements = new
-            {
-                // all 4 are required to be set
-                eula = false,
-                analytics = false,
-                notifications = false,
-                encryption = false,
-            }
-        });
-
-        var response = await client.PatchAsync("/api/settings", jsonContent, ct).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode)
-        {
-            resourceLogger.LogDebug("Could not initialize RedisInsight settings. Reason: {reason}", await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
-        }
-
-        response.EnsureSuccessStatusCode();
-    }
-
-    private static async Task<bool> AreSettingsInitialized(HttpClient client, CancellationToken ct)
-    {
-        var response = await client.GetAsync("/api/settings", ct).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-
-        var content = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-
-        var jsonResponse = JsonNode.Parse(content);
-        var agreements = jsonResponse?["agreements"];
-
-        return agreements is not null;
     }
 
     private class RedisDatabaseDto
@@ -549,14 +431,14 @@ public static class RedisBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.WithAnnotation(new PersistenceAnnotation(interval, keysChangedThreshold), ResourceAnnotationMutationBehavior.Replace)
-            .EnsureCommandLineCallback();
-    }
-
-    private sealed class PersistenceAnnotation(TimeSpan? interval, long keysChangedThreshold) : IResourceAnnotation
-    {
-        public TimeSpan? Interval => interval;
-        public long KeysChangedThreshold => keysChangedThreshold;
+        return builder.WithAnnotation(new CommandLineArgsCallbackAnnotation(context =>
+        {
+            context.Args.Add("--save");
+            context.Args.Add(
+                (interval ?? TimeSpan.FromSeconds(60)).TotalSeconds.ToString(CultureInfo.InvariantCulture));
+            context.Args.Add(keysChangedThreshold.ToString(CultureInfo.InvariantCulture));
+            return Task.CompletedTask;
+        }), ResourceAnnotationMutationBehavior.Replace);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -249,7 +249,7 @@ public static class RedisBuilderExtensions
                         writer.WriteNumber("port", endpoint.TargetPort!.Value);
                         writer.WriteString("name", redisResource.Name);
                         writer.WriteNumber("db", 0);
-                        //todo: provide username and password when https://github.com/dotnet/aspire/pull/4642 merged.
+                        //todo: provide username and password when https://github.com/dotnet/aspire/issues/3838 is fixed.
                         writer.WriteNull("username");
                         writer.WriteNull("password");
                         writer.WriteString("connectionType", "STANDALONE");
@@ -305,7 +305,7 @@ public static class RedisBuilderExtensions
                 {
                     resourceLogger.LogError("Could not import Redis databases into RedisInsight. Reason: {reason}", ex.Message);
                 }
-            };
+            }
         }
     }
 

--- a/src/Aspire.Hosting.Redis/RedisResource.cs
+++ b/src/Aspire.Hosting.Redis/RedisResource.cs
@@ -9,16 +9,6 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 public class RedisResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RedisResource"/> class.
-    /// </summary>
-    /// <param name="name">The name of the resource.</param>
-    /// <param name="password">A parameter that contains the Redis server password.</param>
-    public RedisResource(string name, ParameterResource password) : this(name)
-    {
-        PasswordParameter = password;
-    }
-
     internal const string PrimaryEndpointName = "tcp";
 
     private EndpointReference? _primaryEndpoint;
@@ -28,20 +18,9 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
-    /// <summary>
-    /// Gets the parameter that contains the Redis server password.
-    /// </summary>
-    public ParameterResource? PasswordParameter { get; }
-
-    /// <summary>
-    /// Gets the parameter that contains the Redis server username.
-    /// </summary>
     private ReferenceExpression ConnectionString =>
-        PasswordParameter is null
-            ? ReferenceExpression.Create(
-                $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}")
-            : ReferenceExpression.Create(
-                $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)},password={PasswordParameter}");
+        ReferenceExpression.Create(
+            $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
 
     /// <summary>
     /// Gets the connection string expression for the Redis server.

--- a/src/Aspire.Hosting.Redis/RedisResource.cs
+++ b/src/Aspire.Hosting.Redis/RedisResource.cs
@@ -33,18 +33,15 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
     /// </summary>
     public ParameterResource? PasswordParameter { get; }
 
-    private ReferenceExpression BuildConnectionString()
-    {
-        var builder = new ReferenceExpressionBuilder();
-        builder.Append($"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
-
-        if (PasswordParameter is not null)
-        {
-            builder.Append($",password={PasswordParameter}");
-        }
-
-        return builder.Build();
-    }
+    /// <summary>
+    /// Gets the parameter that contains the Redis server username.
+    /// </summary>
+    private ReferenceExpression ConnectionString =>
+        PasswordParameter is null
+            ? ReferenceExpression.Create(
+                $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}")
+            : ReferenceExpression.Create(
+                $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)},password={PasswordParameter}");
 
     /// <summary>
     /// Gets the connection string expression for the Redis server.
@@ -58,7 +55,7 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
                 return connectionStringAnnotation.Resource.ConnectionStringExpression;
             }
 
-            return BuildConnectionString();
+            return ConnectionString;
         }
     }
 
@@ -74,6 +71,6 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
             return connectionStringAnnotation.Resource.GetConnectionStringAsync(cancellationToken);
         }
 
-        return BuildConnectionString().GetValueAsync(cancellationToken);
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -1119,9 +1119,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 #pragma warning restore CS0618 // Type or member is obsolete
 
         Assert.True(redis.Resource.IsContainer());
-        Assert.NotNull(redis.Resource.PasswordParameter);
 
-        Assert.Equal($"localhost:12455,password={redis.Resource.PasswordParameter.Value}", await redis.Resource.GetConnectionStringAsync());
+        Assert.Equal("localhost:12455", await redis.Resource.GetConnectionStringAsync());
 
         var manifest = await ManifestUtils.GetManifestWithBicep(redis.Resource);
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -143,19 +143,15 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        RedisResource? redisResource = null;
         var redis = builder.AddAzureRedis("cache")
             .RunAsContainer(c =>
             {
-                redisResource = c.Resource;
-
                 c.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 12455));
             });
 
         Assert.True(redis.Resource.IsContainer(), "The resource should now be a container resource.");
 
-        Assert.NotNull(redisResource?.PasswordParameter);
-        Assert.Equal($"localhost:12455,password={redisResource.PasswordParameter.Value}", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
+        Assert.Equal("localhost:12455", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -714,41 +714,4 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
         public int? Db { get; set; }
         public string? ConnectionType { get; set; }
     }
-
-    [Fact]
-    [RequiresDocker]
-    public async Task WithRedisCommanderShouldWorkWithPassword()
-    {
-        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
-
-        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
-
-        var passwordParameter = builder.AddParameter("pass", "p@ssw0rd1");
-
-        var redis = builder.AddRedis("redis", password: passwordParameter)
-           .WithRedisCommander();
-
-        builder.Services.AddHttpClient();
-        using var app = builder.Build();
-
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-
-        await app.StartAsync();
-
-        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var redisCommander = Assert.Single(appModel.Resources.OfType<RedisCommanderResource>());
-
-        await rns.WaitForResourceHealthyAsync(redis.Resource.Name, cts.Token);
-        await rns.WaitForResourceHealthyAsync(redisCommander.Name, cts.Token);
-
-        var endpoint = redisCommander.GetEndpoint("http");
-        var redisCommanderUrl = endpoint.Url;
-        Assert.NotNull(redisCommanderUrl);
-
-        var clientFactory = app.Services.GetRequiredService<IHttpClientFactory>();
-        var client = clientFactory.CreateClient();
-
-        var httpResponse = await client.GetAsync(redisCommanderUrl!);
-        httpResponse.EnsureSuccessStatusCode();
-    }
 }

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Http.Json;
 using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
 using Aspire.Components.Common.Tests;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
+using Aspire.Hosting.Tests.Dcp;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
@@ -15,9 +17,6 @@ using Microsoft.Extensions.Hosting;
 using StackExchange.Redis;
 using Xunit;
 using Xunit.Abstractions;
-using Aspire.Hosting.Tests.Dcp;
-using System.Text.Json.Nodes;
-using Aspire.Hosting;
 
 namespace Aspire.Hosting.Redis.Tests;
 

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -933,14 +933,14 @@ public class DistributedApplicationTests
 
         var service = Assert.Single(exeList.Where(c => $"{testName}-servicea".Equals(c.AppModelResourceName)));
         var env = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redis"));
-        Assert.Equal($"localhost:1234,password={redis.Resource.PasswordParameter?.Value}", env.Value);
+        Assert.Equal("localhost:1234", env.Value);
 
         var list = await s.ListAsync<Container>().DefaultTimeout();
         var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redis-{ReplicaIdRegex}")));
         Assert.Equal(1234, Assert.Single(redisContainer.Spec.Ports!).HostPort);
 
         var otherRedisEnv = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redisNoPort"));
-        Assert.Equal($"localhost:6379,password={redisNoPort.Resource.PasswordParameter?.Value}", otherRedisEnv.Value);
+        Assert.Equal("localhost:6379", otherRedisEnv.Value);
 
         var otherRedisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redisNoPort-{ReplicaIdRegex}")));
         Assert.Equal(6379, Assert.Single(otherRedisContainer.Spec.Ports!).HostPort);
@@ -987,14 +987,14 @@ public class DistributedApplicationTests
 
         var service = Assert.Single(exeList.Where(c => $"{testName}-servicea".Equals(c.AppModelResourceName)));
         var env = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redis"));
-        Assert.Equal($"localhost:1234,password={redis.Resource.PasswordParameter!.Value}", env.Value);
+        Assert.Equal("localhost:1234", env.Value);
 
         var list = await s.ListAsync<Container>().DefaultTimeout();
         var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redis-{ReplicaIdRegex}")));
         Assert.Equal(1234, Assert.Single(redisContainer.Spec.Ports!).HostPort);
 
         var otherRedisEnv = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redisNoPort"));
-        Assert.Equal($"localhost:6379,password={redisNoPort.Resource.PasswordParameter!.Value}", otherRedisEnv.Value);
+        Assert.Equal("localhost:6379", otherRedisEnv.Value);
 
         var otherRedisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redisNoPort-{ReplicaIdRegex}")));
         Assert.Equal(6379, Assert.Single(otherRedisContainer.Spec.Ports!).HostPort);

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -225,7 +225,7 @@ public class ManifestGenerationTests
 
         var container = resources.GetProperty("rediscontainer");
         Assert.Equal("container.v0", container.GetProperty("type").GetString());
-        Assert.Equal("{rediscontainer.bindings.tcp.host}:{rediscontainer.bindings.tcp.port},password={rediscontainer-password.value}", container.GetProperty("connectionString").GetString());
+        Assert.Equal("{rediscontainer.bindings.tcp.host}:{rediscontainer.bindings.tcp.port}", container.GetProperty("connectionString").GetString());
     }
 
     [Fact]
@@ -398,12 +398,8 @@ public class ManifestGenerationTests
                 },
                 "redis": {
                   "type": "container.v0",
-                  "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={redis-password.value}",
+                  "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port}",
                   "image": "{{ComponentTestConstants.AspireTestContainerRegistry}}/{{RedisContainerImageTags.Image}}:{{RedisContainerImageTags.Tag}}",
-                  "args": [
-                    "--requirepass",
-                    "{redis-password.value}"
-                  ],
                   "bindings": {
                     "tcp": {
                       "scheme": "tcp",
@@ -436,21 +432,6 @@ public class ManifestGenerationTests
                 "postgresdb": {
                   "type": "value.v0",
                   "connectionString": "{postgres.connectionString};Database=postgresdb"
-                },
-                "redis-password": {
-                  "type": "parameter.v0",
-                  "value": "{redis-password.inputs.value}",
-                  "inputs": {
-                    "value": {
-                      "type": "string",
-                      "secret": true,
-                      "default": {
-                        "generate": {
-                          "minLength": 22
-                        }
-                      }
-                    }
-                  }
                 },
                 "postgres-password": {
                   "type": "parameter.v0",


### PR DESCRIPTION
## Description

Reverts [Add Password To Redis (dotnet/aspire#4642)](https://github.com/dotnet/aspire/pull/4642).

`azd` doesn't allow for secret parameters to be used in command line args of containers. See the [code comment here](https://github.com/Azure/azure-dev/blob/5f05eaf81dddbe74cf6d1d8481335e5ed32cb59f/cli/azd/pkg/apphost/generate.go#L1779-L1784).

```
		// Unlike environment variables, ACA doesn't provide a way to pass secret values without baking them into the args
		// array directly. We don't want folks to accidentally bake the plaintext value of these secrets into the container
		// definition, so for now, we block this.
		//
		// This logic is similar to what we do in buildEnvBlock to detect when we need to take values and treat them as ACA
		// secrets.
```

For .NET Aspire 9.1, we will revert back to the 9.0 behavior for Redis containers. We will revisit this issue in 9.2 to decide how we can password protect Redis containers in ACA.

Fixes #7429

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
- Does the change require an update in our Aspire docs?
  - [x] No
