### PR TITLE
Mitchdenny/wait-behavior-follow-up

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -263,7 +263,7 @@ public class ResourceNotificationService : IDisposable
 
         return resourceEvent;
 
-                // Determine if we should yield based on the wait behavior and the snapshot of the resource.
+        // Determine if we should yield based on the wait behavior and the snapshot of the resource.
         static bool ShouldYield(WaitBehavior waitBehavior, CustomResourceSnapshot snapshot) =>
             waitBehavior switch
             {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -241,13 +241,12 @@ public class ResourceNotificationService : IDisposable
     /// Waits for a resource to become healthy.
     /// </summary>
     /// <param name="resourceName">The name of the resource.</param>
-    /// <param name="waitBehavior">The behavior to use when waiting for the resource to become healthy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="waitBehavior">The wait behavior.</param>
     /// <returns>A task.</returns>
     /// <remarks>
     /// This method returns a task that will complete with the resource is healthy. A resource
-    /// without <see cref="HealthCheckAnnotation"/> annotations will be considered healthy. This overload
-    /// will throw a <see cref="Aspire.Hosting.DistributedApplicationException"/> if the resource fails to start.
+    /// without <see cref="HealthCheckAnnotation"/> annotations will be considered healthy.
     /// </remarks>
     public async Task<ResourceEvent> WaitForResourceHealthyAsync(string resourceName, WaitBehavior waitBehavior, CancellationToken cancellationToken = default)
     {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -50,7 +50,7 @@ public class ResourceNotificationService : IDisposable
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceProvider = new NullServiceProvider();
         _resourceLoggerService = new ResourceLoggerService();
-        DefaultWaitBehavior = WaitBehavior.StopOnDependencyFailure;
+        DefaultWaitBehavior = WaitBehavior.StopOnResourceUnavailable;
     }
 
     /// <summary>
@@ -69,7 +69,7 @@ public class ResourceNotificationService : IDisposable
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceProvider = serviceProvider;
         _resourceLoggerService = resourceLoggerService ?? throw new ArgumentNullException(nameof(resourceLoggerService));
-        DefaultWaitBehavior = serviceProvider.GetService<IOptions<ResourceNotificationServiceOptions>>()?.Value.DefaultWaitBehavior ?? WaitBehavior.StopOnDependencyFailure;
+        DefaultWaitBehavior = serviceProvider.GetService<IOptions<ResourceNotificationServiceOptions>>()?.Value.DefaultWaitBehavior ?? WaitBehavior.StopOnResourceUnavailable;
 
         // The IHostApplicationLifetime parameter is not used anymore, but we keep it for backwards compatibility.
         // Notification updates will be cancelled when the service is disposed.
@@ -161,7 +161,7 @@ public class ResourceNotificationService : IDisposable
             var resourceEvent = await WaitForResourceCoreAsync(dependency.Name, re => re.ResourceId == resourceId && IsContinuableState(waitBehavior, re.Snapshot), cancellationToken: cancellationToken).ConfigureAwait(false);
             var snapshot = resourceEvent.Snapshot;
 
-            if (waitBehavior == WaitBehavior.StopOnDependencyFailure)
+            if (waitBehavior == WaitBehavior.StopOnResourceUnavailable)
             {
                 if (snapshot.State?.Text == KnownResourceStates.FailedToStart)
                 {
@@ -208,8 +208,8 @@ public class ResourceNotificationService : IDisposable
             static bool IsContinuableState(WaitBehavior waitBehavior, CustomResourceSnapshot snapshot) =>
                 waitBehavior switch
                 {
-                    WaitBehavior.WaitOnDependencyFailure => snapshot.State?.Text == KnownResourceStates.Running,
-                    WaitBehavior.StopOnDependencyFailure => snapshot.State?.Text == KnownResourceStates.Running ||
+                    WaitBehavior.WaitOnResourceUnavailable => snapshot.State?.Text == KnownResourceStates.Running,
+                    WaitBehavior.StopOnResourceUnavailable => snapshot.State?.Text == KnownResourceStates.Running ||
                                                             snapshot.State?.Text == KnownResourceStates.Finished ||
                                                             snapshot.State?.Text == KnownResourceStates.Exited ||
                                                             snapshot.State?.Text == KnownResourceStates.FailedToStart ||
@@ -233,7 +233,7 @@ public class ResourceNotificationService : IDisposable
     {
         return await WaitForResourceHealthyAsync(
             resourceName,
-            WaitBehavior.WaitOnDependencyFailure, // Retain default behavior.
+            WaitBehavior.WaitOnResourceUnavailable, // Retain default behavior.
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -251,15 +251,8 @@ public class ResourceNotificationService : IDisposable
     /// </remarks>
     public async Task<ResourceEvent> WaitForResourceHealthyAsync(string resourceName, WaitBehavior waitBehavior, CancellationToken cancellationToken = default)
     {
-        var waitCondition = waitBehavior switch
-        {
-            WaitBehavior.WaitOnDependencyFailure => (Func<ResourceEvent, bool>)(re => re.Snapshot.HealthStatus == HealthStatus.Healthy),
-            WaitBehavior.StopOnDependencyFailure => (Func<ResourceEvent, bool>)(re => re.Snapshot.HealthStatus == HealthStatus.Healthy || re.Snapshot.State?.Text == KnownResourceStates.FailedToStart),
-            _ => throw new DistributedApplicationException($"Unexpected wait behavior: {waitBehavior}")
-        };
-
         _logger.LogDebug("Waiting for resource '{Name}' to enter the '{State}' state.", resourceName, HealthStatus.Healthy);
-        var resourceEvent = await WaitForResourceCoreAsync(resourceName, waitCondition, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var resourceEvent = await WaitForResourceCoreAsync(resourceName, re => ShouldYield(waitBehavior, re.Snapshot), cancellationToken: cancellationToken).ConfigureAwait(false);
 
         if (resourceEvent.Snapshot.HealthStatus != HealthStatus.Healthy)
         {
@@ -270,6 +263,19 @@ public class ResourceNotificationService : IDisposable
         _logger.LogDebug("Finished waiting for resource '{Name}'.", resourceName);
 
         return resourceEvent;
+
+                // Determine if we should yield based on the wait behavior and the snapshot of the resource.
+        static bool ShouldYield(WaitBehavior waitBehavior, CustomResourceSnapshot snapshot) =>
+            waitBehavior switch
+            {
+                WaitBehavior.WaitOnResourceUnavailable => snapshot.HealthStatus == HealthStatus.Healthy,
+                WaitBehavior.StopOnResourceUnavailable => snapshot.HealthStatus == HealthStatus.Healthy ||
+                                                      snapshot.State?.Text == KnownResourceStates.Finished ||
+                                                      snapshot.State?.Text == KnownResourceStates.Exited ||
+                                                      snapshot.State?.Text == KnownResourceStates.FailedToStart ||
+                                                      snapshot.State?.Text == KnownResourceStates.RuntimeUnhealthy,
+                _ => throw new DistributedApplicationException($"Unexpected wait behavior: {waitBehavior}")
+            };
     }
 
     private async Task WaitUntilCompletionAsync(IResource resource, IResource dependency, int exitCode, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
@@ -65,7 +65,7 @@ public enum WaitBehavior
     WaitOnResourceUnavailable,
 
     /// <summary>
-    /// If the resource s unavailable, stop waiting.
+    /// If the resource is unavailable, stop waiting.
     /// </summary>
     StopOnResourceUnavailable
 }

--- a/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
@@ -60,12 +60,12 @@ public enum WaitType
 public enum WaitBehavior
 {
     /// <summary>
-    /// If the dependency fails, ignore the failure and continue waiting.
+    /// If the resource is unavailable, continue waiting.
     /// </summary>
-    WaitOnDependencyFailure,
+    WaitOnResourceUnavailable,
 
     /// <summary>
-    /// If the dependency fails, stop waiting and fail the wait.
+    /// If the resource s unavailable, stop waiting.
     /// </summary>
-    StopOnDependencyFailure
+    StopOnResourceUnavailable
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -206,7 +206,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         {
             // Default to stopping on dependency failure if the dashboard is disabled. As there's no way to see or easily recover
             // from a failure in that case.
-            o.DefaultWaitBehavior = options.DisableDashboard ? WaitBehavior.StopOnDependencyFailure : WaitBehavior.WaitOnDependencyFailure;
+            o.DefaultWaitBehavior = options.DisableDashboard ? WaitBehavior.StopOnResourceUnavailable : WaitBehavior.WaitOnResourceUnavailable;
         });
 
         ConfigureHealthChecks();

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -738,7 +738,7 @@ public static class ResourceBuilderExtensions
     /// var messaging = builder.AddRabbitMQ("messaging");
     /// builder.AddProject&lt;Projects.MyApp&gt;("myapp")
     ///        .WithReference(messaging)
-    ///        .WaitFor(messaging, WaitBehavior.StopOnDependencyFailure);
+    ///        .WaitFor(messaging, WaitBehavior.StopOnResourceUnavailable);
     /// </code>
     /// </example>
     public static IResourceBuilder<T> WaitFor<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency, WaitBehavior waitBehavior) where T : IResourceWithWaitSupport

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -168,14 +168,14 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     [InlineData(nameof(KnownResourceStates.RuntimeUnhealthy))]
     [InlineData(nameof(KnownResourceStates.Finished))]
     [RequiresDocker]
-    public async Task WaitForBehaviorStopOnDependencyFailure(string status)
+    public async Task WaitForBehaviorStopOnResourceUnavailable(string status)
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
 
         var dependency = builder.AddResource(new CustomResource("test"));
         var nginx = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
                            .WithReference(dependency)
-                           .WaitFor(dependency, WaitBehavior.StopOnDependencyFailure);
+                           .WaitFor(dependency, WaitBehavior.StopOnResourceUnavailable);
 
         using var app = builder.Build();
 
@@ -197,14 +197,14 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
    [Fact]
-   public async Task WhenWaitBehaviorIsStopOnDependencyFailureWaitForResourceHealthyAsyncShouldThrowWhenResourceFailsToStart()
+   public async Task WhenWaitBehaviorIsStopOnResourceUnavailableWaitForResourceHealthyAsyncShouldThrowWhenResourceFailsToStart()
    {
       using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
 
       var failToStart = builder.AddExecutable("failToStart", "does-not-exist", ".");
       var dependency = builder.AddContainer("redis", "redis");
 
-      dependency.WaitFor(failToStart, WaitBehavior.StopOnDependencyFailure);
+      dependency.WaitFor(failToStart, WaitBehavior.StopOnResourceUnavailable);
 
       using var app = builder.Build();
       await app.StartAsync();
@@ -212,7 +212,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
       var ex = await Assert.ThrowsAsync<DistributedApplicationException>(async () => {
         await app.ResourceNotifications.WaitForResourceHealthyAsync(
             dependency.Resource.Name,
-            WaitBehavior.StopOnDependencyFailure
+            WaitBehavior.StopOnResourceUnavailable
             ).WaitAsync(TimeSpan.FromSeconds(15));
       });
 
@@ -220,14 +220,14 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
    }
 
    [Fact]
-   public async Task WhenWaitBehaviorIsWaitOnDependencyFailureWaitForResourceHealthyAsyncShouldThrowWhenResourceFailsToStart()
+   public async Task WhenWaitBehaviorIsWaitOnResourceUnavailableWaitForResourceHealthyAsyncShouldThrowWhenResourceFailsToStart()
    {
       using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
 
       var failToStart = builder.AddExecutable("failToStart", "does-not-exist", ".");
       var dependency = builder.AddContainer("redis", "redis");
 
-      dependency.WaitFor(failToStart, WaitBehavior.StopOnDependencyFailure);
+      dependency.WaitFor(failToStart, WaitBehavior.StopOnResourceUnavailable);
 
       using var app = builder.Build();
       await app.StartAsync();
@@ -235,7 +235,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
       var ex = await Assert.ThrowsAsync<TimeoutException>(async () => {
         await app.ResourceNotifications.WaitForResourceHealthyAsync(
             dependency.Resource.Name,
-            WaitBehavior.WaitOnDependencyFailure
+            WaitBehavior.WaitOnResourceUnavailable
             ).WaitAsync(TimeSpan.FromSeconds(15));
       });
 
@@ -282,14 +282,14 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     [InlineData(nameof(KnownResourceStates.RuntimeUnhealthy))]
     [InlineData(nameof(KnownResourceStates.Finished))]
     [RequiresDocker]
-    public async Task WaitForBehaviorWaitOnDependencyFailure(string status)
+    public async Task WaitForBehaviorWaitOnResourceUnavailable(string status)
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
 
         var dependency = builder.AddResource(new CustomResource("test"));
         var nginx = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
                            .WithReference(dependency)
-                           .WaitFor(dependency, WaitBehavior.WaitOnDependencyFailure);
+                           .WaitFor(dependency, WaitBehavior.WaitOnResourceUnavailable);
 
         using var app = builder.Build();
 
@@ -324,13 +324,13 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     [InlineData(nameof(KnownResourceStates.RuntimeUnhealthy))]
     [InlineData(nameof(KnownResourceStates.Finished))]
     [RequiresDocker]
-    public async Task WaitForBehaviorWaitOnDependencyFailureViaOptions(string status)
+    public async Task WaitForBehaviorWaitOnResourceUnavailableViaOptions(string status)
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
 
         builder.Services.Configure<ResourceNotificationServiceOptions>(o =>
         {
-            o.DefaultWaitBehavior = WaitBehavior.WaitOnDependencyFailure;
+            o.DefaultWaitBehavior = WaitBehavior.WaitOnResourceUnavailable;
         });
 
         var dependency = builder.AddResource(new CustomResource("test"));


### PR DESCRIPTION
## Description

Follow up to #7650. Renames WaitBehavior enumeration values and adopts Davids ShouldYield inner method.


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
