### PR TITLE
Reduce thrown exceptions

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1511,7 +1511,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             // before resorting to more extreme measures.
             if (!resourceNotFound)
             {
-                await DeleteResourceRetryPipeline.ExecuteAsync<bool, string>(async (state, attemptCancellationToken) =>
+                var result = await DeleteResourceRetryPipeline.ExecuteAsync<bool, string>(async (state, attemptCancellationToken) =>
                 {
                     try
                     {
@@ -1524,6 +1524,11 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
                         return true;
                     }
                 }, resourceName, cancellationToken).ConfigureAwait(false);
+
+                if (!result)
+                {
+                    throw new DistributedApplicationException($"Failed to delete '{resourceName}' successfully before restart.");
+                }
             }
         }
     }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1131,7 +1131,7 @@ public class DcpExecutorTests
         var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: dcpEvents);
 
         // Set a custom pipeline without retries or delays to avoid waiting.
-        appExecutor.DeleteResourceRetryPipeline = new ResiliencePipelineBuilder().Build();
+        appExecutor.DeleteResourceRetryPipeline = new ResiliencePipelineBuilder<bool>().Build();
 
         await appExecutor.RunApplicationAsync();
 


### PR DESCRIPTION
Use `WaitAsync` again. Also, avoid throwing `DistributedApplicationException` when restarting resource.
