### PR TITLE
fix casing of CosmosDB

### DIFF
--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj
@@ -14,7 +14,7 @@
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.EventHubs" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Storage" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.ServiceBus" />
-    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.CosmosDb" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.CosmosDB" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
   </ItemGroup>
 


### PR DESCRIPTION
This breaks the build for me on Ubuntu. I assume the official Linux builds are using a case-insensitive file system (?)