### PR TITLE
Use correct properties for EventHub and ServiceBus

### DIFF
--- a/playground/AspireEventHub/EventHubs.AppHost/Program.cs
+++ b/playground/AspireEventHub/EventHubs.AppHost/Program.cs
@@ -7,7 +7,7 @@ var blob = builder.AddAzureStorage("ehstorage")
 
 var eventHub = builder.AddAzureEventHubs("eventhubns")
     .RunAsEmulator()
-    .AddHub("eventhub");
+    .AddHub("eventhubOne", "eventhub");
 
 builder.AddProject<Projects.EventHubsConsumer>("consumer")
     .WithReference(eventHub).WaitFor(eventHub)

--- a/playground/AspireEventHub/EventHubsApi/Program.cs
+++ b/playground/AspireEventHub/EventHubsApi/Program.cs
@@ -5,7 +5,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
-builder.AddAzureEventHubProducerClient("eventhub");
+builder.AddAzureEventHubProducerClient("eventhubOne");
 
 var app = builder.Build();
 

--- a/playground/AspireEventHub/EventHubsConsumer/Program.cs
+++ b/playground/AspireEventHub/EventHubsConsumer/Program.cs
@@ -10,7 +10,7 @@ bool useConsumer = Environment.GetEnvironmentVariable("USE_EVENTHUBCONSUMERCLIEN
 
 if (useConsumer)
 {
-    builder.AddAzureEventHubConsumerClient("eventhub");
+    builder.AddAzureEventHubConsumerClient("eventhubOne");
 
     builder.Services.AddHostedService<Consumer>();
     Console.WriteLine("Starting EventHubConsumerClient...");
@@ -20,7 +20,7 @@ else
     // required for checkpointing our position in the event stream
     builder.AddAzureBlobClient("checkpoints");
 
-    builder.AddAzureEventProcessorClient("eventhub");
+    builder.AddAzureEventProcessorClient("eventhubOne");
 
     builder.Services.AddHostedService<Processor>();
     Console.WriteLine("Starting EventProcessorClient...");

--- a/playground/AzureServiceBus/ServiceBus.AppHost/Program.cs
+++ b/playground/AzureServiceBus/ServiceBus.AppHost/Program.cs
@@ -5,10 +5,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var serviceBus = builder.AddAzureServiceBus("sbemulator");
 
-serviceBus.AddServiceBusQueue("queue1")
+serviceBus.AddServiceBusQueue("queueOne", "queue1")
     .WithProperties(queue => queue.DeadLetteringOnMessageExpiration = false);
 
-serviceBus.AddServiceBusTopic("topic1")
+serviceBus.AddServiceBusTopic("topicOne", "topic1")
     .AddServiceBusSubscription("sub1")
     .WithProperties(subscription =>
     {

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -269,7 +269,7 @@ public static class AzureEventHubsExtensions
             // an event hub namespace without an event hub? :)
             if (builder.Resource.Hubs is { Count: > 0 } && builder.Resource.Hubs[0] is { } hub)
             {
-                var healthCheckConnectionString = $"{connectionString};EntityPath={hub.Name};";
+                var healthCheckConnectionString = $"{connectionString};EntityPath={hub.HubName};";
                 client = new EventHubProducerClient(healthCheckConnectionString);
             }
             else

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -488,8 +488,8 @@ public static class AzureServiceBusExtensions
             serviceBusClient = new ServiceBusClient(connectionString, noRetryOptions);
 
             queueOrTopicName =
-                builder.Resource.Queues.Select(x => x.Name).FirstOrDefault()
-                ?? builder.Resource.Topics.Select(x => x.Name).FirstOrDefault();
+                builder.Resource.Queues.Select(x => x.QueueName).FirstOrDefault()
+                ?? builder.Resource.Topics.Select(x => x.TopicName).FirstOrDefault();
         });
 
         var healthCheckKey = $"{builder.Resource.Name}_check";


### PR DESCRIPTION
## Description

Came across an issue when I was adding both EventHub and ServiceBus emulators to our host. For example we have a hub called "events" and we also have a topic called "events". I couldn't add them with `AddHub("events")` and `AddServiceBusTopic("events")` since there is obviously a resource name collision. I instead used the overloads that take a resource name and hub or topic name, e.g. `Add("hub-events", "events")` and `AddServiceBusTopic("top-events", "events")`. However, the health checks started failing. Looked through the source code and saw that `Name` property was used instead of `HubName`, `QueueName `or `TopicName` respectively. I guess this might be an uncommon situation and why it was not caught before. This PR fixes it.

### Notes
I've also updated the playground for EventHub and ServiceBus to use the scenario above. I'm not sure if that should be part of the PR or not, let me know if you want me to revert those changes.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
