### PR TITLE
Use custom queue/topic names in SB emulator heath-checks

### DIFF
--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
@@ -21,6 +21,7 @@ public class AzureServiceBusQueueResource(string name, string queueName, AzureSe
     : Resource(name), IResourceWithParent<AzureServiceBusResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     private string _queueName = ThrowIfNullOrEmpty(queueName);
+
     /// <summary>
     /// The queue name.
     /// </summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -214,9 +214,11 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         await app.StopAsync();
     }
 
-    [Fact(Skip = "Azure ServiceBus emulator is not reliable in CI - https://github.com/dotnet/aspire/issues/7066")]
+    [Theory(Skip = "Azure ServiceBus emulator is not reliable in CI - https://github.com/dotnet/aspire/issues/7066")]
+    [InlineData(null)]
+    [InlineData("other")]
     [RequiresDocker]
-    public async Task VerifyAzureServiceBusEmulatorResource()
+    public async Task VerifyAzureServiceBusEmulatorResource(string? queueName)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
 
@@ -225,7 +227,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         var serviceBus = builder.AddAzureServiceBus("servicebusns")
             .RunAsEmulator();
 
-        serviceBus.AddServiceBusQueue("queue123");
+        var queueResource = serviceBus.AddServiceBusQueue("queue123", queueName);
 
         using var app = builder.Build();
         await app.StartAsync();
@@ -243,10 +245,10 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
         var serviceBusClient = host.Services.GetRequiredService<ServiceBusClient>();
 
-        await using var sender = serviceBusClient.CreateSender("queue123");
+        await using var sender = serviceBusClient.CreateSender(queueResource.Resource.QueueName);
         await sender.SendMessageAsync(new ServiceBusMessage("Hello, World!"), cts.Token);
 
-        await using var receiver = serviceBusClient.CreateReceiver("queue123");
+        await using var receiver = serviceBusClient.CreateReceiver(queueResource.Resource.QueueName);
         var message = await receiver.ReceiveMessageAsync(cancellationToken: cts.Token);
 
         Assert.Equal("Hello, World!", message.Body.ToString());


### PR DESCRIPTION
## Description

Health-checks currently use the wrong name property for Service Bus emulator. It doesn't work anymore when users provide a custom name.

Fixes https://github.com/dotnet/aspire/issues/7904

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
