### PR TITLE
Ensure containers EH and SB files can be used from non-root containers

### DIFF
--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -322,6 +322,15 @@ public static class AzureEventHubsExtensions
                 // Deterministic file path for the configuration file based on its content
                 var configJsonPath = aspireStore.GetFileNameWithContent($"{builder.Resource.Name}-Config.json", tempConfigFile);
 
+                // The docker container runs as a non-root user, so we need to grant other user's read/write permission
+                if (!OperatingSystem.IsWindows())
+                {
+                    var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                               UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(configJsonPath, mode);
+                }
+
                 builder.WithAnnotation(new ContainerMountAnnotation(
                     configJsonPath,
                     AzureEventHubsEmulatorResource.EmulatorConfigJsonPath,

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -423,6 +423,15 @@ public static class AzureServiceBusExtensions
                 // Deterministic file path for the configuration file based on its content
                 var configJsonPath = aspireStore.GetFileNameWithContent($"{builder.Resource.Name}-Config.json", tempConfigFile);
 
+                // The docker container runs as a non-root user, so we need to grant other user's read/write permission
+                if (!OperatingSystem.IsWindows())
+                {
+                    var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                               UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(configJsonPath, mode);
+                }
+
                 builder.WithAnnotation(new ContainerMountAnnotation(
                     configJsonPath,
                     AzureServiceBusEmulatorResource.EmulatorConfigJsonPath,

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -111,6 +111,41 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    [RequiresDocker]
+    public async Task AzureEventHubsNs_ProducesAndConsumes()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
+        var eventHubns = builder.AddAzureEventHubs("eventhubns")
+            .RunAsEmulator();
+        var eventHub = eventHubns.AddHub("hub");
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var hb = Host.CreateApplicationBuilder();
+
+        hb.Configuration["ConnectionStrings:eventhubns"] = await eventHubns.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
+        hb.AddAzureEventHubProducerClient("eventhubns", settings => settings.EventHubName = "hub");
+        hb.AddAzureEventHubConsumerClient("eventhubns", settings => settings.EventHubName = "hub");
+
+        using var host = hb.Build();
+        await host.StartAsync();
+
+        var producerClient = host.Services.GetRequiredService<EventHubProducerClient>();
+        var consumerClient = host.Services.GetRequiredService<EventHubConsumerClient>();
+
+        // If no exception is thrown when awaited, the Event Hubs service has acknowledged
+        // receipt and assumed responsibility for delivery of the set of events to its partition.
+        await producerClient.SendAsync([new EventData(Encoding.UTF8.GetBytes("hello worlds"))]);
+
+        await foreach (var partitionEvent in consumerClient.ReadEventsAsync(new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(5) }))
+        {
+            Assert.Equal("hello worlds", Encoding.UTF8.GetString(partitionEvent.Data.EventBody.ToArray()));
+            break;
+        }
+    }
+
+    [Fact]
     public void AzureEventHubsUseEmulatorCallbackWithWithDataBindMountResultsInBindMountAnnotationWithDefaultPath()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -392,6 +427,18 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         var volumeAnnotation = eventHubsEmulatorResource.Annotations.OfType<ContainerMountAnnotation>().Single();
 
         var configJsonContent = File.ReadAllText(volumeAnnotation.Source!);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            // Ensure the configuration file has correct attributes
+            var fileInfo = new FileInfo(volumeAnnotation.Source!);
+
+            var expectedUnixFileMode =
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+            Assert.True(fileInfo.UnixFileMode.HasFlag(expectedUnixFileMode));
+        }
 
         Assert.Equal(/*json*/"""
         {

--- a/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
+++ b/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
@@ -23,9 +23,13 @@ public static class DistributedApplicationTestingBuilderExtensions
         builder.Services.AddLogging(builder => builder.AddFilter("Aspire.Hosting", LogLevel.Trace));
         return builder;
     }
+
     public static IDistributedApplicationTestingBuilder WithTempAspireStore(this IDistributedApplicationTestingBuilder builder)
     {
-        builder.Configuration["Aspire:Store:Path"] = Path.GetTempPath();
+        // We create the Aspire Store in a folder with user-only access. This way non-root containers won't be able
+        // to access the files unless they correctly assign the required permissions for the container to work.
+
+        builder.Configuration["Aspire:Store:Path"] = Directory.CreateTempSubdirectory().FullName;
         return builder;
     }
 }


### PR DESCRIPTION
## Description

- Added file modes to containers using `IAspireStore`
- Changed default tests store folder to one that doesn't have non-root read permissions
- Enable SB and EH functional tests making use of non-root permissions
- Added unit tests to ensure expected file mode is set

Fixes [#7759](https://github.com/dotnet/aspire/issues/7762)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No