### PR TITLE
Onboard to the GitHub workflow based issue-labeler

### DIFF
--- a/.github/workflows/labeler-build-predictor.yml
+++ b/.github/workflows/labeler-build-predictor.yml
@@ -1,0 +1,17 @@
+name: "Labeler: Build Predictor App"
+
+on:
+  # Allow dispatching the workflow via the Actions UI
+  workflow_dispatch:
+    inputs:
+      rebuild:
+        description: "Force a rebuild of the app"
+        type: boolean
+
+jobs:
+  build-predictor:
+    permissions:
+      actions: write
+    uses: dotnet/issue-labeler/.github/workflows/build-predictor.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
+    with:
+      rebuild: ${{ inputs.rebuild }}

--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -1,0 +1,13 @@
+name: "Labeler: Cache Retention"
+
+on:
+  schedule:
+    - cron: "25 22 * * *" # 22:25 every day (arbitrary time daily)
+
+  workflow_dispatch:
+
+jobs:
+  cache-retention:
+    # Do not run the workflow on forks outside the 'dotnet' org
+    if: ${{ github.repository_owner == 'dotnet' }}
+    uses: dotnet/issue-labeler/.github/workflows/cache-retention.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -1,0 +1,32 @@
+name: "Labeler: Predict Issue Labels"
+
+on:
+  # Only automatically predict area labels when issues are originally opened
+  issues:
+    types: opened
+
+  # Allow dispatching the workflow via the Actions UI, specifying ranges of numbers
+  workflow_dispatch:
+    inputs:
+      issue_numbers:
+        description: "Issue Numbers (comma-separated list of ranges)"
+        type: string
+      model_cache_key:
+        description: "The cache key suffix to use for loading the model"
+        type: string
+        required: true
+        default: "LIVE"
+
+jobs:
+  predict-issues:
+    # Do not run the workflow on forks outside the 'dotnet' org
+    if: ${{ github.repository_owner == 'dotnet' && (inputs.issue_numbers || github.event.issue.number) }}
+    permissions:
+      issues: write
+    uses: dotnet/issue-labeler/.github/workflows/predict-issues.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
+    with:
+      model_cache_key: ${{ inputs.model_cache_key }}
+      issue_numbers: ${{ inputs.issue_numbers || github.event.issue.number }}
+      label_prefix: "area-"
+      threshold: 0.40
+      default_label: "needs-area-label"

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -1,0 +1,44 @@
+name: "Labeler: Predict Pull Labels"
+
+on:
+  # Per to the following documentation:
+  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
+  #
+  # The `pull_request_target` event runs in the context of the base of the pull request, rather
+  # than in the context of the merge commit, as the `pull_request` event does. This prevents
+  # execution of unsafe code from the head of the pull request that could alter the repository
+  # or steal any secrets you use in your workflow. This event allows your workflow to do things
+  # like label or comment on pull requests from forks.
+  #
+  # Only automatically predict area labels when pull requests are first opened
+  pull_request_target:
+    types: opened
+    branches:
+      - 'main'
+      - 'release/**'
+
+  # Allow dispatching the workflow via the Actions UI, specifying ranges of numbers
+  workflow_dispatch:
+    inputs:
+      pull_numbers:
+        description: "Pull Numbers (comma-separated list of ranges)"
+        type: string
+      model_cache_key:
+        description: "The cache key suffix to use for loading the model"
+        type: string
+        required: true
+        default: "LIVE"
+
+jobs:
+  predict-pulls:
+    # Do not run the workflow on forks outside the 'dotnet' org
+    if: ${{ github.repository_owner == 'dotnet' && (inputs.pull_numbers || github.event.number) }}
+    permissions:
+      pull-requests: write
+    uses: dotnet/issue-labeler/.github/workflows/predict-pulls.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
+    with:
+      model_cache_key: ${{ inputs.model_cache_key }}
+      pull_numbers: ${{ inputs.pull_numbers || github.event.number }}
+      label_prefix: "area-"
+      threshold: 0.40
+      default_label: "needs-area-label"

--- a/.github/workflows/labeler-promote.yml
+++ b/.github/workflows/labeler-promote.yml
@@ -1,0 +1,42 @@
+name: "Labeler: Promote Models"
+
+on:
+  # Dispatched via the Actions UI, promotes the staged models from
+  # a staging slot into the prediction environment
+  workflow_dispatch:
+    inputs:
+      promote_issues:
+        description: "Issues: Promote Model"
+        type: boolean
+        required: true
+      promote_pulls:
+        description: "Pulls: Promote Model"
+        type: boolean
+        required: true
+      model_cache_key:
+        description: "The cache key suffix to promote into the 'LIVE' cache"
+        type: string
+        required: true
+        default: "staging"
+      backup_cache_key:
+        description: "The cache key suffix to use for backing up the currently promoted model"
+        type: string
+        default: "backup"
+
+permissions:
+  actions: write
+
+jobs:
+  labeler-promote-issues:
+    if: ${{ inputs.promote_issues }}
+    uses: dotnet/issue-labeler/.github/workflows/promote-issues.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
+    with:
+      model_cache_key: ${{ inputs.model_cache_key }}
+      backup_cache_key: ${{ inputs.backup_cache_key }}
+
+  labeler-promote-pulls:
+    if: ${{ inputs.promote_pulls }}
+    uses: dotnet/issue-labeler/.github/workflows/promote-pulls.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
+    with:
+      model_cache_key: ${{ inputs.model_cache_key }}
+      backup_cache_key: ${{ inputs.backup_cache_key }}

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -1,0 +1,60 @@
+name: "Labeler: Train Models"
+
+on:
+  # Dispatched via the Actions UI, stages new models for promotion consideration
+  # Each step of the workflow can be run independently: Download, Train, and Test
+  workflow_dispatch:
+    inputs:
+      download_issues:
+        description: "Issues: Download Data"
+        type: boolean
+        default: true
+      train_issues:
+        description: "Issues: Train Model"
+        type: boolean
+        default: true
+      test_issues:
+        description: "Issues: Test Model"
+        type: boolean
+        default: true
+      download_pulls:
+        description: "Pulls: Download Data"
+        type: boolean
+        default: true
+      train_pulls:
+        description: "Pulls: Train Model"
+        type: boolean
+        default: true
+      test_pulls:
+        description: "Pulls: Test Model"
+        type: boolean
+        default: true
+
+      data_limit:
+        description: "Max number of items to include in the model"
+        type: number
+
+      cache_key_suffix:
+        description: "The cache key suffix to use for staging data/models (use 'LIVE' to bypass staging)"
+        type: string
+        required: true
+        default: "staging"
+
+jobs:
+  labeler-train:
+    permissions:
+      issues: read
+      pull-requests: read
+      actions: write
+    uses: dotnet/issue-labeler/.github/workflows/train.yml@f0c098669828a134c0313adf3f58c1909e555d86 # v1.0.1
+    with:
+      download_issues: ${{ inputs.download_issues }}
+      train_issues: ${{ inputs.train_issues }}
+      test_issues: ${{ inputs.test_issues }}
+      download_pulls: ${{ inputs.download_pulls }}
+      train_pulls: ${{ inputs.train_pulls }}
+      test_pulls: ${{ inputs.test_pulls }}
+      data_limit: ${{ inputs.data_limit && fromJSON(inputs.data_limit) || 0 }}
+      cache_key_suffix: ${{ inputs.cache_key_suffix }}
+      label_prefix: "area-"
+      threshold: 0.40


### PR DESCRIPTION
We have a new implementation of [dotnet/issue-labeler](https://github.com/dotnet/issue-labeler) available that is implemented entirely using GitHub workflows. This approach allows for self-service onboarding and re-training of the prediction models. [Onboarding](https://github.com/dotnet/issue-labeler/wiki/Onboarding#) instructions are documented and anyone with write permission to this repository should be able to work through the process of the initial model training, but @RussKie and I are both familiar with the process.

I ran a test set of training from this repository into my fork. The [workflow run can be seen here](https://github.com/jeffhandley/aspire/actions/runs/13733193407), and the model's accuracy looks like it'll start with a good baseline. It took less than 12 minutes to train the model.

* Issues tested: 2834
    * The predicted label matched the existing label: 2706 (95.48 %)
    * The predicted label does not match the existing label: 46 (1.62 %)
    * No prediction was made: 82 (2.89 %)
    * A prediction was made, but no existing label was present: 0 (0.00 %)
* Pulls tested: 2885
    * The predicted label matched the existing label: 2795 (96.88 %)
    * The predicted label does not match the existing label: : 74 (2.56 %)
    * No prediction was made: 16 (0.55 %)
    * A prediction was made, but no existing label was present: 0 (0.00 %)

