### PR TITLE
Add buttons to resource graph to zoom and reset position

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -197,6 +197,26 @@
                                 <div class="resource-graph-container" hidden="@(PageViewModel.SelectedViewKind != ResourceViewKind.Graph)">
                                     <svg class="resource-graph">
                                     </svg>
+                                    <div class="resource-graph-controls">
+                                        <FluentButton Appearance="Appearance.Stealth"
+                                                      Class="graph-zoom-in"
+                                                      Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphZoomInButton)]"
+                                                      aria-label="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphZoomInButton)]">
+                                            <FluentIcon Value="new Icons.Regular.Size24.ZoomIn()" Color="Color.Accent" />
+                                        </FluentButton>
+                                        <FluentButton Appearance="Appearance.Stealth"
+                                                      Class="graph-zoom-out"
+                                                      Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphZoomOutButton)]"
+                                                      aria-label="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphZoomOutButton)]">
+                                            <FluentIcon Value="new Icons.Regular.Size24.ZoomOut()" Color="Color.Accent" />
+                                        </FluentButton>
+                                        <FluentButton Appearance="Appearance.Stealth"
+                                                      Class="graph-reset"
+                                                      Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphResetButton)]"
+                                                      aria-label="@Loc[nameof(Dashboard.Resources.Resources.ResourcesGraphResetButton)]">
+                                            <FluentIcon Value="new Icons.Regular.Size24.ArrowReset()" Color="Color.Accent" />
+                                        </FluentButton>
+                                    </div>
                                 </div>
                             }
                         </div>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -79,6 +79,15 @@
 
 ::deep .resource-graph-container {
     grid-area: resources-tab-content;
+    position: relative; /* So graph buttons are position inside the container */
+}
+
+::deep .resource-graph-controls {
+    position: absolute;
+    right: 30px;
+    bottom: 30px;
+    display: flex;
+    column-gap: 10px;
 }
 
 ::deep .resource-graph .texts {

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -104,22 +104,13 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceActionTracesText", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Collapse child resources.
         /// </summary>
         public static string ResourceCollapseAllChildren {
             get {
                 return ResourceManager.GetString("ResourceCollapseAllChildren", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to View options.
-        /// </summary>
-        public static string ResourcesChangeViewOptions {
-            get {
-                return ResourceManager.GetString("ResourcesChangeViewOptions", resourceCulture);
             }
         }
         
@@ -210,6 +201,15 @@ namespace Aspire.Dashboard.Resources {
         public static string ResourcesActionsColumnHeader {
             get {
                 return ResourceManager.GetString("ResourcesActionsColumnHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View options.
+        /// </summary>
+        public static string ResourcesChangeViewOptions {
+            get {
+                return ResourceManager.GetString("ResourcesChangeViewOptions", resourceCulture);
             }
         }
         
@@ -399,6 +399,33 @@ namespace Aspire.Dashboard.Resources {
         public static string ResourcesFiltered {
             get {
                 return ResourceManager.GetString("ResourcesFiltered", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reset.
+        /// </summary>
+        public static string ResourcesGraphResetButton {
+            get {
+                return ResourceManager.GetString("ResourcesGraphResetButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zoom in.
+        /// </summary>
+        public static string ResourcesGraphZoomInButton {
+            get {
+                return ResourceManager.GetString("ResourcesGraphZoomInButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zoom out.
+        /// </summary>
+        public static string ResourcesGraphZoomOutButton {
+            get {
+                return ResourceManager.GetString("ResourcesGraphZoomOutButton", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,79 +26,79 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -123,27 +123,21 @@
   </data>
   <data name="ResourcesHeader" xml:space="preserve">
     <value>Resources</value>
-    <comment/>
   </data>
   <data name="ResourcesNotFiltered" xml:space="preserve">
     <value>No filters</value>
-    <comment/>
   </data>
   <data name="ResourcesFiltered" xml:space="preserve">
     <value>Has filters</value>
-    <comment/>
   </data>
   <data name="ResourcesResourceTypesHeader" xml:space="preserve">
     <value>Resource types</value>
-    <comment/>
   </data>
   <data name="ResourcesResourceStatesHeader" xml:space="preserve">
     <value>State</value>
-    <comment/>
   </data>
   <data name="ResourceFilterOptionEmpty" xml:space="preserve">
     <value>(Unset)</value>
-    <comment/>
   </data>
   <data name="ResourcesEnvironmentVariablesHeader" xml:space="preserve">
     <value>Environment variables for {0}</value>
@@ -151,103 +145,78 @@
   </data>
   <data name="ResourcesStateColumnHeader" xml:space="preserve">
     <value>State</value>
-    <comment/>
   </data>
   <data name="ResourcesTypeColumnHeader" xml:space="preserve">
     <value>Type</value>
-    <comment/>
   </data>
   <data name="ResourcesStartTimeColumnHeader" xml:space="preserve">
     <value>Start time</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsExitCodeProperty" xml:space="preserve">
     <value>Exit code</value>
-    <comment/>
   </data>
   <data name="ResourcesSourceColumnHeader" xml:space="preserve">
     <value>Source</value>
-    <comment/>
   </data>
   <data name="ResourcesEndpointsColumnHeader" xml:space="preserve">
     <value>Endpoints</value>
-    <comment/>
   </data>
   <data name="ResourcesEnvironmentColumnHeader" xml:space="preserve">
     <value>Environment</value>
-    <comment/>
   </data>
   <data name="ResourcesNoEnvironmentVariables" xml:space="preserve">
     <value>No environment variables</value>
-    <comment/>
   </data>
   <data name="ResourcesNoResources" xml:space="preserve">
     <value>No resources found</value>
-    <comment/>
   </data>
   <data name="ResourceDetailsEndpointUrl" xml:space="preserve">
     <value>Endpoint URL</value>
-    <comment/>
   </data>
   <data name="ResourceDetailsProxyUrl" xml:space="preserve">
     <value>Proxy URL</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsContainerArgumentsProperty" xml:space="preserve">
     <value>Container arguments</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsContainerCommandProperty" xml:space="preserve">
     <value>Container command</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsContainerIdProperty" xml:space="preserve">
     <value>Container ID</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsContainerImageProperty" xml:space="preserve">
     <value>Container image</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsContainerPortsProperty" xml:space="preserve">
     <value>Container ports</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsContainerLifetimeProperty" xml:space="preserve">
     <value>Container lifetime</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsDisplayNameProperty" xml:space="preserve">
     <value>Display name</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsExecutableArgumentsProperty" xml:space="preserve">
     <value>Executable arguments</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsExecutablePathProperty" xml:space="preserve">
     <value>Executable path</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsExecutableProcessIdProperty" xml:space="preserve">
     <value>Process ID</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsExecutableWorkingDirectoryProperty" xml:space="preserve">
     <value>Working directory</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsProjectPathProperty" xml:space="preserve">
     <value>Project path</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsStartTimeProperty" xml:space="preserve">
     <value>Start time</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsStateProperty" xml:space="preserve">
     <value>State</value>
-    <comment/>
   </data>
   <data name="ResourceCommandFailed" xml:space="preserve">
     <value>{0} "{1}" failed</value>
@@ -259,27 +228,21 @@
   </data>
   <data name="ResourceCommandToastViewLogs" xml:space="preserve">
     <value>View console logs</value>
-    <comment/>
   </data>
   <data name="ResourcesActionsColumnHeader" xml:space="preserve">
     <value>Actions</value>
-    <comment/>
   </data>
   <data name="ResourceActionConsoleLogsText" xml:space="preserve">
     <value>Console logs</value>
-    <comment/>
   </data>
   <data name="ResourceDetailsViewConsoleLogs" xml:space="preserve">
     <value>View console logs</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsHealthStateProperty" xml:space="preserve">
     <value>Health state</value>
-    <comment/>
   </data>
   <data name="ResourcesDetailsStopTimeProperty" xml:space="preserve">
     <value>Stop time</value>
-    <comment/>
   </data>
   <data name="ResourceCommandStarting" xml:space="preserve">
     <value>{0} "{1}" starting</value>
@@ -287,15 +250,12 @@
   </data>
   <data name="ResourceActionTracesText" xml:space="preserve">
     <value>Traces</value>
-    <comment/>
   </data>
   <data name="ResourceActionStructuredLogsText" xml:space="preserve">
     <value>Structured logs</value>
-    <comment/>
   </data>
   <data name="ResourceActionMetricsText" xml:space="preserve">
     <value>Metrics</value>
-    <comment/>
   </data>
   <data name="WaitingForHealthDataMessage" xml:space="preserve">
     <value>Waiting for health data...</value>
@@ -307,18 +267,24 @@
   </data>
   <data name="ResourceActionTelemetryTooltip" xml:space="preserve">
     <value>No telemetry found for this resource.</value>
-    <comment/>
   </data>
   <data name="ResourceCollapseAllChildren" xml:space="preserve">
     <value>Collapse child resources</value>
-    <comment/>
   </data>
   <data name="ResourceExpandAllChildren" xml:space="preserve">
     <value>Expand child resources</value>
-    <comment/>
   </data>
   <data name="ResourcesChangeViewOptions" xml:space="preserve">
     <value>View options</value>
     <comment>An icon allowing the user to expand or collapse all child resources.</comment>
+  </data>
+  <data name="ResourcesGraphZoomOutButton" xml:space="preserve">
+    <value>Zoom out</value>
+  </data>
+  <data name="ResourcesGraphZoomInButton" xml:space="preserve">
+    <value>Zoom in</value>
+  </data>
+  <data name="ResourcesGraphResetButton" xml:space="preserve">
+    <value>Reset</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -187,6 +187,21 @@
         <target state="translated">Obsahuje filtry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">Žádné filtry</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -187,6 +187,21 @@
         <target state="translated">Hat Filter</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">Keine Filter</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -187,6 +187,21 @@
         <target state="translated">Tiene filtros</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">No hay ningún filtro</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -187,6 +187,21 @@
         <target state="translated">A des filtres</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">Aucun filtre</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -187,6 +187,21 @@
         <target state="translated">Con filtri</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">Nessun filtro</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -187,6 +187,21 @@
         <target state="translated">フィルターあり</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">フィルターなし</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -187,6 +187,21 @@
         <target state="translated">필터 있음</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">필터 없음</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -187,6 +187,21 @@
         <target state="translated">Ma filtry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">Brak filtrów</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -187,6 +187,21 @@
         <target state="translated">Tem filtros</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">Sem filtros</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -187,6 +187,21 @@
         <target state="translated">Содержит фильтры</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">Нет фильтров</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -187,6 +187,21 @@
         <target state="translated">Filtreleri var</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">Filtre mevcut değil</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -187,6 +187,21 @@
         <target state="translated">具有筛选器</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">无筛选器</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -187,6 +187,21 @@
         <target state="translated">有篩選</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesGraphResetButton">
+        <source>Reset</source>
+        <target state="new">Reset</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomInButton">
+        <source>Zoom in</source>
+        <target state="new">Zoom in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGraphZoomOutButton">
+        <source>Zoom out</source>
+        <target state="new">Zoom out</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesNotFiltered">
         <source>No filters</source>
         <target state="translated">沒有篩選</target>

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -40,10 +40,10 @@ class ResourceGraph {
 
         // Enable zoom + pan
         // https://www.d3indepth.com/zoom-and-pan/
-        let zoom = d3.zoom().on('zoom', (event) => {
+        this.zoom = d3.zoom().scaleExtent([0.2, 4]).on('zoom', (event) => {
             this.baseGroup.attr('transform', event.transform);
         });
-        this.svg.call(zoom);
+        this.svg.call(this.zoom);
 
         // simulation setup with all forces
         this.linkForce = d3
@@ -116,6 +116,26 @@ class ResourceGraph {
 
         this.linkElementsG = this.baseGroup.append("g").attr("class", "links");
         this.nodeElementsG = this.baseGroup.append("g").attr("class", "nodes");
+
+        this.initializeButtons();
+    }
+
+    initializeButtons() {
+        d3.select('.graph-zoom-in').on("click", () => this.zoomIn());
+        d3.select('.graph-zoom-out').on("click", () => this.zoomOut());
+        d3.select('.graph-reset').on("click", () => this.resetZoomAndPan());
+    }
+
+    resetZoomAndPan() {
+        this.svg.call(this.zoom.transform, d3.zoomIdentity);
+    }
+
+    zoomIn() {
+        this.svg.transition().call(this.zoom.scaleBy, 1.5);
+    }
+
+    zoomOut() {
+        this.svg.transition().call(this.zoom.scaleBy, 2 / 3);
     }
 
     createArrowMarker(parent, id, className, width, height, x) {

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -40,6 +40,7 @@ class ResourceGraph {
 
         // Enable zoom + pan
         // https://www.d3indepth.com/zoom-and-pan/
+        // scaleExtent limits zoom to reasonable values
         this.zoom = d3.zoom().scaleExtent([0.2, 4]).on('zoom', (event) => {
             this.baseGroup.attr('transform', event.transform);
         });


### PR DESCRIPTION
## Description

PR adds:

* Buttons to the resource graph to control zoom and reset graph position.
* Limits to zooming in and out to reasonable values.

![image](https://github.com/user-attachments/assets/d3ed74aa-a359-4328-8016-8d147409c74a)

Fixes https://github.com/dotnet/aspire/issues/8135

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
