### PR TITLE
Avoid unnecessary containers in Aspire.Hosting.Testing.Tests

### DIFF
--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -125,10 +125,10 @@ public class TestingBuilderTests(ITestOutputHelper output)
         Assert.NotNull(workerEndpoint);
         Assert.True(workerEndpoint.Host.Length > 0);
 
-        // Get a connection string from a resource
-        var pgConnectionString = await app.GetConnectionStringAsync("postgres1");
-        Assert.NotNull(pgConnectionString);
-        Assert.True(pgConnectionString.Length > 0);
+        // Get a connection string
+        var connectionString = await app.GetConnectionStringAsync("cs");
+        Assert.NotNull(connectionString);
+        Assert.True(connectionString.Length > 0);
     }
 
     [Theory]
@@ -146,7 +146,6 @@ public class TestingBuilderTests(ITestOutputHelper output)
 
         // Ensure that the resource which we added is present in the model.
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        Assert.Contains(appModel.GetContainerResources(), c => c.Name == "redis1");
         Assert.Contains(appModel.GetProjectResources(), p => p.Name == "myworker1");
     }
 
@@ -500,7 +499,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
         try
         {
             var builder = await DistributedApplicationTestingBuilder.CreateAsync<Projects.TestingAppHost1_AppHost>(
-                ["--wait-for-healthy"],
+                ["--wait-for-healthy", "--add-redis"],
                 cts.Token).WaitAsync(cts.Token);
 
             // Make the redis container hang forever.

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -17,17 +17,12 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
 
     [Fact]
     [RequiresDocker]
-    public async Task HasEndPoints()
+    public void HasEndPoints()
     {
         // Get an endpoint from a resource
         var workerEndpoint = _app.GetEndpoint("myworker1", "myendpoint1");
         Assert.NotNull(workerEndpoint);
         Assert.True(workerEndpoint.Host.Length > 0);
-
-        // Get a connection string from a resource
-        var pgConnectionString = await _app.GetConnectionStringAsync("postgres1");
-        Assert.NotNull(pgConnectionString);
-        Assert.True(pgConnectionString.Length > 0);
     }
 
     [Fact]
@@ -44,7 +39,6 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     public void CanGetResources()
     {
         var appModel = _app.Services.GetRequiredService<DistributedApplicationModel>();
-        Assert.Contains(appModel.GetContainerResources(), c => c.Name == "redis1");
         Assert.Contains(appModel.GetProjectResources(), p => p.Name == "myworker1");
     }
 

--- a/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
+++ b/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
@@ -10,7 +10,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 builder.Configuration["ConnectionStrings:cs"] = "testconnection";
 
 builder.AddConnectionString("cs");
-builder.AddRedis("redis1");
+if (args.Contains("--add-redis"))
+{
+    builder.AddRedis("redis1");
+}
+
 var webApp = builder.AddProject<Projects.TestingAppHost1_MyWebApp>("mywebapp1")
     .WithEnvironment("APP_HOST_ARG", builder.Configuration["APP_HOST_ARG"])
     .WithEnvironment("LAUNCH_PROFILE_VAR_FROM_APP_HOST", builder.Configuration["LAUNCH_PROFILE_VAR_FROM_APP_HOST"]);
@@ -22,7 +26,6 @@ if (builder.Configuration.GetValue("USE_HTTPS", false))
 
 builder.AddProject<Projects.TestingAppHost1_MyWorker>("myworker1")
     .WithEndpoint(name: "myendpoint1", env: "myendpoint1_port");
-builder.AddPostgres("postgres1");
 
 if (args.Contains("--add-unknown-container"))
 {


### PR DESCRIPTION
## Description

This PR removes unnecessary containers from the Aspire.Hosting.Testing.Tests suite.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
