### PR TITLE
Add --project option with automatic apphost detection

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -10,7 +10,8 @@
     <AssemblyName>aspire</AssemblyName>
     <RootNamespace>Aspire.Cli</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>aspire</ToolCommandName>
   </PropertyGroup>

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -80,7 +80,7 @@ public class Program
             var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
             var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
 
-            var exitCode = await runner.RunAppHostAsync(effectiveAppHostProjectFile, [], ct).ConfigureAwait(false);
+            var exitCode = await runner.RunAppHostAsync(effectiveAppHostProjectFile, Array.Empty<string>(), ct).ConfigureAwait(false);
 
             return exitCode;
         });

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -25,20 +26,61 @@ public class Program
         return rootCommand;
     }
 
+    private static void ValidateProjectOption(OptionResult result)
+    {
+        var value = result.GetValueOrDefault<FileInfo?>();
+
+        if (result.Implicit)
+        {
+            // Having no value here is fine, but there has to
+            // be a single csproj file in the current
+            // working directory.
+            var csprojFiles = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj");
+
+            if (csprojFiles.Length > 1)
+            {
+                result.AddError("The --project option was not specified and multiple *.csproj files were detected.");
+                return;
+            }
+            else if (csprojFiles.Length == 0)
+            {
+                result.AddError("The --project option was not specified and no *.csproj files were detected.");
+                return;
+            }
+
+            return;
+        }
+
+        if (value is null)
+        {
+            result.AddError("The --project option was specified but no path was provided.");
+            return;
+        }
+
+        if (!File.Exists(value.FullName))
+        {
+            result.AddError("The specified project file does not exist.");
+            return;
+        }
+    }
+
     private static void ConfigureDevCommand(Command parentCommand)
     {
         var command = new Command("dev", "Run a .NET Aspire AppHost project in development mode.");
 
-        var projectArgument = new Argument<FileInfo>("project").AcceptExistingOnly();
-        command.Arguments.Add(projectArgument);
+        var projectOption = new Option<FileInfo?>("--project", "-p");
+        projectOption.Validators.Add(ValidateProjectOption);
+        command.Options.Add(projectOption);
 
         command.SetAction(async (parseResult, ct) => {
             using var app = BuildApplication();
             _ = app.RunAsync(ct).ConfigureAwait(false);
 
             var runner = app.Services.GetRequiredService<AppHostRunner>();
-            var appHostProjectFile = parseResult.GetValue<FileInfo>("project");
-            var exitCode = await runner.RunAppHostAsync(appHostProjectFile!, [], ct).ConfigureAwait(false);
+            var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
+            var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
+
+            var exitCode = await runner.RunAppHostAsync(effectiveAppHostProjectFile, [], ct).ConfigureAwait(false);
 
             return exitCode;
         });
@@ -46,12 +88,26 @@ public class Program
         parentCommand.Subcommands.Add(command);
     }
 
+    private static FileInfo UseOrFindAppHostProjectFile(FileInfo? projectFile)
+    {
+        if (projectFile is not null)
+        {
+            // If the project file is passed, just use it.
+            return projectFile;
+        }
+
+        var projectFilePaths = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj");
+        var projectFilePath = projectFilePaths.Single();
+        return new FileInfo(projectFilePath);
+    }
+
     private static void ConfigurePackCommand(Command parentCommand)
     {
         var command = new Command("pack", "Pack a .NET Aspire AppHost project.");
 
-        var projectArgument = new Argument<FileInfo>("project").AcceptExistingOnly();
-        command.Arguments.Add(projectArgument);
+        var projectOption = new Option<FileInfo?>("--project", "-p");
+        projectOption.Validators.Add(ValidateProjectOption);
+        command.Options.Add(projectOption);
 
         var targetOption = new Option<string>("--target", "-t");
         command.Options.Add(targetOption);
@@ -64,10 +120,12 @@ public class Program
             _ = app.RunAsync(ct).ConfigureAwait(false);
 
             var runner = app.Services.GetRequiredService<AppHostRunner>();
-            var appHostProjectFile = parseResult.GetValue<FileInfo>("project");
+            var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
+            var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
+            
             var target = parseResult.GetValue<string>("--target");
             var outputPath = parseResult.GetValue<string>("--output-path");
-            var exitCode = await runner.RunAppHostAsync(appHostProjectFile!, ["--publisher", target ?? "manifest", "--output-path", outputPath ?? "."], ct).ConfigureAwait(false);
+            var exitCode = await runner.RunAppHostAsync(effectiveAppHostProjectFile, ["--publisher", target ?? "manifest", "--output-path", outputPath ?? "."], ct).ConfigureAwait(false);
 
             return exitCode;
         });

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -1,10 +1,18 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "dev-waitfor": {
+    "dev-waitfor-explicit": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "commandLineArgs": "dev ../../../../../playground/waitfor/WaitForSandbox.AppHost/WaitForSandbox.AppHost.csproj",
+      "environmentVariables": {
+      }
+    },
+    "dev-waitfor-implicit": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "dev",
+      "workingDirectory": "../../playground/waitfor/WaitForSandbox.AppHost",
       "environmentVariables": {
       }
     },


### PR DESCRIPTION
Introduce a new `--project` option for commands, allowing users to specify a project file. If not provided, the system automatically detects a single `.csproj` file in the current directory. This enhances usability by reducing the need for explicit project file specification.