### PR TITLE
Don't skip event hub health checks

### DIFF
--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTestsBase.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTestsBase.cs
@@ -70,8 +70,6 @@ public abstract class ConformanceTestsBase<TService, TOptions> : ConformanceTest
     [ConditionalFact]
     public void HealthChecksClientsAreReused()
     {
-        SkipIfHealthChecksAreNotSupported();
-
         // DisableRetries so the test doesn't take so long retrying when the server isn't available.
         using IHost host = CreateHostWithComponent(configureComponent: DisableRetries);
 

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTestsBase.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTestsBase.cs
@@ -67,7 +67,7 @@ public abstract class ConformanceTestsBase<TService, TOptions> : ConformanceTest
          RuntimeConfigurationOptions = { { "Azure.Experimental.EnableActivitySource", true } }
      };
 
-    [ConditionalFact]
+    [Fact]
     public void HealthChecksClientsAreReused()
     {
         // DisableRetries so the test doesn't take so long retrying when the server isn't available.


### PR DESCRIPTION
## Description

Event Hub singleton health check would be skipped if health checks were not supported. We don't want to not support them so removing this skipping logic.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
