### PR TITLE
Add Role Assignment support for Azure Service Bus

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -312,10 +312,8 @@ internal sealed class AzureContainerAppsInfrastructure(
                 foreach (var (a, roles) in GetInlineRoleAssignments())
                 {
                     var prefix = a.GetBicepIdentifier();
-                    var name = new BicepOutputReference("name", a).AsProvisioningParameter(infra);
-                    var provisionable = a.CreateExistingResource(name);
+                    var provisionable = a.AddAsExistingResource(infra);
 
-                    infra.Add(provisionable);
                     foreach (var role in roles)
                     {
                         infra.Add(CreateRoleAssignment(prefix, provisionable, role.Id, role.Name, userAssignedIdentity.Id, RoleManagementPrincipalType.ServicePrincipal, userAssignedIdentity.PrincipalId));
@@ -355,12 +353,11 @@ internal sealed class AzureContainerAppsInfrastructure(
             private static void AddExistingResourceRoleAssignments(AzureResourceInfrastructure infra, AzureProvisioningResource existingResource, IEnumerable<RoleDefinition> roles, AzureProvisioningResource containerAppIdentityResource)
             {
                 var prefix = existingResource.GetBicepIdentifier();
-                var name = new BicepOutputReference("name", existingResource).AsProvisioningParameter(infra);
-                var provisionable = existingResource.CreateExistingResource(name);
+                var provisionable = existingResource.AddAsExistingResource(infra);
 
                 var appIdentityId = new BicepOutputReference("id", containerAppIdentityResource).AsProvisioningParameter(infra);
                 var appIdentityPrincipalId = new BicepOutputReference("principalId", containerAppIdentityResource).AsProvisioningParameter(infra);
-                infra.Add(provisionable);
+
                 foreach (var role in roles)
                 {
                     var roleAssignment = CreateRoleAssignment(prefix, provisionable, role.Id, role.Name, appIdentityId, RoleManagementPrincipalType.ServicePrincipal, appIdentityPrincipalId);

--- a/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
+++ b/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\Aspire.Hosting.Azure.Storage\Aspire.Hosting.Azure.Storage.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.ServiceBus" />

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.ServiceBus;
 using Azure.Messaging.ServiceBus;
 using Azure.Provisioning;
+using Azure.Provisioning.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using AzureProvisioning = Azure.Provisioning.ServiceBus;
@@ -28,6 +29,13 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The builder for the distributed application.</param>
     /// <param name="name">The name of the resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// By default references to the Azure Service Bus resource will be assigned the following roles:
+    /// 
+    /// - <see cref="ServiceBusBuiltInRole.AzureServiceBusDataOwner"/>
+    ///
+    /// These can be replaced by calling <see cref="WithRoleAssignments{T}(IResourceBuilder{T}, IResourceBuilder{AzureServiceBusResource}, ServiceBusBuiltInRole[])"/>.
+    /// </remarks>
     public static IResourceBuilder<AzureServiceBusResource> AddAzureServiceBus(this IDistributedApplicationBuilder builder, [ResourceName] string name)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -63,14 +71,23 @@ public static class AzureServiceBusExtensions
                     return resource;
                 });
 
-            var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
-            infrastructure.Add(principalTypeParameter);
-            var principalIdParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalId, typeof(string));
-            infrastructure.Add(principalIdParameter);
+            if (infrastructure.AspireResource.TryGetLastAnnotation<AppliedRoleAssignmentsAnnotation>(out var appliedRoleAssignments))
+            {
+                var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
+                infrastructure.Add(principalTypeParameter);
+                var principalIdParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalId, typeof(string));
+                infrastructure.Add(principalIdParameter);
 
-            infrastructure.Add(serviceBusNamespace.CreateRoleAssignment(AzureProvisioning.ServiceBusBuiltInRole.AzureServiceBusDataOwner, principalTypeParameter, principalIdParameter));
+                foreach (var role in appliedRoleAssignments.Roles)
+                {
+                    infrastructure.Add(serviceBusNamespace.CreateRoleAssignment(new ServiceBusBuiltInRole(role.Id), principalTypeParameter, principalIdParameter));
+                }
+            }
 
             infrastructure.Add(new ProvisioningOutput("serviceBusEndpoint", typeof(string)) { Value = serviceBusNamespace.ServiceBusEndpoint });
+
+            // We need to output name to externalize role assignments.
+            infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = serviceBusNamespace.Name });
 
             var azureResource = (AzureServiceBusResource)infrastructure.AspireResource;
 
@@ -104,7 +121,8 @@ public static class AzureServiceBusExtensions
         };
 
         var resource = new AzureServiceBusResource(name, configureInfrastructure);
-        return builder.AddResource(resource);
+        return builder.AddResource(resource)
+                      .WithDefaultRoleAssignments(ServiceBusBuiltInRole.AzureServiceBusDataOwner);
     }
 
     /// <summary>
@@ -646,4 +664,41 @@ public static class AzureServiceBusExtensions
 
         return filePath;
     }
+
+    /// <summary>
+    /// Assigns the specified roles to the given resource, granting it the necessary permissions
+    /// on the target Azure Service Bus namespace. This replaces the default role assignments for the resource.
+    /// </summary>
+    /// <param name="builder">The resource to which the specified roles will be assigned.</param>
+    /// <param name="target">The target Azure Service Bus namespace.</param>
+    /// <param name="roles">The built-in Service Bus roles to be assigned.</param>
+    /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <example>
+    /// Adds the AzureServiceBusDataSender role to the 'Projects.Api' project.
+    /// <code lang="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var sb = builder.AddAzureServiceBus("bus");
+    /// 
+    /// var api = builder.AddProject&lt;Projects.Api&gt;("api")
+    ///   .WithRoleAssignments(sb, ServiceBusBuiltInRole.AzureServiceBusDataSender)
+    ///   .WithReference(sb);
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<T> WithRoleAssignments<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<AzureServiceBusResource> target,
+        params ServiceBusBuiltInRole[] roles)
+        where T : IResource
+    {
+        return builder.WithAnnotation(new RoleAssignmentAnnotation(target.Resource, CreateRoleDefinitions(roles)));
+    }
+
+    private static IResourceBuilder<AzureServiceBusResource> WithDefaultRoleAssignments(this IResourceBuilder<AzureServiceBusResource> builder, params ServiceBusBuiltInRole[] roles)
+    {
+        return builder.WithAnnotation(new DefaultRoleAssignmentsAnnotation(CreateRoleDefinitions(roles)));
+    }
+
+    private static HashSet<RoleDefinition> CreateRoleDefinitions(IReadOnlyList<ServiceBusBuiltInRole> roles) =>
+        [.. roles.Select(r => new RoleDefinition(r.ToString(), ServiceBusBuiltInRole.GetBuiltInRoleName(r)))];
 }

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -86,7 +86,7 @@ public static class AzureStorageExtensions
             infrastructure.Add(new ProvisioningOutput("queueEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.QueueUri });
             infrastructure.Add(new ProvisioningOutput("tableEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.TableUri });
 
-            // We need to name to externalize role assignments.
+            // We need to output name to externalize role assignments.
             infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = storageAccount.Name });
         };
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
@@ -39,6 +39,8 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
     /// </summary>
     public BicepOutputReference TableEndpoint => new("tableEndpoint", this);
 
+    private BicepOutputReference NameOutputReference => new("name", this);
+
     /// <summary>
     /// Gets a value indicating whether the Azure Storage resource is running in the local emulator.
     /// </summary>
@@ -90,10 +92,11 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
     }
 
     /// <inheritdoc/>
-    public override ProvisionableResource CreateExistingResource(BicepValue<string> name)
+    public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)
     {
         var account = StorageAccount.FromExisting(Infrastructure.NormalizeBicepIdentifier(Name));
-        account.Name = name;
+        account.Name = NameOutputReference.AsProvisioningParameter(infra);
+        infra.Add(account);
         return account;
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
@@ -28,11 +28,12 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
     public ProvisioningBuildOptions? ProvisioningBuildOptions { get; set; }
 
     /// <summary>
-    /// Creates a new <see cref="ProvisionableResource"/> representing an existing Azure resource with the specified name.
+    /// Adds a new <see cref="ProvisionableResource"/> into <paramref name="infra"/>. The new resource
+    /// represents a reference to the current <see cref="AzureProvisioningResource"/> via https://learn.microsoft.com/azure/azure-resource-manager/bicep/existing-resource.
     /// </summary>
-    /// <param name="name">The name of the existing resource.</param>
+    /// <param name="infra">The <see cref="AzureResourceInfrastructure"/> to add the existing resource into.</param>
     /// <returns>A new <see cref="ProvisionableResource"/>, typically using the FromExisting method on the derived <see cref="ProvisionableResource"/> class.</returns>
-    public virtual ProvisionableResource CreateExistingResource(BicepValue<string> name) => throw new NotImplementedException();
+    public virtual ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra) => throw new NotImplementedException();
 
     /// <inheritdoc/>
     public override BicepTemplateFile GetBicepTemplateFile(string? directory = null, bool deleteTemporaryFileOnDispose = true)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -1915,6 +1915,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             }
             
             output serviceBusEndpoint string = sb.properties.serviceBusEndpoint
+
+            output name string = sb.name
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
@@ -78,6 +78,8 @@ public class AzureResourceOptionsTests(ITestOutputHelper output)
                 }
 
                 output serviceBusEndpoint string = sb.properties.serviceBusEndpoint
+
+                output name string = sb.name
                 """;
             output.WriteLine(actualBicep);
             Assert.Equal(expectedBicep, actualBicep);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -102,6 +102,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             }
 
             output serviceBusEndpoint string = sb.properties.serviceBusEndpoint
+
+            output name string = sb.name
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);
@@ -168,6 +170,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
             }
 
             output serviceBusEndpoint string = sb.properties.serviceBusEndpoint
+
+            output name string = sb.name
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -66,6 +66,8 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
 
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
+
+            output name string = existingResourceName
             """;
 
         output.WriteLine(BicepText);
@@ -137,6 +139,8 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
 
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
+            
+            output name string = messaging.name
             """;
 
         output.WriteLine(BicepText);
@@ -199,6 +203,8 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
 
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
+            
+            output name string = existingResourceName
             """;
 
         output.WriteLine(BicepText);
@@ -266,6 +272,8 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
 
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
+            
+            output name string = existingResourceName
             """;
 
         output.WriteLine(BicepText);
@@ -327,6 +335,8 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
 
             output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
+            
+            output name string = messaging.name
             """;
 
         output.WriteLine(BicepText);

--- a/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json.Nodes;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+using Azure.Provisioning.ServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class RoleAssignmentTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task ServiceBusSupport()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddAzureContainerAppsInfrastructure();
+
+        var sb = builder.AddAzureServiceBus("sb");
+
+        builder.AddProject<Project>("api", launchProfileName: null)
+            .WithRoleAssignments(sb, ServiceBusBuiltInRole.AzureServiceBusDataReceiver, ServiceBusBuiltInRole.AzureServiceBusDataSender);
+
+        var app = builder.Build();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var projRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>().Where(r => r.Name == $"api-roles"));
+
+        var (rolesManifest, rolesBicep) = await GetManifestWithBicep(projRoles);
+
+        var expectedRolesManifest =
+            """
+            {
+              "type": "azure.bicep.v0",
+              "path": "api-roles.module.bicep",
+              "params": {
+                "sb_outputs_name": "{sb.outputs.name}"
+              }
+            }
+            """;
+        Assert.Equal(expectedRolesManifest, rolesManifest.ToString());
+
+        var expectedRolesBicep =
+            """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param sb_outputs_name string
+
+            resource api_identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+              name: take('api_identity-${uniqueString(resourceGroup().id)}', 128)
+              location: location
+            }
+
+            resource sb 'Microsoft.ServiceBus/namespaces@2024-01-01' existing = {
+              name: sb_outputs_name
+            }
+
+            resource sb_AzureServiceBusDataReceiver 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(sb.id, api_identity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0'))
+              properties: {
+                principalId: api_identity.properties.principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0')
+                principalType: 'ServicePrincipal'
+              }
+              scope: sb
+            }
+
+            resource sb_AzureServiceBusDataSender 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(sb.id, api_identity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39'))
+              properties: {
+                principalId: api_identity.properties.principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39')
+                principalType: 'ServicePrincipal'
+              }
+              scope: sb
+            }
+
+            output id string = api_identity.id
+
+            output clientId string = api_identity.properties.clientId
+
+            output principalId string = api_identity.properties.principalId
+            """;
+        output.WriteLine(rolesBicep);
+        Assert.Equal(expectedRolesBicep, rolesBicep);
+    }
+
+    private static Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource) =>
+        AzureManifestUtils.GetManifestWithBicep(resource, skipPreparer: true);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
+    private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
+
+    private sealed class Project : IProjectMetadata
+    {
+        public string ProjectPath => "project";
+    }
+}


### PR DESCRIPTION

## Description

Adds WithRoleAssignments to Azure Service Bus.

Also I refactored how "CreateExisting" works. I didn't like that the AzureContainerAppsInfrastructure assumes the resource has a "name" bicep output.

Contributes to #6161

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - Ongoing
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] No
        - Link to aspire-docs issue [[New article]: Aspire 9.2 Azure WithRoleAssignments docs (dotnet/docs-aspire#2788)](https://github.com/dotnet/docs-aspire/issues/2788)
