### PR TITLE
Rename WaitBehavior enumeration values for clarity

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
@@ -60,7 +60,7 @@ public enum WaitType
 public enum WaitBehavior
 {
     /// <summary>
-    /// Wait indefinately.
+    /// Wait indefinitely.
     /// </summary>
     Wait,
 

--- a/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
@@ -60,12 +60,12 @@ public enum WaitType
 public enum WaitBehavior
 {
     /// <summary>
-    /// If the resource is unavailable, continue waiting.
+    /// Wait indefinately.
     /// </summary>
-    WaitOnResourceUnavailable,
+    Wait,
 
     /// <summary>
-    /// If the resource is unavailable, stop waiting.
+    /// Throw if the resource enters a terminal state.
     /// </summary>
-    StopOnResourceUnavailable
+    Throw
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -210,7 +210,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         {
             // Default to stopping on dependency failure if the dashboard is disabled. As there's no way to see or easily recover
             // from a failure in that case.
-            o.DefaultWaitBehavior = options.DisableDashboard ? WaitBehavior.StopOnResourceUnavailable : WaitBehavior.WaitOnResourceUnavailable;
+            o.DefaultWaitBehavior = options.DisableDashboard ? WaitBehavior.Throw : WaitBehavior.Wait;
         });
         _innerBuilder.Services.AddSingleton<IAspireStore, AspireStore>(sp =>
         {

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -738,7 +738,7 @@ public static class ResourceBuilderExtensions
     /// var messaging = builder.AddRabbitMQ("messaging");
     /// builder.AddProject&lt;Projects.MyApp&gt;("myapp")
     ///        .WithReference(messaging)
-    ///        .WaitFor(messaging, WaitBehavior.StopOnResourceUnavailable);
+    ///        .WaitFor(messaging, WaitBehavior.Throw);
     /// </code>
     /// </example>
     public static IResourceBuilder<T> WaitFor<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency, WaitBehavior waitBehavior) where T : IResourceWithWaitSupport

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -175,7 +175,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         var dependency = builder.AddResource(new CustomResource("test"));
         var nginx = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
                            .WithReference(dependency)
-                           .WaitFor(dependency, WaitBehavior.StopOnResourceUnavailable);
+                           .WaitFor(dependency, WaitBehavior.Throw);
 
         using var app = builder.Build();
 
@@ -204,7 +204,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
       var failToStart = builder.AddExecutable("failToStart", "does-not-exist", ".");
       var dependency = builder.AddContainer("redis", "redis");
 
-      dependency.WaitFor(failToStart, WaitBehavior.StopOnResourceUnavailable);
+      dependency.WaitFor(failToStart, WaitBehavior.Throw);
 
       using var app = builder.Build();
       await app.StartAsync();
@@ -212,7 +212,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
       var ex = await Assert.ThrowsAsync<DistributedApplicationException>(async () => {
         await app.ResourceNotifications.WaitForResourceHealthyAsync(
             dependency.Resource.Name,
-            WaitBehavior.StopOnResourceUnavailable
+            WaitBehavior.Throw
             ).WaitAsync(TimeSpan.FromSeconds(15));
       });
 
@@ -227,7 +227,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
       var failToStart = builder.AddExecutable("failToStart", "does-not-exist", ".");
       var dependency = builder.AddContainer("redis", "redis");
 
-      dependency.WaitFor(failToStart, WaitBehavior.StopOnResourceUnavailable);
+      dependency.WaitFor(failToStart, WaitBehavior.Throw);
 
       using var app = builder.Build();
       await app.StartAsync();
@@ -235,7 +235,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
       var ex = await Assert.ThrowsAsync<TimeoutException>(async () => {
         await app.ResourceNotifications.WaitForResourceHealthyAsync(
             dependency.Resource.Name,
-            WaitBehavior.WaitOnResourceUnavailable
+            WaitBehavior.Wait
             ).WaitAsync(TimeSpan.FromSeconds(15));
       });
 
@@ -289,7 +289,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         var dependency = builder.AddResource(new CustomResource("test"));
         var nginx = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
                            .WithReference(dependency)
-                           .WaitFor(dependency, WaitBehavior.WaitOnResourceUnavailable);
+                           .WaitFor(dependency, WaitBehavior.Wait);
 
         using var app = builder.Build();
 
@@ -330,7 +330,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
 
         builder.Services.Configure<ResourceNotificationServiceOptions>(o =>
         {
-            o.DefaultWaitBehavior = WaitBehavior.WaitOnResourceUnavailable;
+            o.DefaultWaitBehavior = WaitBehavior.Wait;
         });
 
         var dependency = builder.AddResource(new CustomResource("test"));


### PR DESCRIPTION
Update enumeration values to improve understanding of their intent, changing `WaitOnResourceUnavailable` to `Wait` and `StopOnResourceUnavailable` to `Throw`. Adjust related code to reflect these changes.