### PR TITLE
Revert "Avoid setting --port twice for Azure Functions (#7683)"

### DIFF
--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -114,6 +114,17 @@ public static class AzureFunctionsProjectResourceExtensions
                 // Set the storage connection string.
                 ((IResourceWithAzureFunctionsConfig)resource.HostStorage).ApplyAzureFunctionsConfiguration(context.EnvironmentVariables, "AzureWebJobsStorage");
             })
+            .WithArgs(context =>
+            {
+                // If we're running in publish mode, we don't need to map the port the host should listen on.
+                if (builder.ExecutionContext.IsPublishMode)
+                {
+                    return;
+                }
+                var http = resource.GetEndpoint("http");
+                context.Args.Add("--port");
+                context.Args.Add(http.Property(EndpointProperty.TargetPort));
+            })
             .WithOtlpExporter()
             .WithFunctionsHttpEndpoint();
     }
@@ -167,25 +178,7 @@ public static class AzureFunctionsProjectResourceExtensions
         // the port configured in the `WithArgs` callback when starting the project. To that end
         // we register an endpoint where the target port matches the port the Azure Functions worker
         // is actually configured to listen on and the endpoint is not proxied by DCP.
-        return builder
-            .WithHttpEndpoint(port: port, targetPort: port, isProxied: port == null)
-            .WithArgs(context =>
-            {
-                // Only pass the --port argument to the functions host if
-                // it has not been explicitly defined in the launch profile
-                // already. This covers the case where the user has defined
-                // a launch profile without a `commandLineArgs` property.
-                // We only do this when not in publish mode since the Azure
-                // Functions container image overrides the default port to 80.
-                if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode
-                    || port is not null)
-                {
-                    return;
-                }
-                var http = builder.Resource.GetEndpoint("http");
-                context.Args.Add("--port");
-                context.Args.Add(http.Property(EndpointProperty.TargetPort));
-            });
+        return builder.WithHttpEndpoint(port: port, targetPort: port, isProxied: port == null);
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Components.Common.Tests;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -27,7 +26,7 @@ public class AzureFunctionsTests
     }
 
     [Fact]
-    public async Task AddAzureFunctionsProject_WiresUpHttpEndpointCorrectly_WhenPortArgumentIsProvided()
+    public void AddAzureFunctionsProject_WiresUpHttpEndpointCorrectly_WhenPortArgumentIsProvided()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.AddAzureFunctionsProject<TestProject>("funcapp");
@@ -38,43 +37,21 @@ public class AzureFunctionsTests
         Assert.Equal(7071, endpointAnnotation.Port);
         Assert.Equal(7071, endpointAnnotation.TargetPort);
         Assert.False(endpointAnnotation.IsProxied);
-
-        // Check that no `--port` is present in the generated argument
-        // list if it's already defined in the launch profile
-        using var app = builder.Build();
-        var args = await ArgumentEvaluator.GetArgumentListAsync(functionsResource);
-
-        Assert.Empty(args);
     }
 
     [Fact]
-    public async Task AddAzureFunctionsProject_WiresUpHttpEndpointCorrectly_WhenPortArgumentIsNotProvided()
+    public void AddAzureFunctionsProject_WiresUpHttpEndpointCorrectly_WhenPortArgumentIsNotProvided()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
-        builder.AddAzureFunctionsProject<TestProjectWithoutPortArgument>("funcapp")
-            // Explicit set endpoint values for assertions later
-            .WithEndpoint("http", e =>
-            {
-                e.UriScheme = "http";
-                e.AllocatedEndpoint = new(e, "localhost", 1234);
-                e.TargetPort = 9876;
-            });;
+        builder.AddAzureFunctionsProject<TestProjectWithoutPortArgument>("funcapp");
 
-        // Assert that the EndpointAnnotation is configured correctly
+        // Assert that the EndpointAnnotation uses the first port defined in launch settings when
+        // there are multiple
         var functionsResource = Assert.Single(builder.Resources.OfType<AzureFunctionsProjectResource>());
         Assert.True(functionsResource.TryGetLastAnnotation<EndpointAnnotation>(out var endpointAnnotation));
         Assert.Null(endpointAnnotation.Port);
-        Assert.Equal(9876, endpointAnnotation.TargetPort);
+        Assert.Null(endpointAnnotation.TargetPort);
         Assert.True(endpointAnnotation.IsProxied);
-
-        // Check that `--port` is present in the args
-        using var app = builder.Build();
-        var args = await ArgumentEvaluator.GetArgumentListAsync(functionsResource);
-
-        Assert.Collection(args,
-            arg => Assert.Equal("--port", arg),
-            arg => Assert.Equal("9876", arg)
-        );
     }
 
     [Fact]


### PR DESCRIPTION
This reverts commit 97d5c1c75ec99c3b068b02eafcc34e8a8db17102.

Change is no longer neccessary with https://github.com/dotnet/aspire/pull/7711

Confirmation that double args aren't shown:

![image](https://github.com/user-attachments/assets/0fb1fce1-5049-42d4-8063-7f8236bdf6ba)

From Azure Functions EndToEnd sample.