### PR TITLE
5x test timeout

### DIFF
--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -72,7 +72,7 @@ public partial class ResourcesTests : TestContext
                     ImmutableArray.Create(new HealthReportViewModel("Healthy", HealthStatus.Healthy, "Description2", null))))
             ]);
 
-        cut.WaitForState(() => cut.Instance.GetFilteredResources().Count() == 2);
+        cut.WaitForState(() => cut.Instance.GetFilteredResources().Count() == 2, TestConstants.WaitTimeout);
 
         // Assert 2
         Assert.Collection(cut.Instance.ResourceTypesToVisibility.OrderBy(kvp => kvp.Key),


### PR DESCRIPTION
## Description

Increases timeout on UpdateResources_FiltersUpdated, which is seemingly occurring due to load on the test runner. Increasing from 1 to 5 seconds.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
