### PR TITLE
Enhance resource management for connection strings

### DIFF
--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
@@ -21,9 +21,12 @@ var db = builder.AddSqlServer("sql")
 
 var insertionrows = builder.AddParameter("insertionrows");
 
+var cs = builder.AddConnectionString("cs", $"sql={db};rows={insertionrows}");
+
 builder.AddProject<Projects.ParameterEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()
        .WithEnvironment("InsertionRows", insertionrows)
+       .WithReference(cs)
        .WithReference(db);
 
 #if !SKIP_DASHBOARD_REFERENCE

--- a/playground/withdockerfile/WithDockerfile.AppHost/Program.cs
+++ b/playground/withdockerfile/WithDockerfile.AppHost/Program.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 var builder = DistributedApplication.CreateBuilder(args);
-builder.Configuration["Parameters:goversion"] = "1.22"; // Just for validating parameter handling in Dockerfile builds.
 
-var goVersion = builder.AddParameter("goversion");
+// Just for validating parameter handling in Dockerfile builds.
+var goVersion = builder.AddParameter("goversion", "1.22");
 var secret = builder.AddParameter("secret", secret: true);
 
 builder.AddDockerfile("mycontainer", "qots")

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -174,7 +174,7 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
         return value switch
         {
             ConnectionStringReference cs => await ResolveConnectionStringReferenceAsync(cs).ConfigureAwait(false),
-            IResourceWithConnectionString cs and not ResourceWithConnectionStringSurrogate => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
+            IResourceWithConnectionString cs and not ConnectionStringParameterResource => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
             ReferenceExpression ex => await EvalExpressionAsync(ex).ConfigureAwait(false),
             EndpointReference endpointReference when sourceIsContainer => new ResolvedValue(await EvalEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false), false),
             EndpointReferenceExpression ep when sourceIsContainer => new ResolvedValue(await EvalEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false), false),

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithoutLifetime.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithoutLifetime.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a resource that does not have a lifetime. Reserved for resources that are just holders of data or references to other resources.
+/// </summary>
+public interface IResourceWithoutLifetime : IResource
+{
+
+}

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -65,7 +65,8 @@ public class ParameterResource : Resource, IResourceWithoutLifetime, IManifestEx
     public string ValueExpression => $"{{{Name}.value}}";
 
     /// <summary>
-    /// The configuration key for this parameter, the default is
+    /// The configuration key for this parameter. The default format is "ConnectionStrings:{Name}" if the parameter is a connection string,
+    /// otherwise it is "Parameters:{Name}".
     /// </summary>
     internal string ConfigurationKey
     {

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -6,11 +6,12 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a parameter resource.
 /// </summary>
-public class ParameterResource : Resource, IManifestExpressionProvider, IValueProvider
+public class ParameterResource : Resource, IResourceWithoutLifetime, IManifestExpressionProvider, IValueProvider
 {
     private string? _value;
     private bool _hasValue;
     private readonly Func<ParameterDefault?, string> _valueGetter;
+    private string? _configurationKey;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ParameterResource"/>.
@@ -62,6 +63,15 @@ public class ParameterResource : Resource, IManifestExpressionProvider, IValuePr
     /// Gets the expression used in the manifest to reference the value of the parameter.
     /// </summary>
     public string ValueExpression => $"{{{Name}.value}}";
+
+    /// <summary>
+    /// The configuration key for this parameter, the default is
+    /// </summary>
+    internal string ConfigurationKey
+    {
+        get => _configurationKey ?? (IsConnectionString ? $"ConnectionStrings:{Name}" : $"Parameters:{Name}");
+        set => _configurationKey = value;
+    }
 
     ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => new(Value);
 }

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -132,6 +132,21 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
             _manifestExpressions.Add(valueProvider.ValueExpression);
         }
 
+        /// <summary>
+        /// Appends a formatted value to the expression. The value must implement <see cref="IValueProvider"/> and <see cref="IManifestExpressionProvider"/>.
+        /// </summary>
+        /// <param name="valueProvider">An instance of an object which implements <see cref="IValueProvider"/> and <see cref="IManifestExpressionProvider"/>.</param>
+        /// <exception cref="InvalidOperationException"></exception>
+        public void AppendFormatted<T>(IResourceBuilder<T> valueProvider)
+            where T : IResource, IValueProvider, IManifestExpressionProvider
+        {
+            var index = _valueProviders.Count;
+            _builder.Append(CultureInfo.InvariantCulture, $"{{{index}}}");
+
+            _valueProviders.Add(valueProvider.Resource);
+            _manifestExpressions.Add(valueProvider.Resource.ValueExpression);
+        }
+
         internal readonly ReferenceExpression GetExpression() =>
             new(_builder.ToString(), [.. _valueProviders], [.. _manifestExpressions]);
     }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -288,9 +288,9 @@ public static class ResourceExtensions
                     {
                         (_, string s) => new(s, false),
                         (DistributedApplicationOperation.Run, IValueProvider provider) => await GetValue(key: null, provider, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
-                        (DistributedApplicationOperation.Run, DistributedApplicationResourceBuilder<ParameterResource> parameterResourceBuilder) => await GetValue(key: null, parameterResourceBuilder.Resource, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
-                        (DistributedApplicationOperation.Run, DistributedApplicationResourceBuilder<ResourceWithConnectionStringSurrogate> connectionStringSurrogateBuilder) => await GetValue(key: null, connectionStringSurrogateBuilder.Resource, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
+                        (DistributedApplicationOperation.Run, IResourceBuilder<IResource> rb) when rb.Resource is IValueProvider provider => await GetValue(key: null, provider, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
                         (DistributedApplicationOperation.Publish, IManifestExpressionProvider provider) => new(provider.ValueExpression, false),
+                        (DistributedApplicationOperation.Publish, IResourceBuilder<IResource> rb) when rb.Resource is IManifestExpressionProvider provider => new(provider.ValueExpression, false),
                         (_, { } o) => new(o.ToString(), false),
                         (_, null) => new(null, false),
                     };
@@ -337,7 +337,9 @@ public static class ResourceExtensions
                     {
                         (_, string s) => new(s, false),
                         (DistributedApplicationOperation.Run, IValueProvider provider) => await GetValue(key, provider, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
+                        (DistributedApplicationOperation.Run, IResourceBuilder<IResource> rb) when rb.Resource is IValueProvider provider => await GetValue(key, provider, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
                         (DistributedApplicationOperation.Publish, IManifestExpressionProvider provider) => new(provider.ValueExpression, false),
+                        (DistributedApplicationOperation.Publish, IResourceBuilder<IResource> rb) when rb.Resource is IManifestExpressionProvider provider => new(provider.ValueExpression, false),
                         (_, { } o) => new(o.ToString(), false),
                         (_, null) => new(null, false),
                     };

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -372,11 +372,10 @@ public class ResourceNotificationService : IDisposable
         var pendingDependencies = new List<Task>();
         foreach (var waitAnnotation in waitAnnotations)
         {
-            if (waitAnnotation.Resource is ParameterResource or ResourceWithConnectionStringSurrogate)
+            if (waitAnnotation.Resource is IResourceWithoutLifetime)
             {
-                // Parameters and connection string resources are inert and don't need to be waited on.
-                // If we add support for parameter resources that can be waited on, we can remove this check.
-                // As of right now, we don't support waiting on parameter resources.
+                // IResourceWithoutLifetime are inert and don't need to be waited on.
+                // If we add support for parameter resources that can be waited on.
                 continue;
             }
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -375,7 +375,6 @@ public class ResourceNotificationService : IDisposable
             if (waitAnnotation.Resource is IResourceWithoutLifetime)
             {
                 // IResourceWithoutLifetime are inert and don't need to be waited on.
-                // If we add support for parameter resources that can be waited on.
                 continue;
             }
 

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for adding connection string resources to an application.
+/// </summary>
+public static class ConnectionStringBuilderExtensions
+{
+    /// <summary>
+    /// Adds a connection string to the distributed application a resource with the specified expression.
+    /// </summary>
+    /// <param name="builder">Distributed application builder</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="connectionStringExpression">The connection string expression.</param>
+    /// <returns></returns>
+    public static IResourceBuilder<ConnectionStringResource> AddConnectionString(this IDistributedApplicationBuilder builder, [ResourceName] string name, ReferenceExpression connectionStringExpression)
+    {
+        var cs = new ConnectionStringResource(name, connectionStringExpression);
+        return builder.AddResource(cs)
+                      .WithInitialState(new CustomResourceSnapshot
+                      {
+                          ResourceType = "ConnectionString",
+                          // TODO: We'll hide this until we come up with a sane representation of these in the dashboard
+                          State = KnownResourceStates.Hidden,
+                          Properties = []
+                      });
+    }
+
+    /// <summary>
+    /// Adds a connection string to the distributed application a resource with the specified expression.
+    /// </summary>
+    /// <param name="builder">Distributed application builder</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="connectionStringExpression">The connection string expression.</param>
+    /// <returns></returns>
+    public static IResourceBuilder<ConnectionStringResource> AddConnectionString(this IDistributedApplicationBuilder builder, [ResourceName] string name, ReferenceExpression.ExpressionInterpolatedStringHandler connectionStringExpression)
+    {
+        return builder.AddConnectionString(name, ReferenceExpression.Create(connectionStringExpression));
+    }
+}

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting;
 public static class ConnectionStringBuilderExtensions
 {
     /// <summary>
-    /// Adds a connection string to the distributed application a resource with the specified expression.
+    /// Adds a connection string resource to the distributed application with the specified expression.
     /// </summary>
     /// <param name="builder">Distributed application builder</param>
     /// <param name="name">The name of the resource.</param>

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -12,10 +12,32 @@ public static class ConnectionStringBuilderExtensions
     /// <summary>
     /// Adds a connection string resource to the distributed application with the specified expression.
     /// </summary>
+    /// <remarks>
+    /// This method also enables appending custom data to the connection string based on other resources that expose connection strings.
+    /// </remarks>
     /// <param name="builder">Distributed application builder</param>
     /// <param name="name">The name of the resource.</param>
     /// <param name="connectionStringExpression">The connection string expression.</param>
-    /// <returns></returns>
+    /// <returns>An <see cref="IResourceBuilder{ConnectionStringResource}"/> instance.</returns>
+    /// <example>
+    /// <code language="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var postgres = builder
+    ///     .AddPostgres("postgres")
+    ///
+    /// var database = postgres.AddDatabase("database");
+    ///
+    /// var cs = builder.AddConnectionString("cs", $"{database};Include Error Details=true");
+    ///
+    /// var backend = builder
+    ///     .AddProject&lt;Projects.Backend&gt;("backend")
+    ///     .WithReference(cs) // cs is the connection string name, not database
+    ///     .WaitFor(database);
+    ///
+    /// builder.Build().Run();
+    /// </code>
+    /// </example>
     public static IResourceBuilder<ConnectionStringResource> AddConnectionString(this IDistributedApplicationBuilder builder, [ResourceName] string name, ReferenceExpression connectionStringExpression)
     {
         var cs = new ConnectionStringResource(name, connectionStringExpression);
@@ -32,10 +54,23 @@ public static class ConnectionStringBuilderExtensions
     /// <summary>
     /// Adds a connection string to the distributed application a resource with the specified expression.
     /// </summary>
+    /// <remarks>
+    /// This method also enables appending custom data to the connection string based on other resources that expose connection strings.
+    /// </remarks>
     /// <param name="builder">Distributed application builder</param>
     /// <param name="name">The name of the resource.</param>
     /// <param name="connectionStringExpression">The connection string expression.</param>
-    /// <returns></returns>
+    /// <returns>An <see cref="IResourceBuilder{ConnectionStringResource}"/> instance.</returns>
+    /// <example>
+    /// <code language="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var endpoint = builder.AddParameter("endpoint", "http://localhost:3452");
+    /// var key = builder.AddParameter("key", secret: true);
+    /// 
+    /// builder.AddConnectionString("myconnection", $"Endpoint={endpoint};Key={key}");
+    /// </code>
+    /// </example>
     public static IResourceBuilder<ConnectionStringResource> AddConnectionString(this IDistributedApplicationBuilder builder, [ResourceName] string name, ReferenceExpression.ExpressionInterpolatedStringHandler connectionStringExpression)
     {
         return builder.AddConnectionString(name, ReferenceExpression.Create(connectionStringExpression));

--- a/src/Aspire.Hosting/ConnectionStringParameterResource.cs
+++ b/src/Aspire.Hosting/ConnectionStringParameterResource.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.ApplicationModel;
 
-internal sealed class ResourceWithConnectionStringSurrogate : ParameterResource, IResourceWithConnectionString
+namespace Aspire.Hosting;
+
+internal sealed class ConnectionStringParameterResource : ParameterResource, IResourceWithConnectionString
 {
     private readonly string? _environmentVariableName;
 
-    public ResourceWithConnectionStringSurrogate(string name, Func<ParameterDefault?, string> callback, string? environmentVariableName) : base(name, callback, secret: true)
+    public ConnectionStringParameterResource(string name, Func<ParameterDefault?, string> callback, string? environmentVariableName) : base(name, callback, secret: true)
     {
         _environmentVariableName = environmentVariableName;
 

--- a/src/Aspire.Hosting/ConnectionStringResource.cs
+++ b/src/Aspire.Hosting/ConnectionStringResource.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Adds a connection string to the distributed application a resource with the specified expression.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="connectionStringExpression">The connection string expression.</param>
+public sealed class ConnectionStringResource(string name, ReferenceExpression connectionStringExpression) : Resource(name), IResourceWithConnectionString, IResourceWithoutLifetime
+{
+    /// <summary>
+    /// Describes the connection string format string used for this resource.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => connectionStringExpression;
+}

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -531,5 +531,4 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     /// <returns>The metadata value if found; otherwise, null.</returns>
     private static string? GetMetadataValue(IEnumerable<AssemblyMetadataAttribute>? assemblyMetadata, string key) =>
         assemblyMetadata?.FirstOrDefault(a => string.Equals(a.Key, key, StringComparison.OrdinalIgnoreCase))?.Value;
-
 }

--- a/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
@@ -203,7 +203,7 @@ public interface IDistributedApplicationBuilder
     ///     secret: true,
     ///     connectionString: true);
     /// 
-    ///     var surrogate = new ResourceWithConnectionStringSurrogate(parameterBuilder.Resource, environmentVariableName);
+    ///     var surrogate = new ConnectionStringParameterResource(parameterBuilder.Resource, environmentVariableName);
     ///     return builder.CreateResourceBuilder(surrogate);
     /// }
     /// </code>

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -145,7 +145,7 @@ internal sealed class ApplicationOrchestrator
         }
     }
 
-    private async Task OnResourcesPrepared(OnResourcesPreparedContext context)
+    private async Task OnResourcesPrepared(OnResourcesPreparedContext _)
     {
         await PublishResourcesWithInitialStateAsync().ConfigureAwait(false);
     }
@@ -162,10 +162,7 @@ internal sealed class ApplicationOrchestrator
                 {
                     return s with
                     {
-                        Properties = [
-                            ..s.Properties,
-                            new("Value", value) { IsSensitive = resource is ParameterResource p && p.Secret }
-                        ]
+                        Properties = s.Properties.SetResourceProperty("Value", value ?? "", resource is ParameterResource p && p.Secret)
                     };
                 })
                 .ConfigureAwait(false);
@@ -177,10 +174,7 @@ internal sealed class ApplicationOrchestrator
                     return s with
                     {
                         State = new("Value missing", KnownResourceStateStyles.Error),
-                        Properties = [
-                            ..s.Properties,
-                            new("Value", ex.Message)
-                        ]
+                        Properties = s.Properties.SetResourceProperty("Value", ex.Message)
                     };
                 })
                 .ConfigureAwait(false);

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
@@ -111,8 +108,10 @@ public static class ParameterResourceBuilderExtensions
                 new ParameterResource(
                     name,
                     parameterDefault => GetParameterValue(builder.Configuration, name, parameterDefault, configurationKey),
-                    secret),
-                configurationKey);
+                    secret)
+                {
+                    ConfigurationKey = configurationKey
+                });
     }
 
     /// <summary>
@@ -156,14 +155,9 @@ public static class ParameterResourceBuilderExtensions
             ?? throw new DistributedApplicationException($"Parameter resource could not be used because configuration key '{configurationKey}' is missing and the Parameter has no default value."); ;
     }
 
-    internal static IResourceBuilder<T> AddParameter<T>(this IDistributedApplicationBuilder builder,
-                                                        T resource,
-                                                        string? configurationKey = null)
+    internal static IResourceBuilder<T> AddParameter<T>(this IDistributedApplicationBuilder builder, T resource)
         where T : ParameterResource
     {
-        var name = resource.Name;
-        configurationKey ??= resource.IsConnectionString ? $"ConnectionStrings:{name}" : $"Parameters:{name}";
-
         var state = new CustomResourceSnapshot()
         {
             ResourceType = "Parameter",
@@ -171,45 +165,13 @@ public static class ParameterResourceBuilderExtensions
             State = KnownResourceStates.Hidden,
             Properties = [
                 new("parameter.secret", resource.Secret.ToString()),
-                new(CustomResourceKnownProperties.Source, configurationKey) { IsSensitive = resource.Secret }
+                new(CustomResourceKnownProperties.Source, resource.ConfigurationKey)
             ]
         };
-
-        try
-        {
-            state = state with { Properties = [.. state.Properties, new("Value", resource.Value) { IsSensitive = resource.Secret }] };
-        }
-        catch (DistributedApplicationException ex)
-        {
-            state = state with
-            {
-                State = new ResourceStateSnapshot("Configuration missing", KnownResourceStateStyles.Error),
-                Properties = [.. state.Properties, new("Value", ex.Message)]
-            };
-
-            builder.Services.AddLifecycleHook((sp) => new WriteParameterLogsHook(
-                sp.GetRequiredService<ResourceLoggerService>(),
-                name,
-                ex.Message));
-        }
 
         return builder.AddResource(resource)
                       .WithInitialState(state);
     }
-
-    /// <summary>
-    /// Writes the message to the specified resource's logs.
-    /// </summary>
-    private sealed class WriteParameterLogsHook(ResourceLoggerService loggerService, string resourceName, string message) : IDistributedApplicationLifecycleHook
-    {
-        public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
-        {
-            loggerService.GetLogger(resourceName).LogError(message);
-
-            return Task.CompletedTask;
-        }
-    }
-
     /// <summary>
     /// Adds a parameter to the distributed application but wrapped in a resource with a connection string for use with <see cref="ResourceBuilderExtensions.WithReference{TDestination}(IResourceBuilder{TDestination}, IResourceBuilder{IResourceWithConnectionString}, string?, bool)"/>
     /// </summary>
@@ -224,7 +186,7 @@ public static class ParameterResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(name);
 
         return builder.AddParameter(
-                new ResourceWithConnectionStringSurrogate(
+                new ConnectionStringParameterResource(
                     name,
                     _ => builder.Configuration.GetConnectionString(name) ??
                         throw new DistributedApplicationException($"Connection string parameter resource could not be used because connection string '{name}' is missing."),

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -798,6 +798,16 @@ public static class ResourceBuilderExtensions
             builder.WaitForCore(parentBuilder, waitBehavior, addRelationship: false);
         }
 
+        // Wait for any referenced resources in the connection string.
+        if (dependency.Resource is ConnectionStringResource cs)
+        {
+            // We only look at top level resources with the assumption that they are transitive themselves.
+            foreach (var referencedResource in cs.ConnectionStringExpression.ValueProviders.OfType<IResource>())
+            {
+                builder.WaitForCore(builder.ApplicationBuilder.CreateResourceBuilder(referencedResource), waitBehavior, addRelationship: false);
+            }
+        }
+
         if (addRelationship)
         {
             builder.WithRelationship(dependency.Resource, KnownRelationshipTypes.WaitFor);

--- a/src/Shared/CustomResourceSnapshotExtensions.cs
+++ b/src/Shared/CustomResourceSnapshotExtensions.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting;
 
 internal static class CustomResourceSnapshotExtensions
 {
-    internal static ImmutableArray<ResourcePropertySnapshot> SetResourceProperty(this ImmutableArray<ResourcePropertySnapshot> properties, string name, object value)
+    internal static ImmutableArray<ResourcePropertySnapshot> SetResourceProperty(this ImmutableArray<ResourcePropertySnapshot> properties, string name, object value, bool IsSensitive = false)
     {
         for (var i = 0; i < properties.Length; i++)
         {
@@ -23,12 +23,12 @@ internal static class CustomResourceSnapshotExtensions
                 }
 
                 // Set value.
-                return properties.SetItem(i, property with { Value = value });
+                return properties.SetItem(i, property with { Value = value, IsSensitive = IsSensitive });
             }
         }
 
         // Add property.
-        return [.. properties, new ResourcePropertySnapshot(name, value)];
+        return [.. properties, new ResourcePropertySnapshot(name, value) { IsSensitive = IsSensitive }];
     }
 
     internal static ImmutableArray<ResourcePropertySnapshot> SetResourcePropertyRange(this ImmutableArray<ResourcePropertySnapshot> properties, IEnumerable<ResourcePropertySnapshot> newValues)

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -31,7 +31,9 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     {
         // Get a connection string from a resource
         var connectionString = await _app.GetConnectionStringAsync("cs");
+        var connectionString2 = await _app.GetConnectionStringAsync("cs2");
         Assert.Equal("testconnection", connectionString);
+        Assert.Equal("Value=this is a value", connectionString2);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
@@ -43,54 +42,7 @@ public class AddParameterTests
             {
                 Assert.Equal(CustomResourceKnownProperties.Source, prop.Name);
                 Assert.Equal("Parameters:pass", prop.Value);
-            },
-            prop =>
-            {
-                Assert.Equal("Value", prop.Name);
-                Assert.Equal("pass1", prop.Value);
             });
-    }
-
-    [Fact]
-    public void MissingParametersAreConfigurationMissing()
-    {
-        var appBuilder = DistributedApplication.CreateBuilder();
-
-        appBuilder.AddParameter("pass");
-
-        using var app = appBuilder.Build();
-
-        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-
-        var parameterResource = Assert.Single(appModel.Resources.OfType<ParameterResource>());
-        var annotation = parameterResource.Annotations.OfType<ResourceSnapshotAnnotation>().SingleOrDefault();
-
-        Assert.NotNull(annotation);
-
-        var state = annotation.InitialSnapshot;
-
-        Assert.NotNull(state.State);
-        Assert.Equal("Configuration missing", state.State.Text);
-        Assert.Equal(KnownResourceStateStyles.Error, state.State.Style);
-        Assert.Collection(state.Properties,
-            prop =>
-            {
-                Assert.Equal("parameter.secret", prop.Name);
-                Assert.Equal("False", prop.Value);
-            },
-            prop =>
-            {
-                Assert.Equal(CustomResourceKnownProperties.Source, prop.Name);
-                Assert.Equal("Parameters:pass", prop.Value);
-            },
-            prop =>
-            {
-                Assert.Equal("Value", prop.Name);
-                Assert.Contains("configuration key 'Parameters:pass' is missing", prop.Value?.ToString());
-            });
-
-        // verify that the logging hook is registered
-        Assert.Contains(app.Services.GetServices<IDistributedApplicationLifecycleHook>(), hook => hook.GetType().Name == "WriteParameterLogsHook");
     }
 
     [Fact]
@@ -335,7 +287,7 @@ public class AddParameterTests
     }
 
     [Fact]
-    public async Task AddConnectionStringIsASecretParameterInTheManifest()
+    public async Task AddConnectionStringParameterIsASecretParameterInTheManifest()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
 
@@ -360,6 +312,37 @@ public class AddParameterTests
                   "secret": true
                 }
               }
+            }
+            """;
+
+        var s = connectionStringManifest.ToString();
+
+        Assert.Equal(expectedManifest, s);
+    }
+
+    [Fact]
+    public async Task AddConnectionStringExpressionIsAValueInTheManifest()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var endpoint = appBuilder.AddParameter("endpoint", "http://localhost:3452");
+        var key = appBuilder.AddParameter("key", "secretKey", secret: true);
+
+        // Get the service provider.
+        appBuilder.AddConnectionString("mycs", $"Endpoint={endpoint};Key={key}");
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var connectionStringResource = Assert.Single(appModel.Resources.OfType<ConnectionStringResource>());
+
+        Assert.Equal("mycs", connectionStringResource.Name);
+        var connectionStringManifest = await ManifestUtils.GetManifest(connectionStringResource).DefaultTimeout();
+
+        var expectedManifest = $$"""
+            {
+              "type": "value.v0",
+              "connectionString": "Endpoint={endpoint.value};Key={key.value}"
             }
             """;
 

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -38,7 +38,7 @@ public class ExpressionResolverTests
         data.Add(new ExpressionResolverTestData(true, new ConnectionStringReference(new TestExpressionResolverResource("String"), true)), null, ("String", false));
         data.Add(new ExpressionResolverTestData(true, new ConnectionStringReference(new TestExpressionResolverResource("SecretParameter"), false)), null, ("SecretParameter", true));
 
-        // IResourceWithConnectionString resolves differently for ResourceWithConnectionStringSurrogate (as a secret parameter)
+        // IResourceWithConnectionString resolves differently for ConnectionStringParameterResource (as a secret parameter)
         data.Add(new ExpressionResolverTestData(false, new ConnectionStringParameterResource("SurrogateResource", _ => "SurrogateResource", null)), null, ("SurrogateResource", true));
         data.Add(new ExpressionResolverTestData(false, new TestExpressionResolverResource("String")), null, ("String", false));
 

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -39,7 +39,7 @@ public class ExpressionResolverTests
         data.Add(new ExpressionResolverTestData(true, new ConnectionStringReference(new TestExpressionResolverResource("SecretParameter"), false)), null, ("SecretParameter", true));
 
         // IResourceWithConnectionString resolves differently for ResourceWithConnectionStringSurrogate (as a secret parameter)
-        data.Add(new ExpressionResolverTestData(false, new ResourceWithConnectionStringSurrogate("SurrogateResource", _ => "SurrogateResource", null)), null, ("SurrogateResource", true));
+        data.Add(new ExpressionResolverTestData(false, new ConnectionStringParameterResource("SurrogateResource", _ => "SurrogateResource", null)), null, ("SurrogateResource", true));
         data.Add(new ExpressionResolverTestData(false, new TestExpressionResolverResource("String")), null, ("String", false));
 
         data.Add(new ExpressionResolverTestData(false, new ParameterResource("SecretParameter", _ => "SecretParameter", secret: true)), null, ("SecretParameter", true));

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -255,7 +255,8 @@ public class ApplicationOrchestratorTests
         DistributedApplicationModel distributedAppModel,
         ResourceNotificationService notificationService,
         DcpExecutorEvents? dcpEvents = null,
-        DistributedApplicationEventing? applicationEventing = null)
+        DistributedApplicationEventing? applicationEventing = null,
+        ResourceLoggerService? resourceLoggerService = null)
     {
         return new ApplicationOrchestrator(
             distributedAppModel,
@@ -263,6 +264,7 @@ public class ApplicationOrchestratorTests
             dcpEvents ?? new DcpExecutorEvents(),
             Array.Empty<IDistributedApplicationLifecycleHook>(),
             notificationService,
+            resourceLoggerService ?? new ResourceLoggerService(),
             applicationEventing ?? new DistributedApplicationEventing(),
             new ServiceCollection().BuildServiceProvider()
             );

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -263,7 +263,7 @@ public class ResourceExtensionsTests
     public async Task GetArgumentValuesAsync_ReturnsCorrectValuesForSpecialCases()
     {
         var builder = DistributedApplication.CreateBuilder();
-        var surrogate = builder.AddResource(new ResourceWithConnectionStringSurrogate("ResourceWithConnectionStringSurrogate", _ => "ConnectionString", null));
+        var surrogate = builder.AddResource(new ConnectionStringParameterResource("ResourceWithConnectionStringSurrogate", _ => "ConnectionString", null));
         var secretParameter = builder.AddResource(new ParameterResource("SecretParameter", _ => "SecretParameter", true));
         var nonSecretParameter = builder.AddResource(new ParameterResource("NonSecretParameter", _ => "NonSecretParameter"));
 

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -120,6 +120,36 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
+    public async Task WaitingForConnectionStringResourceWaitsForReferencedResources()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var dependency = builder.AddResource(new CustomResource("test"));
+        var cs = builder.AddConnectionString("cs", $"{dependency};Timeout=100");
+
+        var nginx = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
+                           .WaitFor(cs);
+
+        using var app = builder.Build();
+
+        using var startupCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
+        var startTask = app.StartAsync(startupCts.Token);
+
+        using var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
+        await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+
+        await app.ResourceNotifications.PublishUpdateAsync(dependency.Resource, s => s with
+        {
+            State = KnownResourceStates.Running
+        });
+
+        await startTask;
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    [RequiresDocker]
     public async Task EnsureDependentResourceMovesIntoWaitingState()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -247,6 +247,52 @@ public class WithReferenceTests
     }
 
     [Fact]
+    public async Task ConnectionStringResourceWithExpressiononnectionString()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var endpoint = builder.AddParameter("endpoint", "http://localhost:3452");
+        var key = builder.AddParameter("key", "secretKey", secret: true);
+
+        var cs = ReferenceExpression.Create($"Endpoint={endpoint};Key={key}");
+        
+        // Get the service provider.
+        var resource = builder.AddConnectionString("cs", cs);
+
+        var projectB = builder.AddProject<ProjectB>("projectb")
+                              .WithReference(resource);
+
+        // Call environment variable callbacks.
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
+
+        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
+        Assert.Equal(1, servicesKeysCount);
+        Assert.Equal("Endpoint=http://localhost:3452;Key=secretKey", config["ConnectionStrings__cs"]);
+    }
+
+    [Fact]
+    public async Task ConnectionStringResourceWithInterpolated()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var endpoint = builder.AddParameter("endpoint", "http://localhost:3452");
+        var key = builder.AddParameter("key", "secretKey", secret: true);
+
+        // Get the service provider.
+        var resource = builder.AddConnectionString("cs", $"Endpoint={endpoint};Key={key}");
+
+        var projectB = builder.AddProject<ProjectB>("projectb")
+                              .WithReference(resource);
+
+        // Call environment variable callbacks.
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
+
+        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
+        Assert.Equal(1, servicesKeysCount);
+        Assert.Equal("Endpoint=http://localhost:3452;Key=secretKey", config["ConnectionStrings__cs"]);
+    }
+
+    [Fact]
     public async Task ConnectionStringResourceWithConnectionStringOverwriteName()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
+++ b/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
@@ -10,6 +10,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 builder.Configuration["ConnectionStrings:cs"] = "testconnection";
 
 builder.AddConnectionString("cs");
+
+builder.AddConnectionString("cs2", $"Value={builder.AddParameter("p", "this is a value")}");
+
 if (args.Contains("--add-redis"))
 {
     builder.AddRedis("redis1");


### PR DESCRIPTION
## Description

Introduces the `IResourceWithoutLifetime` interface for resources without a lifetime, such as parameters and connection strings. Updates `ParameterResource` to implement this interface and adds the `ConnectionStringParameterResource` class for better management of connection string parameters.

Implements the `AddConnectionString` method in `ConnectionStringBuilderExtensions` and updates `ApplicationOrchestrator` to handle resources without a lifetime correctly.

Tests have been added and modified to verify the new functionality, and `Program.cs` has been updated to demonstrate the new connection string capabilities, including the addition of a second connection string with a parameter value.

These changes improve the overall resource management in the application, particularly for connection strings and parameters.

Fixes #7641
Fixes #7642
Fixes #2964

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
