### PR TITLE
Add is_inactive to Url, return Urls for non-running resources

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
@@ -19,6 +19,11 @@ internal static class ResourceEndpointHelpers
         {
             if ((includeInternalUrls && url.IsInternal) || !url.IsInternal)
             {
+                if (url.IsInactive)
+                {
+                    continue;
+                }
+
                 endpoints.Add(new DisplayedEndpoint
                 {
                     Name = url.Name,

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -324,8 +324,9 @@ public sealed class UrlViewModel
     public string Name { get; }
     public Uri Url { get; }
     public bool IsInternal { get; }
+    public bool IsInactive { get; }
 
-    public UrlViewModel(string name, Uri url, bool isInternal)
+    public UrlViewModel(string name, Uri url, bool isInternal, bool isInactive)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(url);
@@ -333,6 +334,7 @@ public sealed class UrlViewModel
         Name = name;
         Url = url;
         IsInternal = isInternal;
+        IsInactive = isInactive;
     }
 }
 

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -95,7 +95,7 @@ partial class Resource
             return (from u in Urls
                     let parsedUri = Uri.TryCreate(u.FullUrl, UriKind.Absolute, out var uri) ? uri : null
                     where parsedUri != null
-                    select new UrlViewModel(u.Name, parsedUri, u.IsInternal))
+                    select new UrlViewModel(u.Name, parsedUri, u.IsInternal, u.IsInactive))
                     .ToImmutableArray();
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -178,7 +178,24 @@ public sealed record EnvironmentVariableSnapshot(string Name, string? Value, boo
 /// <param name="Url">The full uri.</param>
 /// <param name="IsInternal">Determines if this url is internal.</param>
 [DebuggerDisplay("{Url}", Name = "{Name}")]
-public sealed record UrlSnapshot(string Name, string Url, bool IsInternal);
+public sealed record UrlSnapshot(string Name, string Url, bool IsInternal)
+{
+    /// <summary>
+    /// Whether this URL is inactive or not.
+    /// </summary>
+    /// <remarks>
+    /// Inactive URLs are not displayed in UI.
+    /// </remarks>
+    public bool IsInactive { get; init; }
+
+    internal void Deconstruct(out string name, out string url, out bool isInternal, out bool isInactive)
+    {
+        name = Name;
+        url = Url;
+        isInternal = IsInternal;
+        isInactive = IsInactive;
+    }
+}
 
 /// <summary>
 /// A snapshot of a volume, mounted to a container.

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -42,7 +42,7 @@ partial class Resource
 
         foreach (var url in snapshot.Urls)
         {
-            resource.Urls.Add(new Url { Name = url.Name, FullUrl = url.Url, IsInternal = url.IsInternal });
+            resource.Urls.Add(new Url { Name = url.Name, FullUrl = url.Url, IsInternal = url.IsInternal, IsInactive = url.IsInactive });
         }
 
         foreach (var relationship in snapshot.Relationships)

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -131,6 +131,9 @@ message Url {
     // Determines if this url shows up in the details view only by default.
     // If true, the url will not be shown in the list of urls in the top level resources view.
     bool is_internal = 3;
+    // Indicates if this URL is inactive. A non-running resource may still return inactive URLs.
+    // If true, the inactive url will not be shown in the dashboard.
+    bool is_inactive = 4;
 }
 
 // Data about a volume mounted to a container.

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -94,7 +94,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
         _distributedApplicationOptions = distributedApplicationOptions;
         _options = options;
         _executionContext = executionContext;
-        _resourceState = new(model.Resources.ToDictionary(r => r.Name));
+        _resourceState = new(model.Resources.ToDictionary(r => r.Name), _appResources);
         _snapshotBuilder = new(_resourceState);
 
         DeleteResourceRetryPipeline = DcpPipelineBuilder.BuildDeleteRetryPipeline(logger);

--- a/src/Aspire.Hosting/Dcp/DcpResourceState.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceState.cs
@@ -7,7 +7,7 @@ using Aspire.Hosting.Dcp.Model;
 
 namespace Aspire.Hosting.Dcp;
 
-internal sealed class DcpResourceState(Dictionary<string, IResource> applicationModel)
+internal sealed class DcpResourceState(Dictionary<string, IResource> applicationModel, List<AppResource> appResources)
 {
     public readonly ConcurrentDictionary<string, Container> ContainersMap = [];
     public readonly ConcurrentDictionary<string, Executable> ExecutablesMap = [];
@@ -16,4 +16,5 @@ internal sealed class DcpResourceState(Dictionary<string, IResource> application
     public readonly ConcurrentDictionary<(string, string), List<string>> ResourceAssociatedServicesMap = [];
 
     public Dictionary<string, IResource> ApplicationModel { get; } = applicationModel;
+    public List<AppResource> AppResources { get; } = appResources;
 }

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -185,20 +185,17 @@ internal class ResourceSnapshotBuilder
 
     private ImmutableArray<UrlSnapshot> GetUrls(CustomResource resource)
     {
-        var name = resource.Metadata.Name;
-
         var urls = ImmutableArray.CreateBuilder<UrlSnapshot>();
 
-        foreach (var (_, endpoint) in _resourceState.EndpointsMap)
-        {
-            if (endpoint.Metadata.OwnerReferences?.Any(or => or.Kind == resource.Kind && or.Name == name) != true)
-            {
-                continue;
-            }
+        var allServices = _resourceState.AppResources.OfType<ServiceAppResource>().Where(r => r.Service.AppModelResourceName == resource.AppModelResourceName).Select(s => s.Service).ToList();
+        var name = resource.Metadata.Name;
 
-            if (endpoint.Spec.ServiceName is not null &&
-                _resourceState.ServicesMap.TryGetValue(endpoint.Spec.ServiceName, out var service) &&
-                service.AppModelResourceName is string resourceName &&
+        foreach (var service in allServices)
+        {
+            var activeEndpoint = _resourceState.EndpointsMap.SingleOrDefault(e => e.Value.Spec.ServiceName == service.Metadata.Name && e.Value.Metadata.OwnerReferences?.Any(or => or.Kind == resource.Kind && or.Name == name) == true).Value;
+            var isInactive = activeEndpoint is null;
+
+            if (service.AppModelResourceName is string resourceName &&
                 _resourceState.ApplicationModel.TryGetValue(resourceName, out var appModelResource) &&
                 appModelResource is IResourceWithEndpoints resourceWithEndpoints &&
                 service.EndpointName is string endpointName)
@@ -236,21 +233,21 @@ internal class ResourceSnapshotBuilder
                     {
                         var url = CombineUrls(ep.Url, launchUrl);
 
-                        urls.Add(new(Name: ep.EndpointName, Url: url, IsInternal: false));
+                        urls.Add(new(Name: ep.EndpointName, Url: url, IsInternal: false) { IsInactive = isInactive });
                     }
                 }
                 else
                 {
                     if (ep.IsAllocated)
                     {
-                        urls.Add(new(Name: ep.EndpointName, Url: ep.Url, IsInternal: false));
+                        urls.Add(new(Name: ep.EndpointName, Url: ep.Url, IsInternal: false) { IsInactive = isInactive });
                     }
                 }
 
-                if (ep.EndpointAnnotation.IsProxied)
+                if (ep.EndpointAnnotation.IsProxied && activeEndpoint != null)
                 {
-                    var endpointString = $"{ep.Scheme}://{endpoint.Spec.Address}:{endpoint.Spec.Port}";
-                    urls.Add(new(Name: $"{ep.EndpointName} target port", Url: endpointString, IsInternal: true));
+                    var endpointString = $"{ep.Scheme}://{activeEndpoint.Spec.Address}:{activeEndpoint.Spec.Port}";
+                    urls.Add(new(Name: $"{ep.EndpointName} target port", Url: endpointString, IsInternal: true) { IsInactive = isInactive });
                 }
             }
         }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -25,7 +25,7 @@ public sealed class ResourceEndpointHelpersTests
     [Fact]
     public void GetEndpoints_HasServices_Results()
     {
-        var endpoints = GetEndpoints(ModelTestHelpers.CreateResource(urls: [new("Test", new("http://localhost:8080"), isInternal: false)]));
+        var endpoints = GetEndpoints(ModelTestHelpers.CreateResource(urls: [new("Test", new("http://localhost:8080"), isInternal: false, isInactive: false)]));
 
         Assert.Collection(endpoints,
             e =>
@@ -42,8 +42,8 @@ public sealed class ResourceEndpointHelpersTests
     public void GetEndpoints_HasEndpointAndService_Results()
     {
         var endpoints = GetEndpoints(ModelTestHelpers.CreateResource(urls: [
-            new("Test", new("http://localhost:8080"), isInternal: false),
-            new("Test2", new("http://localhost:8081"), isInternal: false)])
+            new("Test", new("http://localhost:8080"), isInternal: false, isInactive: false),
+            new("Test2", new("http://localhost:8081"), isInternal: false, isInactive: false)])
         );
 
         Assert.Collection(endpoints,
@@ -69,8 +69,8 @@ public sealed class ResourceEndpointHelpersTests
     public void GetEndpoints_OnlyHttpAndHttpsEndpointsSetTheUrl()
     {
         var endpoints = GetEndpoints(ModelTestHelpers.CreateResource(urls: [
-            new("Test", new("http://localhost:8080"), isInternal: false),
-            new("Test2", new("tcp://localhost:8081"), isInternal: false)])
+            new("Test", new("http://localhost:8080"), isInternal: false, isInactive: false),
+            new("Test2", new("tcp://localhost:8081"), isInternal: false, isInactive: false)])
         );
 
         Assert.Collection(endpoints,
@@ -96,8 +96,8 @@ public sealed class ResourceEndpointHelpersTests
     public void GetEndpoints_IncludeEndpointUrl_HasEndpointAndService_Results()
     {
         var endpoints = GetEndpoints(ModelTestHelpers.CreateResource(urls: [
-            new("First", new("https://localhost:8080/test"), isInternal:false),
-            new("Test", new("https://localhost:8081/test2"), isInternal:false)
+            new("First", new("https://localhost:8080/test"), isInternal: false, isInactive: false),
+            new("Test", new("https://localhost:8081/test2"), isInternal: false, isInactive: false)
         ]));
 
         Assert.Collection(endpoints,
@@ -120,11 +120,30 @@ public sealed class ResourceEndpointHelpersTests
     }
 
     [Fact]
-    public void GetEndpoints_ExcludesIncludeInternalUrls()
+    public void GetEndpoints_ExcludesInternalUrls()
     {
         var endpoints = GetEndpoints(ModelTestHelpers.CreateResource(urls: [
-            new("First", new("https://localhost:8080/test"), isInternal:true),
-            new("Test", new("https://localhost:8081/test2"), isInternal:false)
+            new("First", new("https://localhost:8080/test"), isInternal: true, isInactive : false),
+            new("Test", new("https://localhost:8081/test2"), isInternal: false, isInactive: false)
+        ]));
+
+        Assert.Collection(endpoints,
+            e =>
+            {
+                Assert.Equal("https://localhost:8081/test2", e.Text);
+                Assert.Equal("Test", e.Name);
+                Assert.Equal("https://localhost:8081/test2", e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8081, e.Port);
+            });
+    }
+
+    [Fact]
+    public void GetEndpoints_ExcludesInactiveUrls()
+    {
+        var endpoints = GetEndpoints(ModelTestHelpers.CreateResource(urls: [
+            new("First", new("https://localhost:8080/test"), isInternal: false, isInactive : true),
+            new("Test", new("https://localhost:8081/test2"), isInternal: false, isInactive: false)
         ]));
 
         Assert.Collection(endpoints,
@@ -142,8 +161,8 @@ public sealed class ResourceEndpointHelpersTests
     public void GetEndpoints_IncludesIncludeInternalUrls()
     {
         var endpoints = GetEndpoints(ModelTestHelpers.CreateResource(urls: [
-            new("First", new("https://localhost:8080/test"), isInternal:true),
-            new("Test", new("https://localhost:8081/test2"), isInternal:false)
+            new("First", new("https://localhost:8080/test"), isInternal: true, isInactive: false),
+            new("Test", new("https://localhost:8081/test2"), isInternal: false, isInactive: false)
         ]),
         includeInternalUrls: true);
 
@@ -170,11 +189,11 @@ public sealed class ResourceEndpointHelpersTests
     public void GetEndpoints_OrderByName()
     {
         var endpoints = GetEndpoints(ModelTestHelpers.CreateResource(urls: [
-            new("a", new("http://localhost:8080"), isInternal: false),
-            new("C", new("http://localhost:8080"), isInternal: false),
-            new("D", new("tcp://localhost:8080"), isInternal: false),
-            new("B", new("tcp://localhost:8080"), isInternal: false),
-            new("Z", new("https://localhost:8080"), isInternal: false)
+            new("a", new("http://localhost:8080"), isInternal: false, isInactive: false),
+            new("C", new("http://localhost:8080"), isInternal: false, isInactive: false),
+            new("D", new("tcp://localhost:8080"), isInternal: false, isInactive: false),
+            new("B", new("tcp://localhost:8080"), isInternal: false, isInactive: false),
+            new("Z", new("https://localhost:8080"), isInternal: false, isInactive: false)
         ]));
 
         Assert.Collection(endpoints,

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -17,7 +17,7 @@ public class ResourceOutgoingPeerResolverTests
         return ModelTestHelpers.CreateResource(
             appName: name,
             displayName: displayName,
-            urls: serviceAddress is null || servicePort is null ? [] : [new UrlViewModel(name, new($"http://{serviceAddress}:{servicePort}"), isInternal: false)]);
+            urls: serviceAddress is null || servicePort is null ? [] : [new UrlViewModel(name, new($"http://{serviceAddress}:{servicePort}"), isInternal: false, isInactive: false)]);
     }
 
     [Fact]


### PR DESCRIPTION
Today resources only return URLs for an endpoint to the dashboard if the resource and endpoint are running/active.

It's useful for the dashboard to have a non-running resource's URLs. For example, viewing distributed traces in the UI. The URL is used to match against a trace's attributes. This allows the UI to turn "localhost:12345" into "rabbitmq".

For example, viewing the trace of calling a database, after the database has stopped running:

Before:
![image](https://github.com/user-attachments/assets/d582d577-3a9e-429f-9b05-a08c15db44e1)

After:
![image](https://github.com/user-attachments/assets/c6ad85e6-5d90-4d27-8616-1722cdef7e4b)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
