### PR TITLE
Fix credscan warnings

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -22,6 +22,10 @@
       "_justification": "This is a fake password, used in integration, and other tests."
     },
     {
+      "placeholder": "p@ssw0rd2",
+      "_justification": "This is a fake password, used in integration, and other tests."
+    },
+    {
       "placeholder": "thisIsAFakeSecret",
       "_justification": "This isn't a real secret, it's used in one of the playground applications for testing purposes."
     },

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -480,7 +480,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
                 .WithTempAspireStore(aspireStorePath)
                 .WithResourceCleanUp(false);
 
-            var passwordParameter = builder.AddParameter("pwd", "p@ssword1", secret: true);
+            var passwordParameter = builder.AddParameter("pwd", "p@ssw0rd1", secret: true);
             var mysql = builder
                 .AddMySql("resource", password: passwordParameter).WithLifetime(ContainerLifetime.Persistent)
                 .WithPhpMyAdmin(c => c.WithLifetime(ContainerLifetime.Persistent))
@@ -488,7 +488,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
 
             if (useMultipleInstances)
             {
-                var passwordParameter2 = builder.AddParameter("pwd2", "p@ssword2", secret: true);
+                var passwordParameter2 = builder.AddParameter("pwd2", "p@ssw0rd2", secret: true);
                 builder.AddMySql("resource2", password: passwordParameter2).WithLifetime(ContainerLifetime.Persistent);
             }
 


### PR DESCRIPTION
`##[error]1. Credential Scanner Error CSCAN-MSFT0090 - File: tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs. Line: 483. Column 1. `
`##[error]2. Credential Scanner Error CSCAN-MSFT0090 - File: tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs. Line: 491. Column 1.`

Fixes https://github.com/dotnet/aspire/issues/7855 .
