### PR TITLE
Fix NodeJS Tests

### DIFF
--- a/tests/Aspire.Hosting.NodeJs.Tests/AddNodeAppTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/AddNodeAppTests.cs
@@ -27,7 +27,7 @@ public class AddNodeAppTests
                 "..\\foo\\app.js"
               ],
               "env": {
-                "NODE_ENV": "development",
+                "NODE_ENV": "{{builder.Environment.EnvironmentName.ToLowerInvariant()}}",
                 "PORT": "{nodeapp.bindings.http.targetPort}"
               },
               "bindings": {
@@ -57,7 +57,7 @@ public class AddNodeAppTests
                 "start"
               ],
               "env": {
-                "NODE_ENV": "development",
+                "NODE_ENV": "{{builder.Environment.EnvironmentName.ToLowerInvariant()}}",
                 "PORT": "{npmapp.bindings.http.targetPort}"
               },
               "bindings": {


### PR DESCRIPTION
These tests assumed that the test environment was always "development" which is no longer the case after #7698.
