### PR TITLE
Use WithRoleAssignments in AddAzureFunctionsProject

### DIFF
--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Utils;
-using Azure.Provisioning;
 using Azure.Provisioning.Storage;
 
 namespace Aspire.Hosting;
@@ -47,30 +46,7 @@ public static class AzureFunctionsProjectResourceExtensions
             .OfType<AzureStorageResource>()
             .FirstOrDefault(r => r.Name == storageResourceName);
 
-        // Azure Functions blob triggers require StorageAccountContributor access to the host storage
-        // account when deployed. We assign this role to the host storage resource when running in publish mode.
-        if (storage is null)
-        {
-            if (builder.ExecutionContext.IsPublishMode)
-            {
-                var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>
-                {
-                    var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
-                    var principalIdParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalId, typeof(string));
-
-                    var storageAccount = infrastructure.GetProvisionableResources().OfType<StorageAccount>().FirstOrDefault(r => r.BicepIdentifier == storageResourceName)
-                        ?? throw new InvalidOperationException($"Could not find storage account with '{storageResourceName}' name.");
-                    infrastructure.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageAccountContributor, principalTypeParameter, principalIdParameter));
-                };
-                storage = builder.AddAzureStorage(storageResourceName)
-                    .ConfigureInfrastructure(configureInfrastructure)
-                    .RunAsEmulator().Resource;
-            }
-            else
-            {
-                storage = builder.AddAzureStorage(storageResourceName).RunAsEmulator().Resource;
-            }
-        }
+        storage ??= builder.AddAzureStorage(storageResourceName).RunAsEmulator().Resource;
 
         builder.Eventing.Subscribe<BeforeStartEvent>((data, token) =>
         {
@@ -118,6 +94,13 @@ public static class AzureFunctionsProjectResourceExtensions
                 // Set the storage connection string.
                 ((IResourceWithAzureFunctionsConfig)resource.HostStorage).ApplyAzureFunctionsConfiguration(context.EnvironmentVariables, "AzureWebJobsStorage");
             })
+            // Azure Functions blob triggers require StorageAccountContributor access to the host storage
+            // account when deployed. We assign this role to the host storage resource when running in publish mode.
+            .WithRoleAssignments(builder.CreateResourceBuilder(storage),
+                StorageBuiltInRole.StorageBlobDataContributor,
+                StorageBuiltInRole.StorageQueueDataContributor,
+                StorageBuiltInRole.StorageTableDataContributor,
+                StorageBuiltInRole.StorageAccountContributor)
             .WithOtlpExporter()
             .WithFunctionsHttpEndpoint();
     }


### PR DESCRIPTION
## Description

The current ConfigureInfrastructure code no longer works when using AddAzureContainerAppsInfrastructure because the role assignments are now created in a separate bicep module.

Migrate the ConfigureInfrastructure code to instead use WithRoleAssignments.

Setting to the existing 4 roles - the 3 default Storage roles + StorageAccountContributor

Fix #8125

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - ongoing
- Does the change require an update in our Aspire docs?
  - [x] No
