### PR TITLE
Add retries to publish steps

### DIFF
--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -30,6 +30,7 @@ jobs:
             PathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
             ArtifactName: ${{ coalesce(parameters.artifacts.publish.artifacts.name , 'Artifacts_$(Agent.Os)_$(_BuildConfig)') }}
             condition: always()
+            retryCountOnTaskFailure: 10 # for any logs being locked
             continueOnError: true
         - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
           - output: pipelineArtifact
@@ -38,6 +39,7 @@ jobs:
             displayName: 'Publish logs'
             continueOnError: true
             condition: always()
+            retryCountOnTaskFailure: 10 # for any logs being locked
             sbomEnabled: false  # we don't need SBOM for logs
 
       - ${{ if eq(parameters.enablePublishBuildArtifacts, true) }}:

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -46,6 +46,7 @@ jobs:
               artifactName: ${{ coalesce(parameters.artifacts.publish.artifacts.name , 'Artifacts_$(Agent.Os)_$(_BuildConfig)') }}
               continueOnError: true
               condition: always()
+              retryCountOnTaskFailure: 10 # for any logs being locked
       - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
         - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
           parameters:
@@ -56,6 +57,7 @@ jobs:
               displayName: 'Publish logs'
               continueOnError: true
               condition: always()
+              retryCountOnTaskFailure: 10 # for any logs being locked
               sbomEnabled: false  # we don't need SBOM for logs
 
     - ${{ if ne(parameters.enablePublishBuildArtifacts, 'false') }}:


### PR DESCRIPTION
attempt to work around DCP log locking causing

System.IO.IOException: The process cannot access the file 'D:\a\_work\1\a\artifacts\log\dcp\dcpctrl-1741041174-9644.log' because it is being used by another process.
