### PR TITLE
Rename ASPIRECOSMOS001 to ASPIRECOSMOSDB001

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -1,12 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIRECOSMOSDB001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 var builder = DistributedApplication.CreateBuilder(args);
 
-#pragma warning disable ASPIRECOSMOS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 var cosmos = builder.AddAzureCosmosDB("cosmos")
                 .RunAsPreviewEmulator(e => e.WithDataExplorer());
-#pragma warning restore ASPIRECOSMOS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 var db = cosmos.AddCosmosDatabase("db");
 db.AddContainer("entries", "/id");
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -62,7 +62,7 @@ public static class AzureCosmosExtensions
     /// <remarks>
     /// This version of the package defaults to the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.TagVNextPreview"/> tag of the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="CosmosDBEmulatorContainerImageTags.Image"/> container image.
     /// </remarks>
-    [Experimental("ASPIRECOSMOS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureCosmosDBResource> RunAsPreviewEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer = null)
         => builder.RunAsEmulator(configureContainer, useVNextPreview: true);
 
@@ -275,7 +275,7 @@ public static class AzureCosmosExtensions
     /// <remarks>
     /// The Data Explorer is only available with <see cref="RunAsPreviewEmulator"/>.
     /// </remarks>
-    [Experimental("ASPIRECOSMOS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureCosmosDBEmulatorResource> WithDataExplorer(this IResourceBuilder<AzureCosmosDBEmulatorResource> builder, int? port = null)
     {
         if (!builder.Resource.InnerResource.IsPreviewEmulator)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
@@ -346,9 +346,9 @@ internal static class CosmosExtensions
         }
 
         return usePreview
-#pragma warning disable ASPIRECOSMOS001 // RunAsPreviewEmulator is experimental
+#pragma warning disable ASPIRECOSMOSDB001 // RunAsPreviewEmulator is experimental
             ? builder.RunAsPreviewEmulator(WithVolume)
-#pragma warning restore ASPIRECOSMOS001 // RunAsPreviewEmulator is experimental
+#pragma warning restore ASPIRECOSMOSDB001 // RunAsPreviewEmulator is experimental
             : builder.RunAsEmulator(WithVolume);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -72,7 +72,7 @@ public class AzureCosmosDBExtensionsTests
     [Fact]
     public void AddAzureCosmosDBWithDataExplorer()
     {
-#pragma warning disable ASPIRECOSMOS001 // RunAsPreviewEmulator is experimental
+#pragma warning disable ASPIRECOSMOSDB001 // RunAsPreviewEmulator is experimental
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var cosmos = builder.AddAzureCosmosDB("cosmos");
@@ -85,7 +85,7 @@ public class AzureCosmosDBExtensionsTests
         // WithDataExplorer doesn't work against the non-preview emulator
         var cosmos2 = builder.AddAzureCosmosDB("cosmos2");
         Assert.Throws<NotSupportedException>(() => cosmos2.RunAsEmulator(e => e.WithDataExplorer()));
-#pragma warning restore ASPIRECOSMOS001 // RunAsPreviewEmulator is experimental
+#pragma warning restore ASPIRECOSMOSDB001 // RunAsPreviewEmulator is experimental
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Based on API review feedback. See https://github.com/dotnet/aspire/pull/7374#discussion_r1960972093
## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] No
        - Link to aspire-docs issue [Add docs for CosmosDB vnext-preview emulator (dotnet/docs-aspire#2376)](https://github.com/dotnet/docs-aspire/issues/2376)
