### PR TITLE
Create database for Postgres resource

### DIFF
--- a/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/Program.cs
+++ b/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/Program.cs
@@ -13,7 +13,7 @@ var db4 = pg3.AddDatabase("db4");
 // Containerized resources.
 var db5 = builder.AddPostgres("pg4").WithPgAdmin().PublishAsContainer().AddDatabase("db5");
 var db6 = builder.AddPostgres("pg5").WithPgAdmin().PublishAsContainer().AddDatabase("db6");
-var pg6 = builder.AddPostgres("pg6").WithPgAdmin(c => c.WithHostPort(8999).WithImageTag("8.3")).PublishAsContainer();
+var pg6 = builder.AddPostgres("pg6").WithPgAdmin(c => c.WithHostPort(8999)).PublishAsContainer();
 var db7 = pg6.AddDatabase("db7");
 var db8 = pg6.AddDatabase("db8");
 var db9 = pg6.AddDatabase("db9", "db8"); // different connection string (db9) on same database as db8

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -575,7 +575,7 @@ public static class PostgresBuilderExtensions
             }
             catch (Exception e)
             {
-                var logger = serviceProvider.GetRequiredService<ILogger<DistributedApplicationBuilder>>();
+                var logger = serviceProvider.GetRequiredService<ResourceLoggerService>().GetLogger(npgsqlDatabase.Parent);
                 logger.LogError(e, "Failed to create database '{DatabaseName}'", npgsqlDatabase.DatabaseName);
             }
         }
@@ -591,7 +591,7 @@ public static class PostgresBuilderExtensions
             }
             catch (Exception e)
             {
-                var logger = serviceProvider.GetRequiredService<ILogger<DistributedApplicationBuilder>>();
+                var logger = serviceProvider.GetRequiredService<ResourceLoggerService>().GetLogger(npgsqlDatabase.Parent);
                 logger.LogError(e, "Failed to create database '{DatabaseName}'", npgsqlDatabase.DatabaseName);
             }
         }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
@@ -20,8 +20,8 @@ internal static class PostgresContainerImageTags
     /// <remarks>dpage/pgadmin4</remarks>
     public const string PgAdminImage = "dpage/pgadmin4";
 
-    /// <remarks>8.14</remarks>
-    public const string PgAdminTag = "8.14";
+    /// <remarks>9.1.0</remarks>
+    public const string PgAdminTag = "9.1.0";
 
     /// <remarks>docker.io</remarks>
     public const string PgWebRegistry = "docker.io";

--- a/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -23,9 +24,18 @@ public class PostgresDatabaseResource(string name, string databaseName, Postgres
     /// <summary>
     /// Gets the connection string expression for the Postgres database.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
+    public ReferenceExpression ConnectionStringExpression
+    {
+        get
+        {
+            var connectionStringBuilder = new DbConnectionStringBuilder
+            {
+                ["Database"] = DatabaseName
+            };
 
+            return ReferenceExpression.Create($"{Parent};{connectionStringBuilder.ToString()}");
+        }
+    }
     /// <summary>
     /// Gets the database name.
     /// </summary>

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -134,9 +134,9 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             using var connection = host.Services.GetRequiredService<NpgsqlConnection>();
             await connection.OpenAsync(token);
 
-            var command = connection.CreateCommand();
+            using var command = connection.CreateCommand();
             command.CommandText = $"SELECT 1";
-            var results = await command.ExecuteReaderAsync(token);
+            using var results = await command.ExecuteReaderAsync(token);
 
             Assert.True(results.HasRows);
         }, cts.Token);
@@ -254,14 +254,14 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
                             using var connection = host.Services.GetRequiredService<NpgsqlConnection>();
                             await connection.OpenAsync(token);
 
-                            var command = connection.CreateCommand();
+                            using var command = connection.CreateCommand();
                             command.CommandText = """
                                 CREATE TABLE cars (brand VARCHAR(255));
                                 INSERT INTO cars (brand) VALUES ('BatMobile');
                                 SELECT * FROM cars;
                             """;
 
-                            var results = await command.ExecuteReaderAsync(token);
+                            using var results = await command.ExecuteReaderAsync(token);
 
                             Assert.True(results.HasRows);
                         }, cts.Token);
@@ -316,9 +316,9 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
                             using var connection = host.Services.GetRequiredService<NpgsqlConnection>();
                             await connection.OpenAsync(token);
 
-                            var command = connection.CreateCommand();
+                            using var command = connection.CreateCommand();
                             command.CommandText = $"SELECT * FROM cars;";
-                            var results = await command.ExecuteReaderAsync(token);
+                            using var results = await command.ExecuteReaderAsync(token);
 
                             Assert.True(await results.ReadAsync(token));
                             Assert.Equal("BatMobile", results.GetString("brand"));
@@ -418,9 +418,9 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
                 using var connection = host.Services.GetRequiredService<NpgsqlConnection>();
                 await connection.OpenAsync(token);
 
-                var command = connection.CreateCommand();
+                using var command = connection.CreateCommand();
                 command.CommandText = $"SELECT * FROM \"Cars\";";
-                var results = await command.ExecuteReaderAsync(token);
+                using var results = await command.ExecuteReaderAsync(token);
 
                 Assert.True(await results.ReadAsync(token));
                 Assert.Equal("BatMobile", results.GetString("brand"));

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -515,25 +515,10 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var postgres = builder.AddPostgres("pg1");
 
-        // Create a database. Script derived from TechEmpower.
         var newDb = postgres.AddDatabase(databaseName)
             .WithCreationScript($$"""
-                CREATE DATABASE {{databaseName}} WITH OWNER = postgres ENCODING = 'UTF8';
-
-                BEGIN;
-                
-                CREATE TABLE  World (
-                  id integer NOT NULL,
-                  randomNumber integer NOT NULL default 0,
-                  PRIMARY KEY  (id)
-                );
-                GRANT ALL PRIVILEGES ON World to postgres;
-
-                INSERT INTO World (id, randomnumber)
-                SELECT x.id, least(floor(random() * 33 + 1), 33) FROM generate_series(1, 33) as x(id);
-
-                COMMIT;
-
+                CREATE DATABASE {{databaseName}}
+                    ENCODING = 'UTF8';
                 """);
 
         using var app = builder.Build();
@@ -559,11 +544,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             await conn.OpenAsync(cts.Token);
         }
 
-        var selectCommand = conn.CreateCommand();
-        selectCommand.CommandText = "SELECT * FROM World";
-
-        var results = await selectCommand.ExecuteReaderAsync(cts.Token);
-        Assert.True(results.HasRows);
+        Assert.Equal(ConnectionState.Open, conn.State);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Support database creation for `AddDatabase()` in Postgres container resource. If the database already exists nothing is done. Custom scripts can be provided.

Updated PgAdmin container version.

Part of https://github.com/dotnet/aspire/issues/7101

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
