### PR TITLE
[CI] Fix running pipeline tests on the rolling builds

### DIFF
--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -15,7 +15,7 @@
     <RunTestsOnGithubActions Condition="'$(RunTestsOnGithubActions)' == '' and ('$(IsTestProject)' == 'true' and '$(IsTestSupportProject)' != 'true')">true</RunTestsOnGithubActions>
     <RunTestsOnHelix Condition="'$(RunTestsOnHelix)' == '' and ('$(IsTestProject)' == 'true' and '$(IsTestSupportProject)' != 'true')">true</RunTestsOnHelix>
     <!-- this is for pipeline tests -->
-    <SkipTests Condition="'$(SkipTests)' == '' and ('$(IsTestSupportProject)' == 'true' or '$(RunTestsOnHelix)' == 'true' or '$(RunTestsOnGithubActions)' == 'true')">true</SkipTests>
+    <SkipTests Condition="'$(SkipTests)' == '' and ('$(IsTestSupportProject)' == 'true' or '$(RunTestsOnHelix)' == 'true')">true</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Don't use `RunTestsOnGithubActions` to determine whether to skip
pipeline tests. This regressed in #7842 .
