### PR TITLE
Update WaitForResourceHealthyAsync to use DefaultWaitBehavior

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -233,7 +233,7 @@ public class ResourceNotificationService : IDisposable
     {
         return await WaitForResourceHealthyAsync(
             resourceName,
-            WaitBehavior.WaitOnResourceUnavailable, // Retain default behavior.
+            DefaultWaitBehavior,
             cancellationToken).ConfigureAwait(false);
     }
 

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -243,6 +243,34 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
    }
 
     [Theory]
+    [InlineData(WaitBehavior.WaitOnResourceUnavailable, typeof(TimeoutException), "The operation has timed out.")]
+    [InlineData(WaitBehavior.StopOnResourceUnavailable, typeof(DistributedApplicationException), "Stopped waiting for resource 'redis' to become healthy because it failed to start.")]
+    public async Task WhenWaitBehaviorIsMissingWaitForResourceHealthyAsyncShouldUseDefaultWaitBehavior(WaitBehavior defaultWaitBehavior, Type exceptionType, string exceptionMessage)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
+
+        builder.Services.Configure<ResourceNotificationServiceOptions>(o =>
+        {
+            o.DefaultWaitBehavior = defaultWaitBehavior;
+        });
+
+        var failToStart = builder.AddExecutable("failToStart", "does-not-exist", ".");
+        var dependency = builder.AddContainer("redis", "redis");
+
+        dependency.WaitFor(failToStart, WaitBehavior.StopOnResourceUnavailable);
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var ex = await Assert.ThrowsAsync(exceptionType, async () => {
+            await app.ResourceNotifications.WaitForResourceHealthyAsync(dependency.Resource.Name)
+                .WaitAsync(TimeSpan.FromSeconds(15));
+        });
+
+        Assert.Equal(exceptionMessage, ex.Message);
+    }
+
+    [Theory]
     [InlineData(nameof(KnownResourceStates.Exited))]
     [InlineData(nameof(KnownResourceStates.FailedToStart))]
     [InlineData(nameof(KnownResourceStates.RuntimeUnhealthy))]


### PR DESCRIPTION
## Description

Follow on to #7650 - this changes makes the default behaviour if you call `WaitForResourceHealthyAsync` without a `WaitBehavior` to use `DefaultWaitBehavior` rather than hardcode `WaitOnResourceUnavailable`.

This makes the behaviour match `WaitForDependenciesAsync` when `WaitFor` is called without a `WaitBehavior`, as well as improving the testing (or other dashboardless) experience by making `WaitForResourceHealthyAsync` fail fast in tests when you don't have a way to recover resources if they fail, without needing to explicitly set the `WaitBehavior`

If this change is not wanted, the default test templates should be updated to include `WaitBehavior.StopOnResourceUnavailable` as a follow on to #7619

```diff
- await app.ResourceNotifications.WaitForResourceHealthyAsync(dependency.Resource.Name).WaitAsync(TimeSpan.FromSeconds(15));
+ await app.ResourceNotifications.WaitForResourceHealthyAsync(dependency.Resource.Name, WaitBehavior.StopOnResourceUnavailable).WaitAsync(TimeSpan.FromSeconds(15));
```

Fixes #7601

~~(Pushing this as is to see if any tests break and need adapting to this change in defaults - if any do, I'm expecting them to be tests deep in aspire internals that are unlikely to affect real end user usage, but need to confirm.)~~

Update: Only one test failed first time, but it passes locally and succeeded on the second run

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
