### PR TITLE
Create SQL Server container folders on Windows

### DIFF
--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -110,6 +110,24 @@ public static class SqlServerBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(source);
 
-        return builder.WithBindMount(source, "/var/opt/mssql", isReadOnly);
+        if (!OperatingSystem.IsWindows())
+        {
+            return builder.WithBindMount(source, "/var/opt/mssql", isReadOnly);
+        }
+        else
+        {
+            // c.f. https://learn.microsoft.com/sql/linux/sql-server-linux-docker-container-configure?view=sql-server-ver15&pivots=cs1-bash#mount-a-host-directory-as-data-volume
+
+            foreach (var dir in new string[] { "data", "log", "secrets" })
+            {
+                var path = Path.Combine(source, dir);
+
+                Directory.CreateDirectory(path);
+
+                builder.WithBindMount(path, $"/var/opt/mssql/{dir}", isReadOnly);
+            }
+
+            return builder;
+        }
     }
 }


### PR DESCRIPTION
## Description

Without creating each folder the tests (and playground) fail with permission issues.
This is adding back the code that was shipped in 9.1 and before, which got changed as it didn't pass tests on Linux. In the end we need to handle Linux and Windows independently.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No - Tests are already covering the scenario but not yet run on Windows
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
