### PR TITLE
add logging after tests

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -68,9 +68,11 @@ steps:
       - script: |
           docker info
           docker container ls
+          docker volume ls
           docker network ls
           docker network prune -f
-        displayName: List Docker containers and networks, and prune networks
+        displayName: List Docker containers and networks, and prune networks (Before Tests)
+        condition: always()
 
     - script: ${{ parameters.dotnetScript }} dotnet-coverage collect
               --settings $(Build.SourcesDirectory)/eng/CodeCoverage.config
@@ -86,6 +88,16 @@ steps:
         DCP_DIAGNOSTICS_LOG_FOLDER: $(Build.ArtifactStagingDirectory)/artifacts/log/dcp
         DCP_PRESERVE_EXECUTABLE_LOGS: 1
       displayName: Run non-helix tests
+
+    - ${{ if ne(parameters.isWindows, 'true') }}:
+      - script: |
+          docker info
+          docker container ls
+          docker volume ls
+          docker network ls
+          docker network prune -f
+        displayName: List Docker containers and networks, and prune networks (After Tests always)
+        condition: always()
 
   # Helix tests are run only on the public pipeline
   - ${{ if and(eq(parameters.runAsPublic, 'true'), eq(parameters.runHelixTests, 'true')) }}:


### PR DESCRIPTION
Currently we log `docker network ls` before tests on Linux; add the same logging afterwards to see the size of any leak. 

Throw in `docker volume ls` because why not.