### PR TITLE
Fix Azure PostgreSQL AsExisting

### DIFF
--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -394,14 +394,19 @@ public static class AzurePostgresExtensions
             keyVault.Name = kvNameParam;
             infrastructure.Add(keyVault);
 
-            postgres.AuthConfig = new PostgreSqlFlexibleServerAuthConfig()
+            // bicep doesn't allow for setting properties on existing resources. So we don't set auth properties here.
+            // The administratorLogin and administratorLoginPassword are expected to match what is already configured on the server
+            if (!postgres.IsExistingResource)
             {
-                ActiveDirectoryAuth = PostgreSqlFlexibleServerActiveDirectoryAuthEnum.Disabled,
-                PasswordAuth = PostgreSqlFlexibleServerPasswordAuthEnum.Enabled
-            };
+                postgres.AuthConfig = new PostgreSqlFlexibleServerAuthConfig()
+                {
+                    ActiveDirectoryAuth = PostgreSqlFlexibleServerActiveDirectoryAuthEnum.Disabled,
+                    PasswordAuth = PostgreSqlFlexibleServerPasswordAuthEnum.Enabled
+                };
 
-            postgres.AdministratorLogin = administratorLogin;
-            postgres.AdministratorLoginPassword = administratorLoginPassword;
+                postgres.AdministratorLogin = administratorLogin;
+                postgres.AdministratorLoginPassword = administratorLoginPassword;
+            }
 
             var secret = new KeyVaultSecret("connectionString")
             {
@@ -430,11 +435,14 @@ public static class AzurePostgresExtensions
         }
         else
         {
-            postgres.AuthConfig = new PostgreSqlFlexibleServerAuthConfig()
+            if (!postgres.IsExistingResource)
             {
-                ActiveDirectoryAuth = PostgreSqlFlexibleServerActiveDirectoryAuthEnum.Enabled,
-                PasswordAuth = PostgreSqlFlexibleServerPasswordAuthEnum.Disabled
-            };
+                postgres.AuthConfig = new PostgreSqlFlexibleServerAuthConfig()
+                {
+                    ActiveDirectoryAuth = PostgreSqlFlexibleServerActiveDirectoryAuthEnum.Enabled,
+                    PasswordAuth = PostgreSqlFlexibleServerPasswordAuthEnum.Disabled
+                };
+            }
 
             var principalIdParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalId, typeof(string));
             infrastructure.Add(principalIdParameter);


### PR DESCRIPTION
## Description

In bicep, it is not supported to set properties on "existing" resources. When using AsExisting on an Azure PostgreSQL resource, we are setting authConfig properties to enable/disable password and activeDirectory auth. This is causing errors when trying to deploy because the bicep is invalid.

Fix this by not setting these properties on existing resources. Instead for activeDirectory/Entra ID auth, we will add the principle as an admin on the server. For password auth on an existing resource, we expect the user to pass the correct username/password parameters to connect to the database server.

Fix #7694

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
