### PR TITLE
`aspire new` bootstrap

### DIFF
--- a/src/Aspire.Cli/AppHostRunner.cs
+++ b/src/Aspire.Cli/AppHostRunner.cs
@@ -1,49 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-using System.Globalization;
-
 namespace Aspire.Cli;
 
-internal sealed class AppHostRunner
+internal sealed class AppHostRunner(DotNetCliRunner cli)
 {
-    internal Func<int> GetCurrentProcessId { get; set; } = () => Environment.ProcessId;
-
     public async Task<int> RunAppHostAsync(FileInfo appHostProjectFile, string[] args, CancellationToken cancellationToken)
     {
-        var startInfo = new ProcessStartInfo("dotnet", $"run --project \"{appHostProjectFile.FullName}\"")
-        {
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        if (args.Length > 0)
-        {
-            startInfo.Arguments += " -- " + string.Join(" ", args);
-        }
-
-        // The AppHost uses this environment variable to signal to the CliOrphanDetector which process
-        // it should monitor in order to know when to stop the CLI. As long as the process still exists
-        // the orphan detector will allow the CLI to keep running. If the environment variable does
-        // not exist the orphan detector will exit.
-        startInfo.EnvironmentVariables["ASPIRE_CLI_PID"] = GetCurrentProcessId().ToString(CultureInfo.InvariantCulture);
-
-        using var process = new Process { StartInfo = startInfo };
-        var started = process.Start();
-
-        if (!started)
-        {
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
-        }
-
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-
-        if (!process.HasExited)
-        {
-            process.Kill(false); // DCP should clean everything else up.
-        }
-
-        return process.ExitCode;
+        return await cli.RunAsync(appHostProjectFile, args, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -23,9 +23,9 @@ internal sealed class DotNetCliRunner
         return await ExecuteAsync(cliArgs, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<int> NewProjectAsync(CancellationToken cancellationToken)
+    public async Task<int> NewProjectAsync(string templateName, string name, string outputPath, CancellationToken cancellationToken)
     {
-        string[] cliArgs = ["new", "aspire-starter", "--name", "HelloAspire"];
+        string[] cliArgs = ["new", templateName, "--name", name, "--output", outputPath];
         return await ExecuteAsync(cliArgs, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -37,9 +37,9 @@ internal sealed class DotNetCliRunner
             CreateNoWindow = true
         };
 
-        if (args.Length > 0)
+        foreach (var a in args)
         {
-            startInfo.ArgumentList = args;
+            startInfo.ArgumentList.Add(a);
         }
 
         // The AppHost uses this environment variable to signal to the CliOrphanDetector which process

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Aspire.Cli;
+
+internal sealed class DotNetCliRunner
+{
+    internal Func<int> GetCurrentProcessId { get; set; } = () => Environment.ProcessId;
+
+    public async Task<int> RunAsync(FileInfo projectFile, string[] args, CancellationToken cancellationToken)
+    {
+        string[] cliArgs = ["run", "--project", projectFile.FullName, "--", ..args];
+        return await ExecuteAsync(cliArgs, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<int> InstallTemplateAsync(string packageName, string version, bool force, CancellationToken cancellationToken)
+    {
+        string[] forceArgs = force ? ["--force"] : [];
+        string[] cliArgs = ["new", "install", $"{packageName}::{version}", ..forceArgs];
+        return await ExecuteAsync(cliArgs, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<int> NewProjectAsync(CancellationToken cancellationToken)
+    {
+        string[] cliArgs = ["new", "aspire-starter", "--name", "HelloAspire"];
+        return await ExecuteAsync(cliArgs, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<int> ExecuteAsync(string[] args, CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        if (args.Length > 0)
+        {
+            startInfo.Arguments = string.Join(" ", args);
+        }
+
+        // The AppHost uses this environment variable to signal to the CliOrphanDetector which process
+        // it should monitor in order to know when to stop the CLI. As long as the process still exists
+        // the orphan detector will allow the CLI to keep running. If the environment variable does
+        // not exist the orphan detector will exit.
+        startInfo.EnvironmentVariables["ASPIRE_CLI_PID"] = GetCurrentProcessId().ToString(CultureInfo.InvariantCulture);
+
+        using var process = new Process { StartInfo = startInfo };
+        var started = process.Start();
+
+        if (!started)
+        {
+            return ExitCodeConstants.FailedToDotnetRunAppHost;
+        }
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!process.HasExited)
+        {
+            process.Kill(false);
+        }
+
+        return process.ExitCode;
+    }
+}

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -39,7 +39,7 @@ internal sealed class DotNetCliRunner
 
         if (args.Length > 0)
         {
-            startInfo.Arguments = string.Join(" ", args);
+            startInfo.ArgumentList = args;
         }
 
         // The AppHost uses this environment variable to signal to the CliOrphanDetector which process

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -8,4 +8,6 @@ internal static class ExitCodeConstants
     public const int Success = 0;
     public const int InvalidCommand = 1;
     public const int FailedToDotnetRunAppHost = 2;
+    public const int FailedToInstallTemplates = 3;
+    public const int FailedToCreateNewProject = 4;
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -179,7 +179,6 @@ public class Program
 
         if (value is { } templateName && !validTemplates.Contains(templateName))
         {
-
             result.AddError($"The specified template '{templateName}' is not valid. Valid templates are [{string.Join(", ", validTemplates)}].");
             return;
         }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -163,8 +163,7 @@ public class Program
             "aspire-servicedefaults",
             "aspire-mstest",
             "aspire-nunit",
-            "aspire-xunit",
-            "aspire-nunit"
+            "aspire-xunit"
             ];
 
         var value = result.GetValueOrDefault<string>();


### PR DESCRIPTION
This PR introduces a new `aspire new` command which is a limited wrapper around .NET new. Usage examples:

- `aspire new` (will create a new aspire-starter project in the current working directory adopting the name of the parent directory.
- `aspire new aspire` (same as above, but will use the aspire template instead.
- `aspire new --name HelloAspire` (will create a new starter project in the current working directory with the name HelloAspire as a prefix).
- `aspire new --name HelloAspire --output src` (will create a new aspire-starter project in the src sub directory with the HelloAspire as the solution name).

This will also force install Aspire.ProjectTemplates::*-* (temporary for now) each time it is run.

To make template handling more intelligent we'll look to integrate with the template engine.

If you want to try it out open a codespace and build the CLI project then do the following:

```bash
cd /workspaces
mkdir HelloAspire && cd HelloAspire
aspire new
aspire dev
```