### PR TITLE
Fix triple slash docs in MongoDBBuilderExtensions

### DIFF
--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -170,7 +170,7 @@ public static class MongoDBBuilderExtensions
     /// </summary>
     /// <param name="builder">The resource builder for Mongo Express.</param>
     /// <param name="port">The port to bind on the host. If <see langword="null"/> is used random port will be assigned.</param>
-    /// <returns>The resource builder for PGAdmin.</returns>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<MongoExpressContainerResource> WithHostPort(this IResourceBuilder<MongoExpressContainerResource> builder, int? port)
     {
         ArgumentNullException.ThrowIfNull(builder);


### PR DESCRIPTION
This pull request includes a minor change to the XML documentation in the `WithMongoExpress` method in `MongoDBBuilderExtensions.cs` to correct the return type description.

Documentation update:

* [`src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs`](diffhunk://#diff-9deb2e4323bf0a8b09c22dd30bfe077aa5501a1cda1a7a9a2321009e0d005085L173-R173): Updated the XML documentation for the `WithHostPort` method to correctly describe the return type as a reference to `IResourceBuilder<T>` instead of `PGAdmin`.