### PR TITLE
[ci] Bump code coverage step timeout from 10m to 15m

### DIFF
--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -197,7 +197,7 @@ stages:
         # ----------------------------------------------------------------
         jobs:
         - job: CodeCoverageReport
-          timeoutInMinutes: 10
+          timeoutInMinutes: 15
 
           pool:
             name: $(DncEngPublicBuildPool)


### PR DESCRIPTION
Codeql can take longer some times, which ends up being more than 10mins.