### PR TITLE
[CI] Use LogFilePrefix instead of LogFileName

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -139,7 +139,7 @@ jobs:
           /p:ContinuousIntegrationBuild=true
           -s eng/testing/.runsettings
           -l "console;verbosity=normal"
-          -l "trx;LogFileName=${{ inputs.testShortName }}-TestResults.trx"
+          -l "trx;LogFilePrefix=${{ inputs.testShortName }}"
           -l "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
           "--blame"
           --blame-hang-timeout ${{ inputs.testHangTimeout }}

--- a/.github/workflows/template-tests.yml
+++ b/.github/workflows/template-tests.yml
@@ -25,7 +25,7 @@ jobs:
         id: generate_test_matrix
 
   setup_for_tests_win:
-    name: Setup for template tests (Windows)
+    name: Setup for tests (Windows)
     runs-on: windows-latest
     outputs:
       tests_matrix: ${{ steps.generate_test_matrix.outputs.tests_matrix }}


### PR DESCRIPTION
.. so vstest can create unique log file names when a test project is
multi-targeting. With `LogFileName` the tests for all the tfms would be
written to the same file, resulting in only the last one being available.
