### PR TITLE
Rebuild Azure Functions project before test run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -187,6 +187,7 @@ jobs:
         run: |
           ./build.sh -restore -ci -build -projects ${{ github.workspace }}/${{ matrix.project }} /bl
 
+      # Workaround for bug in Azure Functions Worker SDK. See https://github.com/Azure/azure-functions-dotnet-worker/issues/2969.
       - name: Rebuild for Azure Functions project
         if: matrix.name == 'Playground'
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -187,6 +187,11 @@ jobs:
         run: |
           ./build.sh -restore -ci -build -projects ${{ github.workspace }}/${{ matrix.project }} /bl
 
+      - name: Rebuild for Azure Functions project
+        if: matrix.name == 'Playground'
+        run: |
+          ./dotnet.sh build ${{ github.workspace }}/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj /p:SkipUnstableEmulators=true
+
       - name: Run tests
         id: run-tests
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,6 +189,8 @@ jobs:
 
       - name: Rebuild for Azure Functions project
         if: matrix.name == 'Playground'
+        env:
+          CI: false
         run: |
           ./dotnet.sh build ${{ github.workspace }}/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj /p:SkipUnstableEmulators=true
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,4 +50,8 @@
     <AspireDashboardDir>$(MSBuildThisFileDirectory)/artifacts/bin/Aspire.Dashboard/$(Configuration)/net8.0/</AspireDashboardDir>
   </PropertyGroup>
 
+  <!-- Workaround for resolving Git packaging related targets inner Functions build. -->
+  <Target Name="GitVersion" />
+  <Target Name="GitInfo" />
+
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,8 +50,4 @@
     <AspireDashboardDir>$(MSBuildThisFileDirectory)/artifacts/bin/Aspire.Dashboard/$(Configuration)/net8.0/</AspireDashboardDir>
   </PropertyGroup>
 
-  <!-- Workaround for resolving Git packaging related targets inner Functions build. -->
-  <Target Name="GitVersion" />
-  <Target Name="GitInfo" />
-
 </Project>

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
@@ -42,4 +42,5 @@
     <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.EventHubs" />
     <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.ServiceBus" />
   </ItemGroup>
+
 </Project>

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -27,7 +27,7 @@
   <PropertyGroup Condition="'$(SkipUnstableEmulators)' == 'true'">
     <DefineConstants>SKIP_UNSTABLE_EMULATORS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <!-- on helix, the file will be in the source directory, so it will get
          picked up by msbuild by default -->

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -57,7 +57,6 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     [Fact]
     [RequiresDocker]
     [RequiresTools(["func"])]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7437")]
     public async Task AzureFunctionsTest()
     {
         var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.AzureFunctionsEndToEnd_AppHost), _testOutput);


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/7437 by rebuilding the Functions project again after the build of test projects to force resolution of trigger metadata correctly before the Functions test runs.

This is a workaround for https://github.com/Azure/azure-functions-dotnet-worker/issues/2969.