### PR TITLE
Bump timeout for non-helix tests

### DIFF
--- a/eng/testing/.runsettings
+++ b/eng/testing/.runsettings
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <RunConfiguration>
-    <!-- Timeout in ms, 10 minutes -->
-    <TestSessionTimeout>600000</TestSessionTimeout>
+    <!-- Timeout in ms, 20 minutes -->
+    <TestSessionTimeout>1200000</TestSessionTimeout>
     <!-- Filter out failing (wrong framework, platform, runtime or activeissue) tests -->
     <TestCaseFilter>category!=failing</TestCaseFilter>
   </RunConfiguration>

--- a/eng/testing/.runsettings
+++ b/eng/testing/.runsettings
@@ -20,4 +20,14 @@
       </Logger>
     </Loggers>
   </LoggerRunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <!-- Enables blame -->
+      <DataCollector friendlyName="blame" enabled="True">
+        <Configuration>
+          <CollectDumpOnTestSessionHang TestTimeout="7min" HangDumpType="Full" />
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
 </RunSettings>

--- a/eng/testing/.runsettings
+++ b/eng/testing/.runsettings
@@ -18,6 +18,7 @@
           <Verbosity>normal</Verbosity>
         </Configuration>
       </Logger>
+      <Logger friendlyName="blame" enabled="True" />
     </Loggers>
   </LoggerRunSettings>
   <DataCollectionRunSettings>
@@ -25,6 +26,7 @@
       <!-- Enables blame -->
       <DataCollector friendlyName="blame" enabled="True">
         <Configuration>
+          <CollectDump DumpType="Full" />
           <CollectDumpOnTestSessionHang TestTimeout="7min" HangDumpType="Full" />
         </Configuration>
       </DataCollector>


### PR DESCRIPTION
- **Bump timeout for non-helix tests**
- **Use blame hang timeout for tests same as used for PRs**
