### PR TITLE
Support Existing Azure AppInsights, OpenAI, and CosmosDB

### DIFF
--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -38,57 +38,68 @@ public static class AzureApplicationInsightsExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var appTypeParameter = new ProvisioningParameter("applicationType", typeof(string))
-            {
-                Value = "web"
-            };
-            infrastructure.Add(appTypeParameter);
-
-            var kindParameter = new ProvisioningParameter("kind", typeof(string))
-            {
-                Value = "web"
-            };
-            infrastructure.Add(kindParameter);
-
-            var appInsights = new ApplicationInsightsComponent(infrastructure.AspireResource.GetBicepIdentifier())
-            {
-                ApplicationType = appTypeParameter,
-                Kind = kindParameter,
-                Tags = { { "aspire-resource-name", name } }
-            };
-            infrastructure.Add(appInsights);
-
-            if (logAnalyticsWorkspace != null)
-            {
-                // If someone provides a workspace via the extension method we should use it.
-                appInsights.WorkspaceResourceId = logAnalyticsWorkspace.Resource.WorkspaceId.AsProvisioningParameter(infrastructure, AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId);
-            }
-            else if (builder.ExecutionContext.IsRunMode)
-            {
-                // ... otherwise if we are in run mode, the provisioner expects us to create one ourselves.
-                var autoInjectedLogAnalyticsWorkspaceName = $"law_{appInsights.BicepIdentifier}";
-                var autoInjectedLogAnalyticsWorkspace = new OperationalInsightsWorkspace(autoInjectedLogAnalyticsWorkspaceName)
+            var appInsights = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
+                (identifier, name) =>
                 {
-                    Sku = new OperationalInsightsWorkspaceSku()
+                    var resource = ApplicationInsightsComponent.FromExisting(identifier);
+                    resource.Name = name;
+                    return resource;
+                },
+                (infrastructure) =>
+                {
+                    var appTypeParameter = new ProvisioningParameter("applicationType", typeof(string))
                     {
-                        Name = OperationalInsightsWorkspaceSkuName.PerGB2018
-                    },
-                    Tags = { { "aspire-resource-name", autoInjectedLogAnalyticsWorkspaceName } }
-                };
-                infrastructure.Add(autoInjectedLogAnalyticsWorkspace);
+                        Value = "web"
+                    };
+                    infrastructure.Add(appTypeParameter);
 
-                // If the user does not supply a log analytics workspace of their own we still create a parameter on the Aspire
-                // side and the CDK side so that AZD can fill the value in with the one it generates.
-                appInsights.WorkspaceResourceId = autoInjectedLogAnalyticsWorkspace.Id;
-            }
-            else
-            {
-                // If the user does not supply a log analytics workspace of their own, and we are in publish mode
-                // then we want AZD to provide one to us.
-                var logAnalyticsWorkspaceParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, typeof(string));
-                infrastructure.Add(logAnalyticsWorkspaceParameter);
-                appInsights.WorkspaceResourceId = logAnalyticsWorkspaceParameter;
-            }
+                    var kindParameter = new ProvisioningParameter("kind", typeof(string))
+                    {
+                        Value = "web"
+                    };
+                    infrastructure.Add(kindParameter);
+
+                    var appInsights = new ApplicationInsightsComponent(infrastructure.AspireResource.GetBicepIdentifier())
+                    {
+                        ApplicationType = appTypeParameter,
+                        Kind = kindParameter,
+                        Tags = { { "aspire-resource-name", name } }
+                    };
+
+                    if (logAnalyticsWorkspace != null)
+                    {
+                        // If someone provides a workspace via the extension method we should use it.
+                        appInsights.WorkspaceResourceId = logAnalyticsWorkspace.Resource.WorkspaceId.AsProvisioningParameter(infrastructure, AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId);
+                    }
+                    else if (builder.ExecutionContext.IsRunMode)
+                    {
+                        // ... otherwise if we are in run mode, the provisioner expects us to create one ourselves.
+                        var autoInjectedLogAnalyticsWorkspaceName = $"law_{appInsights.BicepIdentifier}";
+                        var autoInjectedLogAnalyticsWorkspace = new OperationalInsightsWorkspace(autoInjectedLogAnalyticsWorkspaceName)
+                        {
+                            Sku = new OperationalInsightsWorkspaceSku()
+                            {
+                                Name = OperationalInsightsWorkspaceSkuName.PerGB2018
+                            },
+                            Tags = { { "aspire-resource-name", autoInjectedLogAnalyticsWorkspaceName } }
+                        };
+                        infrastructure.Add(autoInjectedLogAnalyticsWorkspace);
+
+                        // If the user does not supply a log analytics workspace of their own we still create a parameter on the Aspire
+                        // side and the CDK side so that AZD can fill the value in with the one it generates.
+                        appInsights.WorkspaceResourceId = autoInjectedLogAnalyticsWorkspace.Id;
+                    }
+                    else
+                    {
+                        // If the user does not supply a log analytics workspace of their own, and we are in publish mode
+                        // then we want AZD to provide one to us.
+                        var logAnalyticsWorkspaceParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, typeof(string));
+                        infrastructure.Add(logAnalyticsWorkspaceParameter);
+                        appInsights.WorkspaceResourceId = logAnalyticsWorkspaceParameter;
+                    }
+
+                    return appInsights;
+                });
 
             infrastructure.Add(new ProvisioningOutput("appInsightsConnectionString", typeof(string)) { Value = appInsights.ConnectionString });
         };

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -26,23 +26,29 @@ public static class AzureOpenAIExtensions
 
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
         {
-            var cogServicesAccount = new CognitiveServicesAccount(infrastructure.AspireResource.GetBicepIdentifier())
-            {
-                Kind = "OpenAI",
-                Sku = new CognitiveServicesSku()
+            var cogServicesAccount = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
+                (identifier, name) =>
                 {
-                    Name = "S0"
+                    var resource = CognitiveServicesAccount.FromExisting(identifier);
+                    resource.Name = name;
+                    return resource;
                 },
-                Properties = new CognitiveServicesAccountProperties()
+                (infrastructure) => new CognitiveServicesAccount(infrastructure.AspireResource.GetBicepIdentifier())
                 {
-                    CustomSubDomainName = ToLower(Take(Concat(infrastructure.AspireResource.Name, GetUniqueString(GetResourceGroup().Id)), 24)),
-                    PublicNetworkAccess = ServiceAccountPublicNetworkAccess.Enabled,
-                    // Disable local auth for AOAI since managed identity is used
-                    DisableLocalAuth = true
-                },
-                Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
-            };
-            infrastructure.Add(cogServicesAccount);
+                    Kind = "OpenAI",
+                    Sku = new CognitiveServicesSku()
+                    {
+                        Name = "S0"
+                    },
+                    Properties = new CognitiveServicesAccountProperties()
+                    {
+                        CustomSubDomainName = ToLower(Take(Concat(infrastructure.AspireResource.Name, GetUniqueString(GetResourceGroup().Id)), 24)),
+                        PublicNetworkAccess = ServiceAccountPublicNetworkAccess.Enabled,
+                        // Disable local auth for AOAI since managed identity is used
+                        DisableLocalAuth = true
+                    },
+                    Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
+                });
 
             infrastructure.Add(new ProvisioningOutput("connectionString", typeof(string))
             {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -329,10 +329,8 @@ public static class AzureCosmosExtensions
         var cosmosAccount = AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
             (identifier, name) =>
             {
-                var resource = new ExistingCosmosDBAccount(identifier, disableLocalAuth)
-                {
-                    Name = name,
-                };
+                var resource = CosmosDBAccount.FromExisting(identifier);
+                resource.Name = name;
                 return resource;
             },
             (infrastructure) => new CosmosDBAccount(infrastructure.AspireResource.GetBicepIdentifier())
@@ -431,28 +429,6 @@ public static class AzureCosmosExtensions
                 Value = cosmosAccount.DocumentEndpoint
             });
         }
-    }
-}
-
-/// <remarks>
-/// The provisioning APIs will mark the DisableLocalAuth as `ReadOnly` after the
-/// `IsExistingResource` property is set, making it impossible to configure the
-/// `DisableLocalAuth` property in our usual flows. This is a workaround to
-/// allow us to set the property on existing resources.
-/// </remarks>
-internal sealed class ExistingCosmosDBAccount : CosmosDBAccount
-{
-    public ExistingCosmosDBAccount(string bicepIdentifier, bool disableLocalAuth, string? resourceVersion = null) : base(bicepIdentifier, resourceVersion)
-    {
-        // only explicitly set DisableLocalAuth if WithAccessKeyAuthentication was called.
-        // We don't want to disable local auth on an existing resource if it is already enabled
-        // as that might break other uses of the resource.
-        if (disableLocalAuth is false)
-        {
-            DisableLocalAuth = false;
-        }
-
-        IsExistingResource = true;
     }
 }
 

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -201,11 +201,8 @@ public static class AzureRedisExtensions
         return AzureProvisioningResource.CreateExistingOrNewProvisionableResource(infrastructure,
         (identifier, name) =>
         {
-            var redisResource = (AzureRedisCacheResource)infrastructure.AspireResource;
-            var resource = new ExistingCdkRedisResource(identifier, !redisResource.UseAccessKeyAuthentication)
-            {
-                Name = name,
-            };
+            var resource = CdkRedisResource.FromExisting(identifier);
+            resource.Name = name;
             return resource;
         },
         (infrastructure) => new CdkRedisResource(infrastructure.AspireResource.GetBicepIdentifier())
@@ -249,12 +246,12 @@ public static class AzureRedisExtensions
         }
         else
         {
-            redis.RedisConfiguration = new RedisCommonConfiguration()
-            {
-                IsAadEnabled = "true"
-            };
             if (!redis.IsExistingResource)
             {
+                redis.RedisConfiguration = new RedisCommonConfiguration()
+                {
+                    IsAadEnabled = "true"
+                };
                 redis.IsAccessKeyAuthenticationDisabled = true;
             }
 
@@ -275,21 +272,6 @@ public static class AzureRedisExtensions
             {
                 Value = BicepFunction.Interpolate($"{redis.HostName},ssl=true")
             });
-        }
-    }
-
-    /// <remarks>
-    /// The provisioning APIs will mark the IsAccessKeyAuthenticationDisabled as `ReadOnly` after the
-    /// `IsExistingResource` property is set, making it impossible to configure the
-    /// `IsAccessKeyAuthenticationDisabled` property in our usual flows. This is a workaround to
-    /// allow us to set the property on existing resources.
-    /// </remarks>
-    private sealed class ExistingCdkRedisResource : CdkRedisResource
-    {
-        public ExistingCdkRedisResource(string bicepIdentifier, bool isAccessKeyAuthenticationDisabled, string? resourceVersion = null) : base(bicepIdentifier, resourceVersion)
-        {
-            IsAccessKeyAuthenticationDisabled = isAccessKeyAuthenticationDisabled;
-            IsExistingResource = true;
         }
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -859,19 +859,6 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param kind string = 'web'
 
-            resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
-              name: take('appInsights-${uniqueString(resourceGroup().id)}', 260)
-              kind: kind
-              location: location
-              properties: {
-                Application_Type: applicationType
-                WorkspaceResourceId: law_appInsights.id
-              }
-              tags: {
-                'aspire-resource-name': 'appInsights'
-              }
-            }
-
             resource law_appInsights 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
               name: take('lawappInsights-${uniqueString(resourceGroup().id)}', 63)
               location: location
@@ -882,6 +869,19 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
               tags: {
                 'aspire-resource-name': 'law_appInsights'
+              }
+            }
+
+            resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+              name: take('appInsights-${uniqueString(resourceGroup().id)}', 260)
+              kind: kind
+              location: location
+              properties: {
+                Application_Type: applicationType
+                WorkspaceResourceId: law_appInsights.id
+              }
+              tags: {
+                'aspire-resource-name': 'appInsights'
               }
             }
 

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 
-public class ExistingAzureResourceTests
+public class ExistingAzureResourceTests(ITestOutputHelper output)
 {
     [Fact]
     public async Task AddExistingAzureServiceBusInRunMode()
@@ -65,6 +67,8 @@ public class ExistingAzureResourceTests
 
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
             """;
+
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -134,6 +138,8 @@ public class ExistingAzureResourceTests
 
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
             """;
+
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -194,6 +200,8 @@ public class ExistingAzureResourceTests
 
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
             """;
+
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -260,8 +268,8 @@ public class ExistingAzureResourceTests
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
-
     }
 
     [Fact]
@@ -321,8 +329,8 @@ public class ExistingAzureResourceTests
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
-
     }
 
     [Fact]
@@ -410,8 +418,8 @@ public class ExistingAzureResourceTests
             output tableEndpoint string = storage.properties.primaryEndpoints.table
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
-
     }
 
     [Fact]
@@ -494,6 +502,7 @@ public class ExistingAzureResourceTests
             output tableEndpoint string = storage.properties.primaryEndpoints.table
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -554,6 +563,7 @@ public class ExistingAzureResourceTests
             output appConfigEndpoint string = appConfig.properties.endpoint
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -614,6 +624,7 @@ public class ExistingAzureResourceTests
             output eventHubsEndpoint string = eventHubs.properties.serviceBusEndpoint
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -674,6 +685,7 @@ public class ExistingAzureResourceTests
             output vaultUri string = keyVault.properties.vaultUri
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -717,6 +729,7 @@ public class ExistingAzureResourceTests
             output logAnalyticsWorkspaceId string = logAnalytics.id
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -798,6 +811,7 @@ public class ExistingAzureResourceTests
             output connectionString string = 'Host=${postgresSql.properties.fullyQualifiedDomainName};Username=${principalName}'
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -868,6 +882,7 @@ public class ExistingAzureResourceTests
             output connectionString string = 'Endpoint=https://${existingResourceName}.search.windows.net'
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -928,6 +943,7 @@ public class ExistingAzureResourceTests
             output hostName string = signalR.properties.hostName
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -988,6 +1004,7 @@ public class ExistingAzureResourceTests
             output endpoint string = 'https://${webPubSub.properties.hostName}'
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -1056,6 +1073,7 @@ public class ExistingAzureResourceTests
             output sqlServerFqdn string = sqlServer.properties.fullyQualifiedDomainName
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -1132,6 +1150,8 @@ public class ExistingAzureResourceTests
 
             output sqlServerFqdn string = sqlServer.properties.fullyQualifiedDomainName
             """;
+
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -1198,6 +1218,7 @@ public class ExistingAzureResourceTests
             output connectionString string = '${redis.properties.hostName},ssl=true'
             """;
 
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 
@@ -1254,6 +1275,314 @@ public class ExistingAzureResourceTests
             }
             """;
 
+        output.WriteLine(BicepText);
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingAzureApplicationInsightsWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var appInsights = builder.AddAzureApplicationInsights("appInsights")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(appInsights.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{appInsights.outputs.appInsightsConnectionString}",
+              "path": "appInsights.module.bicep",
+              "params": {
+                "existingResourceName": "{existingResourceName.value}"
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+    
+            param existingResourceName string
+    
+            resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+              name: existingResourceName
+            }
+    
+            output appInsightsConnectionString string = appInsights.properties.ConnectionString
+            """;
+
+        output.WriteLine(BicepText);
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingAzureOpenAIWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var openAI = builder.AddAzureOpenAI("openAI")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName)
+            .AddDeployment(new AzureOpenAIDeployment("mymodel", "gpt-35-turbo", "0613", "Basic", 4));
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(openAI.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{openAI.outputs.connectionString}",
+              "path": "openAI.module.bicep",
+              "params": {
+                "existingResourceName": "{existingResourceName.value}",
+                "principalType": "",
+                "principalId": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+    
+            param existingResourceName string
+    
+            param principalType string
+    
+            param principalId string
+    
+            resource openAI 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = {
+              name: existingResourceName
+            }
+    
+            resource openAI_CognitiveServicesOpenAIContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(openAI.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442'))
+              properties: {
+                principalId: principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442')
+                principalType: principalType
+              }
+              scope: openAI
+            }
+    
+            resource mymodel 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+              name: 'mymodel'
+              properties: {
+                model: {
+                  format: 'OpenAI'
+                  name: 'gpt-35-turbo'
+                  version: '0613'
+                }
+              }
+              sku: {
+                name: 'Basic'
+                capacity: 4
+              }
+              parent: openAI
+            }
+
+            output connectionString string = 'Endpoint=${openAI.properties.endpoint}'
+            """;
+
+        output.WriteLine(BicepText);
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingAzureCosmosDBWithResourceGroup()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName);
+
+        cosmos.AddCosmosDatabase("mydb")
+            .AddContainer("container", "/id");
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(cosmos.Resource);
+
+        var expectedManifest = $$"""
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{cosmos.outputs.connectionString}",
+              "path": "cosmos.module.bicep",
+              "params": {
+                "existingResourceName": "{existingResourceName.value}",
+                "principalType": "",
+                "principalId": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = $$"""
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param existingResourceName string
+
+            param principalType string
+
+            param principalId string
+
+            resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' existing = {
+              name: existingResourceName
+            }
+
+            resource mydb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
+              name: 'mydb'
+              location: location
+              properties: {
+                resource: {
+                  id: 'mydb'
+                }
+              }
+              parent: cosmos
+            }
+
+            resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
+              name: 'container'
+              location: location
+              properties: {
+                resource: {
+                  id: 'container'
+                  partitionKey: {
+                    paths: [
+                      '/id'
+                    ]
+                  }
+                }
+              }
+              parent: mydb
+            }
+
+            resource cosmos_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-08-15' existing = {
+              name: '00000000-0000-0000-0000-000000000002'
+              parent: cosmos
+            }
+
+            resource cosmos_roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-08-15' = {
+              name: guid(principalId, cosmos_roleDefinition.id, cosmos.id)
+              properties: {
+                principalId: principalId
+                roleDefinitionId: cosmos_roleDefinition.id
+                scope: cosmos.id
+              }
+              parent: cosmos
+            }
+
+            output connectionString string = cosmos.properties.documentEndpoint
+            """;
+
+        output.WriteLine(BicepText);
+        Assert.Equal(expectedBicep, BicepText);
+    }
+
+    [Fact]
+    public async Task SupportsExistingAzureCosmosDBWithResourceGroupAccessKey()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var existingResourceName = builder.AddParameter("existingResourceName");
+        var existingResourceGroupName = builder.AddParameter("existingResourceGroupName");
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+            .PublishAsExisting(existingResourceName, existingResourceGroupName)
+            .WithAccessKeyAuthentication();
+
+        cosmos.AddCosmosDatabase("mydb")
+            .AddContainer("container", "/id");
+
+        var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(cosmos.Resource);
+
+        var expectedManifest = $$"""
+            {
+              "type": "azure.bicep.v1",
+              "connectionString": "{cosmos.secretOutputs.connectionString}",
+              "path": "cosmos.module.bicep",
+              "params": {
+                "existingResourceName": "{existingResourceName.value}",
+                "keyVaultName": ""
+              },
+              "scope": {
+                "resourceGroup": "{existingResourceGroupName.value}"
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, ManifestNode.ToString());
+
+        var expectedBicep = $$"""
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param existingResourceName string
+
+            param keyVaultName string
+
+            resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' existing = {
+              name: existingResourceName
+              properties: {
+                disableLocalAuth: false
+              }
+            }
+
+            resource mydb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
+              name: 'mydb'
+              location: location
+              properties: {
+                resource: {
+                  id: 'mydb'
+                }
+              }
+              parent: cosmos
+            }
+
+            resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
+              name: 'container'
+              location: location
+              properties: {
+                resource: {
+                  id: 'container'
+                  partitionKey: {
+                    paths: [
+                      '/id'
+                    ]
+                  }
+                }
+              }
+              parent: mydb
+            }
+
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+              name: keyVaultName
+            }
+
+            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+              name: 'connectionString'
+              properties: {
+                value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'
+              }
+              parent: keyVault
+            }
+            """;
+
+        output.WriteLine(BicepText);
         Assert.Equal(expectedBicep, BicepText);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1197,12 +1197,6 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
 
             resource redis 'Microsoft.Cache/redis@2024-03-01' existing = {
               name: existingResourceName
-              properties: {
-                disableAccessKeyAuthentication: true
-                redisConfiguration: {
-                  'aad-enabled': 'true'
-                }
-              }
             }
 
             resource redis_contributor 'Microsoft.Cache/redis/accessPolicyAssignments@2024-03-01' = {
@@ -1257,9 +1251,6 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
 
             resource redis 'Microsoft.Cache/redis@2024-03-01' existing = {
               name: 'existingResourceName'
-              properties: {
-                disableAccessKeyAuthentication: false
-              }
             }
 
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
@@ -1415,7 +1406,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
 
         var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
-        var expectedManifest = $$"""
+        var expectedManifest = """
             {
               "type": "azure.bicep.v1",
               "connectionString": "{cosmos.outputs.connectionString}",
@@ -1432,7 +1423,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, ManifestNode.ToString());
 
-        var expectedBicep = $$"""
+        var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
@@ -1511,7 +1502,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
 
         var (ManifestNode, BicepText) = await ManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
-        var expectedManifest = $$"""
+        var expectedManifest = """
             {
               "type": "azure.bicep.v1",
               "connectionString": "{cosmos.secretOutputs.connectionString}",
@@ -1527,7 +1518,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, ManifestNode.ToString());
 
-        var expectedBicep = $$"""
+        var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
@@ -1537,9 +1528,6 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
 
             resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' existing = {
               name: existingResourceName
-              properties: {
-                disableLocalAuth: false
-              }
             }
 
             resource mydb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {


### PR DESCRIPTION
## Description

These resources don't support existing resources yet. Adding support to finish all the Azure resources for existing.

Note that for CosmosDB and Redis, we cannot explicitly set DisableLocalAuth on an existing resource because bicep doesn't support it.

Fix #7665

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
