### PR TITLE
Fix resource cleanup in ungraceful shutdown tests

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -581,8 +581,9 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
 
         public async Task StopAsync(CancellationToken cancellationToken = default)
         {
-            using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, appFactory._disposingCts.Token);
-            await innerHost.StopAsync(linkedToken.Token).ConfigureAwait(false);
+            // The cancellation token is passed as-is here to give the host a chance to stop gracefully.
+            // Internally, in the host itself, the value of HostOptions.ShutdownTimeout limits how long the host has to stop gracefully.
+            await innerHost.StopAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -456,9 +456,6 @@ public class TestingBuilderTests(ITestOutputHelper output)
         {
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync().WaitAsync(cts.Token));
             Assert.Contains(crashArg, exception.Message);
-
-            await app.DisposeAsync().AsTask().WaitAsync(cts.Token);
-            return;
         }
         else
         {

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
@@ -26,8 +26,6 @@ public class TestingFactoryCrashTests
         {
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => factory.StartAsync().WaitAsync(cts.Token));
             Assert.Contains(crashArg, exception.Message);
-            await factory.DisposeAsync().AsTask().WaitAsync(cts.Token);
-            return;
         }
         else
         {


### PR DESCRIPTION
## Description

This fixes an issue we saw where Aspire.Hosting.Testing.Tests were leaking resources (containers) while they were running. The problem is that some of these tests call `DisposeAsync` concurrently with `StopAsync` or before `StopAsync`, so the `CancellationToken` being passing to `StopAsync` was cancelled and hence cleanup was abandoned.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
