### PR TITLE
Add policy to close & re-open github-action PRs

### DIFF
--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -28,7 +28,6 @@ configuration:
           label: 'Closed Github-Action PR'
       - closeIssue
       description: Close and label Github-Action PRs
-      triggerOnOwnActions: true
     - if:
       - payloadType: Pull_Request
       - isAction:

--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -1,0 +1,43 @@
+# Github will not trigger github actions on PRs that were themselves created by a github action.
+# We use github actions to run tests on PRs, and to backport PRs from one branch to another.
+# A workaround for that behavior is to close & re-open such PRs, so that the last action is not by the Github-Action bot.
+# This policy enacts that workaround.
+
+id: eventResponderTask.GithubActionPROpened
+name: Close and re-open PRs opened via Github Action
+description: Closes and re-open PRs opened via Github Action
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - if:
+      - payloadType: Pull_Request
+      - isAction:
+          action: Opened
+      - isActivitySender:
+          user: github-actions[bot]
+          issueAuthor: False
+      - not:
+          hasLabel:
+            label: 'Re-opened Github-Action PR'
+      then:
+      - addLabel:
+          label: 'Closed Github-Action PR'
+      - closeIssue
+      description: Close and label Github-Action PRs
+    - if:
+      - payloadType: Pull_Request
+      - isAction:
+          action: Closed
+      - hasLabel:
+          label: 'Closed Github-Action PR'
+      then:
+      - removeLabel:
+          label: 'Closed Github-Action PR'
+      - addLabel:
+          label: 'Re-opened Github-Action PR'
+      - reopenIssue
+      description: Reopen closed Github-Action PRs

--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -28,6 +28,7 @@ configuration:
           label: 'Closed Github-Action PR'
       - closeIssue
       description: Close and label Github-Action PRs
+      triggerOwnActions: true
     - if:
       - payloadType: Pull_Request
       - isAction:
@@ -41,3 +42,4 @@ configuration:
           label: 'Re-opened Github-Action PR'
       - reopenIssue
       description: Reopen closed Github-Action PRs
+      triggerOwnActions: true

--- a/.github/policies/eventResponderTask.GithubActionPROpened.yml
+++ b/.github/policies/eventResponderTask.GithubActionPROpened.yml
@@ -28,7 +28,7 @@ configuration:
           label: 'Closed Github-Action PR'
       - closeIssue
       description: Close and label Github-Action PRs
-      triggerOwnActions: true
+      triggerOnOwnActions: true
     - if:
       - payloadType: Pull_Request
       - isAction:
@@ -42,4 +42,4 @@ configuration:
           label: 'Re-opened Github-Action PR'
       - reopenIssue
       description: Reopen closed Github-Action PRs
-      triggerOwnActions: true
+      triggerOnOwnActions: true


### PR DESCRIPTION
Reverts dotnet/aspire#7981, and adds `triggerOnOwnActions: true` so that PolicyBot can respond to its own events. Previous PR didn't work because the re-open step was skipped, as by default PolicyBot will not respond to its own events.