### PR TITLE
Fix resource graph disappearing when switching to mobile view

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -2,50 +2,37 @@
 @typeparam T
 
 <div class="summary-details-container">
-    @if (!ViewportInformation.IsDesktop)
-    {
-        @if (_internalShowDetails)
-        {
-            <DetailView
-                DetailsTitle="@DetailsTitle"
-                DetailsTitleTemplate="@(SelectedValue is not null ? DetailsTitleTemplate?.Invoke(SelectedValue) : null)"
-                HandleDismissAsync="@HandleDismissAsync"
-                HandleToggleOrientation="@HandleToggleOrientation"
-                Details="@(SelectedValue is not null ? Details?.Invoke(SelectedValue) : null)"
-                Orientation="@Orientation" />
-        }
-        else
-        {
-            <div class="summary-container">
+    <FluentSplitter Orientation="@Orientation" Collapsed="@(!_internalShowDetails || !ViewportInformation.IsDesktop)"
+                    OnResized="HandleSplitterResize"
+                    Panel1Size="@EffectivePanel1Size" Panel2Size="@EffectivePanel2Size"
+                    Panel1MinSize="@PanelMinimumSize" Panel2MinSize="@PanelMinimumSize"
+                    BarSize="5"
+                    @ref="_splitterRef">
+        <Panel1>
+            @* The summary container should never be added/removed from the DOM *@
+            <div class="summary-container" style="@(_internalShowDetails && !ViewportInformation.IsDesktop ? "display:none" : string.Empty)">
                 @Summary
             </div>
-        }
-    }
-    else
-    {
-        <FluentSplitter Orientation="@Orientation" Collapsed="@(!_internalShowDetails)"
-                        OnResized="HandleSplitterResize"
-                        Panel1Size="@EffectivePanel1Size" Panel2Size="@EffectivePanel2Size"
-                        Panel1MinSize="@PanelMinimumSize" Panel2MinSize="@PanelMinimumSize"
-                        BarSize="5"
-                        @ref="_splitterRef">
-            <Panel1>
-                <div class="summary-container">
-                    @Summary
-                </div>
-            </Panel1>
-            <Panel2>
-                @if (_internalShowDetails)
-                {
-                    <DetailView
-                        DetailsTitle="@DetailsTitle"
-                        DetailsTitleTemplate="@(SelectedValue is not null ? DetailsTitleTemplate?.Invoke(SelectedValue) : null)"
-                        HandleDismissAsync="@HandleDismissAsync"
-                        HandleToggleOrientation="@HandleToggleOrientation"
-                        Details="@(SelectedValue is not null ? Details?.Invoke(SelectedValue) : null)"
-                        Orientation="@Orientation"/>
-                }
-            </Panel2>
-        </FluentSplitter>
-    }
+            @if (_internalShowDetails && !ViewportInformation.IsDesktop)
+            {
+                <DetailView DetailsTitle="@DetailsTitle"
+                            DetailsTitleTemplate="@(SelectedValue is not null ? DetailsTitleTemplate?.Invoke(SelectedValue) : null)"
+                            HandleDismissAsync="@HandleDismissAsync"
+                            HandleToggleOrientation="@HandleToggleOrientation"
+                            Details="@(SelectedValue is not null ? Details?.Invoke(SelectedValue) : null)"
+                            Orientation="@Orientation" />
+            }
+        </Panel1>
+        <Panel2>
+            @if (_internalShowDetails && ViewportInformation.IsDesktop)
+            {
+                <DetailView DetailsTitle="@DetailsTitle"
+                            DetailsTitleTemplate="@(SelectedValue is not null ? DetailsTitleTemplate?.Invoke(SelectedValue) : null)"
+                            HandleDismissAsync="@HandleDismissAsync"
+                            HandleToggleOrientation="@HandleToggleOrientation"
+                            Details="@(SelectedValue is not null ? Details?.Invoke(SelectedValue) : null)"
+                            Orientation="@Orientation" />
+            }
+        </Panel2>
+    </FluentSplitter>
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -9,7 +9,10 @@
                     BarSize="5"
                     @ref="_splitterRef">
         <Panel1>
-            @* The summary container should never be added/removed from the DOM *@
+            @*
+                The summary container should never be added/removed from the DOM. If it is added/removed then content dynamically
+                added by JS libraries, such as the resource graph, will be lost when switching between desktop and mobile views.
+            *@
             <div class="summary-container" style="@(_internalShowDetails && !ViewportInformation.IsDesktop ? "display:none" : string.Empty)">
                 @Summary
             </div>

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -134,10 +134,12 @@ class ResourceGraph {
     }
 
     resize() {
-        var container = document.getElementsByClassName("resources-summary-layout")[0];
-        var width = container.clientWidth;
-        var height = Math.max(container.clientHeight - 50, 0);
-        this.svg.attr("viewBox", [-width / 2, -height / 2, width, height]);
+        var container = document.querySelector(".resources-summary-layout");
+        if (container) {
+            var width = container.clientWidth;
+            var height = Math.max(container.clientHeight - 50, 0);
+            this.svg.attr("viewBox", [-width / 2, -height / 2, width, height]);
+        }
     }
 
     switchTo(resourceName) {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/7948

The splitter view removes and adds the page content when switching between desktop and mobile view. That means dynamically added DOM content from the graph is cleared.

PR fixes issue by ensuring that page content is never removed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
