### PR TITLE
Introduce --operation switch and inspect mode

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -122,19 +122,12 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             _ => throw new DistributedApplicationException("Invalid operation specified. Valid operations are 'publish', 'inspect', or 'run'.")
         };
 
-        if (operation == DistributedApplicationOperation.Run)
+        return operation switch
         {
-            return new DistributedApplicationExecutionContextOptions(operation!);
-        }
-        else if (operation == DistributedApplicationOperation.Inspect)
-        {
-            return new DistributedApplicationExecutionContextOptions(operation);
-        }
-        else
-        {
-            var publisher = _innerBuilder.Configuration["Publishing:Publisher"];
-            return new DistributedApplicationExecutionContextOptions(operation, publisher);
-        }
+            DistributedApplicationOperation.Run => new DistributedApplicationExecutionContextOptions(operation),
+            DistributedApplicationOperation.Inspect => new DistributedApplicationExecutionContextOptions(operation),
+            _ => new DistributedApplicationExecutionContextOptions(operation, _innerBuilder.Configuration["Publishing:Publisher"])
+        };
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -85,4 +85,9 @@ public class DistributedApplicationExecutionContext
     /// Returns true if the current operation is running.
     /// </summary>
     public bool IsRunMode => Operation == DistributedApplicationOperation.Run;
+
+    /// <summary>
+    /// Returns true if the current operation is inspecting.
+    /// </summary>
+    public bool IsInspectMode => Operation == DistributedApplicationOperation.Inspect;
 }

--- a/src/Aspire.Hosting/DistributedApplicationOperation.cs
+++ b/src/Aspire.Hosting/DistributedApplicationOperation.cs
@@ -16,5 +16,10 @@ public enum DistributedApplicationOperation
     /// <summary>
     /// AppHost is being run for the purpose of publishing a manifest for deployment.
     /// </summary>
-    Publish
+    Publish,
+
+    /// <summary>
+    /// AppHost is being run for the purpose of inspecting the application model from the launcher.
+    /// </summary>
+    Inspect
 }

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -18,6 +18,5 @@ internal sealed class DistributedApplicationRunner(IHostApplicationLifetime life
             await publisher.PublishAsync(model, stoppingToken).ConfigureAwait(false);
             lifetime.StopApplication();
         }
-
     }
 }

--- a/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliBackchannelTests.cs
@@ -77,6 +77,39 @@ public class CliBackchannelTests(ITestOutputHelper outputHelper)
     
         await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(10));
     }
+
+    [Fact]
+    public async Task AppHostConnectsBackToCliWithPingRequestInInspectMode()
+    {
+        var testStartedTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        var socketPath = DotNetCliRunner.GetBackchannelSocketPath();
+        using var serverSocket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        var endpoint = new UnixDomainSocketEndPoint(socketPath);
+        serverSocket.Bind(endpoint);
+        serverSocket.Listen(1);
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create("--operation", "inspect")
+            .WithTestAndResourceLogging(outputHelper);
+
+        builder.Configuration["ASPIRE_LAUNCHER_BACKCHANNEL_PATH"] = socketPath;
+        using var app = builder.Build();
+        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(20));
+
+        var clientSocket = await serverSocket.AcceptAsync();
+        using var stream = new NetworkStream(clientSocket, true);
+
+        var cliRpcTarget = new DummyCliRpcTarget();
+        var rpc = JsonRpc.Attach(stream, cliRpcTarget);
+
+        // This assertion is a little absurd, but the apphsot pinging the CLI
+        // after the test starts is an invaraint I can assert on :)
+        var pingTimestamp = await cliRpcTarget.PingAsyncChannel.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(pingTimestamp > testStartedTimestamp);
+    
+        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(10));
+    }
 }
 
 public class DummyCliRpcTarget

--- a/tests/Aspire.Hosting.Tests/OperationModesTests.cs
+++ b/tests/Aspire.Hosting.Tests/OperationModesTests.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Hosting.Tests;
+
+public class OperationModesTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task EnsureWhenAppHostIsRunWithoutAnyArgsThatItDefaultsToRunMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
+        
+        var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
+        builder.Eventing.Subscribe<AfterResourcesCreatedEvent>((e, ct) => {
+            var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();
+            tcs.SetResult(context);
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        
+        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        var context = await tcs.Task.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        Assert.Equal(DistributedApplicationOperation.Run, context.Operation);
+        Assert.True(context.IsRunMode);
+    }
+
+    [Fact]
+    public async Task EnsureWhenAppHostIsRunPublisherAndOutputPathSwitchThatItIsInPublishMode()
+    {
+        using var builder = TestDistributedApplicationBuilder
+            .Create(["--publisher", "manifest", "--output-path", "test-output-path"])
+            .WithTestAndResourceLogging(outputHelper);
+        
+        var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
+        builder.Eventing.Subscribe<AfterResourcesCreatedEvent>((e, ct) => {
+            var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();
+            tcs.SetResult(context);
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        
+        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        var context = await tcs.Task.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        Assert.Equal(DistributedApplicationOperation.Publish, context.Operation);
+        Assert.True(context.IsPublishMode);
+    }
+
+    [Fact]
+    public void TestOperationModes3()
+    {
+        // Optional explicit run mode: AppHost.exe --operation run
+        Assert.True(false);
+
+    }
+    
+    [Fact]
+    public void TestOperationModes4()
+    {
+        // Optional explicit run mode: AppHost.exe --operation publish --publisher manifest --output-path
+        Assert.True(false);
+
+    }
+    
+    [Fact]
+    public void TestOperationModes5()
+    {
+        // Mandatory inspect mode: AppHost.exe --operation inspect
+        Assert.True(false);
+
+    }
+}

--- a/tests/Aspire.Hosting.Tests/OperationModesTests.cs
+++ b/tests/Aspire.Hosting.Tests/OperationModesTests.cs
@@ -42,6 +42,9 @@ public class OperationModesTests(ITestOutputHelper outputHelper)
             .Create(["--publisher", "manifest", "--output-path", "test-output-path"])
             .WithTestAndResourceLogging(outputHelper);
         
+
+        // TOOD: This won't work because this event does not fire in publish mode. We need
+        //       another way to get at this internal state.
         var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
         builder.Eventing.Subscribe<AfterResourcesCreatedEvent>((e, ct) => {
             var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();

--- a/tests/Aspire.Hosting.Tests/OperationModesTests.cs
+++ b/tests/Aspire.Hosting.Tests/OperationModesTests.cs
@@ -12,8 +12,11 @@ namespace Aspire.Hosting.Tests;
 public class OperationModesTests(ITestOutputHelper outputHelper)
 {
     [Fact]
-    public async Task EnsureWhenAppHostIsRunWithoutAnyArgsThatItDefaultsToRunMode()
+    public async Task VerifyBackwardsCompatableRunModeInvocation()
     {
+        // The purpose of this test is to verify that the apphost executable will continue
+        // to enter run mode if executed without any arguments.
+
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(outputHelper);
         
         var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
@@ -36,17 +39,77 @@ public class OperationModesTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task EnsureWhenAppHostIsRunPublisherAndOutputPathSwitchThatItIsInPublishMode()
+    public async Task VerifyExplicitRunModeInvocation()
     {
+        // The purpose of this test is to verify that the apphost executable will enter
+        // run mode if executed with the "--operation run" argument.
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(["--operation", "run"])
+            .WithTestAndResourceLogging(outputHelper);
+        
+        var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
+        builder.Eventing.Subscribe<AfterResourcesCreatedEvent>((e, ct) => {
+            var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();
+            tcs.SetResult(context);
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        
+        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        var context = await tcs.Task.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        Assert.Equal(DistributedApplicationOperation.Run, context.Operation);
+        Assert.True(context.IsRunMode);
+    }
+
+    [Fact]
+    public async Task VerifyExplicitRunModeWithPublisherInvocation()
+    {
+        // The purpose of this test is to verify that the apphost executable will enter
+        // run mode if executed with the "--operation run" argument.
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(["--operation", "run", "--publisher", "manifest"])
+            .WithTestAndResourceLogging(outputHelper);
+        
+        var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
+        builder.Eventing.Subscribe<AfterResourcesCreatedEvent>((e, ct) => {
+            var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();
+            tcs.SetResult(context);
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        
+        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        var context = await tcs.Task.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        Assert.Equal(DistributedApplicationOperation.Run, context.Operation);
+        Assert.True(context.IsRunMode);
+    }
+
+    [Fact]
+    public async Task VerifyBackwardsCompatablePublishModeInvocation()
+    {
+        // The purpose of this test is to verify that the apphost executable will continue
+        // to enter publish mode if the --publisher argument is specified.
+
         using var builder = TestDistributedApplicationBuilder
             .Create(["--publisher", "manifest", "--output-path", "test-output-path"])
             .WithTestAndResourceLogging(outputHelper);
-        
 
         // TOOD: This won't work because this event does not fire in publish mode. We need
         //       another way to get at this internal state.
         var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
-        builder.Eventing.Subscribe<AfterResourcesCreatedEvent>((e, ct) => {
+        builder.Eventing.Subscribe<BeforeStartEvent>((e, ct) => {
             var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();
             tcs.SetResult(context);
             return Task.CompletedTask;
@@ -65,26 +128,95 @@ public class OperationModesTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void TestOperationModes3()
+    public async Task VerifyExplicitPublishModeInvocation()
     {
-        // Optional explicit run mode: AppHost.exe --operation run
-        Assert.True(false);
+        // The purpose of this test is to verify that the apphost executable will continue
+        // to enter publish mode if the --publisher argument is specified.
 
+        using var builder = TestDistributedApplicationBuilder
+            .Create(["--operation", "publish", "--publisher", "manifest", "--output-path", "test-output-path"])
+            .WithTestAndResourceLogging(outputHelper);
+
+        // TOOD: This won't work because this event does not fire in publish mode. We need
+        //       another way to get at this internal state.
+        var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
+        builder.Eventing.Subscribe<BeforeStartEvent>((e, ct) => {
+            var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();
+            tcs.SetResult(context);
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        
+        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        var context = await tcs.Task.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        Assert.Equal(DistributedApplicationOperation.Publish, context.Operation);
+        Assert.True(context.IsPublishMode);
     }
-    
-    [Fact]
-    public void TestOperationModes4()
-    {
-        // Optional explicit run mode: AppHost.exe --operation publish --publisher manifest --output-path
-        Assert.True(false);
 
+    [Fact]
+    public async Task VerifyExplicitInspectModeInvocation()
+    {
+        // The purpose of this test is to verify that the apphost executable will continue
+        // to enter publish mode if the --publisher argument is specified.
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(["--operation", "inspect"])
+            .WithTestAndResourceLogging(outputHelper);
+
+        // TOOD: This won't work because this event does not fire in publish mode. We need
+        //       another way to get at this internal state.
+        var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
+        builder.Eventing.Subscribe<BeforeStartEvent>((e, ct) => {
+            var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();
+            tcs.SetResult(context);
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        
+        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        var context = await tcs.Task.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        Assert.Equal(DistributedApplicationOperation.Inspect, context.Operation);
+        Assert.True(context.IsInspectMode);
     }
-    
-    [Fact]
-    public void TestOperationModes5()
-    {
-        // Mandatory inspect mode: AppHost.exe --operation inspect
-        Assert.True(false);
 
+    [Fact]
+    public async Task VerifyExplicitInspectModeWithPublisherSpecifiedInvocation()
+    {
+        // The purpose of this test is to verify that the apphost executable will continue
+        // to enter publish mode if the --publisher argument is specified.
+
+        using var builder = TestDistributedApplicationBuilder
+            .Create(["--operation", "inspect", "--publisher", "manifest"])
+            .WithTestAndResourceLogging(outputHelper);
+
+        // TOOD: This won't work because this event does not fire in publish mode. We need
+        //       another way to get at this internal state.
+        var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
+        builder.Eventing.Subscribe<BeforeStartEvent>((e, ct) => {
+            var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();
+            tcs.SetResult(context);
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        
+        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        var context = await tcs.Task.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        Assert.Equal(DistributedApplicationOperation.Inspect, context.Operation);
+        Assert.True(context.IsInspectMode);
     }
 }

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -325,6 +325,8 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
         // Arrange
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
+        builder.Configuration["CODESPACES"] = "false";
+
         var service = builder.AddResource(new CustomResource("service"))
             .WithHttpEndpoint()
             .WithHttpCommand("/dothing", "Do The Thing", commandName: "mycommand");
@@ -380,6 +382,8 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     {
         // Arrange
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        
+        builder.Configuration["CODESPACES"] = "false";
 
         var enableCommand = false;
         var callbackCalled = false;


### PR DESCRIPTION
Replaces this PR: #8033

Introducing a `--operation` switch which takes the options `run`, `publish`, and `inspect`. Introduced tests to insure backwards compatability. In inspect mode the apphost sits idle so that the launcher can make RPC requests to interrogate the application model after it has been (partially) evaluated.