### PR TITLE
Remove Aspire.Cli from unexpected packages list

### DIFF
--- a/tests/Shared/Aspire.Workload.Testing.targets
+++ b/tests/Shared/Aspire.Workload.Testing.targets
@@ -100,6 +100,7 @@
       <!-- Exclude the packages with arch-specific nugets -->
       <UnexpectedPackages Remove="@(UnexpectedPackages)" Condition="$([System.String]::Copy('%(UnexpectedPackages.FileName)').StartsWith('Aspire.Dashboard.Sdk.'))" />
       <UnexpectedPackages Remove="@(UnexpectedPackages)" Condition="$([System.String]::Copy('%(UnexpectedPackages.FileName)').StartsWith('Aspire.Hosting.Orchestration.'))" />
+      <UnexpectedPackages Remove="@(UnexpectedPackages)" Condition="$([System.String]::Copy('%(UnexpectedPackages.FileName)').StartsWith('Aspire.Cli.'))" />
 
     </ItemGroup>
 


### PR DESCRIPTION
Exclude Aspire.Cli from the set of unexpected packages. This is currently breaking the build.