### PR TITLE
Backchannel between CLI and AppHost

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -479,3 +479,74 @@ dotnet_diagnostic.CA2007.severity = silent
 
 [*.{cs,vb}]
 dotnet_diagnostic.ASPIREEVENTING001.severity = none
+
+### VSTHRD rules
+
+# VSTHRD001: Avoid legacy thread switching methods.
+dotnet_diagnostic.VSTHRD001.severity = none
+
+# VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead.
+dotnet_diagnostic.VSTHRD002.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks.
+dotnet_diagnostic.VSTHRD003.severity = none
+
+# VSTHRD004: Await SwitchToMainThreadAsync.
+dotnet_diagnostic.VSTHRD004.severity = none
+
+# VSTHRD010: Invoke single-threaded types on Main thread.
+dotnet_diagnostic.VSTHRD010.severity = none
+ 
+# VSTHRD011: Use AsyncLazy<T>.
+dotnet_diagnostic.VSTHRD011.severity = none
+
+# VSTHRD012: Provide JoinableTaskFactory where allowed.
+dotnet_diagnostic.VSTHRD012.severity = none
+
+# VSTHRD100: Avoid "async void" methods, because any exceptions not handled by the method will crash the process.
+dotnet_diagnostic.VSTHRD100.severity = none
+
+# VSTHRD101: Avoid using async lambda for a void returning delegate type, because any exceptions not handled by the delegate will crash the process.
+dotnet_diagnostic.VSTHRD101.severity = none
+
+# VSTHRD102: Implement internal logic asynchronously.
+dotnet_diagnostic.VSTHRD102.severity = none
+
+# VSTHRD103: Call async methods when in an async method.
+dotnet_diagnostic.VSTHRD103.severity = none
+
+# VSTHRD104: Expose an async version of this method that does not synchronously block. Then simplify this method to call that async method within a JoinableTaskFactory.Run delegate.
+dotnet_diagnostic.VSTHRD104.severity = none
+
+# VSTHRD105: Avoid method overloads that assume TaskScheduler.Current. Use an overload that accepts a TaskScheduler and specify TaskScheduler.Default (or any other) explicitly.
+dotnet_diagnostic.VSTHRD105.severity = none
+
+# VSTHRD106: Use InvokeAsync to raise async events.
+dotnet_diagnostic.VSTHRD106.severity = none
+
+# VSTHRD107: Await Task within using expression.
+dotnet_diagnostic.VSTHRD107.severity = none
+
+# VSTHRD108: Assert thread affinity unconditionally.
+dotnet_diagnostic.VSTHRD108.severity = none
+
+# VSTHRD109: Switch instead of assert in async methods.
+dotnet_diagnostic.VSTHRD109.severity = none
+
+# VSTHRD110: Observe the awaitable result of this method call by awaiting it, assigning to a variable, or passing it to another method.
+dotnet_diagnostic.VSTHRD110.severity = none
+
+# VSTHRD111: Add .ConfigureAwait(bool) to your await expression.
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# VSTHRD112: Implement System.IAsyncDisposable.
+dotnet_diagnostic.VSTHRD112.severity = none
+
+# VSTHRD113: Check for System.IAsyncDisposable.
+dotnet_diagnostic.VSTHRD113.severity = none
+
+# VSTHRD114: Avoid returning a null Task.
+dotnet_diagnostic.VSTHRD114.severity = none
+
+# VSTHRD200: Use "Async" suffix in names of methods that return an awaitable type.
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -111,6 +111,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.8.22" />
     <PackageVersion Include="System.IO.Hashing" Version="9.0.1" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.21.10" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="9.0.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />

--- a/playground/waitfor/WaitForSandbox.AppHost/appsettings.json
+++ b/playground/waitfor/WaitForSandbox.AppHost/appsettings.json
@@ -4,7 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning",
-      "Aspire.Hosting": "Information"
+      "Aspire.Hosting": "Information",
+      "Aspire.Hosting.Cli": "Debug"
     }
   }
 }

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Cli/CliRpcTarget.cs
+++ b/src/Aspire.Cli/CliRpcTarget.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli;
+
+internal class CliRpcTarget(Logger<CliRpcTarget> logger)
+{
+    public Task<long> PingAsync(long timestamp)
+    {
+        logger.LogTrace("Received ping from AppHost with timestamp: {Timestamp}", timestamp);
+        return Task.FromResult(timestamp);
+    }
+}

--- a/src/Aspire.Cli/CliRpcTarget.cs
+++ b/src/Aspire.Cli/CliRpcTarget.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli;
 
-internal class CliRpcTarget(Logger<CliRpcTarget> logger)
+internal class CliRpcTarget(ILogger<CliRpcTarget> logger)
 {
     public Task<long> PingAsync(long timestamp)
     {

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -75,9 +75,15 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, CliRpcTar
             logger.LogDebug(ex, "Shutting down AppHost backchannel because of cancellation.");
             return;
         }
+        catch (StreamJsonRpc.ConnectionLostException) when (cancellationToken.IsCancellationRequested)
+        {
+            logger.LogDebug("Ignoring ConnectionLostException because of cancellation.");
+            return;
+        }
         catch (Exception ex)
         {
-            _ = ex;
+            logger.LogError(ex, "AppHost backchannel failed unexpectedly.");
+            return;
         }
     }
 

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -97,12 +97,12 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, CliRpcTar
         // The CLI and the AppHost can communicate to one another using a RPC protocol that makes
         // use of StreamJsonRpc. Not all commands need the backchannel so we selectively enable it.
         // When it is enabled we signal the path to the unix socket or named pipe on the
-        // ASPIRE_CLI_BACKCHANNEL_PATH environment variable.
+        // ASPIRE_LAUNCHER_BACKCHANNEL_PATH environment variable.
         if (startBackchannel)
         {
             var socketPath = GetBackchannelSocketPath();
             _ = StartBackchannelAsync(socketPath, cancellationToken);
-            startInfo.EnvironmentVariables["ASPIRE_CLI_BACKCHANNEL_PATH"] = socketPath;
+            startInfo.EnvironmentVariables["ASPIRE_LAUNCHER_BACKCHANNEL_PATH"] = socketPath;
         }
 
         // The AppHost uses this environment variable to signal to the CliOrphanDetector which process

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -24,6 +24,7 @@ public class Program
 
         builder.Services.AddTransient<AppHostRunner>();
         builder.Services.AddTransient<DotNetCliRunner>();
+        builder.Services.AddSingleton<CliRpcTarget>();
         var app = builder.Build();
         return app;
     }

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="JsonPatch.Net" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" />
     <PackageReference Include="System.IO.Hashing" />
+    <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/Cli/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Cli/AppHostRpcTarget.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Cli;
+
+internal class AppHostRpcTarget(ILogger<AppHostRpcTarget> logger)
+{
+    public Task<long> PingAsync(long timestamp)
+    {
+        logger.LogTrace("Received ping from CLI with timestamp: {Timestamp}", timestamp);
+        return Task.FromResult(timestamp);
+    }
+}

--- a/src/Aspire.Hosting/Cli/CliBackchannel.cs
+++ b/src/Aspire.Hosting/Cli/CliBackchannel.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Net.Sockets;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using StreamJsonRpc;
+
+namespace Aspire.Hosting.Cli;
+
+internal class CliBackchannel(ILogger<CliBackchannel> logger, IConfiguration configuration, AppHostRpcTarget appHostRpcTarget) : BackgroundService
+{
+    private const string UnixSocketPathEnvironmentVariable = "ASPIRE_CLI_BACKCHANNEL_PATH";
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var unixSocketPath = configuration.GetValue<string>(UnixSocketPathEnvironmentVariable);
+
+        if (string.IsNullOrEmpty(unixSocketPath))
+        {
+            logger.LogDebug("Aspire CLI backchannel socket path was not specified.");
+            return;
+        }
+
+        logger.LogInformation("Aspire CLI backchannel socket path: {SocketPath}", unixSocketPath);
+
+        try
+        {
+            using var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            var endpoint = new UnixDomainSocketEndPoint(unixSocketPath);
+            await socket.ConnectAsync(endpoint, stoppingToken).ConfigureAwait(false);
+            using var stream = new NetworkStream(socket, true);
+            var rpc = JsonRpc.Attach(stream, appHostRpcTarget);
+
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+            do
+            {
+                var sendTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                var responseTimestamp = await rpc.InvokeAsync<long>("PingAsync", sendTimestamp).ConfigureAwait(false);
+                Debug.Assert(sendTimestamp == responseTimestamp);
+                var roundtripMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - sendTimestamp;
+                logger.LogDebug("PingAsync round trip time is {RoundTripDuration} ms", roundtripMilliseconds);
+            } while(await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to connect to Aspire CLI backchannel socket.");
+            return;
+        }
+    }
+}

--- a/src/Aspire.Hosting/Cli/CliBackchannel.cs
+++ b/src/Aspire.Hosting/Cli/CliBackchannel.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.Cli;
 
 internal class CliBackchannel(ILogger<CliBackchannel> logger, IConfiguration configuration, AppHostRpcTarget appHostRpcTarget) : BackgroundService
 {
-    private const string UnixSocketPathEnvironmentVariable = "ASPIRE_CLI_BACKCHANNEL_PATH";
+    private const string UnixSocketPathEnvironmentVariable = "ASPIRE_LAUNCHER_BACKCHANNEL_PATH";
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {

--- a/src/Aspire.Hosting/Cli/CliBackchannel.cs
+++ b/src/Aspire.Hosting/Cli/CliBackchannel.cs
@@ -25,6 +25,9 @@ internal class CliBackchannel(ILogger<CliBackchannel> logger, IConfiguration con
         }
 
         logger.LogDebug("Aspire CLI backchannel socket path: {SocketPath}", unixSocketPath);
+        
+        // Forcing to background.
+        await Task.Yield();
 
         try
         {

--- a/src/Aspire.Hosting/Cli/CliBackchannel.cs
+++ b/src/Aspire.Hosting/Cli/CliBackchannel.cs
@@ -24,7 +24,7 @@ internal class CliBackchannel(ILogger<CliBackchannel> logger, IConfiguration con
             return;
         }
 
-        logger.LogInformation("Aspire CLI backchannel socket path: {SocketPath}", unixSocketPath);
+        logger.LogDebug("Aspire CLI backchannel socket path: {SocketPath}", unixSocketPath);
 
         try
         {
@@ -44,9 +44,9 @@ internal class CliBackchannel(ILogger<CliBackchannel> logger, IConfiguration con
                 logger.LogDebug("PingAsync round trip time is {RoundTripDuration} ms", roundtripMilliseconds);
             } while(await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false));
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
         {
-            logger.LogError(ex, "Failed to connect to Aspire CLI backchannel socket.");
+            logger.LogDebug(ex, "Shutting down CLI backchannel because of cancellation.");
             return;
         }
     }

--- a/src/Aspire.Hosting/Cli/CliBackchannel.cs
+++ b/src/Aspire.Hosting/Cli/CliBackchannel.cs
@@ -47,6 +47,10 @@ internal class CliBackchannel(ILogger<CliBackchannel> logger, IConfiguration con
                 logger.LogDebug("PingAsync round trip time is {RoundTripDuration} ms", roundtripMilliseconds);
             } while(await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false));
         }
+        catch (StreamJsonRpc.ConnectionLostException && stoppingToken.IsCancellationRequested)
+        {
+            logger.LogDebug("Ignoring ConnectionLostException because of cancellation.");
+        }
         catch (OperationCanceledException ex)
         {
             logger.LogDebug(ex, "Shutting down CLI backchannel because of cancellation.");

--- a/src/Aspire.Hosting/Cli/CliBackchannel.cs
+++ b/src/Aspire.Hosting/Cli/CliBackchannel.cs
@@ -47,9 +47,10 @@ internal class CliBackchannel(ILogger<CliBackchannel> logger, IConfiguration con
                 logger.LogDebug("PingAsync round trip time is {RoundTripDuration} ms", roundtripMilliseconds);
             } while(await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false));
         }
-        catch (StreamJsonRpc.ConnectionLostException && stoppingToken.IsCancellationRequested)
+        catch (StreamJsonRpc.ConnectionLostException) when (stoppingToken.IsCancellationRequested)
         {
             logger.LogDebug("Ignoring ConnectionLostException because of cancellation.");
+            return;
         }
         catch (OperationCanceledException ex)
         {

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -228,6 +228,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         // Aspire CLI support
         _innerBuilder.Services.AddHostedService<CliOrphanDetector>();
+        _innerBuilder.Services.AddHostedService<CliBackchannel>();
+        _innerBuilder.Services.AddSingleton<AppHostRpcTarget>();
 
         ConfigureHealthChecks();
 

--- a/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
+++ b/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
@@ -23,7 +23,7 @@ public class CliBackchannelTests(ITestOutputHelper outputHelper)
         serverSocket.Listen(1);
 
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
-        builder.Configuration["ASPIRE_CLI_BACKCHANNEL_PATH"] = socketPath;
+        builder.Configuration["ASPIRE_LAUNCHER_BACKCHANNEL_PATH"] = socketPath;
         using var app = builder.Build();
         await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(10));
 
@@ -54,7 +54,7 @@ public class CliBackchannelTests(ITestOutputHelper outputHelper)
         serverSocket.Listen(1);
 
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
-        builder.Configuration["ASPIRE_CLI_BACKCHANNEL_PATH"] = socketPath;
+        builder.Configuration["ASPIRE_LAUNCHER_BACKCHANNEL_PATH"] = socketPath;
         using var app = builder.Build();
         await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(10));
 

--- a/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Sockets;
+using System.Threading.Channels;
+using Aspire.Cli;
+using Aspire.Hosting.Utils;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Hosting.Tests.Cli;
+
+public class CliBackchannelTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task AppHostRespondsToPingWithMatchingTimestamp()
+    {
+        var socketPath = DotNetCliRunner.GetBackchannelSocketPath();
+        using var serverSocket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        var endpoint = new UnixDomainSocketEndPoint(socketPath);
+        serverSocket.Bind(endpoint);
+        serverSocket.Listen(1);
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
+        builder.Configuration["ASPIRE_CLI_BACKCHANNEL_PATH"] = socketPath;
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        var clientSocket = await serverSocket.AcceptAsync();
+        using var stream = new NetworkStream(clientSocket, true);
+
+        var cliRpcTarget = new DummyCliRpcTarget();
+        var rpc = JsonRpc.Attach(stream, cliRpcTarget);
+
+        // When we send a ping, it should return the same timestamp.
+        var sendTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var responseTimestamp = await rpc.InvokeAsync<long>("PingAsync", sendTimestamp);
+
+        Assert.Equal(sendTimestamp, responseTimestamp);
+
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task AppHostConnectsBackToCliWithPingRequest()
+    {
+        var testStartedTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var socketPath = DotNetCliRunner.GetBackchannelSocketPath();
+        using var serverSocket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        var endpoint = new UnixDomainSocketEndPoint(socketPath);
+        serverSocket.Bind(endpoint);
+        serverSocket.Listen(1);
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
+        builder.Configuration["ASPIRE_CLI_BACKCHANNEL_PATH"] = socketPath;
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        var clientSocket = await serverSocket.AcceptAsync();
+        using var stream = new NetworkStream(clientSocket, true);
+
+        var cliRpcTarget = new DummyCliRpcTarget();
+        var rpc = JsonRpc.Attach(stream, cliRpcTarget);
+
+        // This assertion is a little absurd, but the apphsot pinging the CLI
+        // after the test starts is an invaraint I can assert on :)
+        var pingTimestamp = await cliRpcTarget.PingAsyncChannel.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(pingTimestamp > testStartedTimestamp);
+    
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(10));
+    }
+}
+
+public class DummyCliRpcTarget
+{
+    public Channel<long> PingAsyncChannel { get; set; } = Channel.CreateUnbounded<long>();
+
+    public async Task<long> PingAsync(long timestamp)
+    {
+        await PingAsyncChannel.Writer.WriteAsync(timestamp);
+        return timestamp;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
@@ -25,7 +25,13 @@ public class CliBackchannelTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
         builder.Configuration["ASPIRE_LAUNCHER_BACKCHANNEL_PATH"] = socketPath;
         using var app = builder.Build();
-        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(20));
+
+        // Thru trial and error it seems that on the Windows CI machine it
+        // can take a while for this to startup in a quick fashion. On my local
+        // Windows environment it took up to 15 seconds, I'm setting 60 seconds
+        // here for plenty of buffer. If it takes longer than that then we have
+        // a problem.
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
 
         var clientSocket = await serverSocket.AcceptAsync();
         using var stream = new NetworkStream(clientSocket, true);

--- a/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
@@ -25,7 +25,7 @@ public class CliBackchannelTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
         builder.Configuration["ASPIRE_LAUNCHER_BACKCHANNEL_PATH"] = socketPath;
         using var app = builder.Build();
-        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(10));
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(20));
 
         var clientSocket = await serverSocket.AcceptAsync();
         using var stream = new NetworkStream(clientSocket, true);
@@ -56,7 +56,7 @@ public class CliBackchannelTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
         builder.Configuration["ASPIRE_LAUNCHER_BACKCHANNEL_PATH"] = socketPath;
         using var app = builder.Build();
-        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(10));
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(20));
 
         var clientSocket = await serverSocket.AcceptAsync();
         using var stream = new NetworkStream(clientSocket, true);


### PR DESCRIPTION
This PR introduces a bidirectional RPC (using `StreamJsonRpc`) between the CLI and the AppHost. If the CLI isn't the thing invoking the AppHost then the backchannel doesn't spin up in the AppHost. In this PR they just sit there pinging each other but this will be used as the foundation for the AppHost sending information that the console will display (URLs etc).

I still haven't settled on how I want to expose the ability to call the CLI RPC from the AppHost yet. It might be that I move away from using a background service so that code can call the RPC directly via an interface.

Alternatively, the background service might be very constrained in what it sends and so it basicaly uses information in the app model to send information.