### PR TITLE
increase timeout from 1 to 10 sec for bUnit waits

### DIFF
--- a/tests/Aspire.Components.Common.Tests/ComponentTestConstants.cs
+++ b/tests/Aspire.Components.Common.Tests/ComponentTestConstants.cs
@@ -1,9 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace Aspire.Components.Common.Tests;
-
-public static class ComponentTestConstants
-{
-    public const string AspireTestContainerRegistry = "netaspireci.azurecr.io";
-}

--- a/tests/Aspire.Components.Common.Tests/ComponentTestConstants.cs
+++ b/tests/Aspire.Components.Common.Tests/ComponentTestConstants.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Components.Common.Tests;
+
+public static class ComponentTestConstants
+{
+    public const string AspireTestContainerRegistry = "netaspireci.azurecr.io";
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
 using Bunit;
 using Microsoft.Extensions.Configuration;
@@ -13,7 +14,7 @@ using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
 
 namespace Aspire.Dashboard.Components.Tests.Controls;
 
-public class ApplicationNameTests : TestContext
+public class ApplicationNameTests : DashboardTestContext
 {
     [Fact]
     public void Render_DashboardClientDisabled_Success()

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 namespace Aspire.Dashboard.Components.Tests.Controls;
 
 [UseCulture("en-US")]
-public class PlotlyChartTests : TestContext
+public class PlotlyChartTests : DashboardTestContext
 {
     private static string GetContainerHtml(string divId) => $"""<div id="{divId}" class="plotly-chart-container"></div>""";
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace Aspire.Dashboard.Components.Tests.Controls;
 
 [UseCulture("en-US")]
-public class ResourceDetailsTests : TestContext
+public class ResourceDetailsTests : DashboardTestContext
 {
     [Fact]
     public async Task ClickMaskAllSwitch_UpdatedResource_MaskChanged()

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/StructuredLogDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/StructuredLogDetailsTests.cs
@@ -6,7 +6,6 @@ using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Tests.Shared.Telemetry;
-using Bunit;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Common.V1;
@@ -15,7 +14,7 @@ using Xunit;
 namespace Aspire.Dashboard.Components.Tests.Controls;
 
 [UseCulture("en-US")]
-public class StructuredLogDetailsTests : TestContext
+public class StructuredLogDetailsTests : DashboardTestContext
 {
     [Fact]
     public void Render_ManyDuplicateAttributes_NoDuplicateKeys()

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Aspire.Dashboard.Components.Tests.Controls;
 
-public class TextVisualizerDialogTests : TestContext
+public class TextVisualizerDialogTests : DashboardTestContext
 {
     [Fact]
     public async Task Render_TextVisualizerDialog_WithValidJson_FormatsJsonAsync()

--- a/tests/Aspire.Dashboard.Components.Tests/GridColumnManagerTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/GridColumnManagerTests.cs
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.Resize;
+using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
-using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Aspire.Dashboard.Components.Tests;
 
-public class GridColumnManagerTests : TestContext
+public class GridColumnManagerTests : DashboardTestContext
 {
     [Fact]
     public void Returns_Correct_TemplateColumn_String()

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 namespace Aspire.Dashboard.Components.Tests.Layout;
 
 [UseCulture("en-US")]
-public partial class MainLayoutTests : TestContext
+public partial class MainLayoutTests : DashboardTestContext
 {
     [Fact]
     public async Task OnInitialize_UnsecuredOtlp_NotDismissed_DisplayMessageBar()

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -24,7 +24,7 @@ using Xunit.Abstractions;
 namespace Aspire.Dashboard.Components.Tests.Pages;
 
 [UseCulture("en-US")]
-public partial class ConsoleLogsTests : TestContext
+public partial class ConsoleLogsTests : DashboardTestContext
 {
     private readonly ITestOutputHelper _testOutputHelper;
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/LoginTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/LoginTests.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace Aspire.Dashboard.Components.Tests.Pages;
 
 [UseCulture("en-US")]
-public partial class LoginTests : TestContext
+public partial class LoginTests : DashboardTestContext
 {
     private readonly ITestOutputHelper _testOutputHelper;
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -280,7 +280,7 @@ public partial class MetricsTests : DashboardTestContext
         var innerSelect = resourceSelect.Find("fluent-select");
         innerSelect.Change("TestApp2");
 
-        cut.WaitForAssertion(() => Assert.Equal("TestApp2", viewModel.SelectedApplication.Name), TestConstants.WaitTimeout);
+        cut.WaitForAssertion(() => Assert.Equal("TestApp2", viewModel.SelectedApplication.Name));
 
         Assert.Equal(expectedInstrumentNameAfterChange, viewModel.SelectedInstrument?.Name);
         Assert.Equal(expectedMeterNameAfterChange, viewModel.SelectedMeter?.MeterName);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -22,7 +22,7 @@ using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 namespace Aspire.Dashboard.Components.Tests.Pages;
 
 [UseCulture("en-US")]
-public partial class MetricsTests : TestContext
+public partial class MetricsTests : DashboardTestContext
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Aspire.Dashboard.Components.Tests.Pages;
 
 [UseCulture("en-US")]
-public partial class ResourcesTests : TestContext
+public partial class ResourcesTests : DashboardTestContext
 {
     [Fact]
     public void UpdateResources_FiltersUpdated()

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -72,7 +72,7 @@ public partial class ResourcesTests : DashboardTestContext
                     ImmutableArray.Create(new HealthReportViewModel("Healthy", HealthStatus.Healthy, "Description2", null))))
             ]);
 
-        cut.WaitForState(() => cut.Instance.GetFilteredResources().Count() == 2, TestConstants.WaitTimeout);
+        cut.WaitForState(() => cut.Instance.GetFilteredResources().Count() == 2);
 
         // Assert 2
         Assert.Collection(cut.Instance.ResourceTypesToVisibility.OrderBy(kvp => kvp.Key),

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -23,7 +23,7 @@ using Xunit;
 namespace Aspire.Dashboard.Components.Tests.Pages;
 
 [UseCulture("en-US")]
-public partial class StructuredLogsTests : TestContext
+public partial class StructuredLogsTests : DashboardTestContext
 {
     [Fact]
     public void Render_TraceIdAndSpanId_FilterAdded()

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -26,7 +26,7 @@ using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 namespace Aspire.Dashboard.Components.Tests.Pages;
 
 [UseCulture("en-US")]
-public partial class TraceDetailsTests : TestContext
+public partial class TraceDetailsTests : DashboardTestContext
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/DashboardPageTestContext.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/DashboardPageTestContext.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Bunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Dashboard.Components.Tests.Shared;
+public abstract class DashboardTestContext : TestContext
+{
+    public DashboardTestContext()
+    {
+        // Increase from default 1 second as Helix/GitHub Actions can be slow.
+        DefaultWaitTimeout = TestConstants.WaitTimeout;
+    }
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/DashboardPageTestContext.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/DashboardPageTestContext.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Bunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Components.Tests.Shared;
 public abstract class DashboardTestContext : TestContext

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/DashboardPageTestContext.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/DashboardPageTestContext.cs
@@ -9,6 +9,6 @@ public abstract class DashboardTestContext : TestContext
     public DashboardTestContext()
     {
         // Increase from default 1 second as Helix/GitHub Actions can be slow.
-        DefaultWaitTimeout = TestConstants.WaitTimeout;
+        DefaultWaitTimeout = TimeSpan.FromSeconds(10);
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestConstants.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestConstants.cs
@@ -1,9 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace Aspire.Dashboard.Components.Tests.Shared;
-
-internal static class TestConstants
-{
-    public static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
-}


### PR DESCRIPTION
## Description

Increase timeout from 1 to 10 sec for bUnit waits.
Note -- we may want to keep short timeouts on dev machines, but I don't know how to identify them.

default https://github.com/bUnit-dev/bUnit/blob/2284ed6649e404bbe7c86ea80fbb236ac55c2789/src/bunit.core/TestContextBase.cs#L17
used here https://github.com/bUnit-dev/bUnit/blob/2284ed6649e404bbe7c86ea80fbb236ac55c2789/src/bunit.core/Extensions/WaitForHelpers/WaitForHelper.cs#L218

## Checklist

- Is this feature complete?
  - [ x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x ] No
