### PR TITLE
Fix metrics instruments not updating in mobile view

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/TreeMetricSelector.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TreeMetricSelector.razor.cs
@@ -20,4 +20,9 @@ public partial class TreeMetricSelector
 
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
+
+    public void OnResourceChanged()
+    {
+        StateHasChanged();
+    }
 }

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -126,8 +126,8 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     {
         viewModel.SelectedDuration = _durations.SingleOrDefault(d => (int)d.Id.TotalMinutes == DurationMinutes) ?? _durations.Single(d => d.Id == s_defaultDuration);
         viewModel.SelectedApplication = _applicationViewModels.GetApplication(Logger, ApplicationName, canSelectGrouping: true, _selectApplication);
-        var selectedInstance = viewModel.SelectedApplication.Id?.GetApplicationKey();
-        viewModel.Instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentsSummaries(selectedInstance.Value) : null;
+
+        UpdateInstruments(viewModel);
 
         viewModel.SelectedMeter = null;
         viewModel.SelectedInstrument = null;
@@ -144,6 +144,12 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
         return Task.CompletedTask;
     }
 
+    private void UpdateInstruments(MetricsViewModel viewModel)
+    {
+        var selectedInstance = viewModel.SelectedApplication.Id?.GetApplicationKey();
+        viewModel.Instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentsSummaries(selectedInstance.Value) : null;
+    }
+
     private void UpdateApplications()
     {
         _applications = TelemetryRepository.GetApplications();
@@ -154,15 +160,14 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
 
     private async Task HandleSelectedApplicationChangedAsync()
     {
+        UpdateInstruments(PageViewModel);
+
         // The new resource might not have the currently selected meter/instrument.
         // Check whether the new resource has the current values or not, and clear if they're not available.
         if (PageViewModel.SelectedMeter != null ||
             PageViewModel.SelectedInstrument != null)
         {
-            var selectedInstance = PageViewModel.SelectedApplication.Id?.GetApplicationKey();
-            var instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentsSummaries(selectedInstance.Value) : null;
-
-            if (instruments == null || ShouldClearSelectedMetrics(instruments))
+            if (PageViewModel.Instruments == null || ShouldClearSelectedMetrics(PageViewModel.Instruments))
             {
                 PageViewModel.SelectedMeter = null;
                 PageViewModel.SelectedInstrument = null;
@@ -170,6 +175,11 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
         }
 
         await this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: true);
+
+        // The mobile view doesn't update the URL when the application changes.
+        // Because of this, the page doesn't autoamtically use updated instruments.
+        // Force the metrics tree to update so it re-renders with the new app's instruments.
+        _treeMetricSelector?.OnResourceChanged();
     }
 
     private bool ShouldClearSelectedMetrics(List<OtlpInstrumentSummary> instruments)

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -86,7 +86,8 @@
 }
 
 ::deep .metrics-content {
-    margin-left: 10px;
+    /* Match left padding of the page header */
+    margin-left: calc(var(--design-unit)* 4.5px);
 }
 
 ::deep .plotly-chart-container {


### PR DESCRIPTION
## Description

Fix regression from https://github.com/dotnet/aspire/pull/7549 (oops) where the tree doesn't update in mobile view.

Also, I noticed the indent in the mobile view for the metrics page didn't match the new indent of the header.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
