### PR TITLE
Make --wait-for-debugger workin release builds of aspire CLI.

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -47,10 +47,11 @@ public class Program
         debugOption.Recursive = true;
         rootCommand.Options.Add(debugOption);
         
-        #if DEBUG
         var waitForDebuggerOption = new Option<bool>("--wait-for-debugger", "-w");
         waitForDebuggerOption.Recursive = true;
         waitForDebuggerOption.DefaultValueFactory = (result) => false;
+
+        #if DEBUG
         waitForDebuggerOption.Validators.Add((result) => {
 
             var waitForDebugger = result.GetValueOrDefault<bool>();
@@ -68,8 +69,9 @@ public class Program
                 );
             }
         });
-        rootCommand.Options.Add(waitForDebuggerOption);
         #endif
+
+        rootCommand.Options.Add(waitForDebuggerOption);
 
         ConfigureRunCommand(rootCommand);
         ConfigureBuildCommand(rootCommand);
@@ -137,13 +139,7 @@ public class Program
 
             var debug = parseResult.GetValue<bool>("--debug");
 
-            #if DEBUG
             var waitForDebugger = parseResult.GetValue<bool>("--wait-for-debugger");
-            #endif
-            
-            #if !DEBUG
-            var waitForDebugger = false;
-            #endif
             
             var useRichConsole = !debug && !waitForDebugger;
 
@@ -311,12 +307,10 @@ public class Program
             
             var env = new Dictionary<string, string>();
 
-            #if DEBUG
             if (parseResult.GetValue<bool?>("--wait-for-debugger") ?? false)
             {
                 env["ASPIRE_WAIT_FOR_DEBUGGER"] = "true";
             }
-            #endif
 
             var target = parseResult.GetValue<string>("--target");
             var outputPath = parseResult.GetValue<string>("--output-path");

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -136,7 +136,15 @@ public class Program
             var env = new Dictionary<string, string>();
 
             var debug = parseResult.GetValue<bool>("--debug");
+
+            #if DEBUG
             var waitForDebugger = parseResult.GetValue<bool>("--wait-for-debugger");
+            #endif
+            
+            #if !DEBUG
+            var waitForDebugger = false;
+            #endif
+            
             var useRichConsole = !debug && !waitForDebugger;
 
             if (waitForDebugger)
@@ -303,10 +311,12 @@ public class Program
             
             var env = new Dictionary<string, string>();
 
+            #if DEBUG
             if (parseResult.GetValue<bool?>("--wait-for-debugger") ?? false)
             {
                 env["ASPIRE_WAIT_FOR_DEBUGGER"] = "true";
             }
+            #endif
 
             var target = parseResult.GetValue<string>("--target");
             var outputPath = parseResult.GetValue<string>("--output-path");


### PR DESCRIPTION
Fixes a failure in release builds of the Aspire CLI where they were failing because they were checking for the --wait-for-debugger option but it wasn't present. Put the option back across both release and debug builds, but in release builds it won't wait for you to attach the debugger to the CLI itself.