### PR TITLE
Resource graph UI fixes

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -425,6 +425,11 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
             if (_resourceByName.TryGetValue(ResourceName, out var selectedResource))
             {
                 await ShowResourceDetailsAsync(selectedResource, buttonId: null);
+
+                if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph)
+                {
+                    await UpdateResourceGraphSelectedAsync();
+                }
             }
 
             // Navigate to remove ?resource=xxx in the URL.

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -64,7 +64,7 @@
     overflow: hidden;
 }
 
-::deep .resource-tabs fluent-tab:first-child {
+::deep .resource-tabs fluent-tabs {
     margin-left: calc(var(--design-unit) * 3px);
 }
 


### PR DESCRIPTION
## Description

* Fix the first tab on the resources page when it is selected. The under line now better lines up with icon and text
* Fix the graph's selected resource not changing when clicking on relationship links in resource details.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
