### PR TITLE
docs: fix a typo in comment

### DIFF
--- a/src/Aspire.Dashboard/Authentication/OpenIdConnect/AuthorizationPolicyBuilderExtensions.cs
+++ b/src/Aspire.Dashboard/Authentication/OpenIdConnect/AuthorizationPolicyBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace Aspire.Dashboard.Authentication.OpenIdConnect;
 internal static class AuthorizationPolicyBuilderExtensions
 {
     /// <summary>
-    /// Validates that the the expected claim and value are present.
+    /// Validates that the expected claim and value are present.
     /// </summary>
     /// <remarks>
     /// Checks are controlled by configuration.


### PR DESCRIPTION
## Description

Remove duplicated `the`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
