### PR TITLE
Fix flaky ResourceName_SubscribeOnLoadAndChange_SubscribeConsoleLogsOnce

### DIFF
--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -12,6 +12,7 @@ using Aspire.Dashboard.Utils;
 using Aspire.Tests.Shared.DashboardModel;
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -33,10 +34,11 @@ public partial class ConsoleLogsTests : TestContext
     }
 
     [Fact]
-    public void ResourceName_SubscribeOnLoadAndChange_SubscribeConsoleLogsOnce()
+    public async Task ResourceName_SubscribeOnLoadAndChange_SubscribeConsoleLogsOnce()
     {
         // Arrange
-        var subscribedResourceNames = new List<string>();
+        ILogger logger = null!;
+        var subscribedResourceNamesChannel = Channel.CreateUnbounded<string>();
         var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
         var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
         var testResource = ModelTestHelpers.CreateResource(appName: "test-resource", state: KnownResourceState.Running);
@@ -45,13 +47,16 @@ public partial class ConsoleLogsTests : TestContext
             isEnabled: true,
             consoleLogsChannelProvider: name =>
             {
-                subscribedResourceNames.Add(name);
+                logger.LogInformation($"Requesting logs for: {name}");
+                subscribedResourceNamesChannel.Writer.TryWrite(name);
                 return consoleLogsChannel;
             },
             resourceChannelProvider: () => resourceChannel,
             initialResources: [testResource, testResource2]);
 
         SetupConsoleLogsServices(dashboardClient);
+
+        logger = Services.GetRequiredService<ILogger<ConsoleLogsTests>>();
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: "test-resource"));
@@ -68,7 +73,6 @@ public partial class ConsoleLogsTests : TestContext
         });
 
         var instance = cut.Instance;
-        var logger = Services.GetRequiredService<ILogger<ConsoleLogsTests>>();
         var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
 
         // Assert 1
@@ -82,7 +86,8 @@ public partial class ConsoleLogsTests : TestContext
         logger.LogInformation("Waiting for finish message.");
         cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs)]);
 
-        Assert.Equal("test-resource", Assert.Single(subscribedResourceNames));
+        var subscribedResourceName1 = await subscribedResourceNamesChannel.Reader.ReadAsync().DefaultTimeout();
+        Assert.Equal("test-resource", subscribedResourceName1);
 
         navigationManager.LocationChanged += (sender, e) =>
         {
@@ -107,9 +112,8 @@ public partial class ConsoleLogsTests : TestContext
         cut.WaitForState(() => instance.PageViewModel.SelectedResource == testResource2);
         cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsWatchingLogs)]);
 
-        Assert.Collection(subscribedResourceNames,
-            r => Assert.Equal("test-resource", r),
-            r => Assert.Equal("test-resource2", r));
+        var subscribedResourceName2 = await subscribedResourceNamesChannel.Reader.ReadAsync().DefaultTimeout();
+        Assert.Equal("test-resource2", subscribedResourceName2);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -114,6 +114,9 @@ public partial class ConsoleLogsTests : TestContext
 
         var subscribedResourceName2 = await subscribedResourceNamesChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal("test-resource2", subscribedResourceName2);
+
+        subscribedResourceNamesChannel.Writer.Complete();
+        Assert.False(await subscribedResourceNamesChannel.Reader.WaitToReadAsync().DefaultTimeout());
     }
 
     [Fact]


### PR DESCRIPTION
Fix flaky test:

```
 | [0.035s] Bunit.Extensions.WaitForHelpers.WaitForHelper Debug: The waiter for component 3 disposed.
  Failed Aspire.Dashboard.Components.Tests.Pages.ConsoleLogsTests.ResourceName_SubscribeOnLoadAndChange_SubscribeConsoleLogsOnce [39 ms]
  Error Message:
   Assert.Collection() Failure: Mismatched item count
Collection:     ["test-resource"]
Expected count: 2
Actual count:   1
  Stack Trace:
     at Aspire.Dashboard.Components.Tests.Pages.ConsoleLogsTests.ResourceName_SubscribeOnLoadAndChange_SubscribeConsoleLogsOnce() in /_/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs:line 110
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
  Standard Output Messages:
```

I ran this test 500 times on my machine without it failing. Hopefully it is good now 🙏 