### PR TITLE
Optimize required unix file modes

### DIFF
--- a/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/PostgresEndToEnd.AppHost.csproj
+++ b/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/PostgresEndToEnd.AppHost.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>f8cd0caa-3990-4f6f-889f-3cf66ac52de9</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/playground/mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj
+++ b/playground/mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>7359b387-0386-4cd0-9f26-7b40bdb8348d</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -433,6 +433,7 @@ public static class AzureEventHubsExtensions
 
     private static string WriteEmulatorConfigJson(AzureEventHubsResource emulatorResource)
     {
+        // This temporary file is not used by the container, it will be copied and then deleted
         var filePath = Path.GetTempFileName();
 
         using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Write);

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -19,6 +19,8 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class AzureEventHubsExtensions
 {
+    private const UnixFileMode FileMode644 = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+
     /// <summary>
     /// Adds an Azure Event Hubs Namespace resource to the application model. This resource can be used to create Event Hub resources.
     /// </summary>
@@ -325,10 +327,7 @@ public static class AzureEventHubsExtensions
                 // The docker container runs as a non-root user, so we need to grant other user's read/write permission
                 if (!OperatingSystem.IsWindows())
                 {
-                    var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                               UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(configJsonPath, mode);
+                    File.SetUnixFileMode(configJsonPath, FileMode644);
                 }
 
                 builder.WithAnnotation(new ContainerMountAnnotation(

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -558,6 +558,7 @@ public static class AzureServiceBusExtensions
 
     private static string WriteEmulatorConfigJson(AzureServiceBusResource emulatorResource)
     {
+        // This temporary file is not used by the container, it will be copied and then deleted
         var filePath = Path.GetTempFileName();
 
         using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Write);

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -20,6 +20,8 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class AzureServiceBusExtensions
 {
+    private const UnixFileMode FileMode644 = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+
     /// <summary>
     /// Adds an Azure Service Bus Namespace resource to the application model. This resource can be used to create queue, topic, and subscription resources.
     /// </summary>
@@ -426,10 +428,7 @@ public static class AzureServiceBusExtensions
                 // The docker container runs as a non-root user, so we need to grant other user's read/write permission
                 if (!OperatingSystem.IsWindows())
                 {
-                    var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                               UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(configJsonPath, mode);
+                    File.SetUnixFileMode(configJsonPath, FileMode644);
                 }
 
                 builder.WithAnnotation(new ContainerMountAnnotation(

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -103,8 +103,6 @@ public static class MySqlBuilderExtensions
 
         containerName ??= $"{builder.Resource.Name}-phpmyadmin";
 
-        var configurationTempFileName = Path.GetTempFileName();
-
         var phpMyAdminContainer = new PhpMyAdminContainerResource(containerName);
         var phpMyAdminContainerBuilder = builder.ApplicationBuilder.AddResource(phpMyAdminContainer)
                                                 .WithImage(MySqlContainerImageTags.PhpMyAdminImage, MySqlContainerImageTags.PhpMyAdminTag)

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -240,8 +240,7 @@ public static class MySqlBuilderExtensions
         // This temporary file is not used by the container, it will be copied and then deleted
         var filePath = Path.GetTempFileName();
 
-        using var stream = new FileStream(filePath, FileMode.Create);
-        using var writer = new StreamWriter(stream);
+        using var writer = new StreamWriter(filePath);
 
         writer.WriteLine("<?php");
         writer.WriteLine();

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO.Hashing;
 using System.Text;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
@@ -17,6 +18,7 @@ public static class PostgresBuilderExtensions
 {
     private const string UserEnvVarName = "POSTGRES_USER";
     private const string PasswordEnvVarName = "POSTGRES_PASSWORD";
+    private const UnixFileMode FileMode644 = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
 
     /// <summary>
     /// Adds a PostgreSQL resource to the application model. A container is used for local development.
@@ -150,55 +152,44 @@ public static class PostgresBuilderExtensions
                                                  .WithImageRegistry(PostgresContainerImageTags.PgAdminRegistry)
                                                  .WithHttpEndpoint(targetPort: 80, name: "http")
                                                  .WithEnvironment(SetPgAdminEnvironmentVariables)
-                                                 .WithBindMount(Path.GetTempFileName(), "/pgadmin4/servers.json")
                                                  .WithHttpHealthCheck("/browser")
                                                  .ExcludeFromManifest();
 
             builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
             {
-                var serverFileMount = pgAdminContainer.Annotations.OfType<ContainerMountAnnotation>().Single(v => v.Target == "/pgadmin4/servers.json");
+                // Add the servers.json file bind mount to the pgAdmin container
+
                 var postgresInstances = builder.ApplicationBuilder.Resources.OfType<PostgresServerResource>();
 
-                var serverFileBuilder = new StringBuilder();
+                // Create servers.json file content in a temporary file
 
-                using var stream = new FileStream(serverFileMount.Source!, FileMode.Create);
-                using var writer = new Utf8JsonWriter(stream);
-                // Need to grant read access to the config file on unix like systems.
-                if (!OperatingSystem.IsWindows())
+                var tempConfigFile = WritePgAdminServerJson(postgresInstances);
+
+                try
                 {
-                    File.SetUnixFileMode(serverFileMount.Source!, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
-                }
+                    var aspireStore = e.Services.GetRequiredService<IAspireStore>();
 
-                var serverIndex = 1;
+                    // Deterministic file path for the configuration file based on its content
+                    var configJsonPath = aspireStore.GetFileNameWithContent($"{builder.Resource.Name}-pgadmin-servers.json", tempConfigFile);
 
-                writer.WriteStartObject();
-                writer.WriteStartObject("Servers");
-
-                foreach (var postgresInstance in postgresInstances)
-                {
-                    if (postgresInstance.PrimaryEndpoint.IsAllocated)
+                    // Need to grant read access to the config file on unix like systems.
+                    if (!OperatingSystem.IsWindows())
                     {
-                        var endpoint = postgresInstance.PrimaryEndpoint;
-
-                        writer.WriteStartObject($"{serverIndex}");
-                        writer.WriteString("Name", postgresInstance.Name);
-                        writer.WriteString("Group", "Servers");
-                        // PgAdmin assumes Postgres is being accessed over a default Aspire container network and hardcodes the resource address
-                        // This will need to be refactored once updated service discovery APIs are available
-                        writer.WriteString("Host", endpoint.Resource.Name);
-                        writer.WriteNumber("Port", (int)endpoint.TargetPort!);
-                        writer.WriteString("Username", postgresInstance.UserNameParameter?.Value ?? "postgres");
-                        writer.WriteString("SSLMode", "prefer");
-                        writer.WriteString("MaintenanceDB", "postgres");
-                        writer.WriteString("PasswordExecCommand", $"echo '{postgresInstance.PasswordParameter.Value}'"); // HACK: Generating a pass file and playing around with chmod is too painful.
-                        writer.WriteEndObject();
+                        File.SetUnixFileMode(configJsonPath, FileMode644);
                     }
 
-                    serverIndex++;
+                    pgAdminContainerBuilder.WithBindMount(configJsonPath, "/pgadmin4/servers.json");
                 }
-
-                writer.WriteEndObject();
-                writer.WriteEndObject();
+                finally
+                {
+                    try
+                    {
+                        File.Delete(tempConfigFile);
+                    }
+                    catch
+                    {
+                    }
+                }
 
                 return Task.CompletedTask;
             });
@@ -277,13 +268,11 @@ public static class PostgresBuilderExtensions
         else
         {
             containerName ??= $"{builder.Resource.Name}-pgweb";
-            var dir = Directory.CreateTempSubdirectory().FullName;
             var pgwebContainer = new PgWebContainerResource(containerName);
             var pgwebContainerBuilder = builder.ApplicationBuilder.AddResource(pgwebContainer)
                                                .WithImage(PostgresContainerImageTags.PgWebImage, PostgresContainerImageTags.PgWebTag)
                                                .WithImageRegistry(PostgresContainerImageTags.PgWebRegistry)
                                                .WithHttpEndpoint(targetPort: 8081, name: "http")
-                                               .WithBindMount(dir, "/.pgweb/bookmarks")
                                                .WithArgs("--bookmarks-dir=/.pgweb/bookmarks")
                                                .WithArgs("--sessions")
                                                .ExcludeFromManifest();
@@ -294,44 +283,55 @@ public static class PostgresBuilderExtensions
 
             pgwebContainerBuilder.WithHttpHealthCheck();
 
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>(async (e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
             {
-                var adminResource = builder.ApplicationBuilder.Resources.OfType<PgWebContainerResource>().Single();
-                var serverFileMount = adminResource.Annotations.OfType<ContainerMountAnnotation>().Single(v => v.Target == "/.pgweb/bookmarks");
+                // Add the bookmarks to the pgweb container
+
+                // Create a folder using IAspireStore. Its name is deterministic, based on all the database resources
+                // such that the same folder is reused across persistent usages, and changes in configuration require
+                // new folders. Note that when using dynamic proxies the configuration won't be reused, but it only makes
+                // sense for persistent containers (when pg servers are reused) in which case they would have fixed ports.
+
                 var postgresInstances = builder.ApplicationBuilder.Resources.OfType<PostgresDatabaseResource>();
 
-                if (!Directory.Exists(serverFileMount.Source!))
+                var aspireStore = e.Services.GetRequiredService<IAspireStore>();
+
+                var tempDir = WritePgWebBookmarks(postgresInstances, out var contentHash);
+
+                // Create a deterministic folder name based on the content hash such that the same folder is reused across
+                // persistent usages.
+                var pgwebBookmarks = Path.Combine(aspireStore.BasePath, $"{pgwebContainerBuilder.Resource.Name}.{Convert.ToHexString(contentHash)[..12].ToLowerInvariant()}");
+
+                try
                 {
-                    Directory.CreateDirectory(serverFileMount.Source!);
+                    Directory.CreateDirectory(pgwebBookmarks);
+
+                    // Need to grant read access to the config file on unix like systems.
+                    if (!OperatingSystem.IsWindows())
+                    {
+                        File.SetUnixFileMode(pgwebBookmarks, FileMode644);
+                    }
+
+                    foreach (var file in Directory.GetFiles(tempDir))
+                    {
+                        // Target is overwritten just in case the previous attempts has failed
+                        File.Copy(file, Path.Combine(pgwebBookmarks, Path.GetFileName(file)), overwrite: true);
+                    }
+
+                    pgwebContainerBuilder.WithBindMount(pgwebBookmarks, "/.pgweb/bookmarks");
+                }
+                finally
+                {
+                    try
+                    {
+                        Directory.Delete(tempDir, true);
+                    }
+                    catch
+                    {
+                    }
                 }
 
-                if (!OperatingSystem.IsWindows())
-                {
-                    var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                               UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                               UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(serverFileMount.Source!, mode);
-                }
-
-                foreach (var postgresDatabase in postgresInstances)
-                {
-                    var user = postgresDatabase.Parent.UserNameParameter?.Value ?? "postgres";
-
-                    // PgAdmin assumes Postgres is being accessed over a default Aspire container network and hardcodes the resource address
-                    // This will need to be refactored once updated service discovery APIs are available
-                    var fileContent = $"""
-                        host = "{postgresDatabase.Parent.Name}"
-                        port = {postgresDatabase.Parent.PrimaryEndpoint.TargetPort}
-                        user = "{user}"
-                        password = "{postgresDatabase.Parent.PasswordParameter.Value}"
-                        database = "{postgresDatabase.DatabaseName}"
-                        sslmode = "disable"
-                        """;
-
-                    var filePath = Path.Combine(serverFileMount.Source!, $"{postgresDatabase.Name}.toml");
-                    await File.WriteAllTextAsync(filePath, fileContent, ct).ConfigureAwait(false);
-                }
+                return Task.CompletedTask;
             });
 
             return builder;
@@ -402,5 +402,78 @@ public static class PostgresBuilderExtensions
         ArgumentNullException.ThrowIfNull(source);
 
         return builder.WithBindMount(source, "/docker-entrypoint-initdb.d", isReadOnly);
+    }
+
+    private static string WritePgWebBookmarks(IEnumerable<PostgresDatabaseResource> postgresInstances, out byte[] contentHash)
+    {
+        var dir = Directory.CreateTempSubdirectory().FullName;
+
+        // Fast, non-cryptographic hash.
+        var hash = new XxHash3();
+
+        foreach (var postgresDatabase in postgresInstances)
+        {
+            var user = postgresDatabase.Parent.UserNameParameter?.Value ?? "postgres";
+
+            // PgAdmin assumes Postgres is being accessed over a default Aspire container network and hardcodes the resource address
+            // This will need to be refactored once updated service discovery APIs are available
+            var fileContent = $"""
+                    host = "{postgresDatabase.Parent.Name}"
+                    port = {postgresDatabase.Parent.PrimaryEndpoint.TargetPort}
+                    user = "{user}"
+                    password = "{postgresDatabase.Parent.PasswordParameter.Value}"
+                    database = "{postgresDatabase.DatabaseName}"
+                    sslmode = "disable"
+                    """;
+
+            hash.Append(Encoding.UTF8.GetBytes(fileContent));
+
+            File.WriteAllText(Path.Combine(dir, $"{postgresDatabase.Name}.toml"), fileContent);
+        }
+
+        contentHash = hash.GetCurrentHash();
+
+        return dir;
+    }
+
+    private static string WritePgAdminServerJson(IEnumerable<PostgresServerResource> postgresInstances)
+    {
+        var filePath = Path.GetTempFileName();
+
+        using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Write);
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+
+        writer.WriteStartObject();
+        writer.WriteStartObject("Servers");
+
+        var serverIndex = 1;
+
+        foreach (var postgresInstance in postgresInstances)
+        {
+            if (postgresInstance.PrimaryEndpoint.IsAllocated)
+            {
+                var endpoint = postgresInstance.PrimaryEndpoint;
+
+                writer.WriteStartObject($"{serverIndex}");
+                writer.WriteString("Name", postgresInstance.Name);
+                writer.WriteString("Group", "Servers");
+                // PgAdmin assumes Postgres is being accessed over a default Aspire container network and hardcodes the resource address
+                // This will need to be refactored once updated service discovery APIs are available
+                writer.WriteString("Host", endpoint.Resource.Name);
+                writer.WriteNumber("Port", (int)endpoint.TargetPort!);
+                writer.WriteString("Username", postgresInstance.UserNameParameter?.Value ?? "postgres");
+                writer.WriteString("SSLMode", "prefer");
+                writer.WriteString("MaintenanceDB", "postgres");
+                writer.WriteString("PasswordExecCommand", $"echo '{postgresInstance.PasswordParameter.Value}'"); // HACK: Generating a pass file and playing around with chmod is too painful.
+                writer.WriteEndObject();
+            }
+
+            serverIndex++;
+        }
+
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+
+        return filePath;
     }
 }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -444,6 +444,7 @@ public static class PostgresBuilderExtensions
 
     private static string WritePgAdminServerJson(IEnumerable<PostgresServerResource> postgresInstances)
     {
+        // This temporary file is not used by the container, it will be copied and then deleted
         var filePath = Path.GetTempFileName();
 
         using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Write);

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -315,7 +315,13 @@ public static class PostgresBuilderExtensions
                     foreach (var file in Directory.GetFiles(tempDir))
                     {
                         // Target is overwritten just in case the previous attempts has failed
-                        File.Copy(file, Path.Combine(pgwebBookmarks, Path.GetFileName(file)), overwrite: true);
+                        var destinationPath = Path.Combine(pgwebBookmarks, Path.GetFileName(file));
+                        File.Copy(file, destinationPath, overwrite: true);
+
+                        if (!OperatingSystem.IsWindows())
+                        {
+                            File.SetUnixFileMode(destinationPath, FileMode644);
+                        }
                     }
 
                     pgwebContainerBuilder.WithBindMount(pgwebBookmarks, "/.pgweb/bookmarks");

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -19,6 +19,10 @@ public static class PostgresBuilderExtensions
     private const string UserEnvVarName = "POSTGRES_USER";
     private const string PasswordEnvVarName = "POSTGRES_PASSWORD";
     private const UnixFileMode FileMode644 = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+    private const UnixFileMode FileMode777 =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
     /// <summary>
     /// Adds a PostgreSQL resource to the application model. A container is used for local development.
@@ -306,10 +310,10 @@ public static class PostgresBuilderExtensions
                 {
                     Directory.CreateDirectory(pgwebBookmarks);
 
-                    // Need to grant read access to the config file on unix like systems.
+                    // Grant listing access to the bookmarks folder on unix like systems.
                     if (!OperatingSystem.IsWindows())
                     {
-                        File.SetUnixFileMode(pgwebBookmarks, FileMode644);
+                        File.SetUnixFileMode(pgwebBookmarks, FileMode777);
                     }
 
                     foreach (var file in Directory.GetFiles(tempDir))

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -19,10 +19,10 @@ public static class PostgresBuilderExtensions
     private const string UserEnvVarName = "POSTGRES_USER";
     private const string PasswordEnvVarName = "POSTGRES_PASSWORD";
     private const UnixFileMode FileMode644 = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
-    private const UnixFileMode FileMode777 =
+    private const UnixFileMode FileMode755 =
         UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+        UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
 
     /// <summary>
     /// Adds a PostgreSQL resource to the application model. A container is used for local development.
@@ -313,7 +313,7 @@ public static class PostgresBuilderExtensions
                     // Grant listing access to the bookmarks folder on unix like systems.
                     if (!OperatingSystem.IsWindows())
                     {
-                        File.SetUnixFileMode(pgwebBookmarks, FileMode777);
+                        File.SetUnixFileMode(pgwebBookmarks, FileMode755);
                     }
 
                     foreach (var file in Directory.GetFiles(tempDir))

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -174,7 +174,7 @@ public static class PostgresBuilderExtensions
                     var aspireStore = e.Services.GetRequiredService<IAspireStore>();
 
                     // Deterministic file path for the configuration file based on its content
-                    var configJsonPath = aspireStore.GetFileNameWithContent($"{builder.Resource.Name}-pgadmin-servers.json", tempConfigFile);
+                    var configJsonPath = aspireStore.GetFileNameWithContent($"{builder.Resource.Name}-servers.json", tempConfigFile);
 
                     // Need to grant read access to the config file on unix like systems.
                     if (!OperatingSystem.IsWindows())
@@ -293,8 +293,7 @@ public static class PostgresBuilderExtensions
 
                 // Create a folder using IAspireStore. Its name is deterministic, based on all the database resources
                 // such that the same folder is reused across persistent usages, and changes in configuration require
-                // new folders. Note that when using dynamic proxies the configuration won't be reused, but it only makes
-                // sense for persistent containers (when pg servers are reused) in which case they would have fixed ports.
+                // new folders.
 
                 var postgresInstances = builder.ApplicationBuilder.Resources.OfType<PostgresDatabaseResource>();
 
@@ -304,7 +303,7 @@ public static class PostgresBuilderExtensions
 
                 // Create a deterministic folder name based on the content hash such that the same folder is reused across
                 // persistent usages.
-                var pgwebBookmarks = Path.Combine(aspireStore.BasePath, $"{pgwebContainerBuilder.Resource.Name}.{Convert.ToHexString(contentHash)[..12].ToLowerInvariant()}");
+                var pgwebBookmarks = Path.Combine(aspireStore.BasePath, $"{pgwebContainer.Name}.{Convert.ToHexString(contentHash)[..12].ToLowerInvariant()}");
 
                 try
                 {

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -103,13 +103,13 @@ public static class SqlServerBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
     /// The container starts up as non-root and the <paramref name="source"/> directory must be readable by the user that the container runs as.
-    /// https://learn.microsoft.com/sql/linux/sql-server-linux-docker-container-configure?view=sql-server-ver16&pivots=cs1-bash#mount-a-host-directory-as-data-volume
+    /// https://learn.microsoft.com/sql/linux/sql-server-linux-docker-container-configure?view=sql-server-ver16&amp;pivots=cs1-bash#mount-a-host-directory-as-data-volume
     /// </remarks>
     public static IResourceBuilder<SqlServerServerResource> WithDataBindMount(this IResourceBuilder<SqlServerServerResource> builder, string source, bool isReadOnly = false)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(source);
 
-        return builder.WithBindMount(source, $"/var/opt/mssql", isReadOnly);
+        return builder.WithBindMount(source, "/var/opt/mssql", isReadOnly);
     }
 }

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -112,11 +112,6 @@ public static class SqlServerBuilderExtensions
         {
             var path = Path.Combine(source, dir);
 
-            if (!Directory.Exists(path))
-            {
-                Directory.CreateDirectory(path);
-            }
-
             builder.WithBindMount(path, $"/var/opt/mssql/{dir}", isReadOnly);
         }
 

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -101,20 +101,15 @@ public static class SqlServerBuilderExtensions
     /// <param name="source">The source directory on the host to mount into the container.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only mount.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// The container starts up as non-root and the <paramref name="source"/> directory must be readable by the user that the container runs as.
+    /// https://learn.microsoft.com/sql/linux/sql-server-linux-docker-container-configure?view=sql-server-ver16&pivots=cs1-bash#mount-a-host-directory-as-data-volume
+    /// </remarks>
     public static IResourceBuilder<SqlServerServerResource> WithDataBindMount(this IResourceBuilder<SqlServerServerResource> builder, string source, bool isReadOnly = false)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(source);
 
-        // c.f. https://learn.microsoft.com/sql/linux/sql-server-linux-docker-container-configure?view=sql-server-ver15&pivots=cs1-bash#mount-a-host-directory-as-data-volume
-
-        foreach (var dir in new string[] { "data", "log", "secrets" })
-        {
-            var path = Path.Combine(source, dir);
-
-            builder.WithBindMount(path, $"/var/opt/mssql/{dir}", isReadOnly);
-        }
-
-        return builder;
+        return builder.WithBindMount(source, $"/var/opt/mssql", isReadOnly);
     }
 }

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1188,7 +1188,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             spec.Ports = BuildContainerPorts(cr);
         }
 
-        spec.VolumeMounts = BuildBindMounts(modelContainerResource);
+        spec.VolumeMounts = BuildContainerMounts(modelContainerResource);
 
         (spec.RunArgs, var failedToApplyRunArgs) = await BuildRunArgsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
 
@@ -1631,7 +1631,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
         return ports;
     }
 
-    private static List<VolumeMount> BuildBindMounts(IResource container)
+    private static List<VolumeMount> BuildContainerMounts(IResource container)
     {
         var volumeMounts = new List<VolumeMount>();
 

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1080,24 +1080,6 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             ctr.Annotate(CustomResource.OtelServiceInstanceIdAnnotation, containerObjectInstance.Suffix);
             SetInitialResourceState(container, ctr);
 
-            if (container.TryGetContainerMounts(out var containerMounts))
-            {
-                ctr.Spec.VolumeMounts = [];
-
-                foreach (var mount in containerMounts)
-                {
-                    var volumeSpec = new VolumeMount
-                    {
-                        Source = mount.Source,
-                        Target = mount.Target,
-                        Type = mount.Type == ContainerMountType.BindMount ? VolumeMountType.Bind : VolumeMountType.Volume,
-                        IsReadOnly = mount.IsReadOnly
-                    };
-
-                    ctr.Spec.VolumeMounts.Add(volumeSpec);
-                }
-            }
-
             ctr.Spec.Networks = new List<ContainerNetworkConnection>
             {
                 new ContainerNetworkConnection
@@ -1205,6 +1187,8 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
         {
             spec.Ports = BuildContainerPorts(cr);
         }
+
+        spec.VolumeMounts = BuildBindMounts(modelContainerResource);
 
         (spec.RunArgs, var failedToApplyRunArgs) = await BuildRunArgsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
 
@@ -1645,5 +1629,28 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
         }
 
         return ports;
+    }
+
+    private static List<VolumeMount> BuildBindMounts(IResource container)
+    {
+        var volumeMounts = new List<VolumeMount>();
+
+        if (container.TryGetContainerMounts(out var containerMounts))
+        {
+            foreach (var mount in containerMounts)
+            {
+                var volumeSpec = new VolumeMount
+                {
+                    Source = mount.Source,
+                    Target = mount.Target,
+                    Type = mount.Type == ContainerMountType.BindMount ? VolumeMountType.Bind : VolumeMountType.Volume,
+                    IsReadOnly = mount.IsReadOnly
+                };
+
+                volumeMounts.Add(volumeSpec);
+            }
+        }
+
+        return volumeMounts;
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -438,9 +438,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
             // Ensure the configuration file has correct attributes
             var fileInfo = new FileInfo(volumeAnnotation.Source!);
 
-            var expectedUnixFileMode =
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+            var expectedUnixFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
 
             Assert.True(fileInfo.UnixFileMode.HasFlag(expectedUnixFileMode));
         }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -475,9 +475,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             // Ensure the configuration file has correct attributes
             var fileInfo = new FileInfo(volumeAnnotation.Source!);
 
-            var expectedUnixFileMode =
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+            var expectedUnixFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
 
             Assert.True(fileInfo.UnixFileMode.HasFlag(expectedUnixFileMode));
         }

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -133,9 +133,8 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
                 }
                 else
                 {
-                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
+                    // The docker container runs as a non-root user, so we need to grant other user's read/write permission
                     // to the bind mount directory.
-                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
 
                     const UnixFileMode BindMountPermissions =
                         UnixFileMode.UserRead | UnixFileMode.UserWrite |

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -141,7 +141,9 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
                         UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
                         UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
 
-                    Directory.CreateDirectory(bindMountPath, BindMountPermissions);
+                    // Directory.CreateDirectory(bindMountPath, BindMountPermissions);
+                    Directory.CreateDirectory(bindMountPath);
+                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
                 }
 
                 garnet1.WithDataBindMount(bindMountPath);

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -125,23 +125,19 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
-                if (OperatingSystem.IsWindows())
+                if (!OperatingSystem.IsWindows())
                 {
-                    Directory.CreateDirectory(bindMountPath);
-                }
-                else
-                {
-                    // The docker container runs as a non-root user, so we need to grant other user's read/write permission
+                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
                     // to the bind mount directory.
-
+                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
                     const UnixFileMode BindMountPermissions =
                         UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
                         UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
                         UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
-                    Directory.CreateDirectory(bindMountPath, BindMountPermissions);
+                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
                 }
 
                 garnet1.WithDataBindMount(bindMountPath);

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -125,9 +125,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-                Directory.CreateDirectory(bindMountPath);
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 if (!OperatingSystem.IsWindows())
                 {
@@ -135,9 +133,9 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
                     // to the bind mount directory.
                     // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
                     const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
                     File.SetUnixFileMode(bindMountPath, BindMountPermissions);
                 }

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -125,20 +125,9 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-                if (!OperatingSystem.IsWindows())
-                {
-                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
-                    // to the bind mount directory.
-                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
-                    const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
-                }
+                Directory.CreateDirectory(bindMountPath);
 
                 garnet1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -137,13 +137,11 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
                     // to the bind mount directory.
 
                     const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
-                    // Directory.CreateDirectory(bindMountPath, BindMountPermissions);
-                    Directory.CreateDirectory(bindMountPath);
-                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
+                    Directory.CreateDirectory(bindMountPath, BindMountPermissions);
                 }
 
                 garnet1.WithDataBindMount(bindMountPath);

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -135,9 +135,9 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
                     // to the bind mount directory.
                     // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
                     const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
 
                     File.SetUnixFileMode(bindMountPath, BindMountPermissions);
                 }

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -127,7 +127,23 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-                Directory.CreateDirectory(bindMountPath);
+                if (OperatingSystem.IsWindows())
+                {
+                    Directory.CreateDirectory(bindMountPath);
+                }
+                else
+                {
+                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
+                    // to the bind mount directory.
+                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
+
+                    const UnixFileMode BindMountPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
+
+                    Directory.CreateDirectory(bindMountPath, BindMountPermissions);
+                }
 
                 garnet1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -127,6 +127,21 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
+                Directory.CreateDirectory(bindMountPath);
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // The docker container runs as a non-root user, so we need to grant other user's read/write permission
+                    // to the bind mount directory.
+                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
+                    const UnixFileMode BindMountPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
+                }
+
                 garnet1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -125,20 +125,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
-
-                if (!OperatingSystem.IsWindows())
-                {
-                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
-                    // to the bind mount directory.
-                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
-                    const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
-                }
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 garnet1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -136,20 +136,7 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
-
-                if (!OperatingSystem.IsWindows())
-                {
-                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
-                    // to the bind mount directory.
-                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
-                    const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
-                }
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 kafka1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -136,23 +136,19 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
-                if (OperatingSystem.IsWindows())
+                if (!OperatingSystem.IsWindows())
                 {
-                    Directory.CreateDirectory(bindMountPath);
-                }
-                else
-                {
-                    // The docker container runs as a non-root user, so we need to grant other user's read/write permission
+                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
                     // to the bind mount directory.
-
+                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
                     const UnixFileMode BindMountPermissions =
                         UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
                         UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
                         UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
-                    Directory.CreateDirectory(bindMountPath, BindMountPermissions);
+                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
                 }
 
                 kafka1.WithDataBindMount(bindMountPath);

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -146,9 +146,9 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
                     // to the bind mount directory.
                     // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
                     const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
 
                     File.SetUnixFileMode(bindMountPath, BindMountPermissions);
                 }

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -136,9 +136,7 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-                Directory.CreateDirectory(bindMountPath);
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 if (!OperatingSystem.IsWindows())
                 {
@@ -146,9 +144,9 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
                     // to the bind mount directory.
                     // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
                     const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
                     File.SetUnixFileMode(bindMountPath, BindMountPermissions);
                 }

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -148,13 +148,11 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
                     // to the bind mount directory.
 
                     const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
-                    // Directory.CreateDirectory(bindMountPath, BindMountPermissions);
-                    Directory.CreateDirectory(bindMountPath);
-                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
+                    Directory.CreateDirectory(bindMountPath, BindMountPermissions);
                 }
 
                 kafka1.WithDataBindMount(bindMountPath);

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -136,20 +136,10 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-                if (!OperatingSystem.IsWindows())
-                {
-                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
-                    // to the bind mount directory.
-                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
-                    const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+                Directory.CreateDirectory(bindMountPath);
 
-                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
-                }
                 kafka1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -138,7 +138,23 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-                Directory.CreateDirectory(bindMountPath);
+                if (OperatingSystem.IsWindows())
+                {
+                    Directory.CreateDirectory(bindMountPath);
+                }
+                else
+                {
+                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
+                    // to the bind mount directory.
+                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
+
+                    const UnixFileMode BindMountPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
+
+                    Directory.CreateDirectory(bindMountPath, BindMountPermissions);
+                }
 
                 kafka1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -144,9 +144,8 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
                 }
                 else
                 {
-                    // the docker container runs as a non-root user, so we need to grant other user's read/write permission
+                    // The docker container runs as a non-root user, so we need to grant other user's read/write permission
                     // to the bind mount directory.
-                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
 
                     const UnixFileMode BindMountPermissions =
                         UnixFileMode.UserRead | UnixFileMode.UserWrite |

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -138,6 +138,21 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
+                Directory.CreateDirectory(bindMountPath);
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // The docker container runs as a non-root user, so we need to grant other user's read/write permission
+                    // to the bind mount directory.
+                    // Note that we need to do this after creating the directory, because the umask is applied at the time of creation.
+                    const UnixFileMode BindMountPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
+                }
+
                 kafka1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -152,7 +152,9 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
                         UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
                         UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
 
-                    Directory.CreateDirectory(bindMountPath, BindMountPermissions);
+                    // Directory.CreateDirectory(bindMountPath, BindMountPermissions);
+                    Directory.CreateDirectory(bindMountPath);
+                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
                 }
 
                 kafka1.WithDataBindMount(bindMountPath);

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -93,18 +93,8 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
-
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
+                // Milvus container runs as root and will create the directory.
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 milvus1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -93,7 +93,19 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
+
                 milvus1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -134,7 +134,19 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
+
                 mongodb1.WithDataBindMount(bindMountPath);
             }
 
@@ -264,9 +276,9 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
         {
             // Change permissions for non-root accounts (container user account)
             const UnixFileMode OwnershipPermissions =
-                UnixFileMode.UserRead | UnixFileMode.UserWrite |
-                UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
-                UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
             File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
         }

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -260,18 +260,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2) })
             .Build();
 
-        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
-
-        if (!OperatingSystem.IsWindows())
-        {
-            // Change permissions for non-root accounts (container user account)
-            const UnixFileMode OwnershipPermissions =
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-            File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-        }
+        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
         try
         {

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -134,18 +134,8 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
-
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
+                // MongoDB container runs as root and will create the directory.
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 mongodb1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -264,9 +264,9 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
         {
             // Change permissions for non-root accounts (container user account)
             const UnixFileMode OwnershipPermissions =
-               UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-               UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-               UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+                UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
 
             File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
         }

--- a/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
@@ -245,28 +245,38 @@ public class AddMySqlTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(myAdmin, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
+        var container = builder.Resources.Single(r => r.Name == "mySql-phpmyadmin");
+        Assert.Empty(container.Annotations.OfType<ContainerMountAnnotation>());
+
         Assert.Equal($"{mysql.Resource.Name}:{mysql.Resource.PrimaryEndpoint.TargetPort}", config["PMA_HOST"]);
         Assert.NotNull(config["PMA_USER"]);
         Assert.NotNull(config["PMA_PASSWORD"]);
     }
 
     [Fact]
-    public void WithPhpMyAdminAddsContainer()
+    public async Task WithPhpMyAdminAddsContainer()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.AddMySql("mySql").WithPhpMyAdmin();
 
-        var container = builder.Resources.Single(r => r.Name == "mySql-phpmyadmin");
-        var volume = container.Annotations.OfType<ContainerMountAnnotation>().Single();
+        using var app = builder.Build();
+        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
 
-        Assert.True(File.Exists(volume.Source)); // File should exist, but will be empty.
-        Assert.Equal("/etc/phpmyadmin/config.user.inc.php", volume.Target);
+        var container = builder.Resources.Single(r => r.Name == "mySql-phpmyadmin");
+        var volumes = container.Annotations.OfType<ContainerMountAnnotation>();
+
+        // No custom configuration is created for a single instance
+        Assert.Empty(volumes);
     }
 
     [Fact]
     public void WithPhpMyAdminProducesValidServerConfigFile()
     {
         var builder = DistributedApplication.CreateBuilder();
+
+        var tempStorePath = Directory.CreateTempSubdirectory().FullName;
+        builder.Configuration["Aspire:Store:Path"] = tempStorePath;
+
         var mysql1 = builder.AddMySql("mysql1").WithPhpMyAdmin(c => c.WithHostPort(8081));
         var mysql2 = builder.AddMySql("mysql2").WithPhpMyAdmin(c => c.WithHostPort(8081));
 
@@ -274,13 +284,13 @@ public class AddMySqlTests
         mysql1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
         mysql2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5002, "host3"));
 
-        var myAdmin = builder.Resources.Single(r => r.Name.EndsWith("-phpmyadmin"));
-        var volume = myAdmin.Annotations.OfType<ContainerMountAnnotation>().Single();
-
         using var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+
+        var myAdmin = builder.Resources.Single(r => r.Name.EndsWith("-phpmyadmin"));
+        var volume = myAdmin.Annotations.OfType<ContainerMountAnnotation>().Single();
 
         using var stream = File.OpenRead(volume.Source!);
         var fileContents = new StreamReader(stream).ReadToEnd();
@@ -292,6 +302,15 @@ public class AddMySqlTests
         Assert.True(match1.Success);
         Match match2 = Regex.Match(fileContents, pattern2);
         Assert.True(match2.Success);
+
+        try
+        {
+            Directory.Delete(tempStorePath, true);
+        }
+        catch
+        {
+            // Ignore.
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
@@ -254,22 +254,6 @@ public class AddMySqlTests
     }
 
     [Fact]
-    public async Task WithPhpMyAdminAddsContainer()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create();
-        builder.AddMySql("mySql").WithPhpMyAdmin();
-
-        using var app = builder.Build();
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
-        var container = builder.Resources.Single(r => r.Name == "mySql-phpmyadmin");
-        var volumes = container.Annotations.OfType<ContainerMountAnnotation>();
-
-        // No custom configuration is created for a single instance
-        Assert.Empty(volumes);
-    }
-
-    [Fact]
     public void WithPhpMyAdminProducesValidServerConfigFile()
     {
         var builder = DistributedApplication.CreateBuilder();

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -146,6 +146,18 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
             else
             {
                 bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
+
                 mysql1.WithDataBindMount(bindMountPath);
             }
 
@@ -301,17 +313,21 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2), ShouldHandle = new PredicateBuilder().Handle<MySqlException>() })
             .Build();
 
-        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+        if (!OperatingSystem.IsWindows())
+        {
+            // Change permissions for non-root accounts (container user account)
+            const UnixFileMode OwnershipPermissions =
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+            File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+        }
 
         try
         {
-            if (Directory.Exists(bindMountPath))
-            {
-                Directory.Delete(bindMountPath);
-            }
-
-            Directory.CreateDirectory(bindMountPath);
-
             File.WriteAllText(Path.Combine(bindMountPath, "init.sql"), """
                 CREATE TABLE cars (brand VARCHAR(255));
                 INSERT INTO cars (brand) VALUES ('BatMobile');

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -147,17 +147,6 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
-
                 mysql1.WithDataBindMount(bindMountPath);
             }
 
@@ -313,18 +302,9 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2), ShouldHandle = new PredicateBuilder().Handle<MySqlException>() })
             .Build();
 
-        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
+        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-        if (!OperatingSystem.IsWindows())
-        {
-            // Change permissions for non-root accounts (container user account)
-            const UnixFileMode OwnershipPermissions =
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-            File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-        }
+        Directory.CreateDirectory(bindMountPath);
 
         try
         {

--- a/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
@@ -176,17 +176,6 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
-
                 nats1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
@@ -175,6 +175,18 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
             else
             {
                 bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
+
                 nats1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -22,8 +22,9 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
     // for the non-root user in the container to be able to access them.
 
     private const UnixFileMode MountFilePermissions =
-       UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-       UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+                UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
 
     private const string DatabaseReadyText = "Completed: ALTER DATABASE OPEN";
 

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -22,9 +22,8 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
     // for the non-root user in the container to be able to access them.
 
     private const UnixFileMode MountFilePermissions =
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+       UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+       UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
     private const string DatabaseReadyText = "Completed: ALTER DATABASE OPEN";
 

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -22,9 +22,9 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
     // for the non-root user in the container to be able to access them.
 
     private const UnixFileMode MountFilePermissions =
-                UnixFileMode.UserRead | UnixFileMode.UserWrite |
-                UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
-                UnixFileMode.OtherRead | UnixFileMode.OtherWrite;
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
     private const string DatabaseReadyText = "Completed: ALTER DATABASE OPEN";
 

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -369,11 +369,16 @@ public class AddPostgresTests
     }
 
     [Fact]
-    public void WithPgAdminAddsContainer()
+    public async Task WithPgAdminAddsContainer()
     {
-
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.AddPostgres("mypostgres").WithPgAdmin(pga => pga.WithHostPort(8081));
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // The mount annotation is added in the AfterEndpointsAllocatedEvent.
+        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
 
         var container = builder.Resources.Single(r => r.Name == "mypostgres-pgadmin");
         var volume = container.Annotations.OfType<ContainerMountAnnotation>().Single();
@@ -450,6 +455,10 @@ public class AddPostgresTests
     public async Task WithPostgresProducesValidServersJsonFile()
     {
         var builder = DistributedApplication.CreateBuilder();
+
+        var tempStorePath = Directory.CreateTempSubdirectory().FullName;
+        builder.Configuration["Aspire:Store:Path"] = tempStorePath;
+
         var username = builder.AddParameter("pg-user", "myuser");
         var pg1 = builder.AddPostgres("mypostgres1").WithPgAdmin(pga => pga.WithHostPort(8081));
         var pg2 = builder.AddPostgres("mypostgres2", username).WithPgAdmin(pga => pga.WithHostPort(8081));
@@ -458,12 +467,12 @@ public class AddPostgresTests
         pg1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
         pg2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5002, "host2"));
 
-        var pgadmin = builder.Resources.Single(r => r.Name.EndsWith("-pgadmin"));
-        var volume = pgadmin.Annotations.OfType<ContainerMountAnnotation>().Single();
-
         using var app = builder.Build();
 
         await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+
+        var pgadmin = builder.Resources.Single(r => r.Name.EndsWith("-pgadmin"));
+        var volume = pgadmin.Annotations.OfType<ContainerMountAnnotation>().Single();
 
         using var stream = File.OpenRead(volume.Source!);
         var document = JsonDocument.Parse(stream);
@@ -489,12 +498,25 @@ public class AddPostgresTests
         Assert.Equal("prefer", servers.GetProperty("2").GetProperty("SSLMode").GetString());
         Assert.Equal("postgres", servers.GetProperty("2").GetProperty("MaintenanceDB").GetString());
         Assert.Equal($"echo '{pg2.Resource.PasswordParameter.Value}'", servers.GetProperty("2").GetProperty("PasswordExecCommand").GetString());
+
+        try
+        {
+            Directory.Delete(tempStorePath, true);
+        }
+        catch
+        {
+            // Ignore.
+        }
     }
 
     [Fact]
     public async Task WithPgwebProducesValidBookmarkFiles()
     {
         var builder = DistributedApplication.CreateBuilder();
+
+        var tempStorePath = Directory.CreateTempSubdirectory().FullName;
+        builder.Configuration["Aspire:Store:Path"] = tempStorePath;
+
         var pg1 = builder.AddPostgres("mypostgres1").WithPgWeb(pga => pga.WithHostPort(8081));
         var pg2 = builder.AddPostgres("mypostgres2").WithPgWeb(pga => pga.WithHostPort(8081));
 
@@ -505,13 +527,13 @@ public class AddPostgresTests
         var db1 = pg1.AddDatabase("db1");
         var db2 = pg2.AddDatabase("db2");
 
-        var pgadmin = builder.Resources.Single(r => r.Name.EndsWith("-pgweb"));
-        var volume = pgadmin.Annotations.OfType<ContainerMountAnnotation>().Single();
-
         using var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+
+        var pgadmin = builder.Resources.Single(r => r.Name.EndsWith("-pgweb"));
+        var volume = pgadmin.Annotations.OfType<ContainerMountAnnotation>().Single();
 
         var bookMarkFiles = Directory.GetFiles(volume.Source!).OrderBy(f => f).ToArray();
 
@@ -542,6 +564,15 @@ public class AddPostgresTests
             {
                 Assert.Equal(CreatePgWebBookmarkfileContent(db2.Resource), content);
             });
+
+        try
+        {
+            Directory.Delete(tempStorePath, true);
+        }
+        catch
+        {
+            // Ignore.
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -448,7 +448,7 @@ public class AddPostgresTests
         builder.AddPostgres("mypostgres1").WithPgAdmin(pga => pga.WithHostPort(8081));
         builder.AddPostgres("mypostgres2").WithPgAdmin(pga => pga.WithHostPort(8081));
 
-        builder.Resources.Single(r => r.Name.EndsWith("-pgadmin"));
+        Assert.Single(builder.Resources.Where(r => r.Name.EndsWith("-pgadmin")));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -375,18 +375,9 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 10, Delay = TimeSpan.FromSeconds(2) })
             .Build();
 
-        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
+        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-        if (!OperatingSystem.IsWindows())
-        {
-            // Change permissions for non-root accounts (container user account)
-            const UnixFileMode OwnershipPermissions =
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-            File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-        }
+        Directory.CreateDirectory(bindMountPath);
 
         try
         {

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -221,18 +221,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
-
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 postgres1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -222,6 +222,18 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             else
             {
                 bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
+
                 postgres1.WithDataBindMount(bindMountPath);
             }
 
@@ -363,9 +375,18 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 10, Delay = TimeSpan.FromSeconds(2) })
             .Build();
 
-        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
-        Directory.CreateDirectory(bindMountPath);
+        if (!OperatingSystem.IsWindows())
+        {
+            // Change permissions for non-root accounts (container user account)
+            const UnixFileMode OwnershipPermissions =
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+            File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+        }
 
         try
         {

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -114,18 +114,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
-
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 qdrant1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -114,7 +114,19 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
+
                 qdrant1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -120,6 +120,18 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
             else
             {
                 bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
+
                 rabbitMQ1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -121,17 +121,6 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
-
                 rabbitMQ1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -378,11 +378,17 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     [RequiresDocker]
     public async Task WithDataBindMountShouldPersistStateBetweenUsages()
     {
-        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
-        if (!Directory.Exists(bindMountPath))
+        if (!OperatingSystem.IsWindows())
         {
-            Directory.CreateDirectory(bindMountPath);
+            // Change permissions for non-root accounts (container user account)
+            const UnixFileMode OwnershipPermissions =
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+            File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
         }
 
         // Use a bind mount to do a snapshot save
@@ -566,7 +572,19 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
+
                 redisInsightBuilder1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -378,18 +378,9 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     [RequiresDocker]
     public async Task WithDataBindMountShouldPersistStateBetweenUsages()
     {
-        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
+        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-        if (!OperatingSystem.IsWindows())
-        {
-            // Change permissions for non-root accounts (container user account)
-            const UnixFileMode OwnershipPermissions =
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-            File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-        }
+        Directory.CreateDirectory(bindMountPath);
 
         // Use a bind mount to do a snapshot save
 
@@ -572,18 +563,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
-
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 redisInsightBuilder1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -149,9 +149,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-                Directory.CreateDirectory($"{bindMountPath}/data");
-                Directory.CreateDirectory($"{bindMountPath}/log");
-                Directory.CreateDirectory($"{bindMountPath}/secrets");
+                Directory.CreateDirectory(bindMountPath);
 
                 if (!OperatingSystem.IsWindows())
                 {
@@ -163,9 +161,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                         UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
                         UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
-                    File.SetUnixFileMode($"{bindMountPath}/data", BindMountPermissions);
-                    File.SetUnixFileMode($"{bindMountPath}/log", BindMountPermissions);
-                    File.SetUnixFileMode($"{bindMountPath}/secrets", BindMountPermissions);
+                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
                 }
 
                 sqlserver1.WithDataBindMount(bindMountPath);

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -150,39 +150,6 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-                if (OperatingSystem.IsWindows())
-                {
-                    Directory.CreateDirectory(bindMountPath);
-                    Directory.CreateDirectory($"{bindMountPath}/data");
-                    Directory.CreateDirectory($"{bindMountPath}/log");
-                    Directory.CreateDirectory($"{bindMountPath}/secrets");
-                }
-                else
-                {
-                    // The docker container runs as a non-root user, so we need to grant other user's read/write permission
-                    // to the bind mount directory.
-
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode BindMountPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    //Directory.CreateDirectory(bindMountPath, BindMountPermissions);
-                    //Directory.CreateDirectory($"{bindMountPath}/data", BindMountPermissions);
-                    //Directory.CreateDirectory($"{bindMountPath}/log", BindMountPermissions);
-                    //Directory.CreateDirectory($"{bindMountPath}/secrets", BindMountPermissions);
-
-                    Directory.CreateDirectory(bindMountPath);
-                    Directory.CreateDirectory($"{bindMountPath}/data");
-                    Directory.CreateDirectory($"{bindMountPath}/log");
-                    Directory.CreateDirectory($"{bindMountPath}/secrets");
-
-                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
-                    File.SetUnixFileMode($"{bindMountPath}/data", BindMountPermissions);
-                    File.SetUnixFileMode($"{bindMountPath}/log", BindMountPermissions);
-                    File.SetUnixFileMode($"{bindMountPath}/secrets", BindMountPermissions);
-                }
-
                 sqlserver1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -158,10 +158,11 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                     // Change permissions for non-root accounts (container user account)
                     // c.f. https://learn.microsoft.com/sql/linux/sql-server-linux-docker-container-security?view=sql-server-ver16#storagepermissions
 
-                    // This is the minimal set to get the tests passing.
+                    // Change permissions for non-root accounts (container user account)
                     const UnixFileMode MsSqlPermissions =
-                       UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                       UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
                     File.SetUnixFileMode(bindMountPath, MsSqlPermissions);
                     File.SetUnixFileMode($"{bindMountPath}/data", MsSqlPermissions);

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -153,8 +153,6 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                 if (OperatingSystem.IsWindows())
                 {
                     Directory.CreateDirectory(bindMountPath);
-
-                    Directory.CreateDirectory(bindMountPath);
                     Directory.CreateDirectory($"{bindMountPath}/data");
                     Directory.CreateDirectory($"{bindMountPath}/log");
                     Directory.CreateDirectory($"{bindMountPath}/secrets");

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -148,8 +148,18 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-                Directory.CreateDirectory(bindMountPath);
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
 
                 sqlserver1.WithDataBindMount(bindMountPath);
 

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -167,10 +167,20 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                         UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
                         UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
-                    Directory.CreateDirectory(bindMountPath, BindMountPermissions);
-                    Directory.CreateDirectory($"{bindMountPath}/data", BindMountPermissions);
-                    Directory.CreateDirectory($"{bindMountPath}/log", BindMountPermissions);
-                    Directory.CreateDirectory($"{bindMountPath}/secrets", BindMountPermissions);
+                    //Directory.CreateDirectory(bindMountPath, BindMountPermissions);
+                    //Directory.CreateDirectory($"{bindMountPath}/data", BindMountPermissions);
+                    //Directory.CreateDirectory($"{bindMountPath}/log", BindMountPermissions);
+                    //Directory.CreateDirectory($"{bindMountPath}/secrets", BindMountPermissions);
+
+                    Directory.CreateDirectory(bindMountPath);
+                    Directory.CreateDirectory($"{bindMountPath}/data");
+                    Directory.CreateDirectory($"{bindMountPath}/log");
+                    Directory.CreateDirectory($"{bindMountPath}/secrets");
+
+                    File.SetUnixFileMode(bindMountPath, BindMountPermissions);
+                    File.SetUnixFileMode($"{bindMountPath}/data", BindMountPermissions);
+                    File.SetUnixFileMode($"{bindMountPath}/log", BindMountPermissions);
+                    File.SetUnixFileMode($"{bindMountPath}/secrets", BindMountPermissions);
                 }
 
                 sqlserver1.WithDataBindMount(bindMountPath);

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -148,18 +148,9 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
+                Directory.CreateDirectory(bindMountPath);
 
                 sqlserver1.WithDataBindMount(bindMountPath);
 
@@ -171,7 +162,6 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                     // Change permissions for non-root accounts (container user account)
                     const UnixFileMode MsSqlPermissions =
                         UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
                         UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
                     File.SetUnixFileMode(bindMountPath, MsSqlPermissions);

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -80,7 +80,19 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+
+                if (!OperatingSystem.IsWindows())
+                {
+                    // Change permissions for non-root accounts (container user account)
+                    const UnixFileMode OwnershipPermissions =
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+
+                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
+                }
+
                 valkey1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -80,18 +80,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
-
-                if (!OperatingSystem.IsWindows())
-                {
-                    // Change permissions for non-root accounts (container user account)
-                    const UnixFileMode OwnershipPermissions =
-                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-                        UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
-
-                    File.SetUnixFileMode(bindMountPath, OwnershipPermissions);
-                }
+                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 valkey1.WithDataBindMount(bindMountPath);
             }


### PR DESCRIPTION
## Description

- This sets the minimal required file mode for bind mounts, and ensure the tests run with the required file mode for executing non-root containers.
- This delays the preparation of volume mounts such that these can be added in the `AfterEndpointsAllocatedEvent`.
 - Update PostgresQL extensions to use the Aspire Store to store configuration.
 - Update MySql extensions to use the Aspire Store to store configuration.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
