### PR TITLE
[CI] Enumerate test projects at build time for PR validation

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,133 @@
+# Workflow to run tests for a given test project
+
+name: Run Tests
+
+on:
+  workflow_call:
+    inputs:
+      testShortName:
+        required: true
+        type: string
+      testSessionTimeoutMs:
+        required: false
+        type: string
+        default: "600000"
+      testHangTimeout:
+        required: false
+        type: string
+        default: "7m"
+      extraTestArgs:
+        required: false
+        type: string
+
+jobs:
+
+  _:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    name: ${{ inputs.testShortName }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Trust HTTPS development certificate
+        run: ./dotnet.sh dev-certs https --trust
+
+      - name: Verify Docker is running
+        run: docker info
+
+      - name: Install Azure Functions Core Tools
+        if: inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y azure-functions-core-tools-4
+
+      - name: Compute test project path
+        id: compute_project_path
+        env:
+          CI: false
+        # Convert the shortname of the test to a project path in tests/
+        run: |
+          export OPTION_A=${{ github.workspace }}/tests/Aspire.${{ inputs.testShortName }}.Tests/Aspire.${{ inputs.testShortName }}.Tests.csproj; \
+          export OPTION_B=${{ github.workspace }}/tests/${{ inputs.testShortName }}.Tests/${{ inputs.testShortName }}.Tests.csproj; \
+          echo TEST_PROJECT_PATH=$(test -f $OPTION_A && echo $OPTION_A || echo $OPTION_B); \
+          echo TEST_PROJECT_PATH=$(test -f $OPTION_A && echo $OPTION_A || echo $OPTION_B) >> $GITHUB_ENV
+
+      - name: Build test project
+        id: build_t
+        env:
+          CI: false
+        run: |
+          ./build.sh -restore -ci -build -projects $TEST_PROJECT_PATH
+
+      # Workaround for bug in Azure Functions Worker SDK. See https://github.com/Azure/azure-functions-dotnet-worker/issues/2969.
+      - name: Rebuild for Azure Functions project
+        if: inputs.testShortName == 'Playground'
+        env:
+          CI: false
+        run: |
+          ./dotnet.sh build ${{ github.workspace }}/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj /p:SkipUnstableEmulators=true
+
+      - name: Run tests
+        id: run-tests
+        env:
+          CI: false
+          DCP_DIAGNOSTICS_LOG_LEVEL: debug
+          DCP_DIAGNOSTICS_LOG_FOLDER: ${{ github.workspace }}/testresults/dcp
+        run: |
+
+          ./dotnet.sh test $TEST_PROJECT_PATH \
+            /p:ContinuousIntegrationBuild=true \
+            -s eng/testing/.runsettings \
+            --logger "console;verbosity=normal" \
+            --logger "trx" \
+            --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true" \
+            --blame \
+            --blame-hang-timeout ${{ inputs.testHangTimeout }} \
+            --blame-crash \
+            --results-directory testresults \
+            --no-restore \
+            --no-build \
+            ${{ inputs.extraTestArgs }} \
+            -- \
+            RunConfiguration.CollectSourceInformation=true \
+            RunConfiguration.TestSessionTimeout=${{ inputs.testSessionTimeoutMs }}
+
+      # Save the result of the previous steps - success or failure
+      # in the form of a file result-success/result-failure -{name}.rst
+      - name: Store result - success
+        if: ${{ success() }}
+        run: touch result-success-${{ inputs.testShortName }}.rst
+      - name: Store result - failure
+        if: ${{ !success() }}
+        run: touch result-failed-${{ inputs.testShortName }}.rst
+
+      # Upload that result file to artifact named test-job-result-{name}
+      - name: Upload test result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-job-result-${{ inputs.testShortName }}
+          path: result-*.rst
+
+      - name: Dump docker info
+        if: always()
+        run: |
+          docker container ls --all
+          docker container ls --all --format json
+          docker volume ls
+          docker network ls
+
+      - name: Upload bin log artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: binlog-${{ inputs.testShortName }}
+          path: "**/*.binlog"
+
+      - name: Upload test results artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: testresults-${{ inputs.testShortName }}
+          path: testresults/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run Integration Tests
+name: Integration Tests
 
 on:
   pull_request:
@@ -11,261 +11,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  setup_for_tests:
+    name: Get test projects to run
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    name: ${{ matrix.name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Hosting projects
-          - project: tests/Aspire.Hosting.Analyzers.Tests/Aspire.Hosting.Analyzers.Tests.csproj
-            name: Hosting.Analyzers
-          - project: tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
-            name: Hosting.Azure
-          - project: tests/Aspire.Hosting.Containers.Tests/Aspire.Hosting.Containers.Tests.csproj
-            name: Hosting.Containers
-          - project: tests/Aspire.Hosting.Elasticsearch.Tests/Aspire.Hosting.Elasticsearch.Tests.csproj
-            name: Hosting.Elasticsearch
-          - project: tests/Aspire.Hosting.Garnet.Tests/Aspire.Hosting.Garnet.Tests.csproj
-            name: Hosting.Garnet
-          - project: tests/Aspire.Hosting.Kafka.Tests/Aspire.Hosting.Kafka.Tests.csproj
-            name: Hosting.Kafka
-          - project: tests/Aspire.Hosting.Keycloak.Tests/Aspire.Hosting.Keycloak.Tests.csproj
-            name: Hosting.Keycloak
-          - project: tests/Aspire.Hosting.Milvus.Tests/Aspire.Hosting.Milvus.Tests.csproj
-            name: Hosting.Milvus
-          - project: tests/Aspire.Hosting.MongoDB.Tests/Aspire.Hosting.MongoDB.Tests.csproj
-            name: Hosting.MongoDB
-          - project: tests/Aspire.Hosting.MySql.Tests/Aspire.Hosting.MySql.Tests.csproj
-            name: Hosting.MySql
-          - project: tests/Aspire.Hosting.Nats.Tests/Aspire.Hosting.Nats.Tests.csproj
-            name: Hosting.Nats
-          - project: tests/Aspire.Hosting.NodeJs.Tests/Aspire.Hosting.NodeJs.Tests.csproj
-            name: Hosting.NodeJs
-          - project: tests/Aspire.Hosting.Oracle.Tests/Aspire.Hosting.Oracle.Tests.csproj
-            name: Hosting.Oracle
-          - project: tests/Aspire.Hosting.PostgreSQL.Tests/Aspire.Hosting.PostgreSQL.Tests.csproj
-            name: Hosting.PostgreSQL
-          - project: tests/Aspire.Hosting.Python.Tests/Aspire.Hosting.Python.Tests.csproj
-            name: Hosting.Python
-          - project: tests/Aspire.Hosting.Qdrant.Tests/Aspire.Hosting.Qdrant.Tests.csproj
-            name: Hosting.Qdrant
-          - project: tests/Aspire.Hosting.RabbitMQ.Tests/Aspire.Hosting.RabbitMQ.Tests.csproj
-            name: Hosting.RabbitMQ
-          - project: tests/Aspire.Hosting.Redis.Tests/Aspire.Hosting.Redis.Tests.csproj
-            name: Hosting.Redis
-          - project: tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
-            name: Hosting.Sdk
-          - project: tests/Aspire.Hosting.Seq.Tests/Aspire.Hosting.Seq.Tests.csproj
-            name: Hosting.Seq
-          - project: tests/Aspire.Hosting.SqlServer.Tests/Aspire.Hosting.SqlServer.Tests.csproj
-            name: Hosting.SqlServer
-          - project: tests/Aspire.Hosting.Testing.Tests/Aspire.Hosting.Testing.Tests.csproj
-            name: Hosting.Testing
-          - project: tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
-            name: Hosting
-          - project: tests/Aspire.Hosting.Valkey.Tests/Aspire.Hosting.Valkey.Tests.csproj
-            name: Hosting.Valkey
-
-          # Client projects
-          - project: tests/Aspire.Azure.AI.OpenAI.Tests/Aspire.Azure.AI.OpenAI.Tests.csproj
-            name: Azure.AI.OpenAI
-          - project: tests/Aspire.Azure.Data.Tables.Tests/Aspire.Azure.Data.Tables.Tests.csproj
-            name: Azure.Data.Tables
-          - project: tests/Aspire.Azure.Messaging.EventHubs.Tests/Aspire.Azure.Messaging.EventHubs.Tests.csproj
-            name: Azure.Messaging.EventHubs
-          - project: tests/Aspire.Azure.Messaging.ServiceBus.Tests/Aspire.Azure.Messaging.ServiceBus.Tests.csproj
-            name: Azure.Messaging.ServiceBus
-          - project: tests/Aspire.Azure.Messaging.WebPubSub.Tests/Aspire.Azure.Messaging.WebPubSub.Tests.csproj
-            name: Azure.Messaging.WebPubSub
-          - project: tests/Aspire.Azure.Search.Documents.Tests/Aspire.Azure.Search.Documents.Tests.csproj
-            name: Azure.Search.Documents
-          - project: tests/Aspire.Azure.Security.KeyVault.Tests/Aspire.Azure.Security.KeyVault.Tests.csproj
-            name: Azure.Security.KeyVault
-          - project: tests/Aspire.Azure.Storage.Blobs.Tests/Aspire.Azure.Storage.Blobs.Tests.csproj
-            name: Azure.Storage.Blobs
-          - project: tests/Aspire.Azure.Storage.Queues.Tests/Aspire.Azure.Storage.Queues.Tests.csproj
-            name: Azure.Storage.Queues
-          - project: tests/Aspire.Components.Common.Tests/Aspire.Components.Common.Tests.csproj
-            name: Components.Common
-          - project: tests/Aspire.Confluent.Kafka.Tests/Aspire.Confluent.Kafka.Tests.csproj
-            name: Confluent.Kafka
-          - project: tests/Aspire.Elastic.Clients.Elasticsearch.Tests/Aspire.Elastic.Clients.Elasticsearch.Tests.csproj
-            name: Elastic.Clients.Elasticsearch
-          - project: tests/Aspire.Keycloak.Authentication.Tests/Aspire.Keycloak.Authentication.Tests.csproj
-            name: Keycloak.Authentication
-          - project: tests/Aspire.Microsoft.Azure.Cosmos.Tests/Aspire.Microsoft.Azure.Cosmos.Tests.csproj
-            name: Microsoft.Azure.Cosmos
-          - project: tests/Aspire.Microsoft.Data.SqlClient.Tests/Aspire.Microsoft.Data.SqlClient.Tests.csproj
-            name: Microsoft.Data.SqlClient
-          - project: tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests.csproj
-            name: Microsoft.EntityFrameworkCore.Cosmos
-          - project: tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
-            name: Microsoft.EntityFrameworkCore.SqlServer
-          - project: tests/Aspire.Milvus.Client.Tests/Aspire.Milvus.Client.Tests.csproj
-            name: Milvus.Client
-          - project: tests/Aspire.MongoDB.Driver.Tests/Aspire.MongoDB.Driver.Tests.csproj
-            name: MongoDB.Driver
-          - project: tests/Aspire.MongoDB.Driver.v3.Tests/Aspire.MongoDB.Driver.v3.Tests.csproj
-            name: MongoDB.Driver.v3
-          - project: tests/Aspire.MySqlConnector.Tests/Aspire.MySqlConnector.Tests.csproj
-            name: MySqlConnector
-          - project: tests/Aspire.NATS.Net.Tests/Aspire.NATS.Net.Tests.csproj
-            name: NATS.Net
-          - project: tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests.csproj
-            name: Npgsql.EntityFrameworkCore.PostgreSQL
-          - project: tests/Aspire.Npgsql.Tests/Aspire.Npgsql.Tests.csproj
-            name: Npgsql
-          - project: tests/Aspire.OpenAI.Tests/Aspire.OpenAI.Tests.csproj
-            name: OpenAI
-          - project: tests/Aspire.Oracle.EntityFrameworkCore.Tests/Aspire.Oracle.EntityFrameworkCore.Tests.csproj
-            name: Oracle.EntityFrameworkCore
-          - project: tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests.csproj
-            name: Pomelo.EntityFrameworkCore.MySql
-          - project: tests/Aspire.Qdrant.Client.Tests/Aspire.Qdrant.Client.Tests.csproj
-            name: Qdrant.Client
-          - project: tests/Aspire.RabbitMQ.Client.Tests/Aspire.RabbitMQ.Client.Tests.csproj
-            name: RabbitMQ.Client
-          - project: tests/Aspire.RabbitMQ.Client.v7.Tests/Aspire.RabbitMQ.Client.v7.Tests.csproj
-            name: RabbitMQ.Client.v7
-          - project: tests/Aspire.Seq.Tests/Aspire.Seq.Tests.csproj
-            name: Seq
-          - project: tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/Aspire.StackExchange.Redis.DistributedCaching.Tests.csproj
-            name: StackExchange.Redis.DistributedCaching
-          - project: tests/Aspire.StackExchange.Redis.OutputCaching.Tests/Aspire.StackExchange.Redis.OutputCaching.Tests.csproj
-            name: StackExchange.Redis.OutputCaching
-          - project: tests/Aspire.StackExchange.Redis.Tests/Aspire.StackExchange.Redis.Tests.csproj
-            name: StackExchange.Redis
-
-          # Dashboard projects
-          - project: tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
-            name: Dashboard.Components
-          - project: tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
-            name: Dashboard
-
-          # Playground project
-          - project: tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
-            name: Playground
-
-          # Schema generator project
-          - project: tests/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
-            name: ConfigurationSchemaGenerator
-
-          # Service discovery projects
-          - project: tests/Microsoft.Extensions.ServiceDiscovery.Tests/Microsoft.Extensions.ServiceDiscovery.Tests.csproj
-            name: Extensions.ServiceDiscovery
-          - project: tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests.csproj
-            name: Extensions.ServiceDiscovery.Dns
-          - project: tests/Microsoft.Extensions.ServiceDiscovery.Yarp.Tests/Microsoft.Extensions.ServiceDiscovery.Yarp.Tests.csproj
-            name: Extensions.ServiceDiscovery.Yarp
-
-          # Others
-          - project: tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
-            name: Cli
-
+    outputs:
+      tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up .NET Core
-        uses: actions/setup-dotnet@v4
+      - uses: actions/setup-python@v5
         with:
-          dotnet-version: |
-            8.x
-            9.x
+          python-version: '3.12'
 
-      - name: Trust HTTPS development certificate
-        run: dotnet dev-certs https --trust
-
-      - name: Verify Docker is running
-        run: docker info
-
-      - name: Install Azure Functions Core Tools
-        if: matrix.name == 'Playground' || matrix.name == 'Azure'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y azure-functions-core-tools-4
-
-      - name: Build test project
+      - name: Generate tests matrix
+        id: generate_test_matrix
         env:
           CI: false
         run: |
-          ./build.sh -restore -ci -build -projects ${{ github.workspace }}/${{ matrix.project }} /bl
+          ./dotnet.sh build ${{ github.workspace }}/tests/Shared/GetTestProjects.proj \
+          /p:TestsListOutputPath=${{ github.workspace }}/artifacts/TestsForGithubActions.list \
+          /p:ContinuousIntegrationBuild=true && \
+          echo "tests_matrix=$(jq -cR '{shortname: [inputs]}' < ${{ github.workspace }}/artifacts/TestsForGithubActions.list)" >> $GITHUB_OUTPUT
 
-      # Workaround for bug in Azure Functions Worker SDK. See https://github.com/Azure/azure-functions-dotnet-worker/issues/2969.
-      - name: Rebuild for Azure Functions project
-        if: matrix.name == 'Playground'
-        env:
-          CI: false
-        run: |
-          ./dotnet.sh build ${{ github.workspace }}/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj /p:SkipUnstableEmulators=true
-
-      - name: Run tests
-        id: run-tests
-        env:
-          CI: false
-          DCP_DIAGNOSTICS_LOG_LEVEL: debug
-          DCP_DIAGNOSTICS_LOG_FOLDER: ${{ github.workspace }}/testresults/dcp
-        run: |
-          ./dotnet.sh test ${{ github.workspace }}/${{ matrix.project }} \
-            /p:ContinuousIntegrationBuild=true \
-            -s eng/testing/.runsettings \
-            --logger "console;verbosity=normal" \
-            --logger "trx" \
-            --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true" \
-            --blame \
-            --blame-hang-timeout 7m \
-            --blame-crash \
-            --results-directory testresults \
-            --no-restore \
-            --no-build -- RunConfiguration.CollectSourceInformation=true
-
-      # Save the result of the previous steps - success or failure
-      # in the form of a file result-success/result-failure -{name}.rst
-      - name: Store result - success
-        if: ${{ success() }}
-        run: touch result-success-${{ matrix.name }}.rst
-      - name: Store result - failure
-        if: ${{ !success() }}
-        run: touch result-failed-${{ matrix.name }}.rst
-
-      # Upload that result file to artifact named test-job-result-{name}
-      - name: Upload test result
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-job-result-${{ matrix.name }}
-          path: result-*.rst
-
-      - name: Dump docker info
-        if: always()
-        run: |
-          docker container ls --all
-          docker container ls --all --format json
-          docker volume ls
-          docker network ls
-
-      - name: Upload bin log artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: binlog-${{ matrix.name }}
-          path: "**/*.binlog"
-
-      - name: Upload test results artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: testresults-${{ matrix.name }}
-          path: testresults/**
+  _:
+    uses: ./.github/workflows/run-tests.yml
+    needs: setup_for_tests
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      testSessionTimeoutMs: ${{ matrix.testSessionTimeoutMs }}
+      extraTestArgs: ${{ matrix.extraTestArgs }}
 
   results: # This job is used for branch protection. It ensures all the above tests passed
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [test]
+    needs: [_]
     steps:
       # get all the test-job-result* artifacts into a single directory
       - uses: actions/download-artifact@v4
@@ -277,5 +61,4 @@ jobs:
       # return success if zero result-failed-* files are found
       - name: Compute result
         run: |
-          ls -al test-job-result/
           [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
       - name: Generate tests matrix
         id: generate_test_matrix
         env:

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -14,6 +14,7 @@
 
     <RunTestsOnGithubActions Condition="'$(RunTestsOnGithubActions)' == '' and ('$(IsTestProject)' == 'true' and '$(IsTestSupportProject)' != 'true')">true</RunTestsOnGithubActions>
     <RunTestsOnHelix Condition="'$(RunTestsOnHelix)' == '' and ('$(IsTestProject)' == 'true' and '$(IsTestSupportProject)' != 'true')">true</RunTestsOnHelix>
+    <!-- this is for pipeline tests -->
     <SkipTests Condition="'$(SkipTests)' == '' and ('$(IsTestSupportProject)' == 'true' or '$(RunTestsOnHelix)' == 'true' or '$(RunTestsOnGithubActions)' == 'true')">true</SkipTests>
   </PropertyGroup>
 

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -12,8 +12,9 @@
     <XunitRunnerJson Condition="'$(XunitRunnerJson)' == '' and '$(ArchiveTests)' == 'true'">$(RepoRoot)tests\helix\xunit.runner.json</XunitRunnerJson>
     <XunitRunnerJson Condition="'$(XunitRunnerJson)' == ''">$(RepositoryEngineeringDir)testing\xunit.runner.json</XunitRunnerJson>
 
+    <RunTestsOnGithubActions Condition="'$(RunTestsOnGithubActions)' == '' and ('$(IsTestProject)' == 'true' and '$(IsTestSupportProject)' != 'true')">true</RunTestsOnGithubActions>
     <RunTestsOnHelix Condition="'$(RunTestsOnHelix)' == '' and ('$(IsTestProject)' == 'true' and '$(IsTestSupportProject)' != 'true')">true</RunTestsOnHelix>
-    <SkipTests Condition="'$(SkipTests)' == '' and ('$(IsTestSupportProject)' == 'true' or '$(RunTestsOnHelix)' == 'true')">true</SkipTests>
+    <SkipTests Condition="'$(SkipTests)' == '' and ('$(IsTestSupportProject)' == 'true' or '$(RunTestsOnHelix)' == 'true' or '$(RunTestsOnGithubActions)' == 'true')">true</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,7 +37,7 @@
   </Target>
 
   <!-- Used for running one helix job per test class -->
-  <Target Name="_ExtractTestClassNames"
+  <Target Name="ExtractTestClassNames"
           Condition="'$(ExtractTestClassNamesForHelix)' == 'true' and '$(ArchiveTests)' == 'true'"
           BeforeTargets="ZipTestArchive">
 
@@ -65,6 +66,8 @@
                       Lines="@(UniqueTestClassNamesFiltered)"
                       Overwrite="true" />
   </Target>
+
+  <Target Name="GetRunTestsOnGithubActions" Returns="$(RunTestsOnGithubActions)" />
 
   <Import Project="$(TestsSharedDir)Aspire.Workload.Testing.targets" Condition="'$(IsWorkloadTestProject)' == 'true'" />
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -68,7 +68,11 @@
                       Overwrite="true" />
   </Target>
 
-  <Target Name="GetRunTestsOnGithubActions" Returns="$(RunTestsOnGithubActions)" />
+  <Target Name="GetRunTestsOnGithubActions" Returns="@(TestProject)">
+    <ItemGroup>
+      <TestProject Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunTestsOnGithubActions)" />
+    </ItemGroup>
+  </Target>
 
   <Import Project="$(TestsSharedDir)Aspire.Workload.Testing.targets" Condition="'$(IsWorkloadTestProject)' == 'true'" />
 </Project>

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,3 +11,9 @@ The helix CI job builds `tests/helix/send-to-helix-ci.proj`, which in turns buil
 2. `dotnet build tests\workloads.proj`
 
 .. which results in `artifacts\bin\dotnet-tests` which has a sdk (version from `global.json`) with the `aspire` workload installed using packs from `artifacts/packages`.
+
+## Controlling test runs on CI
+
+- Tests on PRs run in github actions. Individual test projects can be disabled for PRs with the property `$(RunTestsOnGithubActions)` which defaults to `true`.
+
+- Tests for rolling builds run on the build machine, and helix. Use `$(RunTestsOnHelix)` which defaults to `true`. If set to `false` then it would run on the build machine. But to skip the tests completely set `$(SkipTests)=true` also.

--- a/tests/Shared/GetTestProjects.proj
+++ b/tests/Shared/GetTestProjects.proj
@@ -32,8 +32,8 @@
     </MSBuild>
 
     <ItemGroup>
-      <ProjectRunTestsOnGithubActions Remove="@(ProjectRunTestsOnGithubActions)" Condition="'%(Identity)' != 'true'" />
-      <ProjectRunTestsOnGithubActions ShortName="$([System.IO.Path]::GetFileNameWithoutExtension('%(MSBuildSourceProjectFile)').Replace('Aspire.', '').Replace('.Tests', ''))" />
+      <ProjectRunTestsOnGithubActions Remove="@(ProjectRunTestsOnGithubActions)" Condition="'%(RunTestsOnGithubActions)' != 'true'" />
+      <ProjectRunTestsOnGithubActions ShortName="$([System.IO.Path]::GetFileNameWithoutExtension('%(Identity)').Replace('Aspire.', '').Replace('.Tests', ''))" />
     </ItemGroup>
 
     <Error Condition="@(ProjectRunTestsOnGithubActions->Count()) == 0" Text="Could not find any test projects" />

--- a/tests/Shared/GetTestProjects.proj
+++ b/tests/Shared/GetTestProjects.proj
@@ -1,0 +1,44 @@
+<Project DefaultTargets="GenerateListOfTestsForGithubActions">
+  <!--
+    This is meant to be invoked directly to get the list of test projects to run for PR validation.
+    It emits "shortnames" for the project which is essentially the project name with `Aspire.` prefix
+    `.Tests` removed.
+
+    Input: $(TestsListOutputPath) -->
+
+  <Target Name="GenerateListOfTestsForGithubActions">
+    <Error Condition="'$(TestsListOutputPath)' == ''"
+           Text="%24(TestsListOutputPath) is unset" />
+
+    <PropertyGroup>
+      <RepoRoot>$(MSBuildThisFileDirectory)..\..\</RepoRoot>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_TestProjectsToExclude Include="$(RepoRoot)tests\Shared\**\*Tests.csproj" />
+      <_TestProjectsToExclude Include="$(RepoRoot)tests\testproject\**\*Tests.csproj" />
+      <_TestProjectsToExclude Include="$(RepoRoot)tests\TestingAppHost1\**\*Tests.csproj" />
+
+      <_TestProjectsToExclude Include="$(RepoRoot)tests\Aspire.Workload.Tests\**\*Tests.csproj" />
+      <_TestProjectsToExclude Include="$(RepoRoot)tests\Aspire.EndToEnd.Tests\**\*Tests.csproj" />
+
+      <_TestProjects Include="$(RepoRoot)tests\**\*Tests.csproj"
+                     Exclude="@(_TestProjectsToExclude)" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(_TestProjects)" Targets="GetRunTestsOnGithubActions">
+      <Output TaskParameter="TargetOutputs" ItemName="ProjectsToTest" />
+    </MSBuild>
+
+    <Error Condition="@(ProjectsToTest->Count()) == 0" Text="Could not find any test projects" />
+
+    <ItemGroup>
+      <ProjectsToTest ShortName="$([System.IO.Path]::GetFileNameWithoutExtension('%(MSBuildSourceProjectFile)').Replace('Aspire.', '').Replace('.Tests', ''))" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(TestsListOutputPath)"
+                      Lines="@(ProjectsToTest->'%(ShortName)')"
+                      Overwrite="true" />
+  </Target>
+
+</Project>

--- a/tests/Shared/GetTestProjects.proj
+++ b/tests/Shared/GetTestProjects.proj
@@ -26,18 +26,20 @@
                      Exclude="@(_TestProjectsToExclude)" />
     </ItemGroup>
 
+    <!-- this returns an item list of [true, true, false...] with %(MSBuildSourceProjectFile) set -->
     <MSBuild Projects="@(_TestProjects)" Targets="GetRunTestsOnGithubActions">
-      <Output TaskParameter="TargetOutputs" ItemName="ProjectsToTest" />
+      <Output TaskParameter="TargetOutputs" ItemName="ProjectRunTestsOnGithubActions" />
     </MSBuild>
 
-    <Error Condition="@(ProjectsToTest->Count()) == 0" Text="Could not find any test projects" />
-
     <ItemGroup>
-      <ProjectsToTest ShortName="$([System.IO.Path]::GetFileNameWithoutExtension('%(MSBuildSourceProjectFile)').Replace('Aspire.', '').Replace('.Tests', ''))" />
+      <ProjectRunTestsOnGithubActions Remove="@(ProjectRunTestsOnGithubActions)" Condition="'%(Identity)' != 'true'" />
+      <ProjectRunTestsOnGithubActions ShortName="$([System.IO.Path]::GetFileNameWithoutExtension('%(MSBuildSourceProjectFile)').Replace('Aspire.', '').Replace('.Tests', ''))" />
     </ItemGroup>
 
+    <Error Condition="@(ProjectRunTestsOnGithubActions->Count()) == 0" Text="Could not find any test projects" />
+
     <WriteLinesToFile File="$(TestsListOutputPath)"
-                      Lines="@(ProjectsToTest->'%(ShortName)')"
+                      Lines="@(ProjectRunTestsOnGithubActions->'%(ShortName)')"
                       Overwrite="true" />
   </Target>
 


### PR DESCRIPTION
Generate list of tests to run for PR validation at run time

- Move core steps to run the tests to a new reusable workflow
  `run-tests.yml`
- Generate the list of test projects using the new
  `tests/Shared/GetTestProjects.proj`

- Adjust `tests.yml` to essentially use `run-tests.yml` to run the test
  matrix generated above

- Also, introduce a new property to control running tests on github
  actions `$(RunTestsOnGithubActions)`.