### PR TITLE
Fixed issues with the azure container apps environment logic

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzdAzureContainerAppEnvironment.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzdAzureContainerAppEnvironment.cs
@@ -46,7 +46,6 @@ internal sealed class AzdAzureContainerAppEnvironment : IAzureContainerAppEnviro
     {
         public string ValueExpression => $"{{.outputs.{outputName}}}";
 
-        public static IManifestExpressionProvider MANAGED_IDENTITY_CLIENT_ID => GetExpression("MANAGED_IDENTITY_CLIENT_ID");
         public static IManifestExpressionProvider MANAGED_IDENTITY_NAME => GetExpression("MANAGED_IDENTITY_NAME");
         public static IManifestExpressionProvider MANAGED_IDENTITY_PRINCIPAL_ID => GetExpression("MANAGED_IDENTITY_PRINCIPAL_ID");
         public static IManifestExpressionProvider AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID => GetExpression("AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID");

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -141,6 +141,9 @@ public static class AzureContainerAppExtensions
                 RoleManagementPrincipalType.ServicePrincipal,
                 userPrincipalId);
 
+            // We need to set the principal type to null to let ARM infer the principal id
+            roleAssignment.PrincipalType.ClearValue();
+
             infra.Add(roleAssignment);
 
             var managedStorages = new Dictionary<string, ContainerAppManagedEnvironmentStorage>();

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -90,6 +90,12 @@ internal sealed class AzureContainerAppsInfrastructure(
             }
         }
 
+        if (environment is AzdAzureContainerAppEnvironment)
+        {
+            // We avoid setting known values if azd is used, it will be resolved by azd at publish time.
+            return;
+        }
+
         // Resolve the known parameters for the container app environment
         foreach (var r in appModel.Resources.OfType<AzureBicepResource>())
         {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -2780,6 +2780,39 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task KnownParametersAreNotSetWhenUsingAzdResources()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureContainerAppsInfrastructure();
+
+        var pg = builder.AddAzurePostgresFlexibleServer("pg")
+                        .WithPasswordAuthentication()
+                        .AddDatabase("db");
+
+        builder.AddContainer("cache", "redis")
+               .WithVolume("data", "/data")
+               .WithReference(pg);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        foreach (var resource in model.Resources.OfType<AzureBicepResource>())
+        {
+            foreach (var param in resource.Parameters)
+            {
+                if (AzureBicepResource.KnownParameters.IsKnownParameterName(param.Key))
+                {
+                    Assert.Equal(string.Empty, param.Value);
+                }
+            }
+        }
+    }
+
+    [Fact]
     public async Task AddContainerAppEnvironmentAddsEnvironmentResource()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
@@ -2898,7 +2931,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           properties: {
             principalId: userPrincipalId
             roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-            principalType: 'ServicePrincipal'
           }
           scope: cae
         }


### PR DESCRIPTION
## Description

- Don't set known variables when using the azd environment
- Remove unused client id from AzureContainerAppsEnvironment
- Clear the PrincipalType from the role assignment for the container app environment

Fixes #8155

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
