### PR TITLE
Fix dashboard formatting tests

### DIFF
--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -47,7 +47,6 @@ public class PlotlyChartTests : TestContext
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public async Task Render_HasInstrument_InitializeChartInvocation()
     {
         // Arrange
@@ -107,7 +106,7 @@ public class PlotlyChartTests : TestContext
                 Assert.Collection((IEnumerable<PlotlyTrace>)i.Arguments[1]!, trace =>
                 {
                     Assert.Equal("Unit-&lt;b&gt;Bold&lt;/b&gt;", trace.Name);
-                    Assert.Equal("<b>Name-&lt;b&gt;Bold&lt;/b&gt;</b><br />Unit-&lt;b&gt;Bold&lt;/b&gt;: 1<br />Time: 12:59:57 AM", trace.Tooltips[0]);
+                    Assert.Equal("<b>Name-&lt;b&gt;Bold&lt;/b&gt;</b><br />Unit-&lt;b&gt;Bold&lt;/b&gt;: 1<br />Time: 12:59:57 AM", trace.Tooltips[0], ignoreWhiteSpaceDifferences: true);
                 });
             });
     }

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -17,7 +17,6 @@ public class FormatHelpersTests
     [InlineData("0.9", 0.9d)]
     [InlineData("12,345,678.9", 12345678.9d)]
     [InlineData("1.234568", 1.23456789d)]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatNumberWithOptionalDecimalPlaces_InvariantCulture(string expected, double value)
     {
         Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, maxDecimalPlaces: 6, CultureInfo.InvariantCulture));
@@ -29,7 +28,6 @@ public class FormatHelpersTests
     [InlineData("0,9", 0.9d)]
     [InlineData("12.345.678,9", 12345678.9d)]
     [InlineData("1,234568", 1.23456789d)]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatNumberWithOptionalDecimalPlaces_GermanCulture(string expected, double value)
     {
         Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, maxDecimalPlaces: 6, CultureInfo.GetCultureInfo("de-DE")));
@@ -41,7 +39,6 @@ public class FormatHelpersTests
     [InlineData("06/15/2009 13:45:30.1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
     [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
     [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatDateTime_WithMilliseconds_InvariantCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
@@ -66,7 +63,6 @@ public class FormatHelpersTests
     [InlineData("15.6.2009 13.45.30,1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
     [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
     [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatDateTime_WithMilliseconds_FinnishCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
@@ -79,7 +75,6 @@ public class FormatHelpersTests
     [InlineData("15/06/2009 1:45:30.1234567 pm", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
     [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
     [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7433")]
     public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -78,7 +78,34 @@ public class FormatHelpersTests
     public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ")));
+        var formattedDate = FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ"));
+
+        try
+        {
+            Assert.Equal(expected, formattedDate);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Expected: {EncodeNonAscii(expected)}, formatted date: {EncodeNonAscii(formattedDate)}", ex);
+        }
+
+        static string EncodeNonAscii(string v)
+        {
+            var result = string.Empty;
+            for (var i = 0; i < v.Length; i++)
+            {
+                if (char.IsAscii(v[i]))
+                {
+                    result += v[i];
+                }
+                else
+                {
+                    result += $"\\u{(int)v[i]:x4}";
+                }
+            }
+
+            return result;
+        }
     }
 
     private static DateTime GetLocalDateTime(string value)

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -78,34 +78,7 @@ public class FormatHelpersTests
     public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
-        var formattedDate = FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ"));
-
-        try
-        {
-            Assert.Equal(expected, formattedDate);
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException($"Expected: {EncodeNonAscii(expected)}, formatted date: {EncodeNonAscii(formattedDate)}", ex);
-        }
-
-        static string EncodeNonAscii(string v)
-        {
-            var result = string.Empty;
-            for (var i = 0; i < v.Length; i++)
-            {
-                if (char.IsAscii(v[i]))
-                {
-                    result += v[i];
-                }
-                else
-                {
-                    result += $"\\u{(int)v[i]:x4}";
-                }
-            }
-
-            return result;
-        }
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ")), ignoreWhiteSpaceDifferences: true);
     }
 
     private static DateTime GetLocalDateTime(string value)


### PR DESCRIPTION
## Description

.NET adds a non-breaking space character before `AM`/`PM`. Expected strings for dates in tests use a regular space. Most most cultures accept the whitespace difference, but I'm guessing GHA's uses a culture that doesn't (invariant?).

The fix is to ignore whitespace differences in the impacted asserts.

Fixes https://github.com/dotnet/aspire/issues/7433

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
