### PR TITLE
Use Kafbat/kafkaui

### DIFF
--- a/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
@@ -15,8 +15,8 @@ internal static class KafkaContainerImageTags
     public const string Tag = "7.8.0";
 
     /// <remarks>provectuslabs/kafka-ui</remarks>
-    public const string KafkaUiImage = "provectuslabs/kafka-ui";
+    public const string KafkaUiImage = "kafbat/kafka-ui";
 
     /// <remarks>v0.7.2</remarks>
-    public const string KafkaUiTag = "v0.7.2";
+    public const string KafkaUiTag = "v1.1.0";
 }

--- a/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
@@ -17,6 +17,6 @@ internal static class KafkaContainerImageTags
     /// <remarks>kafbat/kafka-ui</remarks>
     public const string KafkaUiImage = "kafbat/kafka-ui";
 
-    /// <remarks>v0.7.2</remarks>
+    /// <remarks>v1.1.0</remarks>
     public const string KafkaUiTag = "v1.1.0";
 }

--- a/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
@@ -14,7 +14,7 @@ internal static class KafkaContainerImageTags
     /// <remarks>7.8.0</remarks>
     public const string Tag = "7.8.0";
 
-    /// <remarks>provectuslabs/kafka-ui</remarks>
+    /// <remarks>kafbat/kafka-ui</remarks>
     public const string KafkaUiImage = "kafbat/kafka-ui";
 
     /// <remarks>v0.7.2</remarks>


### PR DESCRIPTION
## Description
The KafkaUi from provectus is not really maintained anymore. The one over at https://github.com/kafbat/kafka-ui is a fork of it and is actively maintained.

This PR exchanges the image. The config is the same for both images.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
