### PR TITLE
Fix event attributes not displaying

### DIFF
--- a/playground/Stress/Stress.ApiService/TraceCreator.cs
+++ b/playground/Stress/Stress.ApiService/TraceCreator.cs
@@ -96,7 +96,7 @@ public class TraceCreator
         for (var i = 0; i < eventCount; i++)
         {
             var activityTags = new ActivityTagsCollection();
-            var tagsCount = Random.Shared.Next(0, 3);
+            var tagsCount = Random.Shared.Next(0, 5);
             for (var j = 0; j < tagsCount; j++)
             {
                 activityTags.Add($"key-{j}", "Value!");

--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -78,7 +78,7 @@ builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard
 
 IResourceBuilder<IResource>? previousResourceBuilder = null;
 
-for (var i = 0; i < 10; i++)
+for (var i = 0; i < 3; i++)
 {
     var resourceBuilder = builder.AddProject<Projects.Stress_Empty>($"empty-{i:0000}");
     if (previousResourceBuilder != null)

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -26,7 +26,7 @@
     display: inline-block;
 }
 
-td:hover .defaultHidden, td:focus-within .defaultHidden {
+td:hover > .container > .button-container > .defaultHidden, td:focus-within > .container > .button-container > .defaultHidden {
     opacity: 1; /* safari has a bug where hover is not always called on an invisible element, so we use opacity instead */
     width: auto;
 }

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -3,39 +3,40 @@
 @typeparam TItem where TItem : IPropertyGridItem
 @inject IStringLocalizer<ControlsStrings> Loc
 
-<FluentDataGrid ColumnResizeLabels="@_resizeLabels"
-                ColumnSortLabels="@_sortLabels"
-                HeaderCellAsButtonWithMenu="true"
-                ResizeType="DataGridResizeType.Discrete"
-                Items="@Items"
-                ItemKey="@ItemKey"
-                ResizableColumns="true"
-                Style="width:100%"
-                GenerateHeader="@GenerateHeader"
-                GridTemplateColumns="@GridTemplateColumns"
-                RowSize="DataGridRowSize.Medium"
-                ShowHover="true"
-                Class="@Class">
-    <AspireTemplateColumn Title="@(NameColumnTitle ?? Loc[nameof(ControlsStrings.NameColumnHeader)])" Class="nameColumn" SortBy="@NameSort" Sortable="@IsNameSortable">
-        <GridValue
-            ValueDescription="@(NameColumnTitle ?? Loc[nameof(ControlsStrings.NameColumnHeader)])"
-            Value="@context.Name"
-            EnableHighlighting="@(!string.IsNullOrEmpty(HighlightText))"
-            HighlightText="@HighlightText" />
-    </AspireTemplateColumn>
-    <AspireTemplateColumn Title="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])" Class="valueColumn" SortBy="@ValueSort" Sortable="@IsValueSortable">
-        <GridValue
-            ValueDescription="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])"
-            Value="@context.Value"
-            ContentAfterValue="@GetContentAfterValue(context)"
-            EnableHighlighting="@(!string.IsNullOrEmpty(HighlightText))"
-            HighlightText="@HighlightText"
-            EnableMasking="@context.IsValueSensitive"
-            IsMasked="@context.IsValueMasked"
-            IsMaskedChanged="(isMasked) => OnIsValueMaskedChanged(context, isMasked)"
-            TextVisualizerTitle="@context.Name"
-            ValueToVisualize="@(context.ValueToVisualize ?? context.Value)" />
-        @ExtraValueContent(context)
-    </AspireTemplateColumn>
-</FluentDataGrid>
+<div class="property-grid">
+    <FluentDataGrid ColumnResizeLabels="@_resizeLabels"
+                    ColumnSortLabels="@_sortLabels"
+                    HeaderCellAsButtonWithMenu="true"
+                    ResizeType="DataGridResizeType.Discrete"
+                    Items="@Items"
+                    ItemKey="@ItemKey"
+                    ResizableColumns="true"
+                    Style="width:100%"
+                    GenerateHeader="@GenerateHeader"
+                    GridTemplateColumns="@GridTemplateColumns"
+                    RowSize="DataGridRowSize.Medium"
+                    ShowHover="true"
+                    Class="@Class"
+                    MultiLine="@Multiline">
+        <AspireTemplateColumn Title="@(NameColumnTitle ?? Loc[nameof(ControlsStrings.NameColumnHeader)])" Class="nameColumn" SortBy="@NameSort" Sortable="@IsNameSortable">
+            <GridValue ValueDescription="@(NameColumnTitle ?? Loc[nameof(ControlsStrings.NameColumnHeader)])"
+                       Value="@context.Name"
+                       EnableHighlighting="@(!string.IsNullOrEmpty(HighlightText))"
+                       HighlightText="@HighlightText" />
+        </AspireTemplateColumn>
+        <AspireTemplateColumn Title="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])" Class="valueColumn" SortBy="@ValueSort" Sortable="@IsValueSortable">
+            <GridValue ValueDescription="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])"
+                       Value="@context.Value"
+                       ContentAfterValue="@GetContentAfterValue(context)"
+                       EnableHighlighting="@(!string.IsNullOrEmpty(HighlightText))"
+                       HighlightText="@HighlightText"
+                       EnableMasking="@context.IsValueSensitive"
+                       IsMasked="@context.IsValueMasked"
+                       IsMaskedChanged="(isMasked) => OnIsValueMaskedChanged(context, isMasked)"
+                       TextVisualizerTitle="@context.Name"
+                       ValueToVisualize="@(context.ValueToVisualize ?? context.Value)" />
+            @ExtraValueContent(context)
+        </AspireTemplateColumn>
+    </FluentDataGrid>
+</div>
 

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.cs
@@ -103,6 +103,9 @@ public partial class PropertyGrid<TItem> where TItem : IPropertyGridItem
     [Parameter]
     public string? ValueColumnTitle { get; set; }
 
+    [Parameter]
+    public bool Multiline { get; set; }
+
     /// <summary>
     /// Gets and sets the sorting behavior of the name column. Defaults to sorting on <see cref="IPropertyGridItem.Name"/>.
     /// </summary>

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.css
@@ -1,0 +1,3 @@
+::deep.property-grid td.multiline-text {
+    overflow-x: hidden !important;
+}

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -76,7 +76,8 @@
                               ValueColumnTitle="@(Loc[nameof(ControlsStrings.EventColumnHeader)])"
                               IsNameSortable="false"
                               IsValueSortable="false"
-                              HighlightText="@_filter">
+                              HighlightText="@_filter"
+                              Multiline="true">
                     <ExtraValueContent>
                         @if (context.Attributes.Length > 0)
                         {


### PR DESCRIPTION
## Description

FluentUI data grid is a fixed height by default. This change happened in a FluentUI update during 9.1. A fixed height causes event attributes to not be displayed. This is a 9.1 regression.

Fix is to make that grid "multiline" so it has a dynamic height. After:

![image](https://github.com/user-attachments/assets/764a856a-213f-4cb7-8c70-1ffc4435a79a)

Suggest reviewing with ignore whitespace on.

Fixes https://github.com/dotnet/aspire/issues/7952

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
