### PR TITLE
avoid duplicate evaluation in ResolveConnectionStringReferenceAsync

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
@@ -27,9 +27,11 @@ public class ConnectionStringReference(IResourceWithConnectionString resource, b
 
         if (string.IsNullOrEmpty(value) && !Optional)
         {
-            throw new DistributedApplicationException($"The connection string for the resource '{Resource.Name}' is not available.");
+            ThrowConnectionStringUnavailableException();
         }
 
         return value;
     }
+
+    internal void ThrowConnectionStringUnavailableException() => throw new DistributedApplicationException($"The connection string for the resource '{Resource.Name}' is not available.");
 }

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -156,10 +156,14 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
     {
         // We are substituting our own logic for ConnectionStringReference's GetValueAsync.
         // However, ConnectionStringReference#GetValueAsync will throw if the connection string is not optional but is not present.
-        // To avoid duplicating that logic, we can defer to ConnectionStringReference#GetValueAsync, which will throw if needed.
-        await ((IValueProvider)cs).GetValueAsync(cancellationToken).ConfigureAwait(false);
+        // so we need to do the same here.
+        var value = await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(value.Value) && !cs.Optional)
+        {
+            cs.ThrowConnectionStringUnavailableException();
+        }
 
-        return await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false);
+        return value;
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

Duplicates logic from ConnectionStringReference#GetValueAsync to avoid evaluating the resource connection string expression twice.

Fixes https://github.com/dotnet/aspire/pull/7662/files/f36a730ab8fdc79867669daed643a5bc1a2a6f52#r1962999417

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No, covered by existing tests
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
