### PR TITLE
[CI] re-enable windows non-helix tests on public pipeline rolling builds

### DIFF
--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -135,6 +135,7 @@ stages:
                 repoTestResultsPath: $(Build.Arcade.TestResultsPath)
                 isWindows: true
                 runHelixTests: ${{ contains(testVariant, 'helix') }}
+                runPipelineTests: ${{ contains(testVariant, '_pipeline') }}
 
       # Linux jobs
       - ${{ each testVariant in split( variables.testVariants, ',' ) }}:

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -221,6 +221,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
    }
 
    [Fact]
+   [RequiresDocker]
    public async Task WhenWaitBehaviorIsWaitOnResourceUnavailableWaitForResourceHealthyAsyncShouldThrowWhenResourceFailsToStart()
    {
       using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -197,6 +197,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
    [Fact]
+   [RequiresDocker]
    public async Task WhenWaitBehaviorIsStopOnResourceUnavailableWaitForResourceHealthyAsyncShouldThrowWhenResourceFailsToStart()
    {
       using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);


### PR DESCRIPTION
Issue: `##[error]Artifact Windows_CodeCoverageResults was not found for build ....`

The underlying problem is that pipeline (non-helix) tests are not being run on Windows at all, since the recent pipeline changes. This was detected now due to the above error because all other tests are passing now, and the CodeCoverage step is run which failed because no codecoverage results were found for windows.