### PR TITLE
Fix console logs menu buttons not updated with resource

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -34,7 +34,8 @@
                 <FluentButton Appearance="Appearance.Lightweight"
                               Title="@(!string.IsNullOrEmpty(command.DisplayDescription) ? command.DisplayDescription : command.DisplayName)"
                               Disabled="@(command.State == CommandViewModelState.Disabled)"
-                              OnClick="@(() => ExecuteResourceCommandAsync(command))">
+                              OnClick="@(() => ExecuteResourceCommandAsync(command))"
+                              Class="highlighted-command">
                     @if (!string.IsNullOrEmpty(command.IconName) && CommandViewModel.ResolveIconName(command.IconName, command.IconVariant) is { } icon)
                     {
                         <FluentIcon Value="@icon" Width="16px" />

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -202,7 +202,14 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                         }
                     }
 
-                    await InvokeAsync(StateHasChanged);
+                    await InvokeAsync(() =>
+                    {
+                        // The selected resource may have changed, so update resource action buttons.
+                        // Update inside in the render's sync context so the buttons don't change while the UI is rendering.
+                        UpdateMenuButtons();
+
+                        StateHasChanged();
+                    });
                 }
             });
         }

--- a/tests/Shared/DashboardModel/ModelTestHelpers.cs
+++ b/tests/Shared/DashboardModel/ModelTestHelpers.cs
@@ -19,7 +19,8 @@ public static class ModelTestHelpers
         string? resourceType = null,
         string? stateStyle = null,
         HealthStatus? reportHealthStatus = null,
-        bool createNullHealthReport = false)
+        bool createNullHealthReport = false,
+        ImmutableArray<CommandViewModel>? commands = null)
     {
         return new ResourceViewModel
         {
@@ -38,7 +39,7 @@ public static class ModelTestHelpers
             KnownState = state,
             StateStyle = stateStyle,
             HealthReports = reportHealthStatus is null && !createNullHealthReport ? [] : [new HealthReportViewModel("healthcheck", reportHealthStatus, null, null)],
-            Commands = [],
+            Commands = commands ?? [],
             Relationships = [],
         };
     }


### PR DESCRIPTION
## Description

A recent regression caused the console logs page to not update the menu buttons when the resource changes. This means resource commands didn't change with the resource.

Fix + add test

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
