### PR TITLE
[CI] Fix code coverage run on the public pipeline

### DIFF
--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -215,4 +215,4 @@ stages:
           - template: /eng/pipelines/templates/VerifyCoverageReport.yml
             parameters:
               # matches what is used in the conditions for the build/test jobs
-              testVariants: ',_helix_tests'
+              testVariants: '_pipeline_tests,_helix_tests'


### PR DESCRIPTION
Update the parameter to get the code coverage files for the `pipeline_tests` (non-helix tests).