### PR TITLE
Clarify DCP Not Found Error

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -167,7 +167,7 @@ internal sealed class DcpHost
         var dcpExePath = _dcpOptions.CliPath;
         if (!File.Exists(dcpExePath))
         {
-            throw new FileNotFoundException($"The Aspire application host is not installed at \"{dcpExePath}\". The application cannot be run without it.", dcpExePath);
+            throw new FileNotFoundException($"The Developer Control Plane is not installed at \"{dcpExePath}\". The application cannot be run without it.", dcpExePath);
         }
 
         var arguments = $"start-apiserver --monitor {Environment.ProcessId} --detach --kubeconfig \"{locations.DcpKubeconfigPath}\"";


### PR DESCRIPTION
## Description

Clarify error to refer to DCP, and not "Application Host", which conflicts with the "AppHost" naming convention used for aspire projects.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
