### PR TITLE
Account for standard environment variable prefixes when simulating launch profile

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -162,7 +162,6 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         };
         applicationOptions.Args = hostBuilderOptions.Args;
 
-        hostBuilderOptions.EnvironmentName = Environments.Development;
         hostBuilderOptions.ApplicationName = entryPointAssembly.GetName().Name ?? string.Empty;
         applicationOptions.AssemblyName = entryPointAssembly.GetName().Name ?? string.Empty;
         applicationOptions.DisableDashboard = true;
@@ -264,6 +263,18 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
                 foreach (var (key, value) in envVars)
                 {
                     SetDefault(key, value);
+
+                    // See https://github.com/dotnet/runtime/blob/8edaf7460777e791b6279b395a68a77533db2d20/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs#L96
+                    if (key.StartsWith("DOTNET_"))
+                    {
+                        SetDefault(key["DOTNET_".Length..], value);
+                    }
+
+                    // See https://github.com/dotnet/aspnetcore/blob/4ce2db7b8d85c07cad2c59242edc19af6a91b0d7/src/DefaultBuilder/src/WebApplicationBuilder.cs#L38
+                    if (key.StartsWith("ASPNETCORE_"))
+                    {
+                        SetDefault(key["ASPNETCORE_".Length..], value);
+                    }
                 }
             }
         }

--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -271,7 +271,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
                     }
 
                     // See https://github.com/dotnet/aspnetcore/blob/4ce2db7b8d85c07cad2c59242edc19af6a91b0d7/src/DefaultBuilder/src/WebApplicationBuilder.cs#L38
-                    if (key.StartsWith("ASPNETCORE_"))
+                    if (key.StartsWith("ASPNETCORE_", StringComparison.OrdinalIgnoreCase))
                     {
                         SetDefault(key["ASPNETCORE_".Length..], value);
                     }

--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -265,7 +265,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
                     SetDefault(key, value);
 
                     // See https://github.com/dotnet/runtime/blob/8edaf7460777e791b6279b395a68a77533db2d20/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs#L96
-                    if (key.StartsWith("DOTNET_"))
+                    if (key.StartsWith("DOTNET_", StringComparison.OrdinalIgnoreCase))
                     {
                         SetDefault(key["DOTNET_".Length..], value);
                     }

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -107,6 +107,20 @@ public class TestingBuilderTests(ITestOutputHelper output)
         }
     }
 
+    [Fact]
+    public async Task CanSetEnvironment()
+    {
+        var builder = await DistributedApplicationTestingBuilder.CreateAsync<Projects.TestingAppHost1_AppHost>(["--environment=Testing"]);
+        Assert.Equal("Testing", builder.Environment.EnvironmentName);
+    }
+
+    [Fact]
+    public async Task EnvironmentDefaultsToDevelopment()
+    {
+        var builder = await DistributedApplicationTestingBuilder.CreateAsync<Projects.TestingAppHost1_AppHost>();
+        Assert.Equal(Environments.Development, builder.Environment.EnvironmentName);
+    }
+
     [Theory]
     [RequiresDocker]
     [InlineData(false)]


### PR DESCRIPTION

## Description

Environment variables prefixed with `DOTNET_` or `ASPNETCORE_` should be propagated into configuration in non-prefixed form. For example, setting `DOTNET_ENVIRONMENT=Testing` via an environment variable should set `ENVIRONMENT=Testing` in configuration.

In the Aspire.Hosting.Testing package, we simulate loading the app host's launch profile, including environment variables. We do not set environment variables in the process since that would leak between concurrently running tests. Instead, we read the environment variables from the launch profile into configuration. This PR changes how we propagate the environment variables into configuration so that we check for those two well-known prefixes and flow them into configuration without those prefixes with the precedence order of _no prefix_ > `DOTNET_` > `ASPNETCORE_`.

In particular, this allows setting the environment name from launch profile to work as expected.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
