### PR TITLE
Fix arg annotations when running in IDE mode

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -986,6 +986,9 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
         // If the executable is a project then include any command line args from the launch profile.
         if (er.ModelResource is ProjectResource project)
         {
+            // Args in the launch profile is used when:
+            // 1. The project is run as an executable. Launch profile args are combined with app host supplied args.
+            // 2. The project is run by the IDE and no app host args are specified.
             if (spec.ExecutionType == ExecutionType.Process || (spec.ExecutionType == ExecutionType.IDE && args.Count == 0))
             {
                 // When the .NET project is launched from an IDE the launch profile args are automatically added.

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -966,6 +966,9 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
         }
         var spec = exe.Spec;
 
+        // Don't create an args collection unless needed. A null args collection means a project run by the will use args
+        // provided by the launch profile.
+        // https://github.com/dotnet/aspire/blob/main/docs/specs/IDE-execution.md#launch-profile-processing-project-launch-configuration
         spec.Args = null;
 
         // An executable can be restarted so args must be reset to an empty state.

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -966,8 +966,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
         }
         var spec = exe.Spec;
 
-        // Don't create an args collection unless needed. A null args collection means a project run by the will use args
-        // provided by the launch profile.
+        // Don't create an args collection unless needed. A null args collection means a project run by the will use args provided by the launch profile.
         // https://github.com/dotnet/aspire/blob/main/docs/specs/IDE-execution.md#launch-profile-processing-project-launch-configuration
         spec.Args = null;
 
@@ -979,28 +978,10 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             spec.Args.AddRange(projectArgs);
         }
 
-        (var args, var failedToApplyArgs) = await BuildArgsAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
+        // Get args from app host model resource.
+        (var appHostArgs, var failedToApplyArgs) = await BuildArgsAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
 
-        var launchArgs = new List<(string Value, bool IsSensitive, bool AnnotationOnly)>();
-
-        // If the executable is a project then include any command line args from the launch profile.
-        if (er.ModelResource is ProjectResource project)
-        {
-            // Args in the launch profile is used when:
-            // 1. The project is run as an executable. Launch profile args are combined with app host supplied args.
-            // 2. The project is run by the IDE and no app host args are specified.
-            if (spec.ExecutionType == ExecutionType.Process || (spec.ExecutionType == ExecutionType.IDE && args.Count == 0))
-            {
-                // When the .NET project is launched from an IDE the launch profile args are automatically added.
-                // We still want to display the args in the dashboard so only add them to the custom arg annotations.
-                var annotationOnly = spec.ExecutionType == ExecutionType.IDE;
-
-                var launchProfileArgs = GetLaunchProfileArgs(project.GetEffectiveLaunchProfile()?.LaunchProfile);
-                launchArgs.AddRange(launchProfileArgs.Select(a => (a, isSensitive: false, annotationOnly)));
-            }
-        }
-
-        launchArgs.AddRange(args.Select(a => (a.Value, a.IsSensitive, annotationOnly: false)));
+        var launchArgs = BuildLaunchArgs(er, spec, appHostArgs);
 
         var executableArgs = launchArgs.Where(a => !a.AnnotationOnly).Select(a => a.Value).ToList();
         if (executableArgs.Count > 0)
@@ -1009,6 +990,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             spec.Args.AddRange(executableArgs);
         }
 
+        // Arg annotations are what is displayed in the dashboard.
         er.DcpResource.SetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, launchArgs.Select(a => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive)));
 
         (spec.Env, var failedToApplyConfiguration) = await BuildEnvVarsAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
@@ -1019,6 +1001,37 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
         }
 
         await _kubernetesService.CreateAsync(exe, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static List<(string Value, bool IsSensitive, bool AnnotationOnly)> BuildLaunchArgs(AppResource er, ExecutableSpec spec, List<(string Value, bool IsSensitive)> appHostArgs)
+    {
+        // Launch args is the final list of args that are displayed in the UI and possibly added to the executable spec.
+        // They're built from app host resource model args and any args in the effective launch profile.
+        // Follows behavior in the IDE execution spec when in IDE execution mode:
+        // https://github.com/dotnet/aspire/blob/main/docs/specs/IDE-execution.md#launch-profile-processing-project-launch-configuration
+        var launchArgs = new List<(string Value, bool IsSensitive, bool AnnotationOnly)>();
+
+        // If the executable is a project then include any command line args from the launch profile.
+        if (er.ModelResource is ProjectResource project)
+        {
+            // Args in the launch profile is used when:
+            // 1. The project is run as an executable. Launch profile args are combined with app host supplied args.
+            // 2. The project is run by the IDE and no app host args are specified.
+            if (spec.ExecutionType == ExecutionType.Process || (spec.ExecutionType == ExecutionType.IDE && appHostArgs.Count == 0))
+            {
+                // When the .NET project is launched from an IDE the launch profile args are automatically added.
+                // We still want to display the args in the dashboard so only add them to the custom arg annotations.
+                var annotationOnly = spec.ExecutionType == ExecutionType.IDE;
+
+                var launchProfileArgs = GetLaunchProfileArgs(project.GetEffectiveLaunchProfile()?.LaunchProfile);
+                launchArgs.AddRange(launchProfileArgs.Select(a => (a, isSensitive: false, annotationOnly)));
+            }
+        }
+
+        // In the situation where args are combined (process execution) the app host args are added after the launch profile args.
+        launchArgs.AddRange(appHostArgs.Select(a => (a.Value, a.IsSensitive, annotationOnly: false)));
+
+        return launchArgs;
     }
 
     private static List<string> GetLaunchProfileArgs(LaunchProfile? launchProfile)


### PR DESCRIPTION
## Description

Apply behavior from https://github.com/dotnet/aspire/blob/main/docs/specs/IDE-execution.md#launch-profile-processing-project-launch-configuration when displaying args in the dashboard.

Two changes:
1. When projects are executed by the IDE, the launch args and app host args aren't merged together. Launch args are only displayed if there are no app host args.
2. If there are no args then `project.Spec.Args` is left as null. That wasn't happening but appears to have special behavior according to the [IDE execution spec](https://github.com/dotnet/aspire/blob/main/docs/specs/IDE-execution.md#launch-profile-processing-project-launch-configuration). Maybe something along the toolchain automatically converts an empty array to null?

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
