### PR TITLE
Fix Aspire CLI test failures on Windows.

### DIFF
--- a/tests/Aspire.Cli.Tests/CliSmokeTests.cs
+++ b/tests/Aspire.Cli.Tests/CliSmokeTests.cs
@@ -21,7 +21,7 @@ public class CliSmokeTests
         // This is just an early signal to make sure the executables selected
         // for the stub processes work.
         using var stubProcess = StubProcess.Create();
-        var stillRunning = stubProcess.Process.WaitForExit(10000);
-        Assert.False(stillRunning);
+        var exited = stubProcess.Process.WaitForExit(1000);
+        Assert.False(exited);
     }
 }

--- a/tests/Aspire.Cli.Tests/Helpers/StubProcess.cs
+++ b/tests/Aspire.Cli.Tests/Helpers/StubProcess.cs
@@ -15,7 +15,7 @@ public class StubProcess(Process process) : IDisposable
             PlatformID.Win32NT => new ProcessStartInfo()
             {
                 FileName = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
-                Arguments = "/c set %never%=WaitUntilDeath"
+                Arguments = "/c set /p discard=WaitingUntilDeath"
             },
             PlatformID.Unix => new ProcessStartInfo()
             {

--- a/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
@@ -109,7 +109,7 @@ public class CliOrphanDetectorTests(ITestOutputHelper testOutputHelper)
 
         // Wait until the apphost is spun up and then kill off the stub
         // process so everything is torn down.
-        _ = await resourcesCreatedEventsChannel.Reader.WaitToReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10000));
+        _ = await resourcesCreatedEventsChannel.Reader.WaitToReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
         stubProcess.Process.Kill();
 
         await pendingRun.WaitAsync(TimeSpan.FromSeconds(10));

--- a/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
@@ -99,7 +99,7 @@ public class CliOrphanDetectorTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
         builder.Configuration["ASPIRE_CLI_PID"] = stubProcess.Process.Id.ToString();
         
-        var resourcesCreatedTcs = new TaskCompletionSource();
+        var resourcesCreatedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         builder.Eventing.Subscribe<AfterResourcesCreatedEvent>((e, ct) => {
             resourcesCreatedTcs.SetResult();
             return Task.CompletedTask;


### PR DESCRIPTION
This PR fixes a build failure happening on main where the Windows command I was using to cause the stub process to wait indefinately was failing, causing the tests not to behave correctly. Once I fixed that issue another issue appeared in a test case which was now throwing a task cancelled exception. I fixed up the test so that we don't need to worry about that (might revisit in the future if it turns out to be an issue).