### PR TITLE
Allow for nested children in the dashboard

### DIFF
--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -238,6 +238,11 @@ internal sealed class ApplicationOrchestrator
                 StopTimeStamp = stopTimeStamp,
                 Properties = s.Properties.SetResourceProperty(KnownProperties.Resource.ParentName, parentName)
             }).ConfigureAwait(false);
+
+            // the parent name needs to be an instance name, not the resource name.
+            // parent the children of the child under the first resource instance.
+            await SetChildResourceAsync(child, child.GetResolvedResourceNames()[0], state, startTimeStamp, stopTimeStamp)
+                .ConfigureAwait(false);
         }
     }
 
@@ -253,6 +258,8 @@ internal sealed class ApplicationOrchestrator
             {
                 Properties = s.Properties.SetResourceProperty(KnownProperties.Resource.ParentName, parentName)
             }).ConfigureAwait(false);
+
+            await SetExecutableChildResourceAsync(child).ConfigureAwait(false);
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -83,6 +83,7 @@ public class ApplicationOrchestratorTests
         await appOrchestrator.RunApplicationAsync();
 
         string? parentResourceId = null;
+        string? childResourceId = null;
         string? childParentResourceId = null;
         string? child2ParentResourceId = null;
         string? nestedChildParentResourceId = null;
@@ -96,6 +97,7 @@ public class ApplicationOrchestratorTests
                 }
                 else if (item.Resource == child.Resource)
                 {
+                    childResourceId = item.ResourceId;
                     childParentResourceId = item.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.ParentName)?.Value?.ToString();
                 }
                 else if (item.Resource == nestedChild.Resource)
@@ -121,8 +123,8 @@ public class ApplicationOrchestratorTests
         Assert.Equal(parentResourceId, childParentResourceId);
         Assert.Equal(parentResourceId, child2ParentResourceId);
 
-        // Nested child should have parent set to the root parent, not direct parent
-        Assert.Equal(parentResourceId, nestedChildParentResourceId);
+        // Nested child should be parented on the direct parent
+        Assert.Equal(childResourceId, nestedChildParentResourceId);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Orchestrator/RelationshipEvaluatorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/RelationshipEvaluatorTests.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Orchestrator;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Orchestrator;
+
+public class RelationshipEvaluatorTests
+{
+    [Fact]
+    public void HandlesNestedChildren()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var parentResource = builder.AddContainer("parent", "image");
+        var childResource = builder.AddResource(new CustomChildResource("child", parentResource.Resource));
+        var grandChildResource = builder.AddResource(new CustomChildResource("grandchild", childResource.Resource));
+        var greatGrandChildResource = builder.AddResource(new CustomChildResource("greatgrandchild", grandChildResource.Resource));
+
+        var childWithAnnotationsResource = builder.AddContainer("child-with-annotations", "image")
+            .WithParentRelationship(parentResource.Resource);
+
+        var grandChildWithAnnotationsResource = builder.AddContainer("grandchild-with-annotations", "image")
+            .WithParentRelationship(childWithAnnotationsResource.Resource);
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parentChildLookup = RelationshipEvaluator.GetParentChildLookup(appModel);
+        Assert.Equal(4, parentChildLookup.Count);
+
+        Assert.Collection(parentChildLookup[parentResource.Resource],
+            x => Assert.Equal(childResource.Resource, x),
+            x => Assert.Equal(childWithAnnotationsResource.Resource, x));
+
+        Assert.Single(parentChildLookup[childResource.Resource], grandChildResource.Resource);
+        Assert.Single(parentChildLookup[grandChildResource.Resource], greatGrandChildResource.Resource);
+
+        Assert.Empty(parentChildLookup[greatGrandChildResource.Resource]);
+
+        Assert.Single(parentChildLookup[childWithAnnotationsResource.Resource], grandChildWithAnnotationsResource.Resource);
+
+        Assert.Empty(parentChildLookup[grandChildWithAnnotationsResource.Resource]);
+    }
+
+    private sealed class CustomChildResource(string name, IResource parent) : Resource(name), IResourceWithParent
+    {
+        public IResource Parent => parent;
+    }
+}


### PR DESCRIPTION
## Description

Originally the parent-child lookup contained the "root" parent and all the descendants in a flat list. This doesn't show up well in the dashboard because grandchildren are parented directly under their root.

Fix this by making the parent-child lookup only contain direct children, and recursively parent the descendants on their direct parent.

Fix #7580

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
