### PR TITLE
Support processing --useHttps flag on Functions applications

### DIFF
--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -184,6 +184,70 @@ public class AzureFunctionsTests
         Assert.StartsWith(AzureFunctionsProjectResourceExtensions.DefaultAzureFunctionsHostStorageName, resource.Name);
     }
 
+    [Fact]
+    public void AddAzureFunctionsProject_WiresUpHttpsEndpointCorrectly_WhenUseHttpsArgumentIsProvided()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.AddAzureFunctionsProject<TestProjectWithHttps>("funcapp");
+
+        // Assert that the EndpointAnnotation is configured correctly
+        var functionsResource = Assert.Single(builder.Resources.OfType<AzureFunctionsProjectResource>());
+        Assert.True(functionsResource.TryGetLastAnnotation<EndpointAnnotation>(out var endpointAnnotation));
+        Assert.Equal(7071, endpointAnnotation.Port);
+        Assert.Equal(7071, endpointAnnotation.TargetPort);
+        Assert.False(endpointAnnotation.IsProxied);
+        Assert.Equal("https", endpointAnnotation.UriScheme);
+    }
+
+    [Fact]
+    public void AddAzureFunctionsProject_ConfiguresEnvironmentVariables_WhenInPublishMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddAzureFunctionsProject<TestProject>("funcapp");
+
+        var functionsResource = Assert.Single(builder.Resources.OfType<AzureFunctionsProjectResource>());
+        Assert.True(functionsResource.TryGetLastAnnotation<EnvironmentCallbackAnnotation>(out var envAnnotation));
+
+        var context = new EnvironmentCallbackContext(builder.ExecutionContext);
+        envAnnotation.Callback(context);
+
+        // Verify ASPNETCORE_URLS is set correctly with the target port
+        var aspNetCoreUrls = context.EnvironmentVariables["ASPNETCORE_URLS"];
+        Assert.NotNull(aspNetCoreUrls);
+        Assert.Contains("8080", aspNetCoreUrls.ToString());
+    }
+
+    [Fact]
+    public async Task AddAzureFunctionsProject_WiresUpHttpsEndpointCorrectly_WhenOnlyUseHttpsArgumentIsProvided()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.AddAzureFunctionsProject<TestProjectWithHttpsNoPort>("funcapp")
+            // Explicit set endpoint values for assertions later
+            .WithEndpoint("https", e =>
+            {
+                e.UriScheme = "https";
+                e.AllocatedEndpoint = new(e, "localhost", 1234);
+                e.TargetPort = 9876;
+            });
+
+        // Assert that the EndpointAnnotation is configured correctly
+        var functionsResource = Assert.Single(builder.Resources.OfType<AzureFunctionsProjectResource>());
+        Assert.True(functionsResource.TryGetLastAnnotation<EndpointAnnotation>(out var endpointAnnotation));
+        Assert.Null(endpointAnnotation.Port);
+        Assert.Equal(9876, endpointAnnotation.TargetPort);
+        Assert.True(endpointAnnotation.IsProxied);
+        Assert.Equal("https", endpointAnnotation.UriScheme);
+
+        // Check that `--port` is present in the args
+        using var app = builder.Build();
+        var args = await ArgumentEvaluator.GetArgumentListAsync(functionsResource);
+
+        Assert.Collection(args,
+            arg => Assert.Equal("--port", arg),
+            arg => Assert.Equal("9876", arg)
+        );
+    }
+
     private sealed class TestProject : IProjectMetadata
     {
         public string ProjectPath => "some-path";
@@ -262,6 +326,40 @@ public class AzureFunctionsTests
                 ["funcapp"] = new()
                 {
                     CommandLineArgs = "--port 7072 --port 7071",
+                    LaunchBrowser = false,
+                }
+            }
+        };
+    }
+
+    private sealed class TestProjectWithHttps : IProjectMetadata
+    {
+        public string ProjectPath => "some-path";
+
+        public LaunchSettings LaunchSettings => new()
+        {
+            Profiles = new Dictionary<string, LaunchProfile>
+            {
+                ["funcapp"] = new()
+                {
+                    CommandLineArgs = "--port 7071 --useHttps",
+                    LaunchBrowser = false,
+                }
+            }
+        };
+    }
+
+    private sealed class TestProjectWithHttpsNoPort : IProjectMetadata
+    {
+        public string ProjectPath => "some-path";
+
+        public LaunchSettings LaunchSettings => new()
+        {
+            Profiles = new Dictionary<string, LaunchProfile>
+            {
+                ["funcapp"] = new()
+                {
+                    CommandLineArgs = "--useHttps",
                     LaunchBrowser = false,
                 }
             }


### PR DESCRIPTION
## Description

The Functions host supports passing a `--useHttps` flag to support binding to `https://localhost:*` instead of `http://localhost:*`. This change supports picking up this flag and mapping to a target endpoint with the correct scheme.

There's likely more work to be done here (validate what happens with custom certs, etc.) but this wires up the Aspire-specific things at least.

Conributes to https://github.com/dotnet/aspire/issues/7150

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [X] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [X] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
