### PR TITLE
Fix components test and remove added padding/margin on tabs

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -30,7 +30,7 @@ else
                 </div>
             }
         </div>
-        <FluentTabs ActiveTabId="@($"tab-{ActiveView}")" OnTabChange="@OnTabChangeAsync" Size="(TabSize)int.MinValue">
+        <FluentTabs ActiveTabId="@($"tab-{ActiveView}")" OnTabChange="@OnTabChangeAsync" Size="null">
             <FluentTab LabelClass="tab-label"
                        Id="@($"tab-{Metrics.MetricViewKind.Graph}")"
                        aria-label="@Loc[nameof(ControlsStrings.ChartContainerGraphAccessibleLabel)]"

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -30,7 +30,7 @@ else
                 </div>
             }
         </div>
-        <FluentTabs ActiveTabId="@($"tab-{ActiveView}")" OnTabChange="@OnTabChangeAsync">
+        <FluentTabs ActiveTabId="@($"tab-{ActiveView}")" OnTabChange="@OnTabChangeAsync" Size="(TabSize)int.MinValue">
             <FluentTab LabelClass="tab-label"
                        Id="@($"tab-{Metrics.MetricViewKind.Graph}")"
                        aria-label="@Loc[nameof(ControlsStrings.ChartContainerGraphAccessibleLabel)]"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -102,7 +102,7 @@
                                 Tab content isn't nested inside FluentTab elements. The tab control is just used to display the tabs.
                                 Content is located in manually created divs so they can be placed in their own CSS grid row.
                             *@
-                            <FluentTabs Class="resources-tab-header" ActiveTabId="@($"tab-{PageViewModel.SelectedViewKind}")" OnTabChange="@OnTabChangeAsync" Size="(TabSize)int.MinValue">
+                            <FluentTabs Class="resources-tab-header" ActiveTabId="@($"tab-{PageViewModel.SelectedViewKind}")" OnTabChange="@OnTabChangeAsync" Size="null">
                                 <FluentTab LabelClass="tab-label"
                                            Id="@($"tab-{ResourceViewKind.Table}")"
                                            Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerTableTab)]"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -102,7 +102,7 @@
                                 Tab content isn't nested inside FluentTab elements. The tab control is just used to display the tabs.
                                 Content is located in manually created divs so they can be placed in their own CSS grid row.
                             *@
-                            <FluentTabs Class="resources-tab-header" ActiveTabId="@($"tab-{PageViewModel.SelectedViewKind}")" OnTabChange="@OnTabChangeAsync">
+                            <FluentTabs Class="resources-tab-header" ActiveTabId="@($"tab-{PageViewModel.SelectedViewKind}")" OnTabChange="@OnTabChangeAsync" Size="(TabSize)int.MinValue">
                                 <FluentTab LabelClass="tab-label"
                                            Id="@($"tab-{ResourceViewKind.Table}")"
                                            Label="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerTableTab)]"

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -161,7 +161,6 @@ public partial class ConsoleLogsTests : TestContext
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7839")]
     public void ClearLogEntries_AllResources_LogsFilteredOut()
     {
         // Arrange
@@ -207,6 +206,8 @@ public partial class ConsoleLogsTests : TestContext
 
         logger.LogInformation("Clear current entries.");
         cut.Find(".clear-button").Click();
+
+        cut.WaitForElement("#clear-menu-all");
         cut.Find("#clear-menu-all").Click();
 
         cut.WaitForState(() => instance._logEntries.EntriesCount == 0);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/7839

* I couldn't repo the flaky test locally with 1000 test runs. I think it's a timing issue which should be solved by this wait.
* Update to FluentUI 4.15.0 added some padding/margin on tabs. Removed by setting size to ~a custom value~ `null`.
