### PR TITLE
Start params flow - fixes for ports, and generated / appsettings

### DIFF
--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -44,10 +44,13 @@ var backend = builder.AddProject<Projects.Publishers_ApiService>("api")
                      .WithReplicas(2);
 
 // need a container to test.
-builder.AddSqlServer("sqlserver")
+var sqlServer = builder.AddSqlServer("sqlserver")
         .WithDataVolume("sqlserver-data");
 
+var sqlDb = sqlServer.AddDatabase("sqldb");
+
 builder.AddProject<Projects.Publishers_Frontend>("frontend")
+       .WithReference(sqlDb)
        .WithReference(backend).WaitFor(backend);
 
 #if !SKIP_DASHBOARD_REFERENCE


### PR DESCRIPTION
Also fixes reference expressions for connection strings

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
