### PR TITLE
Fix DCP logs ending with a new line

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Collections;
+using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Text;
@@ -278,6 +279,11 @@ internal sealed class DcpHost
             tab = line.IndexOf((byte)'\t');
             var category = line[..tab];
             line = line[(tab + 1)..];
+
+            // Trim trailing carraige return.
+            Debug.Assert(line[^1] == '\r', "Expected line to end with a carraige return.");
+            line = line[0..^1];
+
             var message = line;
 
             var logLevel = LogLevel.Information;

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -280,8 +280,8 @@ internal sealed class DcpHost
             var category = line[..tab];
             line = line[(tab + 1)..];
 
-            // Trim trailing carraige return.
-            Debug.Assert(line[^1] == '\r', "Expected line to end with a carraige return.");
+            // Trim trailing carriage return.
+            Debug.Assert(line[^1] == '\r', "Expected line to end with a carriage return.");
             line = line[0..^1];
 
             var message = line;

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Collections;
-using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Text;
@@ -281,8 +280,10 @@ internal sealed class DcpHost
             line = line[(tab + 1)..];
 
             // Trim trailing carriage return.
-            Debug.Assert(line[^1] == '\r', "Expected line to end with a carriage return.");
-            line = line[0..^1];
+            if (line[^1] == '\r')
+            {
+                line = line[0..^1];
+            }
 
             var message = line;
 


### PR DESCRIPTION
## Description

Something that has bothered me forever is DCP logs end with a new line. It doesn't show up in console output, but you see it in debug output:

![image](https://github.com/user-attachments/assets/56d344c9-649d-468d-8433-4cada46008d9)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
