### PR TITLE
Resolve DistributedApplicationResourceBuilder<ResourceWithConnectionStringSurrogate> correctly in args evaluation

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -289,6 +289,7 @@ public static class ResourceExtensions
                         (_, string s) => new(s, false),
                         (DistributedApplicationOperation.Run, IValueProvider provider) => await GetValue(key: null, provider, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
                         (DistributedApplicationOperation.Run, DistributedApplicationResourceBuilder<ParameterResource> parameterResourceBuilder) => await GetValue(key: null, parameterResourceBuilder.Resource, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
+                        (DistributedApplicationOperation.Run, DistributedApplicationResourceBuilder<ResourceWithConnectionStringSurrogate> connectionStringSurrogateBuilder) => await GetValue(key: null, connectionStringSurrogateBuilder.Resource, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
                         (DistributedApplicationOperation.Publish, IManifestExpressionProvider provider) => new(provider.ValueExpression, false),
                         (_, { } o) => new(o.ToString(), false),
                         (_, null) => new(null, false),

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -267,14 +267,10 @@ public class ResourceExtensionsTests
         var secretParameter = new ParameterResource("SecretParameter", _ => "SecretParameter", true);
         var nonSecretParameter = new ParameterResource("NonSecretParameter", _ => "NonSecretParameter");
 
-        builder.AddResource(surrogate);
-        builder.AddResource(secretParameter);
-        builder.AddResource(nonSecretParameter);
-
         var container = builder.AddContainer("elasticsearch", "library/elasticsearch", "8.14.0")
-            .WithArgs(surrogate)
-            .WithArgs(secretParameter)
-            .WithArgs(nonSecretParameter);
+            .WithArgs(builder.AddResource(surrogate))
+            .WithArgs(builder.AddResource(secretParameter))
+            .WithArgs(builder.AddResource(nonSecretParameter));
         var args = await container.Resource.GetArgumentValuesAsync().DefaultTimeout();
 
         Assert.Equal<IEnumerable<string>>(["ConnectionString", "SecretParameter", "NonSecretParameter"], args);


### PR DESCRIPTION
## Description

ResourceWithConnectionStringSurrogate is wrapped in its builder when we are processing args, and so we should evaluate the underlying resource.

The right fix might be to do that for all DistributedApplicationResourceBuilder<T>, but I'm not confident that would be correct. I can't find other cases where a builder is passed instead of the resource, does anyone else know? @mitchdenny for thoughts? keeping this as a draft during discussion

Fixes https://github.com/dotnet/aspire/pull/7662#issuecomment-2670994303

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
