### PR TITLE
Hide secrets in source tooltip, correct ExpressionResolver logic for non-containers

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -10,7 +10,7 @@
     @if (EnableMasking && IsMasked)
     {
         <span class="grid-value masked" id="@_cellTextId">
-            @DashboardUIHelpers.GetMaskingText(length: 8)
+            @DashboardUIHelpers.GetMaskingText(length: 8).MarkupString
         </span>
     }
     else
@@ -32,7 +32,7 @@
                     @((MarkupString)_formattedValue)
                 }
                 @ContentAfterValue
-            }            
+            }
         </span>
     }
 

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -24,7 +24,7 @@
                 }
                 else
                 {
-                    <span class="subtext">&nbsp;@DashboardUIHelpers.GetMaskingText(length: 6)</span>
+                    <span class="subtext">&nbsp;@DashboardUIHelpers.GetMaskingText(length: 6).MarkupString</span>
                 }
             }
         }

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -14,71 +14,22 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
 
     internal static ResourceSourceViewModel? GetSourceViewModel(ResourceViewModel resource)
     {
-        CommandLineInfo? commandLineInfo;
-
-        // If the resource contains launch arguments, these project arguments should be shown in place of all executable arguments,
-        // which include args added by the app host
-        if (resource.TryGetAppArgs(out var launchArguments))
-        {
-            if (launchArguments.IsDefaultOrEmpty)
-            {
-                commandLineInfo = null;
-            }
-            else
-            {
-                var argumentsString = string.Join(" ", launchArguments);
-                if (resource.TryGetAppArgsSensitivity(out var areArgumentsSensitive))
-                {
-                    var arguments = launchArguments
-                        .Select((arg, i) => new LaunchArgument(arg, IsShown: !areArgumentsSensitive[i]))
-                        .ToList();
-
-                    commandLineInfo = new CommandLineInfo(
-                        Arguments: arguments,
-                        ArgumentsString: argumentsString,
-                        TooltipString: string.Join(" ", arguments.Select(arg => arg.IsShown
-                            ? arg.Value
-                            : DashboardUIHelpers.GetMaskingText(6).Text)));
-                }
-                else
-                {
-                    commandLineInfo = new CommandLineInfo(Arguments: launchArguments.Select(arg => new LaunchArgument(arg, true)).ToList(), ArgumentsString: argumentsString, TooltipString: argumentsString);
-                }
-            }
-        }
-        else if (resource.TryGetExecutableArguments(out var executableArguments) && !resource.IsProject())
-        {
-            var arguments = executableArguments.IsDefaultOrEmpty ? [] : executableArguments.Select(arg => new LaunchArgument(arg, true)).ToList();
-            var argumentsString = string.Join(" ", executableArguments);
-
-            commandLineInfo = new CommandLineInfo(Arguments: arguments, ArgumentsString: argumentsString, TooltipString: argumentsString);
-        }
-        else
-        {
-            commandLineInfo = null;
-        }
+        var commandLineInfo = GetCommandLineInfo(resource);
 
         // NOTE projects are also executables, so we have to check for projects first
         if (resource.IsProject() && resource.TryGetProjectPath(out var projectPath))
         {
-            return commandLineInfo is not null
-                ? new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: commandLineInfo.Arguments, valueToVisualize: $"{projectPath} {commandLineInfo.ArgumentsString}", tooltip: $"{projectPath} {commandLineInfo.TooltipString}")
-                // default to project path if there is no executable path or executable arguments
-                : new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: null, valueToVisualize: projectPath, tooltip: projectPath);
+            return CreateResourceSourceViewModel(Path.GetFileName(projectPath), projectPath, commandLineInfo);
         }
 
         if (resource.TryGetExecutablePath(out var executablePath))
         {
-            return commandLineInfo is not null
-                ? new ResourceSourceViewModel(value: Path.GetFileName(executablePath), contentAfterValue: commandLineInfo.Arguments, valueToVisualize: $"{executablePath} {commandLineInfo.ArgumentsString}", tooltip: $"{executablePath} {commandLineInfo.TooltipString}")
-                : new ResourceSourceViewModel(value: Path.GetFileName(executablePath), contentAfterValue: null, valueToVisualize: executablePath, tooltip: executablePath);
+            return CreateResourceSourceViewModel(Path.GetFileName(executablePath), executablePath, commandLineInfo);
         }
 
         if (resource.TryGetContainerImage(out var containerImage))
         {
-            return commandLineInfo is not null
-                ? new ResourceSourceViewModel(value: containerImage, contentAfterValue: commandLineInfo.Arguments, valueToVisualize: $"{containerImage} {commandLineInfo.ArgumentsString}", tooltip: $"{containerImage} {commandLineInfo.TooltipString}")
-                : new ResourceSourceViewModel(value: containerImage, contentAfterValue: null, valueToVisualize: containerImage, tooltip: containerImage);
+            return CreateResourceSourceViewModel(containerImage, containerImage, commandLineInfo);
         }
 
         if (resource.Properties.TryGetValue(KnownProperties.Resource.Source, out var property) && property.Value is { HasStringValue: true, StringValue: var value })
@@ -87,6 +38,53 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
         }
 
         return null;
+
+        static CommandLineInfo? GetCommandLineInfo(ResourceViewModel resourceViewModel)
+        {
+            // If the resource contains launch arguments, these project arguments should be shown in place of all executable arguments,
+            // which include args added by the app host
+            if (resourceViewModel.TryGetAppArgs(out var launchArguments))
+            {
+                if (launchArguments.IsDefaultOrEmpty)
+                {
+                    return null;
+                }
+
+                var argumentsString = string.Join(" ", launchArguments);
+                if (resourceViewModel.TryGetAppArgsSensitivity(out var areArgumentsSensitive))
+                {
+                    var arguments = launchArguments
+                        .Select((arg, i) => new LaunchArgument(arg, IsShown: !areArgumentsSensitive[i]))
+                        .ToList();
+
+                    return new CommandLineInfo(
+                        Arguments: arguments,
+                        ArgumentsString: argumentsString,
+                        TooltipString: string.Join(" ", arguments.Select(arg => arg.IsShown
+                            ? arg.Value
+                            : DashboardUIHelpers.GetMaskingText(6).Text)));
+                }
+
+                return new CommandLineInfo(Arguments: launchArguments.Select(arg => new LaunchArgument(arg, true)).ToList(), ArgumentsString: argumentsString, TooltipString: argumentsString);
+            }
+
+            if (resourceViewModel.TryGetExecutableArguments(out var executableArguments) && !resourceViewModel.IsProject())
+            {
+                var arguments = executableArguments.IsDefaultOrEmpty ? [] : executableArguments.Select(arg => new LaunchArgument(arg, true)).ToList();
+                var argumentsString = string.Join(" ", executableArguments);
+
+                return new CommandLineInfo(Arguments: arguments, ArgumentsString: argumentsString, TooltipString: argumentsString);
+            }
+
+            return null;
+        }
+
+        static ResourceSourceViewModel CreateResourceSourceViewModel(string value, string path, CommandLineInfo? commandLineInfo)
+        {
+            return commandLineInfo is not null
+                ? new ResourceSourceViewModel(value: value, contentAfterValue: commandLineInfo.Arguments, valueToVisualize: $"{path} {commandLineInfo.ArgumentsString}", tooltip: $"{path} {commandLineInfo.TooltipString}")
+                : new ResourceSourceViewModel(value: value, contentAfterValue: null, valueToVisualize: path, tooltip: path);
+        }
     }
 
     private record CommandLineInfo(List<LaunchArgument> Arguments, string ArgumentsString, string TooltipString);

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
+using Aspire.Dashboard.Utils;
+
 namespace Aspire.Dashboard.Model;
 
 public class ResourceSourceViewModel(string value, List<LaunchArgument>? contentAfterValue, string valueToVisualize, string tooltip)
@@ -12,7 +15,7 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
 
     internal static ResourceSourceViewModel? GetSourceViewModel(ResourceViewModel resource)
     {
-        (List<LaunchArgument>? Arguments, string? ArgumentsString) commandLineInfo;
+        CommandLineInfo? commandLineInfo;
 
         // If the resource contains launch arguments, these project arguments should be shown in place of all executable arguments,
         // which include args added by the app host
@@ -20,7 +23,7 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
         {
             if (launchArguments.IsDefaultOrEmpty)
             {
-                commandLineInfo = (null, null);
+                commandLineInfo = null;
             }
             else
             {
@@ -31,46 +34,50 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
                         .Select((arg, i) => new LaunchArgument(arg, IsShown: !areArgumentsSensitive[i]))
                         .ToList();
 
-                    commandLineInfo = (Arguments: arguments, argumentsString);
+                    commandLineInfo = new CommandLineInfo(
+                        Arguments: arguments,
+                        ArgumentsString: argumentsString,
+                        TooltipString: string.Join(" ", arguments.Select(arg => arg.IsShown
+                            ? arg.Value
+                            : WebUtility.HtmlDecode(DashboardUIHelpers.GetMaskingText(6).Value))));
                 }
                 else
                 {
-                    commandLineInfo = (Arguments: launchArguments.Select(arg => new LaunchArgument(arg, true)).ToList(), argumentsString);
+                    commandLineInfo = new CommandLineInfo(Arguments: launchArguments.Select(arg => new LaunchArgument(arg, true)).ToList(), ArgumentsString: argumentsString, TooltipString: argumentsString);
                 }
             }
         }
         else if (resource.TryGetExecutableArguments(out var executableArguments) && !resource.IsProject())
         {
-            var arguments = executableArguments.IsDefaultOrEmpty ? null : executableArguments.Select(arg => new LaunchArgument(arg, true)).ToList();
-            commandLineInfo = (Arguments: arguments, string.Join(' ', executableArguments));
+            var arguments = executableArguments.IsDefaultOrEmpty ? [] : executableArguments.Select(arg => new LaunchArgument(arg, true)).ToList();
+            commandLineInfo = new CommandLineInfo(Arguments: arguments, ArgumentsString: string.Join(' ', executableArguments), TooltipString: string.Join(' ', executableArguments));
         }
         else
         {
-            commandLineInfo = (Arguments: null, null);
+            commandLineInfo = null;
         }
 
         // NOTE projects are also executables, so we have to check for projects first
         if (resource.IsProject() && resource.TryGetProjectPath(out var projectPath))
         {
-            if (commandLineInfo is { Arguments: { } arguments, ArgumentsString: { } fullCommandLine })
-            {
-                return new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: arguments, valueToVisualize: $"{projectPath} {fullCommandLine}", tooltip: $"{projectPath} {fullCommandLine}");
-            }
-
-            // default to project path if there is no executable path or executable arguments
-            return new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: commandLineInfo.Arguments, valueToVisualize: projectPath, tooltip: projectPath);
+            return commandLineInfo is not null
+                ? new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: commandLineInfo.Arguments, valueToVisualize: $"{projectPath} {commandLineInfo.ArgumentsString}", tooltip: $"{projectPath} {commandLineInfo.TooltipString}")
+                // default to project path if there is no executable path or executable arguments
+                : new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: null, valueToVisualize: projectPath, tooltip: projectPath);
         }
 
         if (resource.TryGetExecutablePath(out var executablePath))
         {
-            var fullSource = commandLineInfo.ArgumentsString is not null ? $"{executablePath} {commandLineInfo.ArgumentsString}" : executablePath;
-            return new ResourceSourceViewModel(value: Path.GetFileName(executablePath), contentAfterValue: commandLineInfo.Arguments, valueToVisualize: fullSource, tooltip: fullSource);
+            return commandLineInfo is not null
+                ? new ResourceSourceViewModel(value: Path.GetFileName(executablePath), contentAfterValue: commandLineInfo.Arguments, valueToVisualize: $"{executablePath} {commandLineInfo.ArgumentsString}", tooltip: $"{executablePath} {commandLineInfo.TooltipString}")
+                : new ResourceSourceViewModel(value: Path.GetFileName(executablePath), contentAfterValue: null, valueToVisualize: executablePath, tooltip: executablePath);
         }
 
         if (resource.TryGetContainerImage(out var containerImage))
         {
-            var fullSource = commandLineInfo.ArgumentsString is null ? containerImage : $"{containerImage} {commandLineInfo.ArgumentsString}";
-            return new ResourceSourceViewModel(value: containerImage, contentAfterValue: commandLineInfo.Arguments, valueToVisualize: fullSource, tooltip: fullSource);
+            return commandLineInfo is not null
+                ? new ResourceSourceViewModel(value: containerImage, contentAfterValue: commandLineInfo.Arguments, valueToVisualize: $"{containerImage} {commandLineInfo.ArgumentsString}", tooltip: $"{containerImage} {commandLineInfo.TooltipString}")
+                : new ResourceSourceViewModel(value: containerImage, contentAfterValue: null, valueToVisualize: containerImage, tooltip: containerImage);
         }
 
         if (resource.Properties.TryGetValue(KnownProperties.Resource.Source, out var property) && property.Value is { HasStringValue: true, StringValue: var value })
@@ -80,6 +87,8 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
 
         return null;
     }
+
+    private record CommandLineInfo(List<LaunchArgument> Arguments, string ArgumentsString, string TooltipString);
 }
 
 public record LaunchArgument(string Value, bool IsShown);

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net;
 using Aspire.Dashboard.Utils;
 
 namespace Aspire.Dashboard.Model;
@@ -39,7 +38,7 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
                         ArgumentsString: argumentsString,
                         TooltipString: string.Join(" ", arguments.Select(arg => arg.IsShown
                             ? arg.Value
-                            : WebUtility.HtmlDecode(DashboardUIHelpers.GetMaskingText(6).Value))));
+                            : DashboardUIHelpers.GetMaskingText(6).Text)));
                 }
                 else
                 {

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -50,7 +50,9 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
         else if (resource.TryGetExecutableArguments(out var executableArguments) && !resource.IsProject())
         {
             var arguments = executableArguments.IsDefaultOrEmpty ? [] : executableArguments.Select(arg => new LaunchArgument(arg, true)).ToList();
-            commandLineInfo = new CommandLineInfo(Arguments: arguments, ArgumentsString: string.Join(' ', executableArguments), TooltipString: string.Join(' ', executableArguments));
+            var argumentsString = string.Join(" ", executableArguments);
+
+            commandLineInfo = new CommandLineInfo(Arguments: arguments, ArgumentsString: argumentsString, TooltipString: argumentsString);
         }
         else
         {

--- a/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
@@ -43,16 +43,25 @@ internal static class DashboardUIHelpers
         return (resizeLabels, sortLabels);
     }
 
-    private static readonly ConcurrentDictionary<int, string> s_cachedMasking = new();
+    private static readonly ConcurrentDictionary<int, TextMask> s_cachedMasking = new();
 
-    public static MarkupString GetMaskingText(int length)
+    public static TextMask GetMaskingText(int length)
     {
-        return new MarkupString(s_cachedMasking.GetOrAdd(length, static i =>
+        return s_cachedMasking.GetOrAdd(length, static i =>
         {
-            const string maskingChar = "&#x25cf;";
-            return new StringBuilder(maskingChar.Length * i)
-              .Insert(0, maskingChar, i)
-              .ToString();
-        }));
+            const string markupMaskingChar = "&#x25cf;";
+            const string textMaskingChar = "●";
+
+            return new TextMask(
+                new MarkupString(Repeat(markupMaskingChar, i)),
+                Repeat(textMaskingChar, i)
+            );
+
+            static string Repeat(string s, int n) => new StringBuilder(s.Length * n)
+                .Insert(0, s, n)
+                .ToString();
+        });
     }
 }
+
+internal record TextMask(MarkupString MarkupString, string Text);

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -155,7 +155,7 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
     {
         // GetValueAsync will throw if the connection string is not optional and does not exist.
         // Invoke GetValueAsync to make sure the value isn't resolved, since we are manually resolving the expression.
-        await ((IValueProvider)cs).GetValueAsync().ConfigureAwait(false);
+        await ((IValueProvider)cs).GetValueAsync(cancellationToken).ConfigureAwait(false);
 
         return await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -153,8 +153,9 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
 
     async Task<ResolvedValue> ResolveConnectionStringReferenceAsync(ConnectionStringReference cs)
     {
-        // GetValueAsync will throw if the connection string is not optional and does not exist.
-        // Invoke GetValueAsync to make sure the value isn't resolved, since we are manually resolving the expression.
+        // We are substituting our own logic for ConnectionStringReference's GetValueAsync.
+        // However, ConnectionStringReference#GetValueAsync will throw if the connection string is not optional but is not present.
+        // To avoid duplicating that logic, we can defer to ConnectionStringReference#GetValueAsync, which will throw if needed.
         await ((IValueProvider)cs).GetValueAsync(cancellationToken).ConfigureAwait(false);
 
         return await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false);

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -154,16 +154,14 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
     /// </summary>
     async ValueTask<ResolvedValue> ResolveInternalAsync(object? value)
     {
-        return (value, sourceIsContainer) switch
+        return value switch
         {
-            (ConnectionStringReference cs, true) => await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false),
-            (IResourceWithConnectionString cs, true) => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
-            (ReferenceExpression ex, false) => await EvalExpressionAsync(ex).ConfigureAwait(false),
-            (ReferenceExpression ex, true) => await EvalExpressionAsync(ex).ConfigureAwait(false),
-            (EndpointReference endpointReference, true) => new(await EvalEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false), false),
-            (EndpointReferenceExpression ep, true) => new(await EvalEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false), false),
-            (IValueProvider vp, false) => await EvalValueProvider(vp).ConfigureAwait(false),
-            (IValueProvider vp, true) => await EvalValueProvider(vp).ConfigureAwait(false),
+            ConnectionStringReference cs => await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false),
+            IResourceWithConnectionString cs => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
+            ReferenceExpression ex => await EvalExpressionAsync(ex).ConfigureAwait(false),
+            EndpointReference endpointReference => new(await EvalEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false), false),
+            EndpointReferenceExpression ep => new(await EvalEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false), false),
+            IValueProvider vp => await EvalValueProvider(vp).ConfigureAwait(false),
             _ => throw new NotImplementedException()
         };
     }

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -149,8 +149,7 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
     }
 
     /// <summary>
-    /// Resolve an expression when it is being used from inside a container.
-    /// So it's either a container-to-container or container-to-exe communication.
+    /// Resolve an expression. When it is being used from inside a container, endpoints may be evaluated (either in a container-to-container or container-to-exe communication).
     /// </summary>
     async ValueTask<ResolvedValue> ResolveInternalAsync(object? value)
     {

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -157,7 +157,7 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
         return value switch
         {
             ConnectionStringReference cs => await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false),
-            IResourceWithConnectionString cs => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
+            IResourceWithConnectionString cs and not ResourceWithConnectionStringSurrogate => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
             ReferenceExpression ex => await EvalExpressionAsync(ex).ConfigureAwait(false),
             EndpointReference endpointReference when sourceIsContainer => new ResolvedValue(await EvalEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false), false),
             EndpointReferenceExpression ep when sourceIsContainer => new ResolvedValue(await EvalEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false), false),

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -94,7 +94,10 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
             }
         }
 
-        return new(string.Format(CultureInfo.InvariantCulture, expr.Format, args), isSensitive);
+        // Identically to ReferenceExpression.GetValueAsync, we return null if the format is empty
+        var value = expr.Format.Length == 0 ? null : string.Format(CultureInfo.InvariantCulture, expr.Format, args);
+
+        return new ResolvedValue(value, isSensitive);
     }
 
     async Task<ResolvedValue> EvalValueProvider(IValueProvider vp)

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -159,8 +159,8 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
             ConnectionStringReference cs => await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false),
             IResourceWithConnectionString cs => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
             ReferenceExpression ex => await EvalExpressionAsync(ex).ConfigureAwait(false),
-            EndpointReference endpointReference => new(await EvalEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false), false),
-            EndpointReferenceExpression ep => new(await EvalEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false), false),
+            EndpointReference endpointReference when sourceIsContainer => new ResolvedValue(await EvalEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false), false),
+            EndpointReferenceExpression ep when sourceIsContainer => new ResolvedValue(await EvalEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false), false),
             IValueProvider vp => await EvalValueProvider(vp).ConfigureAwait(false),
             _ => throw new NotImplementedException()
         };

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -55,6 +55,7 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
     /// <returns></returns>
     public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
     {
+        // NOTE: any logical changes to this method should also be made to ExpressionResolver.EvalExpressionAsync
         if (Format.Length == 0)
         {
             return null;

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
 using Aspire.Tests.Shared.DashboardModel;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -94,7 +95,7 @@ public class ResourceSourceViewModelTests
                 value: "project",
                 contentAfterValue: [new LaunchArgument("arg2", true), new LaunchArgument("--key", true), new LaunchArgument("secret", false)],
                 valueToVisualize: "path/to/project arg2 --key secret",
-                tooltip: "path/to/project arg2 --key secret"));
+                tooltip: $"path/to/project arg2 --key {DashboardUIHelpers.GetMaskingText(6).Value}"));
 
         // Project without executable arguments
         data.Add(new TestData(

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -87,15 +87,15 @@ public class ResourceSourceViewModelTests
                 ResourceType: "Project",
                 ExecutablePath: "path/to/executable",
                 ExecutableArguments: ["arg1", "arg2"],
-                AppArgs: ["arg2", "--key", "secret"],
-                AppArgsSensitivity: [false, false, true],
+                AppArgs: ["arg2", "--key", "secret", "secret2", "notsecret"],
+                AppArgsSensitivity: [false, false, true, true, false],
                 ProjectPath: "path/to/project",
                 ContainerImage: null,
                 SourceProperty: null),
             new ResourceSourceViewModel(
                 value: "project",
                 contentAfterValue: [new LaunchArgument("arg2", true), new LaunchArgument("--key", true), new LaunchArgument("secret", false), new LaunchArgument("secret2", false), new LaunchArgument("notsecret", true)],
-                valueToVisualize: "path/to/project arg2 --key secret",
+                valueToVisualize: "path/to/project arg2 --key secret secret2 notsecret",
                 tooltip: $"path/to/project arg2 --key {maskingText} {maskingText} notsecret"));
 
         // Project without executable arguments

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -81,6 +81,7 @@ public class ResourceSourceViewModelTests
                 valueToVisualize: "path/to/project arg2",
                 tooltip: "path/to/project arg2"));
 
+        var maskingText = DashboardUIHelpers.GetMaskingText(6).Text;
         // Project with app arguments, as well as a secret (format argument)
         data.Add(new TestData(
                 ResourceType: "Project",
@@ -93,9 +94,9 @@ public class ResourceSourceViewModelTests
                 SourceProperty: null),
             new ResourceSourceViewModel(
                 value: "project",
-                contentAfterValue: [new LaunchArgument("arg2", true), new LaunchArgument("--key", true), new LaunchArgument("secret", false)],
+                contentAfterValue: [new LaunchArgument("arg2", true), new LaunchArgument("--key", true), new LaunchArgument("secret", false), new LaunchArgument("secret2", false), new LaunchArgument("notsecret", true)],
                 valueToVisualize: "path/to/project arg2 --key secret",
-                tooltip: $"path/to/project arg2 --key {DashboardUIHelpers.GetMaskingText(6).Text}"));
+                tooltip: $"path/to/project arg2 --key {maskingText} {maskingText} notsecret"));
 
         // Project without executable arguments
         data.Add(new TestData(

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Aspire.Tests.Shared.DashboardModel;
@@ -95,7 +96,7 @@ public class ResourceSourceViewModelTests
                 value: "project",
                 contentAfterValue: [new LaunchArgument("arg2", true), new LaunchArgument("--key", true), new LaunchArgument("secret", false)],
                 valueToVisualize: "path/to/project arg2 --key secret",
-                tooltip: $"path/to/project arg2 --key {DashboardUIHelpers.GetMaskingText(6).Value}"));
+                tooltip: $"path/to/project arg2 --key {WebUtility.HtmlDecode(DashboardUIHelpers.GetMaskingText(6).Value)}"));
 
         // Project without executable arguments
         data.Add(new TestData(

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Aspire.Tests.Shared.DashboardModel;
@@ -96,7 +95,7 @@ public class ResourceSourceViewModelTests
                 value: "project",
                 contentAfterValue: [new LaunchArgument("arg2", true), new LaunchArgument("--key", true), new LaunchArgument("secret", false)],
                 valueToVisualize: "path/to/project arg2 --key secret",
-                tooltip: $"path/to/project arg2 --key {WebUtility.HtmlDecode(DashboardUIHelpers.GetMaskingText(6).Value)}"));
+                tooltip: $"path/to/project arg2 --key {DashboardUIHelpers.GetMaskingText(6).Text}"));
 
         // Project without executable arguments
         data.Add(new TestData(

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -10,6 +10,49 @@ namespace Aspire.Hosting.Tests;
 public class ExpressionResolverTests
 {
     [Theory]
+    [MemberData(nameof(ResolveInternalAsync_ResolvesCorrectly_MemberData))]
+    public async Task ResolveInternalAsync_ResolvesCorrectly(ExpressionResolverTestData testData, Type? exceptionType, (string Value, bool IsSensitive)? expectedValue)
+    {
+        if (exceptionType is not null)
+        {
+            await Assert.ThrowsAsync(exceptionType, ResolveAsync);
+        }
+        else
+        {
+            var resolvedValue = await ExpressionResolver.ResolveAsync(testData.SourceIsContainer, testData.ValueProvider, string.Empty, CancellationToken.None);
+
+            Assert.Equal(expectedValue?.Value, resolvedValue.Value);
+            Assert.Equal(expectedValue?.IsSensitive, resolvedValue.IsSensitive);
+        }
+
+        async Task<ResolvedValue> ResolveAsync() => await ExpressionResolver.ResolveAsync(testData.SourceIsContainer, testData.ValueProvider, string.Empty, CancellationToken.None);
+    }
+
+    public static TheoryData<ExpressionResolverTestData, Type?, (string? Value, bool IsSensitive)?> ResolveInternalAsync_ResolvesCorrectly_MemberData()
+    {
+        var data = new TheoryData<ExpressionResolverTestData, Type?, (string? Value, bool IsSensitive)?>();
+
+        // doesn't differ by sourceIsContainer
+        data.Add(new ExpressionResolverTestData(false, new ConnectionStringReference(new TestExpressionResolverResource("Empty"), false)), typeof(DistributedApplicationException), null);
+        data.Add(new ExpressionResolverTestData(false, new ConnectionStringReference(new TestExpressionResolverResource("Empty"), true)), null, (null, false));
+        data.Add(new ExpressionResolverTestData(true, new ConnectionStringReference(new TestExpressionResolverResource("String"), true)), null, ("String", false));
+        data.Add(new ExpressionResolverTestData(true, new ConnectionStringReference(new TestExpressionResolverResource("SecretParameter"), false)), null, ("SecretParameter", true));
+
+        // IResourceWithConnectionString resolves differently for ResourceWithConnectionStringSurrogate (as a secret parameter)
+        data.Add(new ExpressionResolverTestData(false, new ResourceWithConnectionStringSurrogate("SurrogateResource", _ => "SurrogateResource", null)), null, ("SurrogateResource", true));
+        data.Add(new ExpressionResolverTestData(false, new TestExpressionResolverResource("String")), null, ("String", false));
+
+        data.Add(new ExpressionResolverTestData(false, new ParameterResource("SecretParameter", _ => "SecretParameter", secret: true)), null, ("SecretParameter", true));
+        data.Add(new ExpressionResolverTestData(false, new ParameterResource("NonSecretParameter", _ => "NonSecretParameter", secret: false)), null, ("NonSecretParameter", false));
+
+        // ExpressionResolverGeneratesCorrectEndpointStrings separately tests EndpointReference and EndpointReferenceExpression
+
+        return data;
+    }
+
+    public record ExpressionResolverTestData(bool SourceIsContainer, IValueProvider ValueProvider);
+
+    [Theory]
     [InlineData("TwoFullEndpoints", false, false, "Test1=http://127.0.0.1:12345/;Test2=https://localhost:12346/;")]
     [InlineData("TwoFullEndpoints", false, true, "Test1=http://127.0.0.1:12345/;Test2=https://localhost:12346/;")]
     [InlineData("TwoFullEndpoints", true, false, "Test1=http://ContainerHostName:12345/;Test2=https://ContainerHostName:12346/;")]
@@ -28,7 +71,7 @@ public class ExpressionResolverTests
     [InlineData("PortBeforeHost", true, true, "Port=10000;Host=testresource;")]
     [InlineData("FullAndPartial", true, false, "Test1=http://ContainerHostName:12345/;Test2=https://localhost:12346/;")]
     [InlineData("FullAndPartial", true, true, "Test1=http://testresource:10000/;Test2=https://localhost:12346/;")] // Second port not replaced since host is hard coded
-    public async Task ExpressionResolverGeneratesCorrectStrings(string exprName, bool sourceIsContainer, bool targetIsContainer, string expectedConnectionString)
+    public async Task ExpressionResolverGeneratesCorrectEndpointStrings(string exprName, bool sourceIsContainer, bool targetIsContainer, string expectedConnectionString)
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -118,6 +161,14 @@ public class ExpressionResolverTests
     }
 }
 
+sealed class TestValueProviderResource(string name) : Resource(name), IValueProvider
+{
+    public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default)
+    {
+        return new ValueTask<string?>(base.Name);
+    }
+}
+
 sealed class TestExpressionResolverResource : ContainerResource, IResourceWithEndpoints, IResourceWithConnectionString
 {
     readonly string _exprName;
@@ -136,7 +187,11 @@ sealed class TestExpressionResolverResource : ContainerResource, IResourceWithEn
             { "OnlyHost", ReferenceExpression.Create($"Host={Endpoint1.Property(EndpointProperty.Host)};") },
             { "OnlyPort", ReferenceExpression.Create($"Port={Endpoint1.Property(EndpointProperty.Port)};") },
             { "PortBeforeHost", ReferenceExpression.Create($"Port={Endpoint1.Property(EndpointProperty.Port)};Host={Endpoint1.Property(EndpointProperty.Host)};") },
-            { "FullAndPartial", ReferenceExpression.Create($"Test1={Endpoint1.Property(EndpointProperty.Scheme)}://{Endpoint1.Property(EndpointProperty.IPV4Host)}:{Endpoint1.Property(EndpointProperty.Port)}/;Test2={Endpoint2.Property(EndpointProperty.Scheme)}://localhost:{Endpoint2.Property(EndpointProperty.Port)}/;") }
+            { "FullAndPartial", ReferenceExpression.Create($"Test1={Endpoint1.Property(EndpointProperty.Scheme)}://{Endpoint1.Property(EndpointProperty.IPV4Host)}:{Endpoint1.Property(EndpointProperty.Port)}/;Test2={Endpoint2.Property(EndpointProperty.Scheme)}://localhost:{Endpoint2.Property(EndpointProperty.Port)}/;") },
+            { "Empty", ReferenceExpression.Create($"") },
+            { "String", ReferenceExpression.Create($"String") },
+            { "SecretParameter", ReferenceExpression.Create("SecretParameter", [new ParameterResource("SecretParameter", _ => "SecretParameter", secret: true)], []) },
+            { "NonSecretParameter", ReferenceExpression.Create("NonSecretParameter", [new ParameterResource("NonSecretParameter", _ => "NonSecretParameter", secret: false)], []) }
         };
     }
 


### PR DESCRIPTION
## Description

Took the opportunity to clean up my code in `GetSourceViewModel` as well to add a type `CommandLineInfo` instead of relying on a tuple. Hides secrets in tooltips using the same masking characters as appear in the GridValue.

Also removes logic in `ExpressionResolver` that resolves some types of expressions only for containers. All expressions except `EndpointReferenceExpression` and `EndpointReference` should be resolved for all resource types. The only other difference between containers and other types of resources is how HostUrl is resolved (special-cased for containers). 

Fixes #7634, fixes #7632

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
