### PR TITLE
Don't set properties on existing Azure SQL server resources

### DIFF
--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -251,13 +251,13 @@ public static class AzureSqlExtensions
 
         if (distributedApplicationBuilder.ExecutionContext.IsRunMode)
         {
-            // When in run mode we inject the users identity and we need to specify
-            // the principalType.
-            var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
-            infrastructure.Add(principalTypeParameter);
             // Avoid mutating properties on existing resources.
             if (!sqlServer.IsExistingResource)
             {
+                // When in run mode we inject the users identity and we need to specify
+                // the principalType.
+                var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
+                infrastructure.Add(principalTypeParameter);
                 sqlServer.Administrators.PrincipalType = principalTypeParameter;
             }
 
@@ -286,8 +286,8 @@ public static class AzureSqlExtensions
     }
 
     /// <remarks>
-    /// Workaround for immutable properties on SqlServerAzureADAdministrator.
-    /// See https://github.com/Azure/azure-sdk-for-net/issues/48364.
+    /// Workaround for issue using SqlServerAzureADAdministrator.
+    /// See https://github.com/Azure/azure-sdk-for-net/issues/48364 for more information.
     /// </remarks>
     private sealed class SqlServerAzureADAdministratorWorkaround(string bicepIdentifier) : SqlServerAzureADAdministrator(bicepIdentifier)
     {

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -205,14 +205,6 @@ public static class AzureSqlExtensions
         {
             var resource = SqlServer.FromExisting(identifier);
             resource.Name = name;
-            resource.Administrators = new ServerExternalAdministrator()
-            {
-                AdministratorType = SqlAdministratorType.ActiveDirectory,
-                IsAzureADOnlyAuthenticationEnabled = true,
-                Sid = principalIdParameter,
-                Login = principalNameParameter,
-                TenantId = BicepFunction.GetSubscription().TenantId
-            };
             return resource;
         },
         (infrastructure) =>
@@ -248,7 +240,10 @@ public static class AzureSqlExtensions
             // the principalType.
             var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
             infrastructure.Add(principalTypeParameter);
-            sqlServer.Administrators.PrincipalType = principalTypeParameter;
+            if (!sqlServer.IsExistingResource)
+            {
+                sqlServer.Administrators.PrincipalType = principalTypeParameter;
+            }
 
             infrastructure.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllIps")
             {

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -287,6 +287,7 @@ public static class AzureSqlExtensions
 
     /// <remarks>
     /// Workaround for immutable properties on SqlServerAzureADAdministrator.
+    /// See https://github.com/Azure/azure-sdk-for-net/issues/48364.
     /// </remarks>
     private sealed class SqlServerAzureADAdministratorWorkaround(string bicepIdentifier) : SqlServerAzureADAdministrator(bicepIdentifier)
     {

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -5,6 +5,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning;
 using Azure.Provisioning.Expressions;
+using Azure.Provisioning.Primitives;
 using Azure.Provisioning.Sql;
 
 namespace Aspire.Hosting;
@@ -226,6 +227,20 @@ public static class AzureSqlExtensions
             };
         });
 
+        // If the resource is an existing resource, we model the administrator access
+        // for the managed identity as an "edge" between the parent SqlServer resource
+        // and a custom SqlServerAzureADAdministrator resource.
+        if (sqlServer.IsExistingResource)
+        {
+            var admin = new SqlServerAzureADAdministratorWorkaround($"{sqlServer.BicepIdentifier}_admin")
+            {
+                ParentOverride = sqlServer,
+                LoginOverride = principalNameParameter,
+                SidOverride = principalIdParameter
+            };
+            infrastructure.Add(admin);
+        }
+
         infrastructure.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllAzureIps")
         {
             Parent = sqlServer,
@@ -240,6 +255,7 @@ public static class AzureSqlExtensions
             // the principalType.
             var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
             infrastructure.Add(principalTypeParameter);
+            // Avoid mutating properties on existing resources.
             if (!sqlServer.IsExistingResource)
             {
                 sqlServer.Administrators.PrincipalType = principalTypeParameter;
@@ -267,5 +283,80 @@ public static class AzureSqlExtensions
         }
 
         infrastructure.Add(new ProvisioningOutput("sqlServerFqdn", typeof(string)) { Value = sqlServer.FullyQualifiedDomainName });
+    }
+
+    /// <remarks>
+    /// Workaround for immutable properties on SqlServerAzureADAdministrator.
+    /// </remarks>
+    private sealed class SqlServerAzureADAdministratorWorkaround(string bicepIdentifier) : SqlServerAzureADAdministrator(bicepIdentifier)
+    {
+        private BicepValue<string>? _name;
+        private BicepValue<string>? _login;
+        private BicepValue<Guid>? _sid;
+        private ResourceReference<SqlServer>? _parent;
+
+        /// <summary>
+        /// Login name of the server administrator.
+        /// </summary>
+        public BicepValue<string> LoginOverride
+        {
+            get
+            {
+                Initialize();
+                return _login!;
+            }
+            set
+            {
+                Initialize();
+                _login!.Assign(value);
+            }
+        }
+
+        /// <summary>
+        /// SID (object ID) of the server administrator.
+        /// </summary>
+        public BicepValue<Guid> SidOverride
+        {
+            get
+            {
+                Initialize();
+                return _sid!;
+            }
+            set
+            {
+                Initialize();
+                _sid!.Assign(value);
+            }
+        }
+
+        /// <summary>
+        /// Parent resource of the server administrator.
+        /// </summary>
+        public SqlServer? ParentOverride
+        {
+            get
+            {
+                Initialize();
+                return _parent!.Value;
+            }
+            set
+            {
+                Initialize();
+                _parent!.Value = value;
+            }
+        }
+
+        private static BicepValue<string> GetNameDefaultValue()
+        {
+            return new StringLiteralExpression("ActiveDirectory");
+        }
+
+        protected override void DefineProvisionableProperties()
+        {
+            _name = DefineProperty("Name", ["name"], defaultValue: GetNameDefaultValue());
+            _login = DefineProperty<string>("Login", ["properties", "login"]);
+            _sid = DefineProperty<Guid>("Sid", ["properties", "sid"]);
+            _parent = DefineResource<SqlServer>("Parent", ["parent"], isOutput: false, isRequired: true);
+        }
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1122,15 +1122,6 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
 
             resource sqlServer 'Microsoft.Sql/servers@2021-11-01' existing = {
               name: existingResourceName
-              properties: {
-                administrators: {
-                  administratorType: 'ActiveDirectory'
-                  login: principalName
-                  sid: principalId
-                  tenantId: subscription().tenantId
-                  azureADOnlyAuthentication: true
-                }
-              }
             }
 
             resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {
@@ -1190,16 +1181,6 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
 
             resource sqlServer 'Microsoft.Sql/servers@2021-11-01' existing = {
               name: existingResourceName
-              properties: {
-                administrators: {
-                  administratorType: 'ActiveDirectory'
-                  principalType: principalType
-                  login: principalName
-                  sid: principalId
-                  tenantId: subscription().tenantId
-                  azureADOnlyAuthentication: true
-                }
-              }
             }
 
             resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {
@@ -1372,13 +1353,13 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
         var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-    
+
             param existingResourceName string
-    
+
             resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
               name: existingResourceName
             }
-    
+
             output appInsightsConnectionString string = appInsights.properties.ConnectionString
             """;
 
@@ -1419,17 +1400,17 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
         var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-    
+
             param existingResourceName string
-    
+
             param principalType string
-    
+
             param principalId string
-    
+
             resource openAI 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = {
               name: existingResourceName
             }
-    
+
             resource openAI_CognitiveServicesOpenAIContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
               name: guid(openAI.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442'))
               properties: {
@@ -1439,7 +1420,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
               }
               scope: openAI
             }
-    
+
             resource mymodel 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
               name: 'mymodel'
               properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1168,8 +1168,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
               "params": {
                 "existingResourceName": "{existingResourceName.value}",
                 "principalId": "",
-                "principalName": "",
-                "principalType": ""
+                "principalName": ""
               }
             }
             """;

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1124,6 +1124,15 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
               name: existingResourceName
             }
 
+            resource sqlServer_admin 'Microsoft.Sql/servers/administrators@2021-11-01' = {
+              name: 'ActiveDirectory'
+              properties: {
+                login: principalName
+                sid: principalId
+              }
+              parent: sqlServer
+            }
+
             resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {
               name: 'AllowAllAzureIps'
               properties: {
@@ -1181,6 +1190,15 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
 
             resource sqlServer 'Microsoft.Sql/servers@2021-11-01' existing = {
               name: existingResourceName
+            }
+
+            resource sqlServer_admin 'Microsoft.Sql/servers/administrators@2021-11-01' = {
+              name: 'ActiveDirectory'
+              properties: {
+                login: principalName
+                sid: principalId
+              }
+              parent: sqlServer
             }
 
             resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1186,8 +1186,6 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
 
             param existingResourceName string
 
-            param principalType string
-
             resource sqlServer 'Microsoft.Sql/servers@2021-11-01' existing = {
               name: existingResourceName
             }


### PR DESCRIPTION
## Description

Avoid setting fields that will be emitted in the `properties` of the Bicep file for Azure SQL server resources that already exist. Instead, add a SQL Admin through SqlServerAzureADAdministrator child resource.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [X] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [X] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
