### PR TITLE
Add policy to close & re-open github-action PRs

### DIFF
--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -20,14 +20,14 @@ configuration:
           label: 'Closed Github-Action PR'
       - closeIssue
       description: Close and label Github-Action PRs
-      - if:
-        - payloadType: Pull_Request
-        - isAction:
-            action: Closed
-        - hasLabel:
-            label: 'Closed Github-Action PR'
-        then:
-        - removeLabel:
-            label: 'Closed Github-Action PR'
-        - reopenIssue
-        description: Reopen closed Github-Action PRs
+    - if:
+      - payloadType: Pull_Request
+      - isAction:
+          action: Closed
+      - hasLabel:
+          label: 'Closed Github-Action PR'
+      then:
+      - removeLabel:
+          label: 'Closed Github-Action PR'
+      - reopenIssue
+      description: Reopen closed Github-Action PRs

--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -1,0 +1,35 @@
+eventResponderTasks
+
+id: eventResponderTask.GithubActionPROpened
+name: Close and re-open PRs opened via Github Action
+description: Closes and re-open PRs opened via Github Action
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - if:
+      - payloadType: Pull_Request
+      - isAction:
+          action: Opened
+      - isActivitySender:
+          user: github-actions[bot]
+          issueAuthor: False
+      then:
+      - addLabel:
+          label: 'Closed Github-Action PR'
+      - closeIssue
+      description: Close and label Github-Action PRs
+      - if:
+        - payloadType: Pull_Request
+        - isAction:
+            action: Closed
+        - hasLabel:
+            label: 'Closed Github-Action PR'
+        then:
+        - removeLabel:
+            label: 'Closed Github-Action PR'
+        - reopenIssue
+        description: Reopen closed Github-Action PRs

--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -1,6 +1,7 @@
 # Github will not trigger Github Actions on PRs that were themselves created by a github action.
-# We use github actions to run tests on PRs, and to backport PRs from one branch to another - 
-# This action closes & re-opens PRs created via the Github-Action bot, so that our tests will run on those PRs.
+# We use github actions to run tests on PRs, and to backport PRs from one branch to another.
+# A workaround for that behavior is to close & re-open such PRs, so that the last action is not by the Github-Action bot.
+# This policy enacts that workaround.
 
 id: eventResponderTask.GithubActionPROpened
 name: Close and re-open PRs opened via Github Action

--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -1,5 +1,3 @@
-eventResponderTasks
-
 id: eventResponderTask.GithubActionPROpened
 name: Close and re-open PRs opened via Github Action
 description: Closes and re-open PRs opened via Github Action

--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -15,6 +15,9 @@ configuration:
       - isActivitySender:
           user: github-actions[bot]
           issueAuthor: False
+      - not:
+          hasLabel:
+            label: 'Re-opened Github-Action PR'
       then:
       - addLabel:
           label: 'Closed Github-Action PR'
@@ -29,5 +32,7 @@ configuration:
       then:
       - removeLabel:
           label: 'Closed Github-Action PR'
+      - addLabel:
+          label: 'Re-opened Github-Action PR'
       - reopenIssue
       description: Reopen closed Github-Action PRs

--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -1,3 +1,7 @@
+# Github will not trigger Github Actions on PRs that were themselves created by a github action.
+# We use github actions to run tests on PRs, and to backport PRs from one branch to another - 
+# This action closes & re-opens PRs created via the Github-Action bot, so that our tests will run on those PRs.
+
 id: eventResponderTask.GithubActionPROpened
 name: Close and re-open PRs opened via Github Action
 description: Closes and re-open PRs opened via Github Action

--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -1,4 +1,4 @@
-# Github will not trigger Github Actions on PRs that were themselves created by a github action.
+# Github will not trigger github actions on PRs that were themselves created by a github action.
 # We use github actions to run tests on PRs, and to backport PRs from one branch to another.
 # A workaround for that behavior is to close & re-open such PRs, so that the last action is not by the Github-Action bot.
 # This policy enacts that workaround.


### PR DESCRIPTION
Attempt to fix https://github.com/dotnet/aspire/issues/7719

Add a policy that closes & re-opens PRs opened via github action, in order to trigger actions on those PRs. 

Don't merge yet, need to make sure this doesn't infinitely loop