### PR TITLE
[release/9.1] Bump the azure group with 5 updates (#7646)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,9 +16,9 @@
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.10.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
-    <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.11.5" />
-    <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.11.5" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.18.3" />
+    <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.11.6" />
+    <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.11.6" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.18.4" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.6.0" />
     <PackageVersion Include="Azure.Messaging.WebPubSub" Version="1.4.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
@@ -27,8 +27,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.12" />
     <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
-    <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.30.0" />
-    <PackageVersion Include="Microsoft.Azure.SignalR.Management" Version="1.30.0" />
+    <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.30.2" />
+    <PackageVersion Include="Microsoft.Azure.SignalR.Management" Version="1.30.2" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.10.0" />
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.Provisioning" Version="$(AzureProvisiongVersion)" />


### PR DESCRIPTION
Backport of #7646 to release/9.1

## Customer Impact

When users get our 9.1 packages, they expect to have the latest Azure versions brought in transitively. Updating 5 Azure dependencies to the latest shipped versions.

## Testing

Existing tests

## Risk

Low. Just updating to the newest versions. Tests are all passing.

## Regression?

No.