### PR TITLE
Publisher options pattern

### DIFF
--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -1,15 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Azure;
-using Aspire.Hosting.Kubernetes;
+// using Aspire.Hosting.Azure;
+// using Aspire.Hosting.Kubernetes;
 using Aspire.Hosting.Docker;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddPublisher<KubernetesPublisher>("k8s");
-builder.AddPublisher<AzureContainerAppsPublisher>("aca");
-builder.AddPublisher<DockerComposePublisher>("docker-compose");
+builder.AddDockerCompose("docker-compose", options => {
+    options.DefaultContainerRegistry = "override.azurecr.io";
+    // Do stuff here.
+});
+
+// builder.AddKubernetes("k8s", options => {
+//     // Do stuff here.
+// });
+
+// builder.AddAzureContainerApps("aca", options => {
+//     // Do stuff here.
+// });
 
 var db = builder.AddAzurePostgresFlexibleServer("pg")
                 .WithPasswordAuthentication()

--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -3,7 +3,9 @@
 
 // using Aspire.Hosting.Azure;
 // using Aspire.Hosting.Kubernetes;
+using Aspire.Hosting.Azure;
 using Aspire.Hosting.Docker;
+using Aspire.Hosting.Kubernetes;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -12,13 +14,13 @@ builder.AddDockerCompose("docker-compose", options => {
     // Do stuff here.
 });
 
-// builder.AddKubernetes("k8s", options => {
-//     // Do stuff here.
-// });
+builder.AddKubernetes("k8s", options => {
+    // Do stuff here.
+});
 
-// builder.AddAzureContainerApps("aca", options => {
-//     // Do stuff here.
-// });
+builder.AddAzureContainerApps("aca", options => {
+    // Do stuff here.
+});
 
 var db = builder.AddAzurePostgresFlexibleServer("pg")
                 .WithPasswordAuthentication()

--- a/playground/publishers/Publishers.AppHost/Properties/launchSettings.json
+++ b/playground/publishers/Publishers.AppHost/Properties/launchSettings.json
@@ -44,7 +44,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "dotnetRunMessages": true,
-      "commandLineArgs": "--publisher azure-container-apps --output-path publish/azure-container-apps",
+      "commandLineArgs": "--publisher azure-container-apps",
       "applicationUrl": "http://localhost:15888",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
@@ -56,7 +56,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "dotnetRunMessages": true,
-      "commandLineArgs": "--publisher k8s --output-path publish/k8s --default-container-registry foo.azurecr.io",
+      "commandLineArgs": "--publisher k8s --output-path publish/k8s",
       "applicationUrl": "http://localhost:15888",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
@@ -68,7 +68,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "dotnetRunMessages": true,
-      "commandLineArgs": "--publisher docker-compose --output-path publish/docker-compose --default-container-registry foo.azurecr.io",
+      "commandLineArgs": "--publisher docker-compose --output-path publish/docker-compose",
       "applicationUrl": "http://localhost:15888",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",

--- a/playground/publishers/Publishers.AppHost/Properties/launchSettings.json
+++ b/playground/publishers/Publishers.AppHost/Properties/launchSettings.json
@@ -56,7 +56,19 @@
       "commandName": "Project",
       "launchBrowser": true,
       "dotnetRunMessages": true,
-      "commandLineArgs": "--publisher k8s --output-path publish/k8s",
+      "commandLineArgs": "--publisher k8s --output-path publish/k8s --default-container-registry foo.azurecr.io",
+      "applicationUrl": "http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175"
+      }
+    },
+    "publish-docker-compose": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher docker-compose --output-path publish/docker-compose --default-container-registry foo.azurecr.io",
       "applicationUrl": "http://localhost:15888",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",

--- a/src/Aspire.Hosting.Azure/AzureContainerAppPublisher.cs
+++ b/src/Aspire.Hosting.Azure/AzureContainerAppPublisher.cs
@@ -3,13 +3,14 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// TODO
 /// </summary>
-public sealed class AzureContainerAppsPublisher : IDistributedApplicationPublisher
+public sealed class AzureContainerAppsPublisher(IOptions<AzureContainerAppsPublisherOptions> options) : IDistributedApplicationPublisher
 {
     /// <summary>
     /// TODO
@@ -19,6 +20,7 @@ public sealed class AzureContainerAppsPublisher : IDistributedApplicationPublish
     /// <returns></returns>
     public Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {
+        _ = options;
         return Task.CompletedTask;
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureContainerAppPublisher.cs
+++ b/src/Aspire.Hosting.Azure/AzureContainerAppPublisher.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Azure;
@@ -10,7 +11,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// TODO
 /// </summary>
-public sealed class AzureContainerAppsPublisher(IOptions<AzureContainerAppsPublisherOptions> options) : IDistributedApplicationPublisher
+internal sealed class AzureContainerAppsPublisher([ServiceKey]string name, IOptionsMonitor<AzureContainerAppsPublisherOptions> options) : IDistributedApplicationPublisher
 {
     /// <summary>
     /// TODO
@@ -20,7 +21,7 @@ public sealed class AzureContainerAppsPublisher(IOptions<AzureContainerAppsPubli
     /// <returns></returns>
     public Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {
-        _ = options;
+        _ = options.Get(name);
         return Task.CompletedTask;
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureContainerAppsPublisherExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureContainerAppsPublisherExtensions.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Extensions for adding an Azure Container Apps publisher to the application model.
+/// </summary>
+public static class AzureContainerAppsPublisherExtensions
+{
+    /// <summary>
+    /// Adds an Azure Container Apps publisher to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
+    /// <param name="configureOptions">Callback to configure Azure Container Apps publisher options.</param>
+    public static void AddAzureContainerApps(this IDistributedApplicationBuilder builder, string name, Action<AzureContainerAppsPublisherOptions>? configureOptions = null)
+    {
+        builder.AddPublisher<AzureContainerAppsPublisher, AzureContainerAppsPublisherOptions>(name, configureOptions);
+    }
+}

--- a/src/Aspire.Hosting.Azure/AzureContainerAppsPublisherOptions.cs
+++ b/src/Aspire.Hosting.Azure/AzureContainerAppsPublisherOptions.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Options which control generation of artifacts for deploying to Azure targetting Azure Container Apps.
+/// </summary>
+public sealed class AzureContainerAppsPublisherOptions
+{
+}

--- a/src/Aspire.Hosting.Docker/DockerComposePublisher.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisher.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Docker;
@@ -10,7 +11,7 @@ namespace Aspire.Hosting.Docker;
 /// <summary>
 /// TODO
 /// </summary>
-public sealed class DockerComposePublisher(IOptions<DockerComposePublisherOptions> options) : IDistributedApplicationPublisher
+internal sealed class DockerComposePublisher([ServiceKey]string name, IOptionsMonitor<DockerComposePublisherOptions> options) : IDistributedApplicationPublisher
 {
     /// <summary>
     /// TODO
@@ -20,7 +21,7 @@ public sealed class DockerComposePublisher(IOptions<DockerComposePublisherOption
     /// <returns></returns>
     public Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {
-        _ = options;
+        _ = options.Get(name);
         return Task.CompletedTask;
     }
 }

--- a/src/Aspire.Hosting.Docker/DockerComposePublisher.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisher.cs
@@ -3,13 +3,14 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Docker;
 
 /// <summary>
 /// TODO
 /// </summary>
-public sealed class DockerComposePublisher : IDistributedApplicationPublisher
+public sealed class DockerComposePublisher(IOptions<DockerComposePublisherOptions> options) : IDistributedApplicationPublisher
 {
     /// <summary>
     /// TODO
@@ -19,6 +20,7 @@ public sealed class DockerComposePublisher : IDistributedApplicationPublisher
     /// <returns></returns>
     public Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {
+        _ = options;
         return Task.CompletedTask;
     }
 }

--- a/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Docker;
+
+/// <summary>
+/// Extensions for adding a Docker Compose publisher to the application model.
+/// </summary>
+public static class DockerComposePublisherExtensions
+{
+    /// <summary>
+    /// Adds a Docker Compose publisher to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
+    /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
+    public static void AddDockerCompose(this IDistributedApplicationBuilder builder, string name, Action<DockerComposePublisherOptions>? configureOptions = null)
+    {
+        builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>(name, configureOptions);
+
+    }
+}

--- a/src/Aspire.Hosting.Docker/DockerComposePublisherOptions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherOptions.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Docker;
+
+/// <summary>
+/// Options which control generation of Docker Compose artifacts.
+/// </summary>
+public sealed class DockerComposePublisherOptions
+{
+    /// <summary>
+    /// The container registry to use.
+    /// </summary>
+    public string? DefaultContainerRegistry { get; set; }
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisher.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisher.cs
@@ -3,13 +3,14 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Kubernetes;
 
 /// <summary>
 /// TODO
 /// </summary>
-public sealed class KubernetesPublisher : IDistributedApplicationPublisher
+public sealed class KubernetesPublisher(IOptions<KubernetesPublisherOptions> options) : IDistributedApplicationPublisher
 {
     /// <summary>
     /// TODO
@@ -19,6 +20,7 @@ public sealed class KubernetesPublisher : IDistributedApplicationPublisher
     /// <returns></returns>
     public Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {
+        _ = options;
         return Task.CompletedTask;
     }
 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisher.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisher.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Kubernetes;
@@ -10,7 +11,7 @@ namespace Aspire.Hosting.Kubernetes;
 /// <summary>
 /// TODO
 /// </summary>
-public sealed class KubernetesPublisher(IOptions<KubernetesPublisherOptions> options) : IDistributedApplicationPublisher
+internal sealed class KubernetesPublisher([ServiceKey]string name, IOptionsMonitor<KubernetesPublisherOptions> options) : IDistributedApplicationPublisher
 {
     /// <summary>
     /// TODO
@@ -20,7 +21,7 @@ public sealed class KubernetesPublisher(IOptions<KubernetesPublisherOptions> opt
     /// <returns></returns>
     public Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {
-        _ = options;
+        _ = options.Get(name);
         return Task.CompletedTask;
     }
 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Extensions for adding a Docker Compose publisher to the application model.
+/// </summary>
+public static class KubernetesPublisherExtensions
+{
+    /// <summary>
+    /// Adds a Kubernetes publisher to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
+    /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
+    public static void AddKubernetes(this IDistributedApplicationBuilder builder, string name, Action<KubernetesPublisherOptions>? configureOptions = null)
+    {
+        builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>(name, configureOptions);
+    }
+}

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
@@ -4,7 +4,7 @@
 namespace Aspire.Hosting.Kubernetes;
 
 /// <summary>
-/// Extensions for adding a Docker Compose publisher to the application model.
+/// Extensions for adding a Kubernetes publisher to the application model.
 /// </summary>
 public static class KubernetesPublisherExtensions
 {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisherOptions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisherOptions.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Kubernetes;
+
+/// <summary>
+/// Options which control generation of Kubernetes artifacts.
+/// </summary>
+public sealed class KubernetesPublisherOptions
+{
+}

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -420,7 +420,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             { "--dcp-cli-path", "DcpPublisher:CliPath" },
             { "--dcp-container-runtime", "DcpPublisher:ContainerRuntime" },
             { "--dcp-dependency-check-timeout", "DcpPublisher:DependencyCheckTimeout" },
-            { "--dcp-dashboard-path", "DcpPublisher:DashboardPath" },
+            { "--dcp-dashboard-path", "DcpPublisher:DashboardPath" }
         };
         _innerBuilder.Configuration.AddCommandLine(options.Args ?? [], switchMappings);
         _innerBuilder.Services.Configure<PublishingOptions>(_innerBuilder.Configuration.GetSection(PublishingOptions.Publishing));

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -23,7 +23,7 @@ public class DistributedApplicationExecutionContext
     /// Constructs a <see cref="DistributedApplicationExecutionContext" /> without a callback to retrieve the <see cref="IServiceProvider" />.
     /// </summary>
     /// <param name="operation">The operation being performed in this invocation of the AppHost.</param>
-    /// <param name="publisherName">The name of the publisher being used for the publish operation. This corresponds to publishers added via the <see cref="PublisherDistributedApplicationBuilderExtensions.AddPublisher{T}(IDistributedApplicationBuilder, string)"/> extension method.</param>
+    /// <param name="publisherName">The name of the publisher being used for the publish operation. This corresponds to publishers added via the <see cref="PublisherDistributedApplicationBuilderExtensions.AddPublisher{TPublisher, TPublisherOptions}(IDistributedApplicationBuilder, string, Action{TPublisherOptions})"/> extension method.</param>
     /// <remarks>
     /// This constructor is used for internal testing purposes.
     /// </remarks>

--- a/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
@@ -26,13 +26,10 @@ public static class PublisherDistributedApplicationBuilderExtensions
         // TODO: We need to add validation here since this needs to be something we refer to on the CLI.
         builder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, TPublisher>(name);
 
-        // The reason why all publisher options are bound to the same "Publishing" configuration
-        // section is that we expect a lot of overlap in the set of options that they provide. For
-        // example we might have multiple publishers that need the notion of a container registry
-        // from which they pull container images (useful for Docker Compose and Kubernetes). Another
-        // example of a common publishing setting would be output path.
-        builder.Services.Configure<TPublisherOptions>(builder.Configuration.GetSection(nameof(PublishingOptions.Publishing)));
-        builder.Services.Configure<TPublisherOptions>(options =>
+        builder.Services.Configure<TPublisherOptions>("name", configureOptions!);
+
+        builder.Services.Configure<TPublisherOptions>(name, builder.Configuration.GetSection(nameof(PublishingOptions.Publishing)));
+        builder.Services.Configure<TPublisherOptions>(name, options =>
         {
             configureOptions?.Invoke(options);
         });

--- a/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
@@ -14,12 +14,27 @@ public static class PublisherDistributedApplicationBuilderExtensions
     /// <summary>
     /// Adds a publisher to the distributed application for use by the Aspire CLI.
     /// </summary>
-    /// <typeparam name="T">The type of the publisher.</typeparam>
+    /// <typeparam name="TPublisher">The type of the publisher.</typeparam>
+    /// <typeparam name="TPublisherOptions">The type of the publisher.</typeparam>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>. </param>
     /// <param name="name">The name of the publisher.</param>
-    public static void AddPublisher<T>(this IDistributedApplicationBuilder builder, string name) where T: class, IDistributedApplicationPublisher
+    /// <param name="configureOptions">Callback to configure options for the publisher.</param>
+    public static void AddPublisher<TPublisher, TPublisherOptions>(this IDistributedApplicationBuilder builder, string name, Action<TPublisherOptions>? configureOptions = null)
+        where TPublisher: class, IDistributedApplicationPublisher
+        where TPublisherOptions: class
     {
         // TODO: We need to add validation here since this needs to be something we refer to on the CLI.
-        builder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, T>(name);
+        builder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, TPublisher>(name);
+
+        // The reason why all publisher options are bound to the same "Publishing" configuration
+        // section is that we expect a lot of overlap in the set of options that they provide. For
+        // example we might have multiple publishers that need the notion of a container registry
+        // from which they pull container images (useful for Docker Compose and Kubernetes). Another
+        // example of a common publishing setting would be output path.
+        builder.Services.Configure<TPublisherOptions>(builder.Configuration.GetSection(nameof(PublishingOptions.Publishing)));
+        builder.Services.Configure<TPublisherOptions>(options =>
+        {
+            configureOptions?.Invoke(options);
+        });
     }
 }


### PR DESCRIPTION
Expands the publisher pattern to support taking a set of options. This PR doesn't yet add the command-line binding support. It seems that `AddCommandLine(...)` really should only be called once so I'm trying to figure out how I allow each publisher to give the distributed application builder a set of the switch to configuration mappings that it feeds into `AddCommandLine`.

Still working on that detail, but in terms of the core options pattern this should work. Of note is the fact that all options will be bound to the "Publishing" section of configuration. This is because a lot of publishers will have overlapping configuration, but only one publisher will be used at a time.