### PR TITLE
Fix trace order when buffer is full under certain situations

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -168,7 +168,7 @@ public class OtlpTrace
 
     private string DebuggerToString()
     {
-        return $@"TraceId = ""{TraceId}"", Spans = {Spans.Count}, StartDate = {FirstSpan.StartTime.ToLocalTime():yyyy:MM:dd}, StartTime = {FirstSpan.StartTime.ToLocalTime():h:mm:ss.fff tt}, Duration = {Duration}";
+        return $@"TraceId = ""{TraceId}"", Spans = {Spans.Count}, StartDate = {FirstSpan?.StartTime.ToLocalTime():yyyy:MM:dd}, StartTime = {FirstSpan?.StartTime.ToLocalTime():h:mm:ss.fff tt}, Duration = {Duration}";
     }
 
     private sealed class SpanStartDateComparer : IComparer<OtlpSpan>

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -989,6 +989,9 @@ public sealed class TelemetryRepository
                             _tracePropertyKeys.Add((applicationView.Application, kvp.Key));
                         }
 
+                        // Newly added or updated trace should always been in the collection.
+                        Debug.Assert(_traces.Contains(trace), "Trace not found in traces collection.");
+
                         lastTrace = trace;
                     }
                     catch (Exception ex)

--- a/src/Shared/CircularBuffer.cs
+++ b/src/Shared/CircularBuffer.cs
@@ -113,7 +113,6 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
             }
             else if (internalIndex < _end && _end < _buffer.Count - 1)
             {
-                //data.Slice(internalIndex, _end - internalIndex).CopyTo(data.Slice(_end));
                 data.Slice(internalIndex, _end - internalIndex).CopyTo(data.Slice(internalIndex + 1));
             }
             else

--- a/src/Shared/CircularBuffer.cs
+++ b/src/Shared/CircularBuffer.cs
@@ -86,10 +86,8 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
                 ItemRemovedForCapacity?.Invoke(item);
                 return;
             }
-            else
-            {
-                ItemRemovedForCapacity?.Invoke(this[0]);
-            }
+
+            var removedItem = this[0];
 
             var internalIndex = InternalIndex(index);
 
@@ -115,7 +113,8 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
             }
             else if (internalIndex < _end && _end < _buffer.Count - 1)
             {
-                data.Slice(internalIndex, _end - internalIndex).CopyTo(data.Slice(_end));
+                //data.Slice(internalIndex, _end - internalIndex).CopyTo(data.Slice(_end));
+                data.Slice(internalIndex, _end - internalIndex).CopyTo(data.Slice(internalIndex + 1));
             }
             else
             {
@@ -127,6 +126,9 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
 
             Increment(ref _end);
             _start = _end;
+
+            Debug.Assert(!_buffer.Contains(removedItem), "Item was not correctly removed.");
+            ItemRemovedForCapacity?.Invoke(removedItem);
         }
         else
         {
@@ -192,11 +194,14 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
     {
         if (IsFull)
         {
-            ItemRemovedForCapacity?.Invoke(this[0]);
+            var removedItem = this[0];
 
             _buffer[_end] = item;
             Increment(ref _end);
             _start = _end;
+
+            Debug.Assert(!_buffer.Contains(removedItem), "Item was not correctly removed.");
+            ItemRemovedForCapacity?.Invoke(removedItem);
         }
         else
         {
@@ -282,11 +287,21 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
         --index;
     }
 
+    public CircularBuffer<T> Clone()
+    {
+        var buffer = new CircularBuffer<T>(_buffer.ToList(), Capacity, _start, _end);
+        buffer.ItemRemovedForCapacity = ItemRemovedForCapacity;
+
+        return buffer;
+    }
+
     private sealed class CircularBufferDebugView(CircularBuffer<T> collection)
     {
         private readonly CircularBuffer<T> _collection = collection;
 
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public T[] Items => _collection.ToArray();
+        public int Start => _collection._start;
+        public int End => _collection._end;
+        public int Capacity => _collection.Capacity;
     }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/7854

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
