### PR TITLE
Add a Final Results job for branch protection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,7 +229,7 @@ jobs:
           name: testresults-${{ matrix.name }}
           path: testresults/**
 
-  results: # This job does is used for the branch protection. It ensures all the above tests passed
+  results: # This job is used for branch protection. It ensures all the above tests passed
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Final Results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Run Integration Tests
 
 on:
   pull_request:
-    branches: 
+    branches:
       - main
       - 'release/**'
 
@@ -146,7 +146,7 @@ jobs:
           # Playground project
           - project: tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
             name: Playground
-          
+
           # Schema generator project
           - project: tests/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
             name: ConfigurationSchemaGenerator
@@ -207,6 +207,23 @@ jobs:
             --no-restore \
             --no-build -- RunConfiguration.CollectSourceInformation=true
 
+      # Save the result of the previous steps - success or failure
+      # in the form of a file result-success/result-failure -{name}.rst
+      - name: Store result - success
+        if: ${{ success() }}
+        run: touch result-success-${{ matrix.name }}.rst
+      - name: Store result - failure
+        if: ${{ !success() }}
+        run: touch result-failed-${{ matrix.name }}.rst
+
+      # Upload that result file to artifact named test-job-result-{name}
+      - name: Upload test result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-job-result-${{ matrix.name }}
+          path: result-*.rst
+
       - name: Dump docker info
         if: always()
         run: |
@@ -235,10 +252,15 @@ jobs:
     name: Final Results
     needs: [test]
     steps:
-      - run: |
-          result="${{ needs.test.result }}"
-          if [[ $result == "success" ]]; then
-            exit 0
-          else
-            exit 1
-          fi
+      # get all the test-job-result* artifacts into a single directory
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: test-job-result-*
+          merge-multiple: true
+          path: test-job-result
+
+      # return success if zero result-failed-* files are found
+      - name: Compute result
+        run: |
+          ls -al test-job-result/
+          [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
             name: Dashboard
 
           # Playground project
-          - project: tests/Aspire.Playground.Tests/Aspire.Playground.Tests.cspr
+          - project: tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
             name: Playground
 
           # Schema generator project

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,3 +228,17 @@ jobs:
         with:
           name: testresults-${{ matrix.name }}
           path: testresults/**
+
+  results: # This job does is used for the branch protection. It ensures all the above tests passed
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [test]
+    steps:
+      - run: |
+          result="${{ needs.test.result }}"
+          if [[ $result == "success" ]]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
             name: Dashboard
 
           # Playground project
-          - project: tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+          - project: tests/Aspire.Playground.Tests/Aspire.Playground.Tests.cspr
             name: Playground
 
           # Schema generator project


### PR DESCRIPTION
To ensure all tests pass before merging, we add a single "Final Results" job after all the tests that ensures the tests pass. That way the branch protection rule can be set on this one result.