### PR TITLE
Dispose data readers between retries

### DIFF
--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -91,7 +91,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         // Test SqlConnection
         await pipeline.ExecuteAsync(async token =>
         {
-            // The connection is scope, don't dispose if between retries
+            // the connection is scoped, don't dispose if between retries
             var conn = host.Services.GetRequiredService<SqlConnection>();
 
             if (conn.State != ConnectionState.Open)
@@ -196,7 +196,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
                 await pipeline.ExecuteAsync(async token =>
                 {
-                    // The connection is scope, don't dispose if between retries
+                    // the connection is scoped, don't dispose if between retries
                     var conn = host1.Services.GetRequiredService<SqlConnection>();
 
                     if (conn.State != ConnectionState.Open)
@@ -221,7 +221,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
                 await pipeline.ExecuteAsync(async token =>
                 {
-                    // The connection is scope, don't dispose if between retries
+                    // the connection is scoped, don't dispose if between retries
                     var conn = host1.Services.GetRequiredService<SqlConnection>();
 
                     try
@@ -281,7 +281,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
                         await pipeline.ExecuteAsync(async token =>
                         {
-                            // The connection is scope, don't dispose if between retries
+                            // the connection is scoped, don't dispose if between retries
                             var conn = host2.Services.GetRequiredService<SqlConnection>();
 
                             if (conn.State != ConnectionState.Open)
@@ -379,7 +379,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         // Test SqlConnection
         await pipeline.ExecuteAsync(async token =>
         {
-            // The connection is scope, don't dispose if between retries
+            // the connection is scoped, don't dispose if between retries
             var conn = host.Services.GetRequiredService<SqlConnection>();
 
             if (conn.State != ConnectionState.Open)
@@ -432,7 +432,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         // Test SqlConnection
         await pipeline.ExecuteAsync(async token =>
         {
-            // The connection is scope, don't dispose if between retries
+            // the connection is scoped, don't dispose if between retries
             var conn = host.Services.GetRequiredService<SqlConnection>();
 
             if (conn.State != ConnectionState.Open)
@@ -504,7 +504,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Test connection
                 await pipeline.ExecuteAsync(async token =>
                 {
-                    // The connection is scope, don't dispose if between retries
+                    // the connection is scoped, don't dispose if between retries
                     var conn = host.Services.GetRequiredService<SqlConnection>();
 
                     if (conn.State != ConnectionState.Open)

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -91,16 +91,17 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         // Test SqlConnection
         await pipeline.ExecuteAsync(async token =>
         {
+            // The connection is scope, don't dispose if between retries
             var conn = host.Services.GetRequiredService<SqlConnection>();
 
-            if (conn.State != System.Data.ConnectionState.Open)
+            if (conn.State != ConnectionState.Open)
             {
                 await conn.OpenAsync(token);
             }
 
-            var selectCommand = conn.CreateCommand();
+            using var selectCommand = conn.CreateCommand();
             selectCommand.CommandText = $"SELECT 1";
-            var results = await selectCommand.ExecuteReaderAsync(token);
+            using var results = await selectCommand.ExecuteReaderAsync(token);
 
             Assert.True(results.HasRows);
         }, cts.Token);
@@ -195,14 +196,15 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
                 await pipeline.ExecuteAsync(async token =>
                 {
+                    // The connection is scope, don't dispose if between retries
                     var conn = host1.Services.GetRequiredService<SqlConnection>();
 
-                    if (conn.State != System.Data.ConnectionState.Open)
+                    if (conn.State != ConnectionState.Open)
                     {
                         await conn.OpenAsync(token);
                     }
 
-                    var command = conn.CreateCommand();
+                    using var command = conn.CreateCommand();
                     command.CommandText = """
                         DROP TABLE IF EXISTS [Cars];
                         CREATE TABLE [Cars] ([Brand] nvarchar(max) NOT NULL);
@@ -210,7 +212,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                         SELECT * FROM [Cars];
                     """;
 
-                    var results = await command.ExecuteReaderAsync(token);
+                    using var results = await command.ExecuteReaderAsync(token);
 
                     Assert.True(results.HasRows);
                 }, cts.Token);
@@ -219,6 +221,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
                 await pipeline.ExecuteAsync(async token =>
                 {
+                    // The connection is scope, don't dispose if between retries
                     var conn = host1.Services.GetRequiredService<SqlConnection>();
 
                     try
@@ -278,18 +281,20 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
                         await pipeline.ExecuteAsync(async token =>
                         {
+                            // The connection is scope, don't dispose if between retries
                             var conn = host2.Services.GetRequiredService<SqlConnection>();
 
-                            if (conn.State != System.Data.ConnectionState.Open)
+                            if (conn.State != ConnectionState.Open)
                             {
                                 await conn.OpenAsync(token);
                             }
                         }, cts.Token);
 
                         var conn = host2.Services.GetRequiredService<SqlConnection>();
-                        var command = conn.CreateCommand();
+
+                        using var command = conn.CreateCommand();
                         command.CommandText = $"SELECT * FROM [Cars];";
-                        var results = await command.ExecuteReaderAsync(cts.Token);
+                        using var results = await command.ExecuteReaderAsync(cts.Token);
 
                         Assert.True(await results.ReadAsync(cts.Token));
                         Assert.Equal("BatMobile", results.GetString(0));
@@ -374,17 +379,18 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         // Test SqlConnection
         await pipeline.ExecuteAsync(async token =>
         {
+            // The connection is scope, don't dispose if between retries
             var conn = host.Services.GetRequiredService<SqlConnection>();
 
-            if (conn.State != System.Data.ConnectionState.Open)
+            if (conn.State != ConnectionState.Open)
             {
                 await conn.OpenAsync(token);
             }
 
-            var selectCommand = conn.CreateCommand();
+            using var selectCommand = conn.CreateCommand();
             selectCommand.CommandText = "SELECT * FROM [Modeles]; -- Incorrect accent to verify the database collation";
 
-            var results = await selectCommand.ExecuteReaderAsync(token);
+            using var results = await selectCommand.ExecuteReaderAsync(token);
             Assert.True(results.HasRows);
         }, cts.Token);
     }
@@ -426,9 +432,10 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         // Test SqlConnection
         await pipeline.ExecuteAsync(async token =>
         {
+            // The connection is scope, don't dispose if between retries
             var conn = host.Services.GetRequiredService<SqlConnection>();
 
-            if (conn.State != System.Data.ConnectionState.Open)
+            if (conn.State != ConnectionState.Open)
             {
                 await conn.OpenAsync(token);
             }
@@ -497,6 +504,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Test connection
                 await pipeline.ExecuteAsync(async token =>
                 {
+                    // The connection is scope, don't dispose if between retries
                     var conn = host.Services.GetRequiredService<SqlConnection>();
 
                     if (conn.State != ConnectionState.Open)


### PR DESCRIPTION
## Description

There is a flaky test on Helix

> System.InvalidOperationException : There is already an open DataReader associated with this Connection which must be closed first.

This PR disposes the data readers between retries. Probably doesn't show on GH since they work on the first try but Helix agents are slower and may induce retries.

Fixes https://github.com/dotnet/aspire/issues/8089

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
