### PR TITLE
Resources view: Updated icon and tooltip for View options

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -62,7 +62,7 @@
             }
 
             <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
-                              Icon="@(new Icons.Regular.Size20.Settings())"
+                              Icon="@(new Icons.Regular.Size20.Options())"
                               Items="@_logsMenuItems"
                               Title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsSettings)]"
                               slot="end" />

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -44,9 +44,9 @@
                 @if (HasAnyChildResources())
                 {
                     <AspireMenuButton ButtonAppearance="Appearance.Stealth"
-                                      Icon="@(new Icons.Regular.Size20.Settings())"
+                                      Icon="@(new Icons.Regular.Size20.Options())"
                                       Items="@_resourcesMenuItems"
-                                      Title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsSettings)]"
+                                      Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesChangeViewOptions)]"
                                       slot="end" />
                 }
             }

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -104,13 +104,22 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceActionTracesText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Collapse child resources.
         /// </summary>
         public static string ResourceCollapseAllChildren {
             get {
                 return ResourceManager.GetString("ResourceCollapseAllChildren", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View options.
+        /// </summary>
+        public static string ResourcesChangeViewOptions {
+            get {
+                return ResourceManager.GetString("ResourcesChangeViewOptions", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,79 +26,79 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -123,21 +123,27 @@
   </data>
   <data name="ResourcesHeader" xml:space="preserve">
     <value>Resources</value>
+    <comment/>
   </data>
   <data name="ResourcesNotFiltered" xml:space="preserve">
     <value>No filters</value>
+    <comment/>
   </data>
   <data name="ResourcesFiltered" xml:space="preserve">
     <value>Has filters</value>
+    <comment/>
   </data>
   <data name="ResourcesResourceTypesHeader" xml:space="preserve">
     <value>Resource types</value>
+    <comment/>
   </data>
   <data name="ResourcesResourceStatesHeader" xml:space="preserve">
     <value>State</value>
+    <comment/>
   </data>
   <data name="ResourceFilterOptionEmpty" xml:space="preserve">
     <value>(Unset)</value>
+    <comment/>
   </data>
   <data name="ResourcesEnvironmentVariablesHeader" xml:space="preserve">
     <value>Environment variables for {0}</value>
@@ -145,78 +151,103 @@
   </data>
   <data name="ResourcesStateColumnHeader" xml:space="preserve">
     <value>State</value>
+    <comment/>
   </data>
   <data name="ResourcesTypeColumnHeader" xml:space="preserve">
     <value>Type</value>
+    <comment/>
   </data>
   <data name="ResourcesStartTimeColumnHeader" xml:space="preserve">
     <value>Start time</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsExitCodeProperty" xml:space="preserve">
     <value>Exit code</value>
+    <comment/>
   </data>
   <data name="ResourcesSourceColumnHeader" xml:space="preserve">
     <value>Source</value>
+    <comment/>
   </data>
   <data name="ResourcesEndpointsColumnHeader" xml:space="preserve">
     <value>Endpoints</value>
+    <comment/>
   </data>
   <data name="ResourcesEnvironmentColumnHeader" xml:space="preserve">
     <value>Environment</value>
+    <comment/>
   </data>
   <data name="ResourcesNoEnvironmentVariables" xml:space="preserve">
     <value>No environment variables</value>
+    <comment/>
   </data>
   <data name="ResourcesNoResources" xml:space="preserve">
     <value>No resources found</value>
+    <comment/>
   </data>
   <data name="ResourceDetailsEndpointUrl" xml:space="preserve">
     <value>Endpoint URL</value>
+    <comment/>
   </data>
   <data name="ResourceDetailsProxyUrl" xml:space="preserve">
     <value>Proxy URL</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsContainerArgumentsProperty" xml:space="preserve">
     <value>Container arguments</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsContainerCommandProperty" xml:space="preserve">
     <value>Container command</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsContainerIdProperty" xml:space="preserve">
     <value>Container ID</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsContainerImageProperty" xml:space="preserve">
     <value>Container image</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsContainerPortsProperty" xml:space="preserve">
     <value>Container ports</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsContainerLifetimeProperty" xml:space="preserve">
     <value>Container lifetime</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsDisplayNameProperty" xml:space="preserve">
     <value>Display name</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsExecutableArgumentsProperty" xml:space="preserve">
     <value>Executable arguments</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsExecutablePathProperty" xml:space="preserve">
     <value>Executable path</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsExecutableProcessIdProperty" xml:space="preserve">
     <value>Process ID</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsExecutableWorkingDirectoryProperty" xml:space="preserve">
     <value>Working directory</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsProjectPathProperty" xml:space="preserve">
     <value>Project path</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsStartTimeProperty" xml:space="preserve">
     <value>Start time</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsStateProperty" xml:space="preserve">
     <value>State</value>
+    <comment/>
   </data>
   <data name="ResourceCommandFailed" xml:space="preserve">
     <value>{0} "{1}" failed</value>
@@ -228,21 +259,27 @@
   </data>
   <data name="ResourceCommandToastViewLogs" xml:space="preserve">
     <value>View console logs</value>
+    <comment/>
   </data>
   <data name="ResourcesActionsColumnHeader" xml:space="preserve">
     <value>Actions</value>
+    <comment/>
   </data>
   <data name="ResourceActionConsoleLogsText" xml:space="preserve">
     <value>Console logs</value>
+    <comment/>
   </data>
   <data name="ResourceDetailsViewConsoleLogs" xml:space="preserve">
     <value>View console logs</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsHealthStateProperty" xml:space="preserve">
     <value>Health state</value>
+    <comment/>
   </data>
   <data name="ResourcesDetailsStopTimeProperty" xml:space="preserve">
     <value>Stop time</value>
+    <comment/>
   </data>
   <data name="ResourceCommandStarting" xml:space="preserve">
     <value>{0} "{1}" starting</value>
@@ -250,12 +287,15 @@
   </data>
   <data name="ResourceActionTracesText" xml:space="preserve">
     <value>Traces</value>
+    <comment/>
   </data>
   <data name="ResourceActionStructuredLogsText" xml:space="preserve">
     <value>Structured logs</value>
+    <comment/>
   </data>
   <data name="ResourceActionMetricsText" xml:space="preserve">
     <value>Metrics</value>
+    <comment/>
   </data>
   <data name="WaitingForHealthDataMessage" xml:space="preserve">
     <value>Waiting for health data...</value>
@@ -267,11 +307,18 @@
   </data>
   <data name="ResourceActionTelemetryTooltip" xml:space="preserve">
     <value>No telemetry found for this resource.</value>
+    <comment/>
   </data>
   <data name="ResourceCollapseAllChildren" xml:space="preserve">
     <value>Collapse child resources</value>
+    <comment/>
   </data>
   <data name="ResourceExpandAllChildren" xml:space="preserve">
     <value>Expand child resources</value>
+    <comment/>
+  </data>
+  <data name="ResourcesChangeViewOptions" xml:space="preserve">
+    <value>View options</value>
+    <comment>An icon allowing the user to expand or collapse all child resources.</comment>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Akce</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argumenty kontejneru</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Aktionen</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Containerargumente</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Acciones</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argumentos de contenedor</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Actions</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Arguments de conteneur</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Azioni</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argomenti contenitore</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">アクション</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">コンテナー引数</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">작업</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">컨테이너 인수</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Akcje</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argumenty kontenera</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Ações</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argumentos de contêiner</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Действия</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Аргументы контейнера</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Eylemler</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Kapsayıcı bağımsız değişkenleri</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">操作</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">容器参数</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">動作</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesChangeViewOptions">
+        <source>View options</source>
+        <target state="new">View options</target>
+        <note>An icon allowing the user to expand or collapse all child resources.</note>
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">容器引數</target>


### PR DESCRIPTION
## Description

The settings gear for the resources page has been replaced with a new icon and tooltip. Previously it was showing the "ConsoleLogsSettings" tooltip and had the same settings icon as right above it:
![image](https://github.com/user-attachments/assets/206b5934-ea91-45ce-b57f-f3f44bac4f70)

It now uses the fluent "Options" icon and the tooltip is "View options", added as "ResourcesChangeViewOptions" in the resx
![image](https://github.com/user-attachments/assets/e0d5ce96-d397-462d-be61-3d590f4a7d71)
![image](https://github.com/user-attachments/assets/ab51fcf1-fecd-4708-8726-1d84f52bceca)


I also considered [table settings](https://raw.githubusercontent.com/microsoft/fluentui-system-icons/refs/heads/main/assets/Table%20Settings/SVG/ic_fluent_table_settings_28_regular.svg) and [more circle](https://raw.githubusercontent.com/microsoft/fluentui-system-icons/refs/heads/main/assets/More%20Circle/SVG/ic_fluent_more_circle_48_regular.svg) but I like this one the best I think :)


Fixes # (issue)
my sanity

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
