### PR TITLE
Test to ensure SB emulator supports queues and custom config

### DIFF
--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -449,7 +449,6 @@ public static class AzureServiceBusExtensions
 
                     foreach (var annotation in configJsonAnnotations)
                     {
-
                         annotation.Configure(jsonObject);
                     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -851,9 +851,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         hb.Configuration["ConnectionStrings:servicebusns"] = await serviceBus.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
         hb.AddAzureServiceBusClient("servicebusns");
 
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(serviceBus.Resource.Name, KnownResourceStates.Running, cts.Token);
-        await rns.WaitForResourceHealthyAsync(serviceBus.Resource.Name, cts.Token);
+        await app.ResourceNotifications.WaitForResourceAsync(serviceBus.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(serviceBus.Resource.Name, cts.Token);
 
         using var host = hb.Build();
         await host.StartAsync();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -810,7 +810,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
     [Fact(Skip = "Azure ServiceBus emulator is not reliable in CI - https://github.com/dotnet/aspire/issues/7066")]
     [RequiresDocker]
-    public async Task AzureServiceBusEmulator_WithCustomConfig_HasHealthChecks()
+    public async Task AzureServiceBusEmulator_WithCustomConfig()
     {
         const string queueName = "queue456";
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -671,10 +671,13 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 "Namespaces": [
                   {
                     "Name": "servicebusns",
-                    "Queues": [ "queue456" ],
+                    "Queues": [ { "Name": "queue456" } ],
                     "Topics": []
                   }
-                ]
+                ],
+                "Logging": {
+                  "Type": "File"
+                }
               }
             }
             """);
@@ -697,10 +700,13 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
                 "Namespaces": [
                   {
                     "Name": "servicebusns",
-                    "Queues": [ "queue456" ],
+                    "Queues": [ { "Name": "queue456" } ],
                     "Topics": []
                   }
-                ]
+                ],
+                "Logging": {
+                  "Type": "File"
+                }
               }
             }
             """, configJsonContent);
@@ -800,5 +806,66 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
         Assert.Collection(target.Keys.OrderBy(k => k),
             k => Assert.Equal("Aspire__Azure__Messaging__ServiceBus__sub__FullyQualifiedNamespace", k),
             k => Assert.Equal("sub__fullyQualifiedNamespace", k));
+    }
+
+    [Fact(Skip = "Azure ServiceBus emulator is not reliable in CI - https://github.com/dotnet/aspire/issues/7066")]
+    [RequiresDocker]
+    public async Task AzureServiceBusEmulator_WithCustomConfig_HasHealthChecks()
+    {
+        const string queueName = "queue456";
+
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
+
+        using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(output);
+
+        var configJsonPath = Path.GetTempFileName();
+
+        File.WriteAllText(configJsonPath,
+            $$"""
+            {
+              "UserConfig": {
+                "Namespaces": [
+                  {
+                    "Name": "sbemulatorns",
+                    "Queues": [ { "Name": "{{queueName}}" } ],
+                    "Topics": []
+                  }
+                ],
+                "Logging": {
+                  "Type": "File"
+                }
+              }
+            }
+            """);
+
+        var serviceBus = builder
+            .AddAzureServiceBus("servicebusns")
+            .RunAsEmulator(configure => configure.WithConfigurationFile(configJsonPath));
+
+        var queueResource = serviceBus.AddServiceBusQueue("queue123", queueName);
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var hb = Host.CreateApplicationBuilder();
+        hb.Configuration["ConnectionStrings:servicebusns"] = await serviceBus.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
+        hb.AddAzureServiceBusClient("servicebusns");
+
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        await rns.WaitForResourceAsync(serviceBus.Resource.Name, KnownResourceStates.Running, cts.Token);
+        await rns.WaitForResourceHealthyAsync(serviceBus.Resource.Name, cts.Token);
+
+        using var host = hb.Build();
+        await host.StartAsync();
+
+        var serviceBusClient = host.Services.GetRequiredService<ServiceBusClient>();
+
+        await using var sender = serviceBusClient.CreateSender(queueResource.Resource.QueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("Hello, World!"), cts.Token);
+
+        await using var receiver = serviceBusClient.CreateReceiver(queueResource.Resource.QueueName);
+        var message = await receiver.ReceiveMessageAsync(cancellationToken: cts.Token);
+
+        Assert.Equal("Hello, World!", message.Body.ToString());
     }
 }


### PR DESCRIPTION
## Description

Add a test to ensure we can have SB emulator health checks in a custom configuration is provided.

Fixes https://github.com/dotnet/aspire/issues/7949

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
