### PR TITLE
Support CosmosDB child resources in client integration

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
@@ -10,7 +10,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 builder.AddAzureCosmosDatabase("db");
 builder.AddAzureCosmosContainer("entries");
-builder.AddCosmosDbContext<TestCosmosContext>("cosmos", "ef", configureDbContextOptions =>
+builder.AddCosmosDbContext<TestCosmosContext>("db", configureDbContextOptions =>
 {
     configureDbContextOptions.RequestTimeout = TimeSpan.FromSeconds(120);
 });

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
@@ -8,7 +8,8 @@ using Newtonsoft.Json;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
-builder.AddAzureCosmosClient("cosmos");
+builder.AddAzureCosmosDatabase("db");
+builder.AddAzureCosmosContainer("entries");
 builder.AddCosmosDbContext<TestCosmosContext>("cosmos", "ef", configureDbContextOptions =>
 {
     configureDbContextOptions.RequestTimeout = TimeSpan.FromSeconds(120);
@@ -17,11 +18,8 @@ builder.AddCosmosDbContext<TestCosmosContext>("cosmos", "ef", configureDbContext
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
-app.MapGet("/", async (CosmosClient cosmosClient) =>
+app.MapGet("/", async (Database db, Container container) =>
 {
-    var db = cosmosClient.GetDatabase("db");
-    var container = db.GetContainer("entries");
-
     // Add an entry to the database on each request.
     var newEntry = new Entry() { Id = Guid.NewGuid().ToString() };
     await container.CreateItemAsync(newEntry);

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -13,9 +13,8 @@ var container = db.AddContainer("entries", "/id");
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()
-       .WithReference(cosmos).WaitFor(cosmos)
-       .WithReference(db)
-       .WithReference(container);
+       .WithReference(db).WaitFor(db)
+       .WithReference(container).WaitFor(container);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -9,11 +9,13 @@ var cosmos = builder.AddAzureCosmosDB("cosmos")
                 .RunAsPreviewEmulator(e => e.WithDataExplorer());
 
 var db = cosmos.AddCosmosDatabase("db");
-db.AddContainer("entries", "/id");
+var container = db.AddContainer("entries", "/id");
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()
-       .WithReference(cosmos).WaitFor(cosmos);
+       .WithReference(cosmos).WaitFor(cosmos)
+       .WithReference(db)
+       .WithReference(container);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -38,8 +38,17 @@ public class AzureCosmosDBContainerResource(string name, string containerName, s
     public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Container={ContainerName}");
 
     // ensure Azure Functions projects can WithReference a CosmosDB database container
-    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName) =>
-        ((IResourceWithAzureFunctionsConfig)Parent).ApplyAzureFunctionsConfiguration(target, connectionName);
+    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
+    {
+        if (Parent.Parent.IsEmulator || Parent.Parent.UseAccessKeyAuthentication)
+        {
+            Parent.Parent.SetConnectionString(target, connectionName, ConnectionStringExpression);
+        }
+        else
+        {
+            Parent.Parent.SetAccountEndpoint(target, connectionName, ConnectionStringExpression);
+        }
+    }
 
     private static string ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -50,6 +50,10 @@ public class AzureCosmosDBContainerResource(string name, string containerName, s
         else
         {
             Parent.Parent.SetAccountEndpoint(target, connectionName, ConnectionStringExpression);
+            target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__DatabaseName"] = Parent.DatabaseName;
+            target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__DatabaseName"] = Parent.DatabaseName;
+            target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__ContainerName"] = ContainerName;
+            target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__ContainerName"] = ContainerName;
         }
     }
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -36,9 +36,7 @@ public class AzureCosmosDBContainerResource(string name, string containerName, s
     /// Gets the connection string expression for the Azure Cosmos DB Database Container.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        Parent.Parent.IsEmulator || Parent.Parent.UseAccessKeyAuthentication
-            ? ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Container={ContainerName}")
-            : Parent.Parent.ConnectionStringExpression;
+        ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Container={ContainerName}");
 
     // ensure Azure Functions projects can WithReference a CosmosDB database container
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -35,7 +35,10 @@ public class AzureCosmosDBContainerResource(string name, string containerName, s
     /// <summary>
     /// Gets the connection string expression for the Azure Cosmos DB Database Container.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Container={ContainerName}");
+    public ReferenceExpression ConnectionStringExpression =>
+        Parent.Parent.IsEmulator || Parent.Parent.UseAccessKeyAuthentication
+            ? ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Container={ContainerName}")
+            : Parent.Parent.ConnectionStringExpression;
 
     // ensure Azure Functions projects can WithReference a CosmosDB database container
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -35,7 +35,7 @@ public class AzureCosmosDBContainerResource(string name, string containerName, s
     /// <summary>
     /// Gets the connection string expression for the Azure Cosmos DB Database Container.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Container={ContainerName}");
 
     // ensure Azure Functions projects can WithReference a CosmosDB database container
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName) =>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -47,7 +47,7 @@ public class AzureCosmosDBContainerResource(string name, string containerName, s
         }
         else
         {
-            Parent.Parent.SetAccountEndpoint(target, connectionName, ConnectionStringExpression);
+            Parent.Parent.SetAccountEndpoint(target, connectionName);
             target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__DatabaseName"] = Parent.DatabaseName;
             target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__DatabaseName"] = Parent.DatabaseName;
             target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__ContainerName"] = ContainerName;

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -35,7 +35,7 @@ public class AzureCosmosDBDatabaseResource(string name, string databaseName, Azu
     /// <summary>
     /// Gets the connection string expression for the Azure Cosmos DB database.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => Parent.ConnectionStringExpression;
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Database={DatabaseName}");
 
     // ensure Azure Functions projects can WithReference a CosmosDB database
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName) =>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -35,7 +35,10 @@ public class AzureCosmosDBDatabaseResource(string name, string databaseName, Azu
     /// <summary>
     /// Gets the connection string expression for the Azure Cosmos DB database.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Database={DatabaseName}");
+    public ReferenceExpression ConnectionStringExpression =>
+        Parent.IsEmulator || Parent.UseAccessKeyAuthentication
+            ? ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Database={DatabaseName}")
+            : Parent.ConnectionStringExpression;
 
     // ensure Azure Functions projects can WithReference a CosmosDB database
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -38,7 +38,7 @@ public class AzureCosmosDBDatabaseResource(string name, string databaseName, Azu
     public ReferenceExpression ConnectionStringExpression =>
         Parent.IsEmulator || Parent.UseAccessKeyAuthentication
             ? ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Database={DatabaseName}")
-            : Parent.ConnectionStringExpression;
+            : ReferenceExpression.Create($"AccountEndpoint={Parent.ConnectionStringExpression};Database={DatabaseName}");
 
     // ensure Azure Functions projects can WithReference a CosmosDB database
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -50,6 +50,8 @@ public class AzureCosmosDBDatabaseResource(string name, string databaseName, Azu
         else
         {
             Parent.SetAccountEndpoint(target, connectionName, ConnectionStringExpression);
+            target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__DatabaseName"] = DatabaseName;
+            target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__DatabaseName"] = DatabaseName;
         }
     }
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -49,7 +49,7 @@ public class AzureCosmosDBDatabaseResource(string name, string databaseName, Azu
         }
         else
         {
-            Parent.SetAccountEndpoint(target, connectionName, ConnectionStringExpression);
+            Parent.SetAccountEndpoint(target, connectionName);
             target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__DatabaseName"] = DatabaseName;
             target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__DatabaseName"] = DatabaseName;
         }

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -38,8 +38,17 @@ public class AzureCosmosDBDatabaseResource(string name, string databaseName, Azu
     public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent.ConnectionStringExpression};Database={DatabaseName}");
 
     // ensure Azure Functions projects can WithReference a CosmosDB database
-    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName) =>
-        ((IResourceWithAzureFunctionsConfig)Parent).ApplyAzureFunctionsConfiguration(target, connectionName);
+    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
+    {
+        if (Parent.IsEmulator || Parent.UseAccessKeyAuthentication)
+        {
+            Parent.SetConnectionString(target, connectionName, ConnectionStringExpression);
+        }
+        else
+        {
+            Parent.SetAccountEndpoint(target, connectionName, ConnectionStringExpression);
+        }
+    }
 
     private static string ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -78,7 +78,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
         }
         else
         {
-            SetAccountEndpoint(target, connectionName, ConnectionStringExpression);
+            SetAccountEndpoint(target, connectionName);
         }
     }
 
@@ -93,15 +93,15 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
         target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__ConnectionString"] = connectionStringExpression;
     }
 
-    internal void SetAccountEndpoint(IDictionary<string, object> target, string connectionName, ReferenceExpression connectionStringExpression)
+    internal void SetAccountEndpoint(IDictionary<string, object> target, string connectionName)
     {
         // Always inject the connection string associated with the top-level resource
         // for the Azure Functions host.
         target[$"{connectionName}__accountEndpoint"] = ConnectionStringExpression;
         // Injected to support Aspire client integration for CosmosDB in Azure Functions projects.
         // Use the child resource connection string here to support child resource integrations.
-        target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__AccountEndpoint"] = connectionStringExpression;
-        target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__AccountEndpoint"] = connectionStringExpression;
+        target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__AccountEndpoint"] = ConnectionStringExpression;
+        target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__AccountEndpoint"] = ConnectionStringExpression;
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -74,20 +74,34 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     {
         if (IsEmulator || UseAccessKeyAuthentication)
         {
-            // Injected to support Azure Functions listener initialization.
-            target[connectionName] = ConnectionStringExpression;
-            // Injected to support Aspire client integration for CosmosDB in Azure Functions projects.
-            target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__ConnectionString"] = ConnectionStringExpression;
-            target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__ConnectionString"] = ConnectionStringExpression;
+            SetConnectionString(target, connectionName, ConnectionStringExpression);
         }
         else
         {
-            // Injected to support Azure Functions listener initialization.
-            target[$"{connectionName}__accountEndpoint"] = ConnectionStringExpression;
-            // Injected to support Aspire client integration for CosmosDB in Azure Functions projects.
-            target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__AccountEndpoint"] = ConnectionStringExpression;
-            target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__AccountEndpoint"] = ConnectionStringExpression;
+            SetAccountEndpoint(target, connectionName, ConnectionStringExpression);
         }
+    }
+
+    internal void SetConnectionString(IDictionary<string, object> target, string connectionName, ReferenceExpression connectionStringExpression)
+    {
+        // Always inject the connection string associated with the top-level resource
+        // for the Azure Functions host.
+        target[connectionName] = ConnectionStringExpression;
+        // Injected to support Aspire client integration for CosmosDB in Azure Functions projects.
+        // Use the child resource connection string here to support child resource integrations.
+        target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__ConnectionString"] = connectionStringExpression;
+        target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__ConnectionString"] = connectionStringExpression;
+    }
+
+    internal void SetAccountEndpoint(IDictionary<string, object> target, string connectionName, ReferenceExpression connectionStringExpression)
+    {
+        // Always inject the connection string associated with the top-level resource
+        // for the Azure Functions host.
+        target[$"{connectionName}__accountEndpoint"] = ConnectionStringExpression;
+        // Injected to support Aspire client integration for CosmosDB in Azure Functions projects.
+        // Use the child resource connection string here to support child resource integrations.
+        target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__AccountEndpoint"] = connectionStringExpression;
+        target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__AccountEndpoint"] = connectionStringExpression;
     }
 
     /// <inheritdoc/>

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
@@ -33,11 +33,9 @@ public static class AspireMicrosoftAzureCosmosExtensions
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(connectionName);
-        var cosmosConnectionInfo = GetCosmosConnectionInfo(builder, connectionName);
-        var settings = builder.GetSettings(connectionName, configureSettings, cosmosConnectionInfo);
+        var settings = builder.GetSettings(connectionName, configureSettings);
         var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        builder.Services.AddSingleton(sp => ConfigureDb(connectionName, settings, clientOptions));
+        builder.Services.AddSingleton(sp => GetCosmosClient(connectionName, settings, clientOptions));
     }
 
     /// <summary>
@@ -55,17 +53,16 @@ public static class AspireMicrosoftAzureCosmosExtensions
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
     {
-        var cosmosConnectionInfo = GetCosmosConnectionInfo(builder, connectionName);
-        if (cosmosConnectionInfo is null || string.IsNullOrEmpty(cosmosConnectionInfo.Value.DatabaseName))
-        {
-            throw new InvalidOperationException($"The connection string '{connectionName}' does not exist or is missing the database name.");
-        }
-        var settings = builder.GetSettings(connectionName, configureSettings, cosmosConnectionInfo);
+        var settings = builder.GetSettings(connectionName, configureSettings);
         var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
         builder.Services.AddSingleton(sp =>
         {
-            var client = ConfigureDb(connectionName, settings, clientOptions);
-            return client.GetDatabase(cosmosConnectionInfo.Value.DatabaseName);
+            if (string.IsNullOrEmpty(settings.DatabaseName))
+            {
+                throw new InvalidOperationException($"The connection string '{connectionName}' does not exist or is missing the database name.");
+            }
+            var client = GetCosmosClient(connectionName, settings, clientOptions);
+            return client.GetDatabase(settings.DatabaseName);
         });
     }
 
@@ -84,17 +81,16 @@ public static class AspireMicrosoftAzureCosmosExtensions
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
     {
-        var cosmosConnectionInfo = GetCosmosConnectionInfo(builder, connectionName);
-        if (cosmosConnectionInfo is null || string.IsNullOrEmpty(cosmosConnectionInfo.Value.ContainerName) || string.IsNullOrEmpty(cosmosConnectionInfo.Value.DatabaseName))
-        {
-            throw new InvalidOperationException($"The connection string '{connectionName}' does not exist or is missing the container name or database name.");
-        }
-        var settings = builder.GetSettings(connectionName, configureSettings, cosmosConnectionInfo);
+        var settings = builder.GetSettings(connectionName, configureSettings);
         var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
         builder.Services.AddSingleton(sp =>
         {
-            var client = ConfigureDb(connectionName, settings, clientOptions);
-            return client.GetContainer(cosmosConnectionInfo.Value.DatabaseName, cosmosConnectionInfo.Value.ContainerName);
+            if (string.IsNullOrEmpty(settings.ContainerName) || string.IsNullOrEmpty(settings.DatabaseName))
+            {
+                throw new InvalidOperationException($"The connection string '{connectionName}' does not exist or is missing the container name or database name.");
+            }
+            var client = GetCosmosClient(connectionName, settings, clientOptions);
+            return client.GetContainer(settings.DatabaseName, settings.ContainerName);
         });
     }
 
@@ -116,12 +112,11 @@ public static class AspireMicrosoftAzureCosmosExtensions
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cosmosConnectionInfo = GetCosmosConnectionInfo(builder, name);
-        var settings = builder.GetSettings(name, configureSettings, cosmosConnectionInfo);
+        var settings = builder.GetSettings(name, configureSettings);
         var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
         builder.Services.AddKeyedSingleton(name, (sp, key) =>
         {
-            var client = ConfigureDb(name, settings, clientOptions);
+            var client = GetCosmosClient(name, settings, clientOptions);
             return client;
         });
     }
@@ -141,17 +136,16 @@ public static class AspireMicrosoftAzureCosmosExtensions
        Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
        Action<CosmosClientOptions>? configureClientOptions = null)
     {
-        var cosmosConnectionInfo = GetCosmosConnectionInfo(builder, name);
-        if (cosmosConnectionInfo is null || string.IsNullOrEmpty(cosmosConnectionInfo.Value.DatabaseName))
-        {
-            throw new InvalidOperationException($"The connection string '{name}' does not exist or is missing the database name.");
-        }
-        var settings = builder.GetSettings(name, configureSettings, cosmosConnectionInfo);
+        var settings = builder.GetSettings(name, configureSettings);
         var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
         builder.Services.AddKeyedSingleton(name, (sp, key) =>
         {
-            var client = ConfigureDb(name, settings, clientOptions);
-            return client.GetDatabase(cosmosConnectionInfo.Value.DatabaseName);
+            if (string.IsNullOrEmpty(settings.DatabaseName))
+            {
+                throw new InvalidOperationException($"The connection string '{name}' does not exist or is missing the database name.");
+            }
+            var client = GetCosmosClient(name, settings, clientOptions);
+            return client.GetDatabase(settings.DatabaseName);
         });
     }
 
@@ -170,17 +164,16 @@ public static class AspireMicrosoftAzureCosmosExtensions
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
     {
-        var cosmosConnectionInfo = GetCosmosConnectionInfo(builder, name);
-        if (cosmosConnectionInfo is null || string.IsNullOrEmpty(cosmosConnectionInfo.Value.ContainerName) || string.IsNullOrEmpty(cosmosConnectionInfo.Value.DatabaseName))
-        {
-            throw new InvalidOperationException($"The connection string '{name}' does not exist or is missing the container name or database name.");
-        }
-        var settings = builder.GetSettings(name, configureSettings, cosmosConnectionInfo);
+        var settings = builder.GetSettings(name, configureSettings);
         var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
         builder.Services.AddKeyedSingleton(name, (sp, key) =>
         {
-            var client = ConfigureDb(name, settings, clientOptions);
-            return client.GetContainer(cosmosConnectionInfo.Value.DatabaseName, cosmosConnectionInfo.Value.ContainerName);
+            if (string.IsNullOrEmpty(settings.ContainerName) || string.IsNullOrEmpty(settings.DatabaseName))
+            {
+                throw new InvalidOperationException($"The connection string '{name}' does not exist or is missing the container name or database name.");
+            }
+            var client = GetCosmosClient(name, settings, clientOptions);
+            return client.GetContainer(settings.DatabaseName, settings.ContainerName);
         });
     }
 
@@ -200,10 +193,10 @@ public static class AspireMicrosoftAzureCosmosExtensions
     private static MicrosoftAzureCosmosSettings GetSettings(
         this IHostApplicationBuilder builder,
         string connectionName,
-        Action<MicrosoftAzureCosmosSettings>? configureSettings,
-        CosmosConnectionInfo? cosmosConnectionInfo = null
+        Action<MicrosoftAzureCosmosSettings>? configureSettings
     )
     {
+        var cosmosConnectionInfo = GetCosmosConnectionInfo(builder, connectionName);
         var settings = new MicrosoftAzureCosmosSettings();
         var configSection = builder.Configuration.GetSection(DefaultConfigSectionName);
         var namedConfigSection = configSection.GetSection(connectionName);
@@ -219,8 +212,8 @@ public static class AspireMicrosoftAzureCosmosExtensions
         {
             settings.ConnectionString = connectionString;
         }
-        var databaseName = cosmosConnectionInfo?.DatabaseName;
-        var containerName = cosmosConnectionInfo?.ContainerName;
+        settings.DatabaseName = cosmosConnectionInfo?.DatabaseName;
+        settings.ContainerName = cosmosConnectionInfo?.ContainerName;
 
         configureSettings?.Invoke(settings);
 
@@ -251,8 +244,6 @@ public static class AspireMicrosoftAzureCosmosExtensions
             clientOptions.LimitToEndpoint = true;
         }
 
-        configureClientOptions?.Invoke(clientOptions);
-
         var cosmosApplicationName = CosmosConstants.CosmosApplicationName;
         if (!string.IsNullOrEmpty(clientOptions.ApplicationName))
         {
@@ -264,7 +255,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
         return clientOptions;
     }
 
-    private static CosmosClient ConfigureDb(string connectionName, MicrosoftAzureCosmosSettings settings, CosmosClientOptions clientOptions)
+    private static CosmosClient GetCosmosClient(string connectionName, MicrosoftAzureCosmosSettings settings, CosmosClientOptions clientOptions)
     {
         if (!string.IsNullOrEmpty(settings.ConnectionString))
         {

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
@@ -31,6 +31,14 @@
                       "type": "string",
                       "description": "Gets or sets the connection string of the Azure Cosmos database to connect to."
                     },
+                    "ContainerName": {
+                      "type": "string",
+                      "description": "Gets or sets the name of the container to connect to."
+                    },
+                    "DatabaseName": {
+                      "type": "string",
+                      "description": "Gets or sets the name of the database to connect to."
+                    },
                     "DisableTracing": {
                       "type": "boolean",
                       "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/MicrosoftAzureCosmosSettings.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/MicrosoftAzureCosmosSettings.cs
@@ -16,6 +16,16 @@ public sealed class MicrosoftAzureCosmosSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
+    /// Gets or sets the name of the database to connect to.
+    /// </summary>
+    public string? DatabaseName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the container to connect to.
+    /// </summary>
+    public string? ContainerName { get; set; }
+
+    /// <summary>
     /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
@@ -43,26 +43,26 @@ public static class AspireAzureEFCoreCosmosExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(connectionName);
 
+        string? databaseName = null;
         if (builder.Configuration.GetConnectionString(connectionName) is string connectionString)
         {
             var cosmosConnectionInfo = CosmosUtils.ParseConnectionString(connectionString);
-            if (cosmosConnectionInfo.DatabaseName is not null)
-            {
-                var targetDatabaseName = cosmosConnectionInfo.DatabaseName;
-                AddCosmosDbContext<TContext>(
-                    builder,
-                    connectionName,
-                    cosmosConnectionInfo.DatabaseName,
-                    configureSettings,
-                    configureDbContextOptions);
-            }
-            else
-            {
-                throw new InvalidOperationException(
-                  "A DbContext could not be configured with this AddCosmosDbContext overload. "
-                  + $"Ensure the connection string '{connectionName}' contains a database name or use the overload that takes a database name as a parameter.");
-            }
+            databaseName = cosmosConnectionInfo.DatabaseName;
         }
+
+        if (databaseName is null)
+        {
+            throw new InvalidOperationException(
+                "A DbContext could not be configured with this AddCosmosDbContext overload. "
+                + $"Ensure the connection string '{connectionName}' contains a database name or use the overload that takes a database name as a parameter.");
+        }
+
+        AddCosmosDbContext<TContext>(
+            builder,
+            connectionName,
+            databaseName,
+            configureSettings,
+            configureDbContextOptions);
     }
 
     /// <summary>

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
@@ -49,6 +49,10 @@
                       "type": "string",
                       "description": "The connection string of the Azure Cosmos DB server database to connect to."
                     },
+                    "DatabaseName": {
+                      "type": "string",
+                      "description": "The name of the database to connect to."
+                    },
                     "DisableTracing": {
                       "type": "boolean",
                       "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosSettings.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosSettings.cs
@@ -16,6 +16,11 @@ public sealed class EntityFrameworkCoreCosmosSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
+    /// The name of the database to connect to.
+    /// </summary>
+    public string? DatabaseName { get; set; }
+
+    /// <summary>
     /// A <see cref="Uri"/> referencing the Azure Cosmos DB Endpoint.
     /// This is likely to be similar to "https://{account_name}.documents.azure.com".
     /// </summary>

--- a/src/Shared/Cosmos/CosmosUtils.cs
+++ b/src/Shared/Cosmos/CosmosUtils.cs
@@ -49,12 +49,12 @@ internal static class CosmosUtils
 
         // Strip out the database and container from the connection string in order
         // to tell if we are left with just AccountEndpoint.
-        if (connectionBuilder.TryGetValue("Database", out var _))
+        if (connectionBuilder.TryGetValue("Database", out var databaseValue))
         {
             connectionBuilder["Database"] = null;
         }
 
-        if (connectionBuilder.TryGetValue("Container", out var _))
+        if (connectionBuilder.TryGetValue("Container", out var containerValue))
         {
             connectionBuilder["Container"] = null;
         }
@@ -68,20 +68,24 @@ internal static class CosmosUtils
             return new CosmosConnectionInfo(accountEndpoint, null);
         }
 
-        return new CosmosConnectionInfo(null, connectionBuilder.ConnectionString);
+        return new CosmosConnectionInfo(null, connectionBuilder.ConnectionString, databaseValue?.ToString(), containerValue?.ToString());
     }
 }
 
 internal readonly struct CosmosConnectionInfo
 {
-    public CosmosConnectionInfo(Uri? accountEndpoint, string? connectionString)
+    public CosmosConnectionInfo(Uri? accountEndpoint, string? connectionString, string? databaseName = null, string? containerName = null)
     {
         Debug.Assert(accountEndpoint is not null ^ connectionString is not null, "only one should be set.");
 
         AccountEndpoint = accountEndpoint;
         ConnectionString = connectionString;
+        DatabaseName = databaseName;
+        ContainerName = containerName;
     }
 
     public Uri? AccountEndpoint { get; }
     public string? ConnectionString { get; }
+    public string? DatabaseName { get; }
+    public string? ContainerName { get; }
 }

--- a/src/Shared/Cosmos/CosmosUtils.cs
+++ b/src/Shared/Cosmos/CosmosUtils.cs
@@ -60,12 +60,12 @@ internal static class CosmosUtils
         }
 
         // if we are only left with the AccountEndpoint, then we set the AccountEndpoint and
-        // not the connection string.
+        // not the connection string and include the database and container names.
         if (connectionBuilder.Count == 1 &&
             connectionBuilder.TryGetValue("AccountEndpoint", out var accountEndpointValue) &&
             Uri.TryCreate(accountEndpointValue.ToString(), UriKind.Absolute, out accountEndpoint))
         {
-            return new CosmosConnectionInfo(accountEndpoint, null);
+            return new CosmosConnectionInfo(accountEndpoint, null, databaseValue?.ToString(), containerValue?.ToString());
         }
 
         return new CosmosConnectionInfo(null, connectionBuilder.ConnectionString, databaseValue?.ToString(), containerValue?.ToString());

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -103,8 +103,8 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         // database and container should have the same connection string as the cosmos account, for now.
         // In the future, we can add the database and container info to the connection string.
         Assert.Equal("{cosmos.outputs.connectionString}", cosmos.Resource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal("{cosmos.outputs.connectionString}", db1.Resource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal("{cosmos.outputs.connectionString}", container1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{cosmos.outputs.connectionString};Database=db1", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{cosmos.outputs.connectionString};Database=db1;Container=container1", container1.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -100,11 +100,11 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         var db1 = cosmos.AddCosmosDatabase("db1");
         var container1 = db1.AddContainer("container1", "id");
 
-        // database and container should have the same connection string as the cosmos account, for now.
-        // In the future, we can add the database and container info to the connection string.
         Assert.Equal("{cosmos.outputs.connectionString}", cosmos.Resource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal("{cosmos.outputs.connectionString}", db1.Resource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal("{cosmos.outputs.connectionString}", container1.Resource.ConnectionStringExpression.ValueExpression);
+        // Endpoint-based connection info gets passed as a connection string to
+        // support setting the correct properties on child resources.
+        Assert.Equal("AccountEndpoint={cosmos.outputs.connectionString};Database=db1", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("AccountEndpoint={cosmos.outputs.connectionString};Database=db1;Container=container1", container1.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -142,14 +142,20 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         ((IResourceWithAzureFunctionsConfig)db1.Resource).ApplyAzureFunctionsConfiguration(target, "db1");
         Assert.Collection(target.Keys.OrderBy(k => k),
             k => Assert.Equal("Aspire__Microsoft__Azure__Cosmos__db1__AccountEndpoint", k),
+            k => Assert.Equal("Aspire__Microsoft__Azure__Cosmos__db1__DatabaseName", k),
             k => Assert.Equal("Aspire__Microsoft__EntityFrameworkCore__Cosmos__db1__AccountEndpoint", k),
+            k => Assert.Equal("Aspire__Microsoft__EntityFrameworkCore__Cosmos__db1__DatabaseName", k),
             k => Assert.Equal("db1__accountEndpoint", k));
 
         target.Clear();
         ((IResourceWithAzureFunctionsConfig)container1.Resource).ApplyAzureFunctionsConfiguration(target, "container1");
         Assert.Collection(target.Keys.OrderBy(k => k),
             k => Assert.Equal("Aspire__Microsoft__Azure__Cosmos__container1__AccountEndpoint", k),
+            k => Assert.Equal("Aspire__Microsoft__Azure__Cosmos__container1__ContainerName", k),
+            k => Assert.Equal("Aspire__Microsoft__Azure__Cosmos__container1__DatabaseName", k),
             k => Assert.Equal("Aspire__Microsoft__EntityFrameworkCore__Cosmos__container1__AccountEndpoint", k),
+            k => Assert.Equal("Aspire__Microsoft__EntityFrameworkCore__Cosmos__container1__ContainerName", k),
+            k => Assert.Equal("Aspire__Microsoft__EntityFrameworkCore__Cosmos__container1__DatabaseName", k),
             k => Assert.Equal("container1__accountEndpoint", k));
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -92,7 +92,7 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void AzureCosmosDBHasCorrectConnectionStrings()
+    public void AzureCosmosDBHasCorrectConnectionStrings_ForAccountEndpoint()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
@@ -103,8 +103,23 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         // database and container should have the same connection string as the cosmos account, for now.
         // In the future, we can add the database and container info to the connection string.
         Assert.Equal("{cosmos.outputs.connectionString}", cosmos.Resource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal("{cosmos.outputs.connectionString};Database=db1", db1.Resource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal("{cosmos.outputs.connectionString};Database=db1;Container=container1", container1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{cosmos.outputs.connectionString}", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{cosmos.outputs.connectionString}", container1.Resource.ConnectionStringExpression.ValueExpression);
+    }
+
+    [Fact]
+    public void AzureCosmosDBHasCorrectConnectionStrings()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
+        var db1 = cosmos.AddCosmosDatabase("db1");
+        var container1 = db1.AddContainer("container1", "id");
+
+        Assert.DoesNotContain(";Database=db1", cosmos.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.DoesNotContain(";Database=db1;Container=container1", cosmos.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Contains(";Database=db1", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Contains(";Database=db1;Container=container1", container1.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
@@ -254,14 +254,14 @@ public class ResourceWithAzureFunctionsConfigTests
         // Assert
         Assert.True(target.ContainsKey("cosmosdb__accountEndpoint"));
         var targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["cosmosdb__accountEndpoint"]);
-        Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal(cosmosResource.Resource.ConnectionStringExpression.ValueExpression, targetReferenceExpression.ValueExpression);
         Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"));
         targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"]);
-        Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal(cosmosResource.Resource.ConnectionStringExpression.ValueExpression, targetReferenceExpression.ValueExpression);
         // Validate DatabaseName for non-EF settings
-        Assert.Equal(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__DatabaseName"], dbResource.DatabaseName);
+        Assert.Equal(dbResource.DatabaseName, target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__DatabaseName"]);
         // Validate DatabaseName for EF settings
-        Assert.Equal(target["Aspire__Microsoft__EntityFrameworkCore__Cosmos__cosmosdb__DatabaseName"], dbResource.DatabaseName);
+        Assert.Equal(dbResource.DatabaseName, target["Aspire__Microsoft__EntityFrameworkCore__Cosmos__cosmosdb__DatabaseName"]);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
@@ -257,7 +257,7 @@ public class ResourceWithAzureFunctionsConfigTests
         Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
         Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"));
         targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"]);
-        Assert.Equal(targetReferenceExpression.ValueExpression, dbResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -278,17 +278,16 @@ public class ResourceWithAzureFunctionsConfigTests
         Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
         Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"));
         targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"]);
-        Assert.Equal(targetReferenceExpression.ValueExpression, containerResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
     public void AzureCosmosDBDatabaseEmulator_AppliesCorrectConfigurationFormat()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        using var builder = TestDistributedApplicationBuilder.Create();
         var cosmosResource = builder.AddAzureCosmosDB("cosmos")
-            // Mock as emulator
-            .WithAnnotation(new ContainerImageAnnotation { Image = "mcr.microsoft.com/azure-cosmos-db/linux/azure-cosmos-emulator:v2" });
+            .RunAsEmulator();
         var dbResource = cosmosResource.AddCosmosDatabase("database").Resource;
         var target = new Dictionary<string, object>();
 
@@ -308,10 +307,9 @@ public class ResourceWithAzureFunctionsConfigTests
     public void AzureCosmosDBContainerEmulator_AppliesCorrectConfigurationFormat()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        using var builder = TestDistributedApplicationBuilder.Create();
         var cosmosResource = builder.AddAzureCosmosDB("cosmos")
-            // Mock as emulator
-            .WithAnnotation(new ContainerImageAnnotation { Image = "mcr.microsoft.com/azure-cosmos-db/linux/azure-cosmos-emulator:v2" });;
+            .RunAsEmulator();
         var containerResource = cosmosResource.AddCosmosDatabase("database").AddContainer("container", "/partitionKey").Resource;
         var target = new Dictionary<string, object>();
 

--- a/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Xunit;
 
@@ -236,6 +237,94 @@ public class ResourceWithAzureFunctionsConfigTests
         // Assert
         Assert.True(target.ContainsKey("mycosmosdb__accountEndpoint"));
         Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__mycosmosdb__AccountEndpoint"));
+    }
+
+    [Fact]
+    public void AzureCosmosDBDatabase_AppliesCorrectConfigurationFormat()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var cosmosResource = builder.AddAzureCosmosDB("cosmos");
+        var dbResource = cosmosResource.AddCosmosDatabase("database").Resource;
+        var target = new Dictionary<string, object>();
+
+        // Act
+        ((IResourceWithAzureFunctionsConfig)dbResource).ApplyAzureFunctionsConfiguration(target, "cosmosdb");
+
+        // Assert
+        Assert.True(target.ContainsKey("cosmosdb__accountEndpoint"));
+        var targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["cosmosdb__accountEndpoint"]);
+        Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"));
+        targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"]);
+        Assert.Equal(targetReferenceExpression.ValueExpression, dbResource.ConnectionStringExpression.ValueExpression);
+    }
+
+    [Fact]
+    public void AzureCosmosDBContainer_AppliesCorrectConfigurationFormat()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var cosmosResource = builder.AddAzureCosmosDB("cosmos");
+        var containerResource = cosmosResource.AddCosmosDatabase("database").AddContainer("container", "/partitionKey").Resource;
+        var target = new Dictionary<string, object>();
+
+        // Act
+        ((IResourceWithAzureFunctionsConfig)containerResource).ApplyAzureFunctionsConfiguration(target, "cosmosdb");
+
+        // Assert
+        Assert.True(target.ContainsKey("cosmosdb__accountEndpoint"));
+        var targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["cosmosdb__accountEndpoint"]);
+        Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"));
+        targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"]);
+        Assert.Equal(targetReferenceExpression.ValueExpression, containerResource.ConnectionStringExpression.ValueExpression);
+    }
+
+    [Fact]
+    public void AzureCosmosDBDatabaseEmulator_AppliesCorrectConfigurationFormat()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var cosmosResource = builder.AddAzureCosmosDB("cosmos")
+            // Mock as emulator
+            .WithAnnotation(new ContainerImageAnnotation { Image = "mcr.microsoft.com/azure-cosmos-db/linux/azure-cosmos-emulator:v2" });
+        var dbResource = cosmosResource.AddCosmosDatabase("database").Resource;
+        var target = new Dictionary<string, object>();
+
+        // Act
+        ((IResourceWithAzureFunctionsConfig)dbResource).ApplyAzureFunctionsConfiguration(target, "cosmosdb");
+
+        // Assert
+        Assert.True(target.ContainsKey("cosmosdb"));
+        var targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["cosmosdb"]);
+        Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__cosmosdb__ConnectionString"));
+        targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__ConnectionString"]);
+        Assert.Equal(targetReferenceExpression.ValueExpression, dbResource.ConnectionStringExpression.ValueExpression);
+    }
+
+    [Fact]
+    public void AzureCosmosDBContainerEmulator_AppliesCorrectConfigurationFormat()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var cosmosResource = builder.AddAzureCosmosDB("cosmos")
+            // Mock as emulator
+            .WithAnnotation(new ContainerImageAnnotation { Image = "mcr.microsoft.com/azure-cosmos-db/linux/azure-cosmos-emulator:v2" });;
+        var containerResource = cosmosResource.AddCosmosDatabase("database").AddContainer("container", "/partitionKey").Resource;
+        var target = new Dictionary<string, object>();
+
+        // Act
+        ((IResourceWithAzureFunctionsConfig)containerResource).ApplyAzureFunctionsConfiguration(target, "cosmosdb");
+
+        // Assert
+        Assert.True(target.ContainsKey("cosmosdb"));
+        var targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["cosmosdb"]);
+        Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__cosmosdb__ConnectionString"));
+        targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__ConnectionString"]);
+        Assert.Equal(targetReferenceExpression.ValueExpression, containerResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
@@ -258,6 +258,10 @@ public class ResourceWithAzureFunctionsConfigTests
         Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"));
         targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"]);
         Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
+        // Validate DatabaseName for non-EF settings
+        Assert.Equal(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__DatabaseName"], dbResource.DatabaseName);
+        // Validate DatabaseName for EF settings
+        Assert.Equal(target["Aspire__Microsoft__EntityFrameworkCore__Cosmos__cosmosdb__DatabaseName"], dbResource.DatabaseName);
     }
 
     [Fact]
@@ -279,6 +283,12 @@ public class ResourceWithAzureFunctionsConfigTests
         Assert.True(target.ContainsKey("Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"));
         targetReferenceExpression = Assert.IsType<ReferenceExpression>(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint"]);
         Assert.Equal(targetReferenceExpression.ValueExpression, cosmosResource.Resource.ConnectionStringExpression.ValueExpression);
+        // Validate DatabaseName and ContainerName for non-EF settings
+        Assert.Equal(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__DatabaseName"], containerResource.Parent.DatabaseName);
+        Assert.Equal(target["Aspire__Microsoft__Azure__Cosmos__cosmosdb__ContainerName"], containerResource.ContainerName);
+        // Validate DatabaseName and ContainerName for EF settings
+        Assert.Equal(target["Aspire__Microsoft__EntityFrameworkCore__Cosmos__cosmosdb__DatabaseName"], containerResource.Parent.DatabaseName);
+        Assert.Equal(target["Aspire__Microsoft__EntityFrameworkCore__Cosmos__cosmosdb__ContainerName"], containerResource.ContainerName);
     }
 
     [Fact]

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/AspireMicrosoftAzureCosmosExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/AspireMicrosoftAzureCosmosExtensionsTests.cs
@@ -135,6 +135,64 @@ public class AspireMicrosoftAzureCosmosExtensionsTests
         Assert.Equal(expectedEndpoint, client.Endpoint.ToString());
     }
 
+    [Theory]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake;Container=containerName")]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake;Database=databaseName")]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake")]
+    public void AddAzureCosmosContainer_ThrowsForInvalidConnectionString(string connectionString)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var serviceKey = "cosmos-key";
+
+        PopulateConfiguration(builder.Configuration, connectionString);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddAzureCosmosContainer(serviceKey));
+        Assert.Equal("The connection string 'cosmos-key' does not exist or is missing the container name or database name.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake;Container=containerName")]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake;Database=databaseName")]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake")]
+    public void AddKeyedAzureCosmosContainer_ThrowsForInvalidConnectionString(string connectionString)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var serviceKey = "cosmos-key";
+
+        PopulateConfiguration(builder.Configuration, connectionString, serviceKey);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddKeyedAzureCosmosContainer(serviceKey));
+        Assert.Equal("The connection string 'cosmos-key' does not exist or is missing the container name or database name.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake;Container=containerName")]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake")]
+    public void AddAzureCosmosDatabase_ThrowsForInvalidConnectionString(string connectionString)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var serviceKey = "cosmos-key";
+
+        PopulateConfiguration(builder.Configuration, connectionString);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddAzureCosmosDatabase(serviceKey));
+        Assert.Equal("The connection string 'cosmos-key' does not exist or is missing the database name.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake;Container=containerName")]
+    [InlineData("AccountEndpoint=https://localhost:8081/;AccountKey=fake")]
+    public void AddKeyedAzureCosmosDatabase_ThrowsForInvalidConnectionString(string connectionString)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var serviceKey = "cosmos-key";
+
+        PopulateConfiguration(builder.Configuration, connectionString, serviceKey);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddKeyedAzureCosmosDatabase(serviceKey));
+        Assert.Contains("The connection string 'cosmos-key' does not exist or is missing the database name.", exception.Message);
+    }
+
     private static void PopulateConfiguration(ConfigurationManager configuration, string connectionString, string? key = null) =>
         configuration.AddInMemoryCollection([
             new KeyValuePair<string, string?>($"ConnectionStrings:{key ?? "cosmos"}", connectionString)

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/AspireMicrosoftAzureCosmosExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/AspireMicrosoftAzureCosmosExtensionsTests.cs
@@ -56,12 +56,12 @@ public class AspireMicrosoftAzureCosmosExtensionsTests
 
         using var host = builder.Build();
         var database = host.Services.GetRequiredService<Database>();
-        var client = host.Services.GetRequiredService<CosmosClient>();
+        var client = host.Services.GetService<CosmosClient>();
 
-        Assert.NotNull(client);
+        Assert.Null(client);
         Assert.NotNull(database);
         Assert.Equal(databaseName, database.Id);
-        Assert.Equal(expectedEndpoint, client.Endpoint.ToString());
+        Assert.Equal(expectedEndpoint, database.Client.Endpoint.ToString());
     }
 
     [Fact]
@@ -79,13 +79,13 @@ public class AspireMicrosoftAzureCosmosExtensionsTests
         using var host = builder.Build();
         var container = host.Services.GetRequiredService<Container>();
         var database = host.Services.GetService<Database>();
-        var client = host.Services.GetRequiredService<CosmosClient>();
+        var client = host.Services.GetService<CosmosClient>();
 
         Assert.NotNull(container);
-        Assert.NotNull(client);
+        Assert.Null(client);
         Assert.Null(database);
         Assert.Equal(containerName, container.Id);
-        Assert.Equal(expectedEndpoint, client.Endpoint.ToString());
+        Assert.Equal(expectedEndpoint, container.Database.Client.Endpoint.ToString());
     }
 
     [Fact]
@@ -102,12 +102,12 @@ public class AspireMicrosoftAzureCosmosExtensionsTests
 
         using var host = builder.Build();
         var database = host.Services.GetRequiredKeyedService<Database>(serviceKey);
-        var client = host.Services.GetRequiredKeyedService<CosmosClient>(serviceKey);
+        var client = host.Services.GetKeyedService<CosmosClient>(serviceKey);
 
-        Assert.NotNull(client);
+        Assert.Null(client);
         Assert.NotNull(database);
         Assert.Equal(databaseName, database.Id);
-        Assert.Equal(expectedEndpoint, client.Endpoint.ToString());
+        Assert.Equal(expectedEndpoint, database.Client.Endpoint.ToString());
     }
 
     [Fact]
@@ -126,13 +126,13 @@ public class AspireMicrosoftAzureCosmosExtensionsTests
         using var host = builder.Build();
         var container = host.Services.GetRequiredKeyedService<Container>(serviceKey);
         var database = host.Services.GetKeyedService<Database>(serviceKey);
-        var client = host.Services.GetRequiredKeyedService<CosmosClient>(serviceKey);
+        var client = host.Services.GetKeyedService<CosmosClient>(serviceKey);
 
         Assert.NotNull(container);
-        Assert.NotNull(client);
+        Assert.Null(client);
         Assert.Null(database);
         Assert.Equal(containerName, container.Id);
-        Assert.Equal(expectedEndpoint, client.Endpoint.ToString());
+        Assert.Equal(expectedEndpoint, container.Database.Client.Endpoint.ToString());
     }
 
     [Theory]

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
@@ -237,6 +237,39 @@ public class AspireAzureEfCoreCosmosDBExtensionsTests
     }
 
     [Fact]
+    public void AddCosmosDbContext_SetsDatabaseWhenPresentInConnectionString()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var databaseName = "testdb";
+        var expectedEndpoint = "https://localhost:8081/";
+
+        PopulateConfiguration(builder.Configuration, $"AccountEndpoint={expectedEndpoint};AccountKey=fake;Database={databaseName};");
+
+        builder.AddCosmosDbContext<TestDbContext>("cosmos");
+
+        using var host = builder.Build();
+        var context = host.Services.GetRequiredService<TestDbContext>();
+        var client = context.Database.GetCosmosClient();
+
+        Assert.NotNull(client);
+        Assert.Equal(expectedEndpoint, client.Endpoint.ToString());
+        Assert.NotNull(context.Database);
+        Assert.Equal(databaseName, context.Database.GetCosmosDatabaseId());
+    }
+
+    [Fact]
+    public void AddCosmosDbContext_ThrowWhenDatabaseNotInConnectionString()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var expectedEndpoint = "https://localhost:8081/";
+
+        PopulateConfiguration(builder.Configuration, $"AccountEndpoint={expectedEndpoint};AccountKey=fake;");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddCosmosDbContext<TestDbContext>("cosmos"));
+        Assert.Contains("A DbContext could not be configured with this AddCosmosDbContext overload.", exception.Message);
+    }
+
+    [Fact]
     public void AddAzureCosmosClient_FailsWithError()
     {
         var e = Assert.Throws<ArgumentException>(() =>

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
@@ -305,6 +305,29 @@ public class AspireAzureEfCoreCosmosDBExtensionsTests
     }
 
     [Fact]
+    public void AddCosmosDbContext_WithNoConnectionString_ThrowsException()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddCosmosDbContext<TestDbContext>("cosmos"));
+
+        Assert.Contains("A DbContext could not be configured with this AddCosmosDbContext overload.", exception.Message);
+    }
+
+    [Fact]
+    public void AddCosmosDbContext_WithDatabaseName_WithNoConnectionString_ThrowsException()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        builder.AddCosmosDbContext<TestDbContext>("cosmos", "testdb");
+
+        using var host = builder.Build();
+        var exception = Assert.Throws<InvalidOperationException>(host.Services.GetRequiredService<TestDbContext>);
+
+        Assert.Contains("A DbContext could not be configured.", exception.Message);
+    }
+
+    [Fact]
     public void AddCosmosDbContext_ThrowWhenDatabaseNotInConnectionString()
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);


### PR DESCRIPTION
Contributes towards https://github.com/dotnet/aspire/issues/7907.

Note: this doesn't include support for setting the container on the DbContext for Cosmos. Apparently, in addition to setting it on a per-entity basis in the `OnModelCreating` method, you can configure an [IModelInitializedConvention](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.metadata.conventions.imodelinitializedconvention?view=efcore-9.0) that will run implicitl when models are created. However, EF Core only respects these conventions when they are added to its internal service provider and that requires some additional code. I opted not to include this in the initial PR.