### PR TITLE
[CI] Enable Workload tests for PR validation

### DIFF
--- a/.github/actions/enumerate-template-tests/action.yml
+++ b/.github/actions/enumerate-template-tests/action.yml
@@ -1,0 +1,51 @@
+name: 'Enumerate Workload tests'
+description: 'Enumerate list of workload tests'
+outputs:
+  tests_matrix:
+    description: tests matrix
+    value: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up .NET Core
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.x
+          9.x
+
+    - name: Generate list of tests
+      env:
+        CI: false
+      shell: pwsh
+      run: >
+          dotnet build ${{ github.workspace }}/tests/Aspire.Workload.Tests/Aspire.Workload.Tests.csproj
+          "/t:Build;ExtractTestClassNames"
+          /bl:${{ github.workspace }}/artifacts/log/Debug/BuildWorkloadTests.binlog
+          -p:ExtractTestClassNamesForHelix=true
+          -p:ArchiveTests=true
+          -p:ExtractTestClassNamesPrefix=Aspire.Workload.Tests
+
+    - name: Generate tests matrix
+      id: generate_test_matrix
+      shell: pwsh
+      env:
+        CI: false
+      run: |
+        $inputFilePath = "${{ github.workspace }}/artifacts/helix/workload-tests/Aspire.Workload.Tests.tests.list"
+        $lines = Get-Content $inputFilePath
+
+        $prefix = "Aspire.Workload.Tests."
+        $lines = Get-Content $inputFilePath | ForEach-Object {
+            $_ -replace "^$prefix", ""
+        }
+
+        $jsonObject = @{
+            "shortname" = $lines | Sort-Object
+        }
+        $jsonString = ConvertTo-Json $jsonObject -Compress
+        "tests_matrix=$jsonString"
+        "tests_matrix=$jsonString" | Out-File -FilePath $env:GITHUB_OUTPUT

--- a/.github/actions/enumerate-tests/action.yml
+++ b/.github/actions/enumerate-tests/action.yml
@@ -1,0 +1,41 @@
+name: 'Enumerate test projects'
+description: 'Enumerate list of test projects'
+outputs:
+  tests_matrix:
+    description: tests matrix
+    value: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up .NET Core
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          9.x
+
+    - name: Get list of tests
+      env:
+        CI: false
+      shell: pwsh
+      run: >
+        dotnet build ${{ github.workspace }}/tests/Shared/GetTestProjects.proj
+        /p:TestsListOutputPath=${{ github.workspace }}/artifacts/TestsForGithubActions.list
+        /p:ContinuousIntegrationBuild=true
+
+    - name: Generate tests matrix
+      id: generate_test_matrix
+      shell: pwsh
+      env:
+        CI: false
+      run: |
+        $filePath = "${{ github.workspace }}/artifacts/TestsForGithubActions.list"
+        $lines = Get-Content $filePath
+        $jsonObject = @{
+            "shortname" = $lines | Sort-Object
+        }
+        $jsonString = ConvertTo-Json $jsonObject -Compress
+        "tests_matrix=$jsonString"
+        "tests_matrix=$jsonString" | Out-File -FilePath $env:GITHUB_OUTPUT

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,39 +19,52 @@ on:
       extraTestArgs:
         required: false
         type: string
+      os:
+        required: false
+        type: string
+        default: "ubuntu-latest"
 
 jobs:
 
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-          include:
-            - os: ubuntu-latest
-              name: linux
-              dotnet_script: ./dotnet.sh
-              build_script: ./build.sh
-            - os: windows-latest
-              name: windows
-              dotnet_script: .\dotnet.cmd
-              build_script: .\build.cmd
+    runs-on: ${{ inputs.os }}
     timeout-minutes: 60
-    name: ${{ matrix.name }}
+    name: ${{ inputs.os }}
     steps:
+      - name: Validate arguments
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrEmpty("${{ inputs.testShortName }}")) {
+            Write-Error "Error: testShortName is required."
+            exit 1
+          }
+
+      - name: Setup vars
+        if: ${{ inputs.os == 'ubuntu-latest' }}
+        run: |
+          echo "dotnet_script=./dotnet.sh" >> $GITHUB_ENV
+          echo "build_script=./build.sh" >> $GITHUB_ENV
+
+      - name: Setup vars
+        if: ${{ inputs.os == 'windows-latest' }}
+        run: |
+          echo "dotnet_script=.\dotnet.cmd" >> $env:GITHUB_ENV
+          echo "build_script=.\build.cmd" >> $env:GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Trust HTTPS development certificate
-        if: matrix.os == 'ubuntu-latest'
-        run: ${{ matrix.dotnet_script }} dev-certs https --trust
+      - name: Trust HTTPS development certificate (Linux)
+        if: inputs.os == 'ubuntu-latest'
+        run: ${{ env.dotnet_script }} dev-certs https --trust
 
       - name: Verify Docker is running
         # nested docker containers not supported on windows
-        if: matrix.os == 'ubuntu-latest'
+        if: inputs.os == 'ubuntu-latest'
         run: docker info
 
       - name: Install Azure Functions Core Tools
-        if: matrix.os == 'ubuntu-latest' && (inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure')
+        if: inputs.os == 'ubuntu-latest' && (inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure')
         run: |
           sudo apt-get update
           sudo apt-get install -y azure-functions-core-tools-4
@@ -82,7 +95,7 @@ jobs:
         env:
           CI: false
         run: |
-          ${{ matrix.build_script }} -restore -ci -build -projects ${{ env.TEST_PROJECT_PATH }}
+          ${{ env.build_script }} -restore -ci -build -projects ${{ env.TEST_PROJECT_PATH }}
 
       # Workaround for bug in Azure Functions Worker SDK. See https://github.com/Azure/azure-functions-dotnet-worker/issues/2969.
       - name: Rebuild for Azure Functions project
@@ -90,7 +103,7 @@ jobs:
         env:
           CI: false
         run: |
-          ${{ matrix.dotnet_script }} build ${{ github.workspace }}/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj /p:SkipUnstableEmulators=true
+          ${{ env.dotnet_script }} build ${{ github.workspace }}/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj /p:SkipUnstableEmulators=true
 
       - name: Run tests
         id: run-tests
@@ -99,7 +112,7 @@ jobs:
           DCP_DIAGNOSTICS_LOG_LEVEL: debug
           DCP_DIAGNOSTICS_LOG_FOLDER: ${{ github.workspace }}/testresults/dcp
         run: >
-          ${{ matrix.dotnet_script }} test ${{ env.TEST_PROJECT_PATH }}
+          ${{ env.dotnet_script }} test ${{ env.TEST_PROJECT_PATH }}
           /p:ContinuousIntegrationBuild=true
           -s eng/testing/.runsettings
           -l "console;verbosity=normal"
@@ -130,7 +143,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-job-result-${{ inputs.testShortName }}-${{ matrix.os }}
+          name: test-job-result-${{ inputs.testShortName }}-${{ inputs.os }}
           path: result-*.rst
 
       - name: Dump docker info
@@ -145,7 +158,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ inputs.testShortName }}-${{ matrix.os }}
+          name: logs-${{ inputs.testShortName }}-${{ inputs.os }}
           path: |
             **/*.binlog
             testresults/**

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,10 @@ on:
       testShortName:
         required: true
         type: string
+      testProjectPath:
+        # relative the repo root
+        required: false
+        type: string
       testSessionTimeoutMs:
         required: false
         type: string
@@ -63,6 +67,21 @@ jobs:
         if: inputs.os == 'ubuntu-latest'
         run: docker info
 
+      - name: Build with packages
+        if: ${{ contains(inputs.testProjectPath, 'Aspire.Workload.Tests') }}
+        env:
+          CI: false
+        run: ${{ env.build_script }} -restore -build -ci -pack -testnobuild /bl
+
+      - name: Install sdk for workload testing
+        if: ${{ contains(inputs.testProjectPath, 'Aspire.Workload.Tests') }}
+        env:
+          CI: false
+        run: >
+          ${{ env.dotnet_script }} build ${{ github.workspace }}/tests/workloads.proj
+          /p:SkipPackageCheckForWorkloadTesting=true
+          /bl:${{ github.workspace }}/artifacts/log/Debug/InstallSdkForTesting.binlog
+
       - name: Install Azure Functions Core Tools
         if: inputs.os == 'ubuntu-latest' && (inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure')
         run: |
@@ -74,13 +93,15 @@ jobs:
         shell: pwsh
         env:
           CI: false
-        # Convert the shortname of the test to a project path in tests/
         run: |
           $testShortName = "${{ inputs.testShortName }}"
+          $overrideTestProjectPath = "${{ inputs.testProjectPath }}"
           $projectPath1 = "${{ github.workspace }}/tests/$testShortName.Tests/$testShortName.Tests.csproj"
           $projectPath2 = "${{ github.workspace }}/tests/Aspire.$testShortName.Tests/Aspire.$testShortName.Tests.csproj"
 
-          if (Test-Path -Path $projectPath1) {
+          if (-not [string]::IsNullOrEmpty($overrideTestProjectPath)) {
+              $projectPath = "${{ github.workspace }}/$overrideTestProjectPath"
+          } elseif (Test-Path -Path $projectPath1) {
               $projectPath = $projectPath1
           } elseif (Test-Path -Path $projectPath2) {
               $projectPath = $projectPath2
@@ -111,6 +132,7 @@ jobs:
           CI: false
           DCP_DIAGNOSTICS_LOG_LEVEL: debug
           DCP_DIAGNOSTICS_LOG_FOLDER: ${{ github.workspace }}/testresults/dcp
+          DISABLE_PLAYWRIGHT_TESTS: ${{ inputs.os == 'ubuntu-latest' }}
         run: >
           ${{ env.dotnet_script }} test ${{ env.TEST_PROJECT_PATH }}
           /p:ContinuousIntegrationBuild=true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -138,7 +138,7 @@ jobs:
           /p:ContinuousIntegrationBuild=true
           -s eng/testing/.runsettings
           -l "console;verbosity=normal"
-          -l "trx"
+          -l "trx;LogFileName=${{ inputs.testShortName }}-TestResults.trx"
           -l "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
           "--blame"
           --blame-hang-timeout ${{ inputs.testHangTimeout }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,24 +43,24 @@ jobs:
             exit 1
           }
 
-      - name: Setup vars
+      - name: Setup vars (Linux)
         if: ${{ inputs.os == 'ubuntu-latest' }}
         run: |
-          echo "dotnet_script=./dotnet.sh" >> $GITHUB_ENV
-          echo "build_script=./build.sh" >> $GITHUB_ENV
+          echo "DOTNET_SCRIPT=./dotnet.sh" >> $GITHUB_ENV
+          echo "BUILD_SCRIPT=./build.sh" >> $GITHUB_ENV
 
-      - name: Setup vars
+      - name: Setup vars (Windows)
         if: ${{ inputs.os == 'windows-latest' }}
         run: |
-          echo "dotnet_script=.\dotnet.cmd" >> $env:GITHUB_ENV
-          echo "build_script=.\build.cmd" >> $env:GITHUB_ENV
+          echo "DOTNET_SCRIPT=.\dotnet.cmd" >> $env:GITHUB_ENV
+          echo "BUILD_SCRIPT=.\build.cmd" >> $env:GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Trust HTTPS development certificate (Linux)
         if: inputs.os == 'ubuntu-latest'
-        run: ${{ env.dotnet_script }} dev-certs https --trust
+        run: ${{ env.DOTNET_SCRIPT }} dev-certs https --trust
 
       - name: Verify Docker is running
         # nested docker containers not supported on windows
@@ -71,14 +71,14 @@ jobs:
         if: ${{ contains(inputs.testProjectPath, 'Aspire.Workload.Tests') }}
         env:
           CI: false
-        run: ${{ env.build_script }} -restore -build -ci -pack -testnobuild /bl
+        run: ${{ env.BUILD_SCRIPT }} -restore -build -ci -pack -testnobuild /bl
 
       - name: Install sdk for workload testing
         if: ${{ contains(inputs.testProjectPath, 'Aspire.Workload.Tests') }}
         env:
           CI: false
         run: >
-          ${{ env.dotnet_script }} build ${{ github.workspace }}/tests/workloads.proj
+          ${{ env.DOTNET_SCRIPT }} build ${{ github.workspace }}/tests/workloads.proj
           /p:SkipPackageCheckForWorkloadTesting=true
           /bl:${{ github.workspace }}/artifacts/log/Debug/InstallSdkForTesting.binlog
 
@@ -116,7 +116,7 @@ jobs:
         env:
           CI: false
         run: |
-          ${{ env.build_script }} -restore -ci -build -projects ${{ env.TEST_PROJECT_PATH }}
+          ${{ env.BUILD_SCRIPT }} -restore -ci -build -projects ${{ env.TEST_PROJECT_PATH }}
 
       # Workaround for bug in Azure Functions Worker SDK. See https://github.com/Azure/azure-functions-dotnet-worker/issues/2969.
       - name: Rebuild for Azure Functions project
@@ -124,7 +124,7 @@ jobs:
         env:
           CI: false
         run: |
-          ${{ env.dotnet_script }} build ${{ github.workspace }}/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj /p:SkipUnstableEmulators=true
+          ${{ env.DOTNET_SCRIPT }} build ${{ github.workspace }}/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj /p:SkipUnstableEmulators=true
 
       - name: Run tests
         id: run-tests
@@ -134,7 +134,7 @@ jobs:
           DCP_DIAGNOSTICS_LOG_FOLDER: ${{ github.workspace }}/testresults/dcp
           DISABLE_PLAYWRIGHT_TESTS: ${{ inputs.os == 'ubuntu-latest' }}
         run: >
-          ${{ env.dotnet_script }} test ${{ env.TEST_PROJECT_PATH }}
+          ${{ env.DOTNET_SCRIPT }} test ${{ env.TEST_PROJECT_PATH }}
           /p:ContinuousIntegrationBuild=true
           -s eng/testing/.runsettings
           -l "console;verbosity=normal"

--- a/.github/workflows/template-tests.yml
+++ b/.github/workflows/template-tests.yml
@@ -81,3 +81,16 @@ jobs:
       - name: Compute result
         run: |
           [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: logs-*
+          merge-multiple: true
+          path: testresults
+
+      - name: Upload test result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Template-TestResults
+          path: testresults/**/*.trx

--- a/.github/workflows/template-tests.yml
+++ b/.github/workflows/template-tests.yml
@@ -31,8 +31,8 @@ jobs:
       tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
     steps:
       - uses: actions/checkout@v4
-      - id: generate_test_matrix
-        uses: ./.github/actions/enumerate-template-tests
+      - uses: ./.github/actions/enumerate-template-tests
+        id: generate_test_matrix
 
   test_linux:
     name: Linux

--- a/.github/workflows/template-tests.yml
+++ b/.github/workflows/template-tests.yml
@@ -1,0 +1,83 @@
+name: Templates
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Duplicated jobs so their dependencies are not blocked on both the
+  # setup jobs
+
+  setup_for_template_tests_lin:
+    name: Setup for template tests (Linux)
+    runs-on: ubuntu-latest
+    outputs:
+      tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/enumerate-template-tests
+        id: generate_test_matrix
+
+  setup_for_template_tests_win:
+    name: Setup for template tests (Windows)
+    runs-on: windows-latest
+    outputs:
+      tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: generate_test_matrix
+        uses: ./.github/actions/enumerate-template-tests
+
+  test_linux:
+    name: Linux
+    uses: ./.github/workflows/run-tests.yml
+    needs: setup_for_template_tests_lin
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup_for_template_tests_lin.outputs.tests_matrix) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      os: "ubuntu-latest"
+      testProjectPath: tests/Aspire.Workload.Tests/Aspire.Workload.Tests.csproj
+      testSessionTimeoutMs: 1200000
+      testHangTimeout: 12m
+      extraTestArgs: "-p:InstallBrowsersForPlaywright=false -p:VSTestTestCaseFilter=FullyQualifiedName~Aspire.Workload.Tests.${{ matrix.shortname }}"
+
+  test_windows:
+    name: Windows
+    uses: ./.github/workflows/run-tests.yml
+    needs: setup_for_template_tests_win
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup_for_template_tests_win.outputs.tests_matrix) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      os: "windows-latest"
+      testProjectPath: tests/Aspire.Workload.Tests/Aspire.Workload.Tests.csproj
+      testSessionTimeoutMs: 1200000
+      testHangTimeout: 12m
+      extraTestArgs: "-p:InstallBrowsersForPlaywright=true -p:VSTestTestCaseFilter=FullyQualifiedName~Aspire.Workload.Tests.${{ matrix.shortname }}"
+
+  results: # This job is used for branch protection. It ensures all the above tests passed
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [test_linux, test_windows]
+    steps:
+      # get all the test-job-result* artifacts into a single directory
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: test-job-result-*
+          merge-multiple: true
+          path: test-job-result
+
+      # return success if zero result-failed-* files are found
+      - name: Compute result
+        run: |
+          [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]

--- a/.github/workflows/template-tests.yml
+++ b/.github/workflows/template-tests.yml
@@ -79,15 +79,21 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: logs-*
+          pattern: logs-*-ubuntu-latest
           merge-multiple: true
-          path: testresults
+          path: testresults/ubuntu-latest
 
-      - name: Upload test result
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: logs-*-windows-latest
+          merge-multiple: true
+          path: testresults/windows-latest
+
+      - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Template-TestResults
+          name: Templates-TestResults
           path: testresults/**/*.trx
 
       # return success if zero result-failed-* files are found

--- a/.github/workflows/template-tests.yml
+++ b/.github/workflows/template-tests.yml
@@ -14,8 +14,8 @@ jobs:
   # Duplicated jobs so their dependencies are not blocked on both the
   # setup jobs
 
-  setup_for_template_tests_lin:
-    name: Setup for template tests (Linux)
+  setup_for_tests_lin:
+    name: Setup for tests (Linux)
     runs-on: ubuntu-latest
     outputs:
       tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
@@ -24,7 +24,7 @@ jobs:
       - uses: ./.github/actions/enumerate-template-tests
         id: generate_test_matrix
 
-  setup_for_template_tests_win:
+  setup_for_tests_win:
     name: Setup for template tests (Windows)
     runs-on: windows-latest
     outputs:
@@ -37,10 +37,10 @@ jobs:
   test_linux:
     name: Linux
     uses: ./.github/workflows/run-tests.yml
-    needs: setup_for_template_tests_lin
+    needs: setup_for_tests_lin
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.setup_for_template_tests_lin.outputs.tests_matrix) }}
+      matrix: ${{ fromJson(needs.setup_for_tests_lin.outputs.tests_matrix) }}
     with:
       testShortName: ${{ matrix.shortname }}
       os: "ubuntu-latest"
@@ -52,10 +52,10 @@ jobs:
   test_windows:
     name: Windows
     uses: ./.github/workflows/run-tests.yml
-    needs: setup_for_template_tests_win
+    needs: setup_for_tests_win
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.setup_for_template_tests_win.outputs.tests_matrix) }}
+      matrix: ${{ fromJson(needs.setup_for_tests_win.outputs.tests_matrix) }}
     with:
       testShortName: ${{ matrix.shortname }}
       os: "windows-latest"

--- a/.github/workflows/template-tests.yml
+++ b/.github/workflows/template-tests.yml
@@ -77,11 +77,6 @@ jobs:
           merge-multiple: true
           path: test-job-result
 
-      # return success if zero result-failed-* files are found
-      - name: Compute result
-        run: |
-          [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]
-
       - uses: actions/download-artifact@v4
         with:
           pattern: logs-*
@@ -94,3 +89,8 @@ jobs:
         with:
           name: Template-TestResults
           path: testresults/**/*.trx
+
+      # return success if zero result-failed-* files are found
+      - name: Compute result
+        run: |
+          [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,11 +77,6 @@ jobs:
           merge-multiple: true
           path: test-job-result
 
-      # return success if zero result-failed-* files are found
-      - name: Compute result
-        run: |
-          [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]
-
       - uses: actions/download-artifact@v4
         with:
           pattern: logs-*-ubuntu-latest
@@ -100,3 +95,8 @@ jobs:
         with:
           name: Integration-TestResults
           path: testresults/**/*.trx
+
+      # return success if zero result-failed-* files are found
+      - name: Compute result
+        run: |
+          [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,9 +81,15 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: logs-*
+          pattern: logs-*-ubuntu-latest
           merge-multiple: true
-          path: testresults
+          path: testresults/ubuntu-latest
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: logs-*-windows-latest
+          merge-multiple: true
+          path: testresults/windows-latest
 
       - name: Upload test result
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Duplicated jobs so their dependencies are not blocked on both the
+  # setup jobs
+
   setup_for_tests_lin:
     name: Setup for tests (Linux)
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,53 +11,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup_for_tests:
-    name: Enumerate test projects (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-          include:
-            - os: ubuntu-latest
-              dotnet_script: ./dotnet.sh
-            - os: windows-latest
-              dotnet_script: .\dotnet.cmd
+  setup_for_tests_lin:
+    name: Setup for tests (Linux)
+    runs-on: ubuntu-latest
     outputs:
       tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Get list of tests
+      - uses: actions/checkout@v4
         env:
-          CI: false
-        run: >
-          ${{ matrix.dotnet_script }} build ${{ github.workspace }}/tests/Shared/GetTestProjects.proj
-          /p:TestsListOutputPath=${{ github.workspace }}/artifacts/TestsForGithubActions.list
-          /p:ContinuousIntegrationBuild=true
+          DISABLE_PLAYWRIGHT_TESTS: true
 
-      - name: Generate tests matrix
+      - uses: ./.github/actions/enumerate-tests
         id: generate_test_matrix
-        shell: pwsh
-        env:
-          CI: false
-        run: |
-          $filePath = "${{ github.workspace }}/artifacts/TestsForGithubActions.list"
-          $lines = Get-Content $filePath
-          $jsonObject = @{
-              "shortname" = $lines | Sort-Object
-          }
-          $jsonString = ConvertTo-Json $jsonObject -Compress
-          "tests_matrix=$jsonString"
-          "tests_matrix=$jsonString" | Out-File -FilePath $env:GITHUB_OUTPUT
 
-  test:
+  setup_for_tests_win:
+    name: Setup for tests (Windows)
+    runs-on: windows-latest
+    outputs:
+      tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: generate_test_matrix
+        uses: ./.github/actions/enumerate-tests
+
+  test_linux:
     uses: ./.github/workflows/run-tests.yml
-    needs: setup_for_tests
+    name: Linux
+    needs: setup_for_tests_lin
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix) }}
+      matrix: ${{ fromJson(needs.setup_for_tests_lin.outputs.tests_matrix) }}
     with:
       testShortName: ${{ matrix.shortname }}
+      os: ubuntu-latest
+      testSessionTimeoutMs: ${{ matrix.testSessionTimeoutMs }}
+      extraTestArgs: ${{ matrix.extraTestArgs }}
+
+  test_windows:
+    uses: ./.github/workflows/run-tests.yml
+    name: Windows
+    needs: setup_for_tests_win
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup_for_tests_win.outputs.tests_matrix) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      os: windows-latest
       testSessionTimeoutMs: ${{ matrix.testSessionTimeoutMs }}
       extraTestArgs: ${{ matrix.extraTestArgs }}
 
@@ -65,7 +65,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [test]
+    needs: [test_linux, test_windows]
     steps:
       # get all the test-job-result* artifacts into a single directory
       - uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
           merge-multiple: true
           path: testresults/windows-latest
 
-      - name: Upload test result
+      - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,3 +78,16 @@ jobs:
       - name: Compute result
         run: |
           [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: logs-*
+          merge-multiple: true
+          path: testresults
+
+      - name: Upload test result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Integration-TestResults
+          path: testresults/**/*.trx

--- a/tests/Aspire.Components.Common.Tests/RequiresSSLCertificateAttribute.cs
+++ b/tests/Aspire.Components.Common.Tests/RequiresSSLCertificateAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit.Sdk;
+
+namespace Aspire.Components.Common.Tests;
+
+[TraitDiscoverer("Aspire.Components.Common.Tests.RequiresSSLCertificateDiscoverer", "Aspire.Components.Common.Tests")]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+public class RequiresSSLCertificateAttribute(string? reason = null) : Attribute, ITraitAttribute
+{
+    // Not supported on Windows CI
+    public static bool IsSupported => !PlatformDetection.IsRunningOnCI || !OperatingSystem.IsWindows();
+
+    public string? Reason { get; init; } = reason;
+}

--- a/tests/Aspire.Components.Common.Tests/RequiresSSLCertificateDiscoverer.cs
+++ b/tests/Aspire.Components.Common.Tests/RequiresSSLCertificateDiscoverer.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.XUnitExtensions;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Aspire.Components.Common.Tests;
+
+public class RequiresSSLCertificateDiscoverer : ITraitDiscoverer
+{
+    public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+    {
+        if (!RequiresSSLCertificateAttribute.IsSupported)
+        {
+            yield return new KeyValuePair<string, string>(XunitConstants.Category, "failing");
+        }
+    }
+}

--- a/tests/Aspire.Workload.Tests/BuildAndRunTemplateTests.cs
+++ b/tests/Aspire.Workload.Tests/BuildAndRunTemplateTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
+using Aspire.Components.Common.Tests;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,6 +28,7 @@ public partial class BuildAndRunTemplateTests : WorkloadTestsBase
 
     [Theory]
     [MemberData(nameof(TestFrameworkTypeWithConfig))]
+    [RequiresSSLCertificate]
     public async Task BuildAndRunStarterTemplateBuiltInTest(string config, string testType)
     {
         string id = GetNewProjectId(prefix: $"starter test.{config}-{testType.Replace(".", "_")}");
@@ -43,6 +45,7 @@ public partial class BuildAndRunTemplateTests : WorkloadTestsBase
     [Theory]
     [InlineData("Debug")]
     [InlineData("Release")]
+    [RequiresSSLCertificate]
     public async Task BuildAndRunAspireTemplate(string config)
     {
         string id = GetNewProjectId(prefix: $"aspire_{config}");
@@ -111,6 +114,7 @@ public partial class BuildAndRunTemplateTests : WorkloadTestsBase
     [Theory]
     [InlineData("Debug")]
     [InlineData("Release")]
+    [RequiresSSLCertificate]
     public async Task StarterTemplateNewAndRunWithoutExplicitBuild(string config)
     {
         var id = GetNewProjectId(prefix: $"aspire_starter_run_{config}");

--- a/tests/Aspire.Workload.Tests/EmptyTemplateRunTests.cs
+++ b/tests/Aspire.Workload.Tests/EmptyTemplateRunTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,6 +19,7 @@ public class EmptyTemplateRunTests : WorkloadTestsBase, IClassFixture<EmptyTempl
 
     [Fact]
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.DoesNotHavePlaywrightSupport))]
+    [RequiresSSLCertificate("Needed for dashboard access")]
     public async Task ResourcesShowUpOnDashboad()
     {
         await using var context = await CreateNewBrowserContextAsync();

--- a/tests/Aspire.Workload.Tests/PerTestFrameworkTemplatesTests.cs
+++ b/tests/Aspire.Workload.Tests/PerTestFrameworkTemplatesTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Microsoft.Playwright;
 using Xunit;
 using Xunit.Abstractions;
@@ -38,7 +39,7 @@ public abstract partial class PerTestFrameworkTemplatesTests : WorkloadTestsBase
             buildEnvironment: BuildEnvironment.ForDefaultFramework);
 
         await project.BuildAsync(extraBuildArgs: [$"-c {config}"]);
-        if (PlaywrightProvider.HasPlaywrightSupport)
+        if (PlaywrightProvider.HasPlaywrightSupport && RequiresSSLCertificateAttribute.IsSupported)
         {
             await using (var context = await CreateNewBrowserContextAsync())
             {

--- a/tests/Aspire.Workload.Tests/StarterTemplateProjectNamesTests.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateProjectNamesTests.cs
@@ -16,13 +16,8 @@ public abstract class StarterTemplateProjectNamesTests : WorkloadTestsBase
         _testType = testType;
     }
 
-    public static IEnumerable<object[]> ProjectNamesWithTestType_TestData()
-    {
-        foreach (var name in GetProjectNamesForTest())
-        {
-            yield return [name];
-        }
-    }
+    public static TheoryData<string> ProjectNamesWithTestType_TestData()
+        => new(GetProjectNamesForTest());
 
     [Theory]
     [MemberData(nameof(ProjectNamesWithTestType_TestData))]

--- a/tests/Aspire.Workload.Tests/StarterTemplateProjectNamesTests.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateProjectNamesTests.cs
@@ -1,36 +1,35 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Aspire.Workload.Tests;
 
-public class StarterTemplateProjectNamesTests : WorkloadTestsBase
+public abstract class StarterTemplateProjectNamesTests : WorkloadTestsBase
 {
-    public StarterTemplateProjectNamesTests(ITestOutputHelper testOutput)
+    private readonly string _testType;
+    public StarterTemplateProjectNamesTests(string testType, ITestOutputHelper testOutput)
         : base(testOutput)
     {
+        _testType = testType;
     }
 
-    public static TheoryData<string, string> ProjectNamesWithTestType_TestData()
+    public static IEnumerable<object[]> ProjectNamesWithTestType_TestData()
     {
-        var data = new TheoryData<string, string>();
-        foreach (var testType in TestFrameworkTypes)
+        foreach (var name in GetProjectNamesForTest())
         {
-            foreach (var name in GetProjectNamesForTest())
-            {
-                data.Add(name, testType);
-            }
+            yield return [name];
         }
-        return data;
     }
 
     [Theory]
     [MemberData(nameof(ProjectNamesWithTestType_TestData))]
-    public async Task StarterTemplateWithTest_ProjectNames(string prefix, string testType)
+    [RequiresSSLCertificate("Needs dashboard, web front end access")]
+    public async Task StarterTemplateWithTest_ProjectNames(string prefix)
     {
-        string id = $"{prefix}-{testType}";
+        string id = $"{prefix}-{_testType}";
         string config = "Debug";
 
         await using var project = await AspireProject.CreateNewTemplateProjectAsync(
@@ -38,13 +37,42 @@ public class StarterTemplateProjectNamesTests : WorkloadTestsBase
             "aspire-starter",
             _testOutput,
             BuildEnvironment.ForDefaultFramework,
-            $"-t {testType}");
+            $"-t {_testType}");
 
         await using var context = PlaywrightProvider.HasPlaywrightSupport ? await CreateNewBrowserContextAsync() : null;
         _testOutput.WriteLine($"Checking the starter template project");
         await AssertStarterTemplateRunAsync(context, project, config, _testOutput);
 
         _testOutput.WriteLine($"Checking the starter template project tests");
-        await AssertTestProjectRunAsync(project.TestsProjectDirectory, testType, _testOutput, config);
+        await AssertTestProjectRunAsync(project.TestsProjectDirectory, _testType, _testOutput, config);
+    }
+}
+
+// Individual class for each test framework so the tests can run in separate helix jobs
+public class None_StarterTemplateProjectNamesTests : StarterTemplateProjectNamesTests
+{
+    public None_StarterTemplateProjectNamesTests(ITestOutputHelper testOutput) : base("none", testOutput)
+    {
+    }
+}
+
+public class MSTest_StarterTemplateProjectNamesTests : StarterTemplateProjectNamesTests
+{
+    public MSTest_StarterTemplateProjectNamesTests(ITestOutputHelper testOutput) : base("mstest", testOutput)
+    {
+    }
+}
+
+public class Xunit_StarterTemplateProjectNamesTests : StarterTemplateProjectNamesTests
+{
+    public Xunit_StarterTemplateProjectNamesTests(ITestOutputHelper testOutput) : base("xunit.net", testOutput)
+    {
+    }
+}
+
+public class Nunit_StarterTemplateProjectNamesTests : StarterTemplateProjectNamesTests
+{
+    public Nunit_StarterTemplateProjectNamesTests(ITestOutputHelper testOutput) : base("nunit", testOutput)
+    {
     }
 }

--- a/tests/Aspire.Workload.Tests/StarterTemplateRunTests.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateRunTests.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Xunit.Abstractions;
 
 namespace Aspire.Workload.Tests;
 
+[RequiresSSLCertificate]
 public class StarterTemplateRunTests : StarterTemplateRunTestsBase<StarterTemplateFixture>
 {
     public StarterTemplateRunTests(StarterTemplateFixture fixture, ITestOutputHelper testOutput)

--- a/tests/Aspire.Workload.Tests/StarterTemplateRunTests_PreviousTFM.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateRunTests_PreviousTFM.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Xunit.Abstractions;
 
 namespace Aspire.Workload.Tests;
 
+[RequiresSSLCertificate]
 public class StarterTemplateRunTests_PreviousTFM : StarterTemplateRunTestsBase<StarterTemplateFixture_PreviousTFM>
 {
     public StarterTemplateRunTests_PreviousTFM(StarterTemplateFixture_PreviousTFM fixture, ITestOutputHelper testOutput)

--- a/tests/Aspire.Workload.Tests/StarterTemplateWithRedisCacheTests.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateWithRedisCacheTests.cs
@@ -7,6 +7,7 @@ using Xunit.Abstractions;
 namespace Aspire.Workload.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
+[RequiresSSLCertificate]
 public class StarterTemplateWithWithRedisCacheTests : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;

--- a/tests/Aspire.Workload.Tests/StarterTemplateWithRedisCacheTests.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateWithRedisCacheTests.cs
@@ -8,11 +8,11 @@ namespace Aspire.Workload.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
-public class StarterTemplateWithWithRedisCacheTests : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture>
+public class StarterTemplateWithRedisCacheTests : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;
 
-    public StarterTemplateWithWithRedisCacheTests(StarterTemplateWithRedisCacheFixture fixture, ITestOutputHelper testOutput)
+    public StarterTemplateWithRedisCacheTests(StarterTemplateWithRedisCacheFixture fixture, ITestOutputHelper testOutput)
         : base(fixture, testOutput)
     {
         HasRedisCache = true;

--- a/tests/Aspire.Workload.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
@@ -8,11 +8,11 @@ namespace Aspire.Workload.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
-public class StarterTemplateWithWithRedisCacheTests_PreviousTFM : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture_PreviousTFM>
+public class StarterTemplateWithRedisCacheTests_PreviousTFM : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture_PreviousTFM>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;
 
-    public StarterTemplateWithWithRedisCacheTests_PreviousTFM(StarterTemplateWithRedisCacheFixture_PreviousTFM fixture, ITestOutputHelper testOutput)
+    public StarterTemplateWithRedisCacheTests_PreviousTFM(StarterTemplateWithRedisCacheFixture_PreviousTFM fixture, ITestOutputHelper testOutput)
         : base(fixture, testOutput)
     {
         HasRedisCache = true;

--- a/tests/Aspire.Workload.Tests/StarterTemplateWithWithRedisCacheTests_PreviousTFM.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateWithWithRedisCacheTests_PreviousTFM.cs
@@ -7,6 +7,7 @@ using Xunit.Abstractions;
 namespace Aspire.Workload.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
+[RequiresSSLCertificate]
 public class StarterTemplateWithWithRedisCacheTests_PreviousTFM : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture_PreviousTFM>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -39,7 +39,7 @@
 
   <!-- Used for running one helix job per test class -->
   <Target Name="ExtractTestClassNames"
-          Condition="'$(ExtractTestClassNamesForHelix)' == 'true' and '$(ArchiveTests)' == 'true'"
+          Condition="'$(ExtractTestClassNamesForHelix)' == 'true' and '$(ArchiveTests)' == 'true' and '$(IsTestSupportProject)' != 'true'"
           BeforeTargets="ZipTestArchive">
 
     <Error Condition="'$(ExtractTestClassNamesPrefix)' == ''"

--- a/tests/Shared/Playwright/PlaywrightProvider.cs
+++ b/tests/Shared/Playwright/PlaywrightProvider.cs
@@ -58,6 +58,10 @@ public class PlaywrightProvider
                 Environment.SetEnvironmentVariable(PlaywrightBrowsersPathEnvironmentVariableName, probePath);
                 Console.WriteLine($"** Found playwright dependencies in {probePath}");
             }
+            else
+            {
+                Console.WriteLine($"** Did not find playwright dependencies in {probePath}");
+            }
         }
     }
 }

--- a/tests/Shared/WorkloadTesting/BuildEnvironment.cs
+++ b/tests/Shared/WorkloadTesting/BuildEnvironment.cs
@@ -33,7 +33,8 @@ public class BuildEnvironment
 
     public static bool IsRunningOnHelix => Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null;
     public static bool IsRunningOnCIBuildMachine => Environment.GetEnvironmentVariable("BUILD_BUILDID") is not null;
-    public static bool IsRunningOnCI => IsRunningOnHelix || IsRunningOnCIBuildMachine;
+    public static bool IsRunningOnGithubActions => Environment.GetEnvironmentVariable("GITHUB_JOB") is not null;
+    public static bool IsRunningOnCI => IsRunningOnHelix || IsRunningOnCIBuildMachine || IsRunningOnGithubActions;
 
     private static readonly Lazy<BuildEnvironment> s_instance_80 = new(() =>
         new BuildEnvironment(

--- a/tests/Shared/WorkloadTesting/TemplateCustomHive.cs
+++ b/tests/Shared/WorkloadTesting/TemplateCustomHive.cs
@@ -100,12 +100,14 @@ public class TemplatesCustomHive
     public static async Task<CommandResult> InstallTemplatesAsync(string packagePath, string customHiveDirectory, string dotnet)
     {
         var installCmd = $"new install --debug:custom-hive {customHiveDirectory} {packagePath}";
+        string workingDir = BuildEnvironment.IsRunningOnCI
+                                ? Path.GetTempPath()
+                                : Path.Combine(BuildEnvironment.TempDir, "templates", "working"); // avoid running from the repo
+        Directory.CreateDirectory(workingDir);
         using var cmd = new ToolCommand(dotnet,
                                         new TestOutputWrapper(forceShowBuildOutput: true),
                                         label: "template install")
-                            .WithWorkingDirectory(BuildEnvironment.IsRunningOnCI
-                                ? Path.GetTempPath()
-                                : Path.Combine(BuildEnvironment.TempDir, "templates", "working")); // avoid running from the repo
+                            .WithWorkingDirectory(workingDir);
 
         var res = await cmd.ExecuteAsync(installCmd);
         res.EnsureSuccessful();


### PR DESCRIPTION
- Extract the existing job to enumerate the test class names to a custom action, so that it can be re-used
- Split the jobs so linux, and windows ones can run independently. And can have separate list of tests.
- Add a new workflow for running Workload tests, with a corresponding new action `enumerate-template-tests`
- Disable tests on windows/CI that need to trust the SSL certificate
- Also, add an artifact with all the test results for `Integration`, and `Template` workflows.

With this PR the `setup` jobs run independently for each OS, thus allowing their test jobs to start running immediately. This helps because Windows job can be a little slower, and doesn't block the Linux test jobs.

Fixes https://github.com/dotnet/aspire/issues/7583 .