### PR TITLE
Install newer Docker CLI as part of pipeline

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -48,6 +48,11 @@ steps:
               $(_OfficialBuildIdArgs)
       displayName: Build
 
+    - task: DockerInstaller@0
+      inputs:
+        dockerVersion: '28.0.0'
+      displayName: Install Docker CLI
+
   # Non-helix tests are run only on the public pipeline
   - ${{ if and(eq(parameters.runAsPublic, 'true'), eq(parameters.runPipelineTests, 'true')) }}:
     # non-helix tests

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -134,7 +134,7 @@ steps:
             HelixTargetQueues: Ubuntu.2204.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             HelixTargetQueues: Ubuntu.2204.Amd64
-          ${{ if ne(parameters.dockerCliVersion, '') }}:
+          ${{ if and(ne(parameters.isWindows, 'true'), ne(parameters.dockerCliVersion, '')) }}:
             DockerCliPath: /opt/hostedtoolcache/docker-stable/${{ parameters.dockerCliVersion }}/x64/
 
         IsWindows: ${{ parameters.isWindows }}

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -22,6 +22,9 @@ parameters:
   - name: runPipelineTests
     type: boolean
     default: false
+  - name: dockerCliVersion
+    type: string
+    default: '28.0.0'
 
 steps:
   # Internal pipeline: Build with pack+sign
@@ -50,7 +53,7 @@ steps:
 
     - task: DockerInstaller@0
       inputs:
-        dockerVersion: '28.0.0'
+        dockerVersion: ${{ parameters.dockerCliVersion }}
       displayName: Install Docker CLI
 
   # Non-helix tests are run only on the public pipeline
@@ -131,6 +134,8 @@ steps:
             HelixTargetQueues: Ubuntu.2204.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             HelixTargetQueues: Ubuntu.2204.Amd64
+          ${{ if ne(parameters.dockerCliVersion, '') }}:
+            DockerCliPath: /opt/hostedtoolcache/docker-stable/${{ parameters.dockerCliVersion }}/x64/
 
         IsWindows: ${{ parameters.isWindows }}
         ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/eng/pipelines/templates/send-to-helix.yml
+++ b/eng/pipelines/templates/send-to-helix.yml
@@ -31,6 +31,7 @@ parameters:
   IsWindows: false                       # optional
   condition: succeeded()                 # optional -- condition for step to execute; defaults to succeeded()
   continueOnError: false                 # optional -- determines whether to continue the build if the step errors; defaults to false
+  dockerCliPath: ''                      # optional -- path to custom Docker CLI for helix
 
 steps:
   - ${{ if and(parameters.condition, eq(parameters.IsWindows, 'true')) }}:
@@ -92,4 +93,5 @@ steps:
         HelixBaseUri: ${{ parameters.HelixBaseUri }}
         Creator: ${{ parameters.Creator }}
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        DockerCliToolDir: ${{ parameters.dockerCliPath }}
       continueOnError: ${{ parameters.continueOnError }}

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -126,6 +126,12 @@
     <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="export PATH=$HELIX_CORRELATION_PAYLOAD/azure-func-cli:$PATH" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(OS)' != 'Windows_NT' and '$(DockerCliToolDir)' != ''">
+    <!-- Update it to the latest cli. This path is set from the eng/pipelines/templates/BuildAndTest.yml -->
+    <HelixPreCommand Include="export PATH=$HELIX_CORRELATION_PAYLOAD/docker-cli:$PATH" />
+    <HelixPreCommand Include="which docker" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(HasDocker)' == 'true'">
     <HelixPreCommand Include="docker info" />
     <HelixPreCommand Include="docker container ls --all" />
@@ -155,8 +161,6 @@
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_DIAGNOSTICS_LOG_LEVEL=debug" />
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_DIAGNOSTICS_LOG_FOLDER=$(_HelixLogsPath)" />
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_PRESERVE_EXECUTABLE_LOGS=1" />
-    <HelixPreCommand Condition="'$(OS)' == 'Windows_NT' and '$(DockerCliToolDir)' != ''" Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\docker-cli%3B%PATH%" />
-    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT' and '$(DockerCliToolDir)' != ''" Include="export PATH=$HELIX_CORRELATION_PAYLOAD/docker-cli:$PATH" />
 
     <HelixPostCommand Include="$(_WaitForDcpCommand)" />
   </ItemGroup>

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -24,7 +24,6 @@
 
     <_CreateDotNetDevCertsDirectory>$(ArtifactsObjDir)create-dotnet-devcert</_CreateDotNetDevCertsDirectory>
     <_SupportDataStagingDir>$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'support-data'))</_SupportDataStagingDir>
-    <_DockerCliPath Condition="'$(DockerCliToolDir)' != ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'docker-cli', 'docker'))</_DockerCliPath>
 
     <_AzureFunctionsCliUrl Condition="'$(OS)' == 'Windows_NT'">https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/Azure.Functions.Cli.min.win-x64_net8.4.0.6280.zip</_AzureFunctionsCliUrl>
     <_AzureFunctionsCliUrl Condition="'$(OS)' != 'Windows_NT'">https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/Azure.Functions.Cli.linux-x64_net8.4.0.6280.zip</_AzureFunctionsCliUrl>
@@ -156,8 +155,8 @@
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_DIAGNOSTICS_LOG_LEVEL=debug" />
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_DIAGNOSTICS_LOG_FOLDER=$(_HelixLogsPath)" />
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_PRESERVE_EXECUTABLE_LOGS=1" />
-    <HelixPreCommand Condition="'$(OS)' == 'Windows_NT' and '$(_DockerCliPath)' != ''" Include="set PATH=$(_DockerCliPath)%3B%PATH%" />
-    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT' and '$(_DockerCliPath)' != ''" Include="export PATH=$(_DockerCliPath):$PATH" />
+    <HelixPreCommand Condition="'$(OS)' == 'Windows_NT' and '$(DockerCliToolDir)' != ''" Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\docker-cli%3B%PATH%" />
+    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT' and '$(DockerCliToolDir)' != ''" Include="export PATH=$HELIX_CORRELATION_PAYLOAD/docker-cli:$PATH" />
 
     <HelixPostCommand Include="$(_WaitForDcpCommand)" />
   </ItemGroup>

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -24,6 +24,7 @@
 
     <_CreateDotNetDevCertsDirectory>$(ArtifactsObjDir)create-dotnet-devcert</_CreateDotNetDevCertsDirectory>
     <_SupportDataStagingDir>$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'support-data'))</_SupportDataStagingDir>
+    <_DockerCliPath Condition="'$(DockerCliToolDir)' != ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'docker-cli', 'docker'))</_DockerCliPath>
 
     <_AzureFunctionsCliUrl Condition="'$(OS)' == 'Windows_NT'">https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/Azure.Functions.Cli.min.win-x64_net8.4.0.6280.zip</_AzureFunctionsCliUrl>
     <_AzureFunctionsCliUrl Condition="'$(OS)' != 'Windows_NT'">https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/Azure.Functions.Cli.linux-x64_net8.4.0.6280.zip</_AzureFunctionsCliUrl>
@@ -155,6 +156,8 @@
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_DIAGNOSTICS_LOG_LEVEL=debug" />
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_DIAGNOSTICS_LOG_FOLDER=$(_HelixLogsPath)" />
     <HelixPreCommand Include="$(_EnvVarSetKeyword) DCP_PRESERVE_EXECUTABLE_LOGS=1" />
+    <HelixPreCommand Condition="'$(OS)' == 'Windows_NT' and '$(_DockerCliPath)' != ''" Include="set PATH=$(_DockerCliPath)%3B%PATH%" />
+    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT' and '$(_DockerCliPath)' != ''" Include="export PATH=$(_DockerCliPath):$PATH" />
 
     <HelixPostCommand Include="$(_WaitForDcpCommand)" />
   </ItemGroup>
@@ -214,6 +217,7 @@
       <HelixCorrelationPayload Include="$(_DotNetCoverageToolDir)" Destination="dotnet-coverage" />
       <HelixCorrelationPayload Include="$(_SupportDataStagingDir)" Destination="support-data" />
       <HelixCorrelationPayload Condition="'$(NeedsCreateDotNetDevScripts)' == 'true'" Include="$(_CreateDotNetDevCertsDirectory)" Destination="create-dotnet-devcert" />
+      <HelixCorrelationPayload Condition="'$(DockerCliToolDir)' != ''" Include="$(DockerCliToolDir)" Destination="docker-cli" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(NeedsWorkload)' == 'true'">


### PR DESCRIPTION
## Description

The default Docker CLI available in the pipeline is out of date and causing issues with tests. This PR seeks to update the CLI version used for our test coverage.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
