### PR TITLE
Fix Windows CI

### DIFF
--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -245,6 +245,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
    }
 
     [Theory]
+    [RequiresDocker]
     [InlineData(WaitBehavior.WaitOnResourceUnavailable, typeof(TimeoutException), "The operation has timed out.")]
     [InlineData(WaitBehavior.StopOnResourceUnavailable, typeof(DistributedApplicationException), "Stopped waiting for resource 'redis' to become healthy because it failed to start.")]
     public async Task WhenWaitBehaviorIsMissingWaitForResourceHealthyAsyncShouldUseDefaultWaitBehavior(WaitBehavior defaultWaitBehavior, Type exceptionType, string exceptionMessage)


### PR DESCRIPTION
Tests for `main` on CI are failing on `Windows_pipeline_tests-trx_3` - `Aspire.Hosting.Tests.WaitForTests.WhenWaitBehaviorIsMissingWaitForResourceHealthyAsyncShouldUseDefaultWaitBehavior` with:

`Aspire.Hosting.DistributedApplicationException : Container runtime 'docker' was found but appears to be unhealthy. Ensure that Docker is running and that the Docker daemon is accessible. If Resource Saver mode is enabled, containers may not run. For more information, visit: https://docs.docker.com/desktop/use-desktop/resource-saver/`

This is because of a missing `RequiresDocker` attribute on the test.
