### PR TITLE
Include Aspire.Hosting.Analyzers in Aspire.Hosting.AppHost nuget package

### DIFF
--- a/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
+++ b/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(RepoRoot)eng/ReplaceText.targets" />
 
@@ -39,13 +39,20 @@
 
   <ItemGroup>
     <!-- Reference the analyzer to ensure it's built but don't reference its output -->
-    <ProjectReference Include="..\Aspire.Hosting.Analyzers\Aspire.Hosting.Analyzers.csproj" OutputItemType="AnalyzerAssemblyPath" ReferenceOutputAssembly="false" Private="true" />
+    <ProjectReference Include="..\Aspire.Hosting.Analyzers\Aspire.Hosting.Analyzers.csproj" ReferenceOutputAssembly="false" Private="true" />
   </ItemGroup>
 
   <!-- Include the analyzer in the package -->
-  <Target Name="IncludeAnalyzerInPackage" AfterTargets="ResolveProjectReferences">
+  <PropertyGroup>
+    <BeforePack>$(BeforePack);IncludeAnalyzerInPackage</BeforePack>
+  </PropertyGroup>
+  <Target Name="IncludeAnalyzerInPackage">
+    <MSBuild Projects="..\Aspire.Hosting.Analyzers\Aspire.Hosting.Analyzers.csproj" Targets="GetTargetPath">
+      <Output TaskParameter="TargetOutputs" ItemName="_AnalyzerFile" />
+    </MSBuild>
+
     <ItemGroup>
-      <None Include="@(AnalyzerAssemblyPath -> '%(Identity)')" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+      <None Include="@(_AnalyzerFile)" Pack="True" PackagePath="analyzers/dotnet/cs" />
     </ItemGroup>
   </Target>
 

--- a/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
+++ b/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
@@ -48,11 +48,13 @@
   </PropertyGroup>
   <Target Name="IncludeAnalyzerInPackage">
     <MSBuild Projects="..\Aspire.Hosting.Analyzers\Aspire.Hosting.Analyzers.csproj" Targets="GetTargetPath">
-      <Output TaskParameter="TargetOutputs" ItemName="_AnalyzerFile" />
+      <Output TaskParameter="TargetOutputs" PropertyName="AspireHostingAnalyzerFile" />
     </MSBuild>
 
+    <Error Condition="'$(AspireHostingAnalyzerFile)' == ''" Text="Could not find Aspire.Hosting.Analyzers.dll." />
+
     <ItemGroup>
-      <None Include="@(_AnalyzerFile)" Pack="True" PackagePath="analyzers/dotnet/cs" />
+      <None Include="$(AspireHostingAnalyzerFile)" Pack="True" PackagePath="analyzers/dotnet/cs" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This was broken when the Aspire.Hosting.AppHost package multi-targeted to net8 and net9. The AnalyzerAssemblyPath was no longer being populated in the multi-targeted build.

The fix is to explicitly get the TargetPath from the Analyzer project and use it to add to the analyzers folder.
