### PR TITLE
Fix FileNotFoundException usage

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/AspireStore.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AspireStore.cs
@@ -36,7 +36,7 @@ internal sealed class AspireStore : IAspireStore
 
         if (!File.Exists(sourceFilename))
         {
-            throw new FileNotFoundException("The source file '{0}' does not exist.", sourceFilename);
+            throw new FileNotFoundException("The source file does not exist.", sourceFilename);
         }
 
         EnsureDirectory();

--- a/tests/Aspire.Hosting.Tests/AspireStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/AspireStoreTests.cs
@@ -88,6 +88,14 @@ public class AspireStoreTests
     }
 
     [Fact]
+    public void GetOrCreateFileWithContent_Throws_WhenSourceDoesntExist()
+    {
+        var store = CreateStore();
+
+        Assert.Throws<FileNotFoundException>(() => store.GetFileNameWithContent("testfile.txt", "randomfilename.txt"));
+    }
+
+    [Fact]
     public void GetOrCreateFileWithContent_ShouldNotRecreateFile()
     {
         var store = CreateStore();


### PR DESCRIPTION
## Description

Wrong string format used in exception message.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
