### PR TITLE
`aspire pack [project] --target [publisher] --output-path [manifest filename]`

### DIFF
--- a/src/Aspire.Cli/AppHostRunner.cs
+++ b/src/Aspire.Cli/AppHostRunner.cs
@@ -3,11 +3,10 @@
 
 using System.Diagnostics;
 using System.Globalization;
-using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Cli;
 
-internal sealed class AppHostRunner(IHostApplicationLifetime lifetime)
+internal sealed class AppHostRunner
 {
     internal Func<int> GetCurrentProcessId { get; set; } = () => Environment.ProcessId;
 
@@ -44,8 +43,6 @@ internal sealed class AppHostRunner(IHostApplicationLifetime lifetime)
         {
             process.Kill(false); // DCP should clean everything else up.
         }
-
-        lifetime.StopApplication();
 
         return process.ExitCode;
     }

--- a/src/Aspire.Cli/AppHostRunner.cs
+++ b/src/Aspire.Cli/AppHostRunner.cs
@@ -7,17 +7,22 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Cli;
 
-internal sealed class AppHostRunner(IHostLifetime hostLifetime)
+internal sealed class AppHostRunner(IHostApplicationLifetime lifetime)
 {
     internal Func<int> GetCurrentProcessId { get; set; } = () => Environment.ProcessId;
 
-    public async Task<int> RunAppHostAsync(FileInfo appHostProjectFile, CancellationToken cancellationToken)
+    public async Task<int> RunAppHostAsync(FileInfo appHostProjectFile, string[] args, CancellationToken cancellationToken)
     {
         var startInfo = new ProcessStartInfo("dotnet", $"run --project \"{appHostProjectFile.FullName}\"")
         {
             UseShellExecute = false,
             CreateNoWindow = true
         };
+
+        if (args.Length > 0)
+        {
+            startInfo.Arguments += " -- " + string.Join(" ", args);
+        }
 
         // The AppHost uses this environment variable to signal to the CliOrphanDetector which process
         // it should monitor in order to know when to stop the CLI. As long as the process still exists
@@ -40,7 +45,7 @@ internal sealed class AppHostRunner(IHostLifetime hostLifetime)
             process.Kill(false); // DCP should clean everything else up.
         }
 
-        await hostLifetime.StopAsync(cancellationToken).ConfigureAwait(false);
+        lifetime.StopApplication();
 
         return process.ExitCode;
     }

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -12,6 +12,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PublishAot>true</PublishAot>
     <PackAsTool>true</PackAsTool>
+    <IsPackable>true</IsPackable>
     <ToolCommandName>aspire</ToolCommandName>
   </PropertyGroup>
 

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,7 +12,6 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PublishAot>true</PublishAot>
     <PackAsTool>true</PackAsTool>
-    <IsPackable>true</IsPackable>
     <ToolCommandName>aspire</ToolCommandName>
   </PropertyGroup>
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -34,13 +34,11 @@ public class Program
 
         command.SetAction(async (parseResult, ct) => {
             using var app = BuildApplication();
-            var pendingRun = app.RunAsync(ct).ConfigureAwait(false);
+            _ = app.RunAsync(ct).ConfigureAwait(false);
 
             var runner = app.Services.GetRequiredService<AppHostRunner>();
             var appHostProjectFile = parseResult.GetValue<FileInfo>("project");
             var exitCode = await runner.RunAppHostAsync(appHostProjectFile!, [], ct).ConfigureAwait(false);
-
-            await pendingRun;
 
             return exitCode;
         });
@@ -63,15 +61,13 @@ public class Program
 
         command.SetAction(async (parseResult, ct) => {
             using var app = BuildApplication();
-            var pendingRun = app.RunAsync(ct).ConfigureAwait(false);
+            _ = app.RunAsync(ct).ConfigureAwait(false);
 
             var runner = app.Services.GetRequiredService<AppHostRunner>();
             var appHostProjectFile = parseResult.GetValue<FileInfo>("project");
             var target = parseResult.GetValue<string>("--target");
             var outputPath = parseResult.GetValue<string>("--output-path");
             var exitCode = await runner.RunAppHostAsync(appHostProjectFile!, ["--publisher", target ?? "manifest", "--output-path", outputPath ?? "."], ct).ConfigureAwait(false);
-
-            await pendingRun;
 
             return exitCode;
         });

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -7,6 +7,13 @@
       "commandLineArgs": "dev ../../../../../playground/waitfor/WaitForSandbox.AppHost/WaitForSandbox.AppHost.csproj",
       "environmentVariables": {
       }
+    },
+    "pack-waitfor": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "pack ../../../../../playground/waitfor/WaitForSandbox.AppHost/WaitForSandbox.AppHost.csproj --target manifest --output-path aspire-manifest.json",
+      "environmentVariables": {
+      }
     }
   }
 }


### PR DESCRIPTION
This PR introduces the `aspire pack` command. It's pretty much pass thru to `dotnet run -- --publisher manifest --output-path [path]` at this point. This is just a first pass at laying down the command a bunch more work will need to be done on the app host side to give publishers more superpowers.