### PR TITLE
[CI] Simplify gathering test projects to run for non-templates on PRs

### DIFF
--- a/.github/actions/enumerate-tests/action.yml
+++ b/.github/actions/enumerate-tests/action.yml
@@ -35,6 +35,15 @@ runs:
         $lines = Get-Content $filePath
         $jsonObject = @{
             "shortname" = $lines | Sort-Object
+            "os" = @(
+              @{
+                  "name"="ubuntu-latest"
+                  "title"="Linux"
+              }
+              @{
+                  "name"="windows-latest"
+                  "title"="Windows"
+              })
         }
         $jsonString = ConvertTo-Json $jsonObject -Compress
         "tests_matrix=$jsonString"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,7 +33,8 @@ jobs:
   test:
     runs-on: ${{ inputs.os }}
     timeout-minutes: 60
-    name: ${{ inputs.os }}
+    name: ${{ inputs.testShortName }}
+    if: inputs.os != 'windows-latest' || inputs.testShortName != 'Playground'
     steps:
       - name: Validate arguments
         shell: pwsh

--- a/.github/workflows/template-tests.yml
+++ b/.github/workflows/template-tests.yml
@@ -67,7 +67,7 @@ jobs:
   results: # This job is used for branch protection. It ensures all the above tests passed
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Final Results
+    name: Templates Results
     needs: [test_linux, test_windows]
     steps:
       # get all the test-job-result* artifacts into a single directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
   # Duplicated jobs so their dependencies are not blocked on both the
   # setup jobs
 
-  setup_for_tests_lin:
-    name: Setup for tests (Linux)
+  setup_for_tests:
+    name: Setup for tests
     runs-on: ubuntu-latest
     outputs:
       tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
@@ -27,48 +27,22 @@ jobs:
       - uses: ./.github/actions/enumerate-tests
         id: generate_test_matrix
 
-  setup_for_tests_win:
-    name: Setup for tests (Windows)
-    runs-on: windows-latest
-    outputs:
-      tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: generate_test_matrix
-        uses: ./.github/actions/enumerate-tests
-
-  test_linux:
+  test:
     uses: ./.github/workflows/run-tests.yml
-    name: Linux
-    needs: setup_for_tests_lin
+    name: ${{ matrix.os.title }}
+    needs: setup_for_tests
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.setup_for_tests_lin.outputs.tests_matrix) }}
+      matrix: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix) }}
     with:
       testShortName: ${{ matrix.shortname }}
-      os: ubuntu-latest
-      testSessionTimeoutMs: ${{ matrix.testSessionTimeoutMs }}
-      extraTestArgs: ${{ matrix.extraTestArgs }}
-
-  test_windows:
-    uses: ./.github/workflows/run-tests.yml
-    name: Windows
-    needs: setup_for_tests_win
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup_for_tests_win.outputs.tests_matrix) }}
-    with:
-      testShortName: ${{ matrix.shortname }}
-      os: windows-latest
-      testSessionTimeoutMs: ${{ matrix.testSessionTimeoutMs }}
-      extraTestArgs: ${{ matrix.extraTestArgs }}
+      os: ${{ matrix.os.name }}
 
   results: # This job is used for branch protection. It ensures all the above tests passed
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [test_linux, test_windows]
+    needs: [test]
     steps:
       # get all the test-job-result* artifacts into a single directory
       - uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
   results: # This job is used for branch protection. It ensures all the above tests passed
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Final Results
+    name: Integration Results
     needs: [test]
     steps:
       # get all the test-job-result* artifacts into a single directory

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;
@@ -18,6 +19,7 @@ using Xunit.Sdk;
 
 namespace Aspire.Playground.Tests;
 
+[RequiresDocker]
 public class AppHostTests
 {
     private readonly ITestOutputHelper _testOutput;

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -8,8 +8,6 @@
 
     <!-- no docker support on helix/windows yet -->
     <RunTestsOnHelix Condition="'$(OS)' != 'Windows_NT'">true</RunTestsOnHelix>
-    <!-- no docker support on github-actions/windows yet -->
-    <RunTestsOnGithubActions Condition="'$(OS)' == 'Windows_NT'">false</RunTestsOnGithubActions>
     <SkipTests Condition="'$(OS)' == 'Windows_NT'">true</SkipTests>
 
     <DeployOutsideOfRepoSupportFilesRelativeDir>staging-archive\</DeployOutsideOfRepoSupportFilesRelativeDir>

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace Aspire.Playground.Tests;
 
+[RequiresDocker]
 public class ProjectSpecificTests(ITestOutputHelper _testOutput)
 {
     [Fact]


### PR DESCRIPTION
Two separate jobs (for Linux, and Windows) are currently used to get the list of non-template projects to run. But only the `Playground` is skipped on Windows. So, this can be simplified to use a single job.