### PR TITLE
Hoist StopApplication out of ManifestPublisher.

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -16,8 +16,8 @@ internal sealed class DistributedApplicationRunner(IHostApplicationLifetime life
         {
             var publisher = serviceProvider.GetRequiredKeyedService<IDistributedApplicationPublisher>(executionContext.PublisherName);
             await publisher.PublishAsync(model, stoppingToken).ConfigureAwait(false);
+            lifetime.StopApplication();
         }
 
-        lifetime.StopApplication();
     }
 }

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -8,15 +8,16 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting;
 
-internal sealed class DistributedApplicationRunner(DistributedApplicationExecutionContext executionContext, DistributedApplicationModel model, IServiceProvider serviceProvider) : BackgroundService
+internal sealed class DistributedApplicationRunner(IHostApplicationLifetime lifetime, DistributedApplicationExecutionContext executionContext, DistributedApplicationModel model, IServiceProvider serviceProvider) : BackgroundService
 {
-    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (executionContext.IsPublishMode)
         {
-            return serviceProvider.GetRequiredKeyedService<IDistributedApplicationPublisher>(executionContext.PublisherName).PublishAsync(model, stoppingToken);
+            var publisher = serviceProvider.GetRequiredKeyedService<IDistributedApplicationPublisher>(executionContext.PublisherName);
+            await publisher.PublishAsync(model, stoppingToken).ConfigureAwait(false);
         }
 
-        return Task.CompletedTask;
+        lifetime.StopApplication();
     }
 }

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -11,12 +10,10 @@ namespace Aspire.Hosting.Publishing;
 
 internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
                                IOptions<PublishingOptions> options,
-                               IHostApplicationLifetime lifetime,
                                DistributedApplicationExecutionContext executionContext) : IDistributedApplicationPublisher
 {
     private readonly ILogger<ManifestPublisher> _logger = logger;
     private readonly IOptions<PublishingOptions> _options = options;
-    private readonly IHostApplicationLifetime _lifetime = lifetime;
     private readonly DistributedApplicationExecutionContext _executionContext = executionContext;
 
     public Utf8JsonWriter? JsonWriter { get; set; }
@@ -24,7 +21,6 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
     public async Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {
         await PublishInternalAsync(model, cancellationToken).ConfigureAwait(false);
-        _lifetime.StopApplication();
     }
 
     protected virtual async Task PublishInternalAsync(DistributedApplicationModel model, CancellationToken cancellationToken)

--- a/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
@@ -4,7 +4,6 @@
 using System.Text.Json;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -13,8 +12,8 @@ namespace Aspire.Hosting.Tests.Helpers;
 internal sealed class JsonDocumentManifestPublisher(
     ILogger<ManifestPublisher> logger,
     IOptions<PublishingOptions> options,
-    IHostApplicationLifetime lifetime, DistributedApplicationExecutionContext executionContext
-    ) : ManifestPublisher(logger, options, lifetime, executionContext)
+    DistributedApplicationExecutionContext executionContext
+    ) : ManifestPublisher(logger, options, executionContext)
 {
     protected override async Task PublishInternalAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
This PR hoists the call to StopApplication out of the ManifestPublisher. It should never have been there to begin with.

Longer term we might want to do some more work to make the DistributedApplicationRunner call the App executor plumbing for local development - but I am avoiding pulling that thread for now in the interests of getting this in for the publishers work.