### PR TITLE
Spike on inspect mode.

### DIFF
--- a/playground/waitfor/WaitForSandbox.AppHost/Properties/launchSettings.json
+++ b/playground/waitfor/WaitForSandbox.AppHost/Properties/launchSettings.json
@@ -39,6 +39,17 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175"
       }
+    },
+    "inspect-mode": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--inspect true",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175"
+      }
     }
   }
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -237,6 +237,22 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddHostedService<CliBackchannel>();
         _innerBuilder.Services.AddSingleton<AppHostRpcTarget>();
 
+        // Orchestrator
+        _innerBuilder.Services.AddSingleton<ApplicationOrchestrator>();
+
+        // DCP stuff
+        _innerBuilder.Services.AddSingleton<IDcpExecutor, DcpExecutor>();
+        _innerBuilder.Services.AddSingleton<DcpExecutorEvents>();
+        _innerBuilder.Services.AddSingleton<DcpHost>();
+        _innerBuilder.Services.AddSingleton<IDcpDependencyCheckService, DcpDependencyCheck>();
+        _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DcpOptions>, ConfigureDefaultDcpOptions>());
+        _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DcpOptions>, ValidateDcpOptions>());
+        _innerBuilder.Services.AddSingleton<DcpNameGenerator>();
+
+        // We need a unique path per application instance
+        _innerBuilder.Services.AddSingleton(new Locations());
+        _innerBuilder.Services.AddSingleton<IKubernetesService, KubernetesService>();
+
         ConfigureHealthChecks();
 
         if (ExecutionContext.IsRunMode)
@@ -311,22 +327,6 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                 // This must be added before DcpHostService to ensure that it can subscribe to the ResourceNotificationService and ResourceLoggerService
                 _innerBuilder.Services.AddHostedService<ResourceLoggerForwarderService>();
             }
-
-            // Orchestrator
-            _innerBuilder.Services.AddSingleton<ApplicationOrchestrator>();
-
-            // DCP stuff
-            _innerBuilder.Services.AddSingleton<IDcpExecutor, DcpExecutor>();
-            _innerBuilder.Services.AddSingleton<DcpExecutorEvents>();
-            _innerBuilder.Services.AddSingleton<DcpHost>();
-            _innerBuilder.Services.AddSingleton<IDcpDependencyCheckService, DcpDependencyCheck>();
-            _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DcpOptions>, ConfigureDefaultDcpOptions>());
-            _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DcpOptions>, ValidateDcpOptions>());
-            _innerBuilder.Services.AddSingleton<DcpNameGenerator>();
-
-            // We need a unique path per application instance
-            _innerBuilder.Services.AddSingleton(new Locations());
-            _innerBuilder.Services.AddSingleton<IKubernetesService, KubernetesService>();
 
             // Devcontainers & Codespaces
             _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<CodespacesOptions>, ConfigureCodespacesOptions>());

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -85,4 +85,9 @@ public class DistributedApplicationExecutionContext
     /// Returns true if the current operation is running.
     /// </summary>
     public bool IsRunMode => Operation == DistributedApplicationOperation.Run;
+
+    /// <summary>
+    /// Returns true if the current operation is running in inspect mode.
+    /// </summary>
+    public bool IsInspectMode => Operation == DistributedApplicationOperation.Inspect;
 }

--- a/src/Aspire.Hosting/DistributedApplicationOperation.cs
+++ b/src/Aspire.Hosting/DistributedApplicationOperation.cs
@@ -16,5 +16,10 @@ public enum DistributedApplicationOperation
     /// <summary>
     /// AppHost is being run for the purpose of publishing a manifest for deployment.
     /// </summary>
-    Publish
+    Publish,
+
+    /// <summary>
+    /// AppHost is being run in inspect mode by the launcher.
+    /// </summary>
+    Inspect
 }

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -2,22 +2,44 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Orchestrator;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting;
 
-internal sealed class DistributedApplicationRunner(IHostApplicationLifetime lifetime, DistributedApplicationExecutionContext executionContext, DistributedApplicationModel model, IServiceProvider serviceProvider) : BackgroundService
+internal sealed class DistributedApplicationRunner(ApplicationOrchestrator orchestrator, DcpHost dcpHost, IHostApplicationLifetime lifetime, DistributedApplicationExecutionContext executionContext, DistributedApplicationModel model, IServiceProvider serviceProvider) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        if (executionContext.IsPublishMode)
+        if (executionContext.IsRunMode)
+        {
+            await dcpHost.StartAsync(stoppingToken).ConfigureAwait(false);
+            await orchestrator.RunApplicationAsync(stoppingToken).ConfigureAwait(false);
+        }
+        else if (executionContext.IsPublishMode)
         {
             var publisher = serviceProvider.GetRequiredKeyedService<IDistributedApplicationPublisher>(executionContext.PublisherName);
             await publisher.PublishAsync(model, stoppingToken).ConfigureAwait(false);
             lifetime.StopApplication();
         }
+        else if (executionContext.IsInspectMode)
+        {
+            // No op for now.
+        }
+        else
+        {
+            throw new DistributedApplicationException($"Unexpected mode: {executionContext.Operation}");
+        }
+    }
 
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (executionContext.IsRunMode)
+        {
+            await orchestrator.StopAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Aspire.Hosting/Orchestrator/OrchestratorHostService.cs
+++ b/src/Aspire.Hosting/Orchestrator/OrchestratorHostService.cs
@@ -1,91 +1,91 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Dcp;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+// using Aspire.Hosting.Dcp;
+// using Microsoft.Extensions.Hosting;
+// using Microsoft.Extensions.Logging;
 
-namespace Aspire.Hosting.Orchestrator;
+// namespace Aspire.Hosting.Orchestrator;
 
-internal sealed class OrchestratorHostService : IHostedLifecycleService, IAsyncDisposable
-{
-    private readonly ApplicationOrchestrator _appOrchestrator;
-    private readonly DcpHost _dcpHost;
-    private readonly ILogger _logger;
-    private readonly DistributedApplicationExecutionContext _executionContext;
-    private IAsyncDisposable? _dcpRunDisposable;
+// internal sealed class OrchestratorHostService : IHostedLifecycleService, IAsyncDisposable
+// {
+//     private readonly ApplicationOrchestrator _appOrchestrator;
+//     private readonly DcpHost _dcpHost;
+//     private readonly ILogger _logger;
+//     private readonly DistributedApplicationExecutionContext _executionContext;
+//     private IAsyncDisposable? _dcpRunDisposable;
 
-    public OrchestratorHostService(
-        ILoggerFactory loggerFactory,
-        DistributedApplicationExecutionContext executionContext,
-        ApplicationOrchestrator appOrchestrator,
-        DcpHost dcpHost)
-    {
-        _logger = loggerFactory.CreateLogger<OrchestratorHostService>();
-        _executionContext = executionContext;
-        _appOrchestrator = appOrchestrator;
-        _dcpHost = dcpHost;
-    }
+//     public OrchestratorHostService(
+//         ILoggerFactory loggerFactory,
+//         DistributedApplicationExecutionContext executionContext,
+//         ApplicationOrchestrator appOrchestrator,
+//         DcpHost dcpHost)
+//     {
+//         _logger = loggerFactory.CreateLogger<OrchestratorHostService>();
+//         _executionContext = executionContext;
+//         _appOrchestrator = appOrchestrator;
+//         _dcpHost = dcpHost;
+//     }
 
-    private bool IsSupported => !_executionContext.IsPublishMode;
+//     private bool IsSupported => _executionContext.IsRunMode;
 
-    public async Task StartAsync(CancellationToken cancellationToken = default)
-    {
-        if (!IsSupported)
-        {
-            return;
-        }
+//     public async Task StartAsync(CancellationToken cancellationToken = default)
+//     {
+//         if (!IsSupported)
+//         {
+//             return;
+//         }
 
-        await _dcpHost.StartAsync(cancellationToken).ConfigureAwait(false);
+//         await _dcpHost.StartAsync(cancellationToken).ConfigureAwait(false);
 
-        await _appOrchestrator.RunApplicationAsync(cancellationToken).ConfigureAwait(false);
-    }
+//         await _appOrchestrator.RunApplicationAsync(cancellationToken).ConfigureAwait(false);
+//     }
 
-    public async Task StopAsync(CancellationToken cancellationToken = default)
-    {
-        await _appOrchestrator.StopAsync(cancellationToken).ConfigureAwait(false);
-    }
+//     public async Task StopAsync(CancellationToken cancellationToken = default)
+//     {
+//         await _appOrchestrator.StopAsync(cancellationToken).ConfigureAwait(false);
+//     }
 
-    public async ValueTask DisposeAsync()
-    {
-        if (_dcpRunDisposable is { } disposable)
-        {
-            _dcpRunDisposable = null;
+//     public async ValueTask DisposeAsync()
+//     {
+//         if (_dcpRunDisposable is { } disposable)
+//         {
+//             _dcpRunDisposable = null;
 
-            try
-            {
-                await disposable.DisposeAsync().AsTask().ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Shutdown requested.
-            }
-            catch (Exception ex)
-            {
-                _logger.LogCritical(ex, "One or more monitoring tasks terminated with an error.");
-            }
-        }
-    }
+//             try
+//             {
+//                 await disposable.DisposeAsync().AsTask().ConfigureAwait(false);
+//             }
+//             catch (OperationCanceledException)
+//             {
+//                 // Shutdown requested.
+//             }
+//             catch (Exception ex)
+//             {
+//                 _logger.LogCritical(ex, "One or more monitoring tasks terminated with an error.");
+//             }
+//         }
+//     }
 
-    public Task StartedAsync(CancellationToken cancellationToken)
-    {
-        AspireEventSource.Instance.DcpHostStartupStop();
-        return Task.CompletedTask;
-    }
+//     public Task StartedAsync(CancellationToken cancellationToken)
+//     {
+//         AspireEventSource.Instance.DcpHostStartupStop();
+//         return Task.CompletedTask;
+//     }
 
-    public Task StartingAsync(CancellationToken cancellationToken)
-    {
-        AspireEventSource.Instance.DcpHostStartupStart();
-        return Task.CompletedTask;
-    }
+//     public Task StartingAsync(CancellationToken cancellationToken)
+//     {
+//         AspireEventSource.Instance.DcpHostStartupStart();
+//         return Task.CompletedTask;
+//     }
 
-    public Task StoppedAsync(CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
+//     public Task StoppedAsync(CancellationToken cancellationToken)
+//     {
+//         return Task.CompletedTask;
+//     }
 
-    public Task StoppingAsync(CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
-}
+//     public Task StoppingAsync(CancellationToken cancellationToken)
+//     {
+//         return Task.CompletedTask;
+//     }
+// }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -159,6 +159,11 @@ public class DistributedApplicationTests
     {
         const string testName = "explicit-start-executable";
         using var testProgram = CreateTestProgram(testName, randomizePorts: false);
+
+        // This test is sensitive to codespaces and so needs to explicitly 
+        // disable codespace URL rewriting support.
+        testProgram.AppBuilder.Configuration["CODESPACES"] = "false";
+
         SetupXUnitLogging(testProgram.AppBuilder.Services);
 
         var notStartedResourceName = $"{testName}-servicea";
@@ -217,6 +222,11 @@ public class DistributedApplicationTests
     {
         const string testName = "explicit-start-container";
         using var testProgram = CreateTestProgram(testName, randomizePorts: false);
+
+        // This test is sensitive to codespaces and so needs to explicitly 
+        // disable codespace URL rewriting support.
+        testProgram.AppBuilder.Configuration["CODESPACES"] = "false";
+
         SetupXUnitLogging(testProgram.AppBuilder.Services);
 
         var notStartedResourceName = $"{testName}-redis";


### PR DESCRIPTION
This is a spike on adding "inspect mode" to the app model. The goal of this mode is to neither spin up DCP or initiate publishing but rather just sit idle so that the launcher of the apphost can interrogate the application model via RPC requests (which will land in another PR).

Also as part of this PR I removed (commented out of rnow) `OrchestratorHostService` since it overlaps in function quite a bit with `DistributedApplicationRunner` which until now was just used for launching a publisher, but with inspect mode it does more work and it makes more sense to consolidate the lauch of the orchestrator into this service.

Related #8029 #8018