### PR TITLE
Set explicit package ID for Aspire.Cli

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -14,6 +14,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>aspire</ToolCommandName>
+    <PackageId>Aspire.Cli</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Define the package ID in the project file to ensure proper identification of the package.

This is currently breaking the build because the package name that gets produced is aspire.<version>.nupkg.