### PR TITLE
Generate env file with defaults and descriptions

### DIFF
--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -30,6 +30,8 @@ var param1 = builder.AddParameter("param1", secret: true);
 var param2 = builder.AddParameter("param2", "default", publishValueAsDefault: true);
 var param3 = builder.AddParameter("param3", "default"); // Runtime only default value.
 
+var azpgdb = builder.AddAzurePostgresFlexibleServer("azpg").RunAsContainer().AddDatabase("azdb");
+
 var db = builder.AddPostgres("pg").AddDatabase("db");
 
 var dbsetup = builder.AddProject<Projects.Publishers_DbSetup>("dbsetup")
@@ -39,6 +41,7 @@ var backend = builder.AddProject<Projects.Publishers_ApiService>("api")
                      .WithExternalHttpEndpoints()
                      .WithHttpHealthCheck("/health")
                      .WithReference(db).WaitFor(db)
+                     .WithReference(azpgdb).WaitFor(azpgdb)
                      .WaitForCompletion(dbsetup)
                      .WithReplicas(2);
 

--- a/playground/publishers/Publishers.AppHost/docker-compose.yaml
+++ b/playground/publishers/Publishers.AppHost/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     networks:
       - "aspire"
   dbsetup:
+    image: "${DBSETUP_IMAGE}"
     environment:
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "true"
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
@@ -24,6 +25,7 @@ services:
     networks:
       - "aspire"
   api:
+    image: "${API_IMAGE}"
     environment:
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "true"
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
@@ -51,6 +53,7 @@ services:
     networks:
       - "aspire"
   frontend:
+    image: "${FRONTEND_IMAGE}"
     environment:
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "true"
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
@@ -60,7 +63,7 @@ services:
       ConnectionStrings__sqldb: "Server=sqlserver,1433;User ID=sa;Password=${SQLSERVER_PASSWORD};TrustServerCertificate=true;Database=sqldb"
       P0: "${PARAM0}"
       P1: "${PARAM1}"
-      P2: "${PARAM2:-default}"
+      P2: "${PARAM2}"
       P3: "${PARAM3}"
       services__api__http__0: "http://api:8005"
       services__api__https__0: "https://api:8007"

--- a/playground/publishers/Publishers.AppHost/docker-compose.yaml
+++ b/playground/publishers/Publishers.AppHost/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
       ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
       HTTP_PORTS: "8006"
       ConnectionStrings__db: "Host=pg;Port=5432;Username=postgres;Password=${PG_PASSWORD};Database=db"
+      ConnectionStrings__azdb: "${AZPG_OUTPUTS_CONNECTIONSTRING};Database=azdb"
     ports:
       - "8006:8005"
       - "8008:8007"


### PR DESCRIPTION
Simplify parameter handling and use env files for default values and as documentation for required parameters. 

Unclear if we should leave defaults in the compose file instead

This is what the env file looks like.

```.env
# Parameter pg-password
PG_PASSWORD=

# Container image name for dbsetup
DBSETUP_IMAGE=dbsetup:latest

# Unknown reference {azpg.outputs.connectionString}
AZPG_OUTPUTS_CONNECTIONSTRING=

# Container image name for api
API_IMAGE=api:latest

# Parameter sqlserver-password
SQLSERVER_PASSWORD=

# Parameter param0
PARAM0=

# Parameter param1
PARAM1=

# Parameter param2
PARAM2=default

# Parameter param3
PARAM3=

# Container image name for frontend
FRONTEND_IMAGE=frontend:latest
```