### PR TITLE
Allow ServiceBus connection strings to work with EntityPath key

### DIFF
--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AspireServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AspireServiceBusExtensionsTests.cs
@@ -173,4 +173,31 @@ public class AspireServiceBusExtensionsTests
         var client = host.Services.GetRequiredService<ServiceBusClient>();
         Assert.Equal("local-identifier", client.Identifier);
     }
+
+    [Theory]
+    [InlineData("Endpoint=sb://aspireservicebustests.servicebus.windows.net;EntityPath=myqueue;", "aspireservicebustests.servicebus.windows.net")]
+    [InlineData("Endpoint=sb://aspireservicebustests.servicebus.windows.net;EntityPath=mytopic;", "aspireservicebustests.servicebus.windows.net")]
+    [InlineData("Endpoint=sb://aspireservicebustests.servicebus.windows.net;EntityPath=mytopic/Subscriptions/mysub;", "aspireservicebustests.servicebus.windows.net")]
+    [InlineData("Endpoint=sb://localhost:50418;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true", "localhost")]
+    [InlineData("Endpoint=sb://localhost:50418;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;EntityPath=myqueue", "localhost")]
+    [InlineData("Endpoint=sb://localhost:50418;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;EntityPath=mytopic/Subscriptions/mysub;", "localhost")]
+    [InlineData("aspireservicebustests.servicebus.windows.net", "aspireservicebustests.servicebus.windows.net")]
+    public void AddAzureServiceBusClient_EnsuresConnectionStringIsCorrect(string connectionString, string expectedEndpoint)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        PopulateConfiguration(builder.Configuration, connectionString);
+
+        builder.AddAzureServiceBusClient("sb");
+
+        using var host = builder.Build();
+        var client = host.Services.GetRequiredService<ServiceBusClient>();
+
+        Assert.Equal(expectedEndpoint, client.FullyQualifiedNamespace);
+    }
+
+    private static void PopulateConfiguration(ConfigurationManager configuration, string connectionString) =>
+    configuration.AddInMemoryCollection([
+        new KeyValuePair<string, string?>("ConnectionStrings:sb", connectionString)
+    ]);
 }


### PR DESCRIPTION
## Description

In the future, the ServiceBus Host integration will append this value to the connection string. This will allow the queue, topic, and subscription names to be specified outside of the application. (Today they are hard-coded in both, or specified separately in config.) We can also add new client APIs to register a Sender or Processor in DI.

Note that the Subscription can be passed in the EntityPath using the format {topic}/Subscriptions/{subscription}.

This is a stop-gap to support these values in .NET Aspire 9.1 client integration so it doesn't break applications when we start adding these values in the future.

Contributes to #7407

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
