### PR TITLE
Move filters into a menu, add a remove all filters button

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -29,7 +29,7 @@
     }
 </FluentButton>
 
-<FluentMenu Anchor="@MenuButtonId" aria-labelledby="button" @bind-Open="@_visible" VerticalThreshold="200">
+<FluentMenu Anchor="@MenuButtonId" aria-labelledby="button" @bind-Open="@_visible" VerticalThreshold="200" tabindex="0">
     @foreach (var item in Items)
     {
         @if (item.IsDivider)
@@ -40,10 +40,10 @@
         {
             var additionalMenuItemAttributes = new Dictionary<string, object>(item.AdditionalAttributes ?? ImmutableDictionary<string, object>.Empty)
             {
-                { "title", item.Tooltip ?? string.Empty }
+                { "title", item.Tooltip ?? item.Text ?? string.Empty }
             };
 
-            <FluentMenuItem Id="@item.Id" OnClick="() => HandleItemClicked(item)" Disabled="@item.IsDisabled" AdditionalAttributes="@additionalMenuItemAttributes">
+            <FluentMenuItem Id="@item.Id" Class="@item.Class" OnClick="() => HandleItemClicked(item)" Disabled="@item.IsDisabled" AdditionalAttributes="@additionalMenuItemAttributes">
                 @item.Text
                 @if (item.Icon != null)
                 {

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -21,7 +21,11 @@
     else
     {
         @Text
-        <FluentIcon Value="@_icon" Color="@IconColor" Slot="end" />
+
+        @if (!DisableIcon)
+        {
+            <FluentIcon Value="@_icon" Color="@IconColor" Slot="end" />
+        }
     }
 </FluentButton>
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -22,7 +22,7 @@
     {
         @Text
 
-        @if (!DisableIcon)
+        @if (!HideIcon)
         {
             <FluentIcon Value="@_icon" Color="@IconColor" Slot="end" />
         }

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -29,7 +29,7 @@
     }
 </FluentButton>
 
-<FluentMenu Anchor="@MenuButtonId" aria-labelledby="button" @bind-Open="@_visible" VerticalThreshold="200" tabindex="0">
+<FluentMenu Anchor="@MenuButtonId" aria-labelledby="button" @bind-Open="@_visible" VerticalThreshold="200">
     @foreach (var item in Items)
     {
         @if (item.IsDivider)

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -43,6 +43,9 @@ public partial class AspireMenuButton : FluentComponentBase
     [Parameter]
     public string MenuButtonId { get; set; } = Identifier.NewId();
 
+    [Parameter]
+    public bool DisableIcon { get; set; }
+
     protected override void OnParametersSet()
     {
         _icon = Icon ?? s_defaultIcon;

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -44,7 +44,7 @@ public partial class AspireMenuButton : FluentComponentBase
     public string MenuButtonId { get; set; } = Identifier.NewId();
 
     [Parameter]
-    public bool DisableIcon { get; set; }
+    public bool HideIcon { get; set; }
 
     protected override void OnParametersSet()
     {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -6,6 +6,7 @@
 @using Aspire.Dashboard.Resources
 @using System.Globalization
 @using Aspire.Dashboard.Components.Controls.Grid
+@using Aspire.Dashboard.Model
 @inject IJSRuntime JS
 @implements IDisposable
 
@@ -68,22 +69,17 @@
                                 HandleSelectedLogLevelChangedAsync="@HandleSelectedLogLevelChangedAsync" />
             }
             <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-            <FluentLabel slot="end">@FilterLoc[nameof(StructuredFiltering.Filters)]</FluentLabel>
             @if (ViewModel.Filters.Count == 0)
             {
                 <span slot="end">@FilterLoc[nameof(StructuredFiltering.NoFilters)]</span>
             }
             else
             {
-                for (var i = 0; i < ViewModel.Filters.Count; i++)
-                {
-                    var filter = ViewModel.Filters[i];
-                    if (i != 0)
-                    {
-                        <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-                    }
-                    <FluentButton slot="end" Appearance="Appearance.Outline" OnClick="() => OpenFilterAsync(filter)" class="telemetry-filter-button" title="@filter.GetDisplayText(FilterLoc)">@filter.GetDisplayText(FilterLoc)</FluentButton>
-                }
+                <div slot="end">
+                    <FluentCounterBadge HorizontalPosition="70" Count="@(ViewModel.Filters.Count)" Appearance="Appearance.Accent">
+                        <AspireMenuButton DisableIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
+                    </FluentCounterBadge>
+                </div>
             }
             <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             @if (ViewportInformation.IsDesktop)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -77,7 +77,7 @@
             {
                 <div slot="end">
                     <FluentCounterBadge HorizontalPosition="70" Count="@(ViewModel.Filters.Count)" Appearance="Appearance.Accent">
-                        <AspireMenuButton DisableIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
+                        <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
                     </FluentCounterBadge>
                 </div>
             }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -375,7 +375,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
             OnClick = () =>
             {
                 ViewModel.ClearFilters();
-                return InvokeAsync(StateHasChanged);
+                return this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false);
             }
         });
 

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -349,6 +349,38 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         }
     }
 
+    private List<MenuButtonItem> GetFilterMenuItems()
+    {
+        var filterMenuItems = new List<MenuButtonItem>();
+
+        foreach (var filter in ViewModel.Filters)
+        {
+            filterMenuItems.Add(new MenuButtonItem
+            {
+                OnClick = () => OpenFilterAsync(filter),
+                Text = filter.GetDisplayText(FilterLoc)
+            });
+        }
+
+        filterMenuItems.Add(new MenuButtonItem
+        {
+            IsDivider = true
+        });
+
+        filterMenuItems.Add(new MenuButtonItem
+        {
+            Text = DialogsLoc[nameof(Dashboard.Resources.Dialogs.SettingsRemoveAllButtonText)],
+            Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size16.Delete(),
+            OnClick = () =>
+            {
+                ViewModel.ClearFilters();
+                return InvokeAsync(StateHasChanged);
+            }
+        });
+
+        return filterMenuItems;
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (_applicationChanged)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -358,7 +358,8 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
             filterMenuItems.Add(new MenuButtonItem
             {
                 OnClick = () => OpenFilterAsync(filter),
-                Text = filter.GetDisplayText(FilterLoc)
+                Text = filter.GetDisplayText(FilterLoc),
+                Class = "filter-menu-item",
             });
         }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -47,22 +47,17 @@
                           title="@Loc[nameof(Dashboard.Resources.Traces.TracesNameFilter)]"
                           slot="end" />
             <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-            <FluentLabel slot="end">@FilterLoc[nameof(StructuredFiltering.Filters)]</FluentLabel>
             @if (TracesViewModel.Filters.Count == 0)
             {
                 <span slot="end">@FilterLoc[nameof(StructuredFiltering.NoFilters)]</span>
             }
             else
             {
-                for (var i = 0; i < TracesViewModel.Filters.Count; i++)
-                {
-                    var filter = TracesViewModel.Filters[i];
-                    if (i != 0)
-                    {
-                        <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-                    }
-                    <FluentButton slot="end" Appearance="Appearance.Outline" OnClick="() => OpenFilterAsync(filter)" class="telemetry-filter-button" title="@filter.GetDisplayText(FilterLoc)">@filter.GetDisplayText(FilterLoc)</FluentButton>
-                }
+                <div slot="end">
+                    <FluentCounterBadge HorizontalPosition="70" Count="@(TracesViewModel.Filters.Count)" Appearance="Appearance.Accent">
+                        <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
+                    </FluentCounterBadge>
+                </div>
             }
             <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             @if (ViewportInformation.IsDesktop)

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -343,6 +343,39 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
         return Task.CompletedTask;
     }
 
+    private List<MenuButtonItem> GetFilterMenuItems()
+    {
+        var filterMenuItems = new List<MenuButtonItem>();
+
+        foreach (var filter in TracesViewModel.Filters)
+        {
+            filterMenuItems.Add(new MenuButtonItem
+            {
+                OnClick = () => OpenFilterAsync(filter),
+                Text = filter.GetDisplayText(FilterLoc),
+                Class = "filter-menu-item",
+            });
+        }
+
+        filterMenuItems.Add(new MenuButtonItem
+        {
+            IsDivider = true
+        });
+
+        filterMenuItems.Add(new MenuButtonItem
+        {
+            Text = DialogsLoc[nameof(Dashboard.Resources.Dialogs.SettingsRemoveAllButtonText)],
+            Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Regular.Size16.Delete(),
+            OnClick = () =>
+            {
+                TracesViewModel.ClearFilters();
+                return this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false);
+            }
+        });
+
+        return filterMenuItems;
+    }
+
     public class TracesPageViewModel
     {
         public required SelectViewModel<ResourceTypeDetails> SelectedApplication { get; set; }

--- a/src/Aspire.Dashboard/Model/MenuButtonItem.cs
+++ b/src/Aspire.Dashboard/Model/MenuButtonItem.cs
@@ -14,5 +14,6 @@ public class MenuButtonItem
     public Func<Task>? OnClick { get; set; }
     public bool IsDisabled { get; set; }
     public string Id { get; set; } = Identifier.NewId();
+    public string? Class { get; set; }
     public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
 }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -535,12 +535,6 @@ fluent-switch.table-switch::part(label) {
     padding: calc(((var(--design-unit) * 0.5) - var(--stroke-width)) * 1px) calc((var(--design-unit) - var(--stroke-width)) * 1px);
 }
 
-.telemetry-filter-button::part(content) {
-    max-width: 350px;
-    overflow: hidden;
-    text-overflow: ellipsis
-}
-
 .mobile-toolbar {
     width: 100%;
     height: max(5vh, 30px);

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -746,3 +746,7 @@ fluent-switch.table-switch::part(label) {
     max-height: 400px;
     overflow-y: auto;
 }
+
+.filter-menu-item::part(content) {
+    max-width: 300px;
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -189,6 +189,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         Services.AddSingleton<ShortcutManager>();
         Services.AddSingleton<LibraryConfiguration>();
         Services.AddSingleton<IKeyCodeService, KeyCodeService>();
+        Services.AddSingleton<GlobalState>();
     }
 
     private static string GetFluentFile(string filePath, Version version)

--- a/tests/Shared/AsyncTestHelpers.cs
+++ b/tests/Shared/AsyncTestHelpers.cs
@@ -182,7 +182,7 @@ internal static class AsyncTestHelpers
         {
             if (i > 0)
             {
-                await Task.Delay((i + 1) * (i + 1) * 10);
+                await Task.Delay((i + 1) * (i + 1) * 10 * 5);
             }
 
             if (await assert())


### PR DESCRIPTION
## Description

This PR removes the current horizontal filter view, moving the filters into a fluent menu with a counter badge to hint at the number of filters set.

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/59f1ac81-a628-4800-9914-963b0f274b63" />

Inside the menu, set filters are presented first, then a divider and a clear all filters item. Maybe we could think of icons to set for each of the filter types? 
<img width="272" alt="image" src="https://github.com/user-attachments/assets/17caeef7-8916-45b5-b2dc-11b4155b5459" />
 
If no filters are present, "No filters" continues to be shown.
<img width="618" alt="image" src="https://github.com/user-attachments/assets/21716352-9762-4c16-b5d9-16484ec4eeb2" />


Fixes #5673

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
