### PR TITLE
Adding spectre.console to package deps and using it in Aspire.CLI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -173,7 +173,9 @@
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
+
   <!-- The following 2 groups are for packages that need to switch based on the .NET TFM being used. -->
+
   <ItemGroup>
     <!-- EF -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="$(MicrosoftEntityFrameworkCoreCosmosLTSVersion)" />
@@ -204,6 +206,7 @@
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1LTSVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonLTSVersion)" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <!-- EF -->
     <PackageVersion Update="Microsoft.EntityFrameworkCore.Cosmos" Version="$(MicrosoftEntityFrameworkCoreCosmosVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,6 +108,7 @@
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageVersion Include="Qdrant.Client" Version="1.12.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.0.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.49.2-preview.0.76" />
     <PackageVersion Include="StackExchange.Redis" Version="2.8.22" />
     <PackageVersion Include="System.IO.Hashing" Version="9.0.1" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
@@ -172,9 +173,7 @@
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
-
   <!-- The following 2 groups are for packages that need to switch based on the .NET TFM being used. -->
-
   <ItemGroup>
     <!-- EF -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="$(MicrosoftEntityFrameworkCoreCosmosLTSVersion)" />
@@ -205,7 +204,6 @@
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1LTSVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonLTSVersion)" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <!-- EF -->
     <PackageVersion Update="Microsoft.EntityFrameworkCore.Cosmos" Version="$(MicrosoftEntityFrameworkCoreCosmosVersion)" />

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Spectre.Console" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -120,7 +120,8 @@ public class Program
             {
                 throw new InvalidOperationException("No project file found.");
             }
-            else {
+            else
+            {
                 return new FileInfo(projectFilePath);
             }
             

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -128,7 +128,14 @@ public class Program
         catch (Exception ex)
         {
             Debug.WriteLine(ex.Message);
-            AnsiConsole.MarkupLine("[red bold]The --project option was not specified and no *.csproj files were detected.[/]");
+            if (projectFilePaths.Length > 1)
+            {
+                AnsiConsole.MarkupLine("[red bold]The --project option was not specified and multiple *.csproj files were detected.[/]");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[red bold]The --project option was not specified and no *.csproj files were detected.[/]");
+            }
             return new FileInfo(Environment.CurrentDirectory);
         };
     }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -115,7 +115,7 @@ public class Program
         var projectFilePaths = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj");
         try 
         {
-            var projectFilePath = projectFilePaths?.Single();
+            var projectFilePath = projectFilePaths?.SingleOrDefault();
             if (projectFilePath is null)
             {
                 throw new InvalidOperationException("No project file found.");

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -3,9 +3,11 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Spectre.Console;
 
 namespace Aspire.Cli;
 
@@ -111,8 +113,24 @@ public class Program
         }
 
         var projectFilePaths = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj");
-        var projectFilePath = projectFilePaths.Single();
-        return new FileInfo(projectFilePath);
+        try 
+        {
+            var projectFilePath = projectFilePaths?.Single();
+            if (projectFilePath is null)
+            {
+                throw new InvalidOperationException("No project file found.");
+            }
+            else {
+                return new FileInfo(projectFilePath);
+            }
+            
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex.Message);
+            AnsiConsole.MarkupLine("[red bold]The --project option was not specified and no *.csproj files were detected.[/]");
+            return new FileInfo(Environment.CurrentDirectory);
+        };
     }
 
     private static void ConfigurePackCommand(Command parentCommand)

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -22,6 +22,13 @@
       "commandLineArgs": "pack ../../../../../playground/waitfor/WaitForSandbox.AppHost/WaitForSandbox.AppHost.csproj --target manifest --output-path aspire-manifest.json",
       "environmentVariables": {
       }
-    }
+    },
+    "dev-noproject": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "dev",
+      "environmentVariables": {
+      }
+    },
   }
 }


### PR DESCRIPTION
## Description

- Added Spectre.Console package (latest version on nuget)
- Threw a try catch into Program.cs for UseOrFindAppHostProjectFile

cc @mitchdenny 