### PR TITLE
Bump the priority of processing paramters to avoid infinite recursion

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -634,6 +634,13 @@ internal sealed class AzureContainerAppsInfrastructure(
                     return (url, secretType);
                 }
 
+                if (value is ParameterResource param)
+                {
+                    var st = param.Secret ? SecretType.Normal : secretType;
+
+                    return (AllocateParameter(param, secretType: st), st);
+                }
+
                 if (value is ConnectionStringReference cs)
                 {
                     return await ProcessValueAsync(cs.Resource.ConnectionStringExpression, executionContext, cancellationToken, secretType: secretType, parent: parent).ConfigureAwait(false);
@@ -642,13 +649,6 @@ internal sealed class AzureContainerAppsInfrastructure(
                 if (value is IResourceWithConnectionString csrs)
                 {
                     return await ProcessValueAsync(csrs.ConnectionStringExpression, executionContext, cancellationToken, secretType: secretType, parent: parent).ConfigureAwait(false);
-                }
-
-                if (value is ParameterResource param)
-                {
-                    var st = param.Secret ? SecretType.Normal : secretType;
-
-                    return (AllocateParameter(param, secretType: st), st);
                 }
 
                 if (value is BicepOutputReference output)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -785,6 +785,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         // Postgres uses secret outputs + a literal connection string
         var pgdb = builder.AddAzurePostgresFlexibleServer("pg").WithPasswordAuthentication().AddDatabase("db");
 
+        var rawCs = builder.AddConnectionString("cs");
+
         // Connection string (should be considered a secret)
         var blob = builder.AddAzureStorage("storage").AddBlobs("blobs");
 
@@ -803,7 +805,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             .WithReference(pgdb)
             .WithEnvironment("SecretVal", secretValue)
             .WithEnvironment("secret_value_1", secretValue)
-            .WithEnvironment("Value", value);
+            .WithEnvironment("Value", value)
+            .WithEnvironment("CS", rawCs);
 
         project.WithEnvironment(context =>
         {
@@ -851,6 +854,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "value0_value": "{value0.value}",
             "value1_value": "{value1.value}",
+            "cs_connectionstring": "{cs.connectionString}",
             "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_managed_identity_client_id": "{.outputs.MANAGED_IDENTITY_CLIENT_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
@@ -881,6 +885,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         param value0_value string
 
         param value1_value string
+
+        @secure()
+        param cs_connectionstring string
 
         param outputs_azure_container_apps_environment_default_domain string
 
@@ -919,6 +926,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 {
                   name: 'secret-value-1'
                   value: value0_value
+                }
+                {
+                  name: 'cs'
+                  value: cs_connectionstring
                 }
               ]
               activeRevisionsMode: 'Single'
@@ -994,6 +1005,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                     {
                       name: 'Value'
                       value: value1_value
+                    }
+                    {
+                      name: 'CS'
+                      secretRef: 'cs'
                     }
                     {
                       name: 'HTTP_EP'


### PR DESCRIPTION
## Description

Second part to https://github.com/dotnet/aspire/pull/7500. Since we changed the connection string resource to be a parameter resource (that points to itself), we needed to bump the priority of processing parameters VS connection strings much like we did in manifest parsing.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No