### PR TITLE
Support WithEntrypoint on Containers

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -187,6 +187,7 @@ internal sealed class AzureContainerAppsInfrastructure(
                 containerAppContainer.Image = containerImageParam is null ? containerImageName! : containerImageParam;
                 containerAppContainer.Name = resource.Name;
 
+                SetEntryPoint(containerAppContainer);
                 AddEnvironmentVariablesAndCommandLineArgs(containerAppContainer);
 
                 foreach (var (_, mountedVolume) in Volumes)
@@ -822,6 +823,14 @@ internal sealed class AzureContainerAppsInfrastructure(
                 }
 
                 config.Ingress = caIngress;
+            }
+
+            private void SetEntryPoint(ContainerAppContainer container)
+            {
+                if (resource is ContainerResource containerResource && containerResource.Entrypoint is { } entrypoint)
+                {
+                    container.Command = [entrypoint];
+                }
             }
 
             private void AddEnvironmentVariablesAndCommandLineArgs(ContainerAppContainer container)


### PR DESCRIPTION
## Description

ACA infrastructure wasn't respecting the entrypoint on a ContainerResource. To fix this, set the container command to the entrypoint, if it is supplied.

Fix #7576

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
