### PR TITLE
Moving property IsAspireHost to the SDK

### DIFF
--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -4,5 +4,6 @@
     <!-- Do not import the workload targets as this project is instead using
     the Aspire.AppHost.Sdk -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
+    <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
 </Project>

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/9.2/Aspire.AppHost1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/9.2/Aspire.AppHost1.csproj
@@ -7,7 +7,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>98048c9c-bf28-46ba-a98e-63767ee5e3a8</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/9.2/AspireApplication.1.AppHost/AspireApplication.1.AppHost.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/9.2/AspireApplication.1.AppHost/AspireApplication.1.AppHost.csproj
@@ -7,7 +7,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>98048c9c-bf28-46ba-a98e-63767ee5e3a8</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj
@@ -7,7 +7,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>98048c9c-bf28-46ba-a98e-63767ee5e3a8</UserSecretsId>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

When we introduced the Aspire SDK, we tried to minimize the changes to the AppHost templates for backward compatibility, which meant that the definition of `IsAspireHost` stayed in the AppHost file. This could sometimes cause issues when restore wouldn't succeed the first time (like #7977) so this change is finally moving that property from the AppHost and into the SDK to avoid those types of issues.

cc: @DamianEdwards 

Fixes #7977 
Fixes #6142 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No

Tracking docs update issue: https://github.com/dotnet/docs-aspire/issues/2847