### PR TITLE
Introduce AzureKeyVaultSecretReference

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/account-kv.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/account-kv.module.bicep
@@ -1,0 +1,24 @@
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource account_kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: take('accountkv-${uniqueString(resourceGroup().id)}', 24)
+  location: location
+  properties: {
+    tenantId: tenant().tenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    enableRbacAuthorization: true
+  }
+  tags: {
+    'aspire-resource-name': 'account-kv'
+  }
+}
+
+output vaultUri string = account_kv.properties.vaultUri
+
+output name string = account_kv.name
+
+output id string = account_kv.id

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/account.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/account.module.bicep
@@ -41,7 +41,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  name: 'connectionString'
+  name: 'connectionstrings--account'
   properties: {
     value: 'AccountEndpoint=${account.properties.documentEndpoint};AccountKey=${account.listKeys().primaryMasterKey}'
   }

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/api-roles-account-kv.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/api-roles-account-kv.module.bicep
@@ -1,0 +1,20 @@
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param account_kv_outputs_name string
+
+param principalId string
+
+resource account_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: account_kv_outputs_name
+}
+
+resource account_kv_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(account_kv.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+    principalType: 'ServicePrincipal'
+  }
+  scope: account_kv
+}

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
@@ -12,9 +12,7 @@ param storage_outputs_blobendpoint string
 @secure()
 param cache_password_value string
 
-param infra_outputs_secret_output_account string
-
-param infra_outputs_azure_container_registry_managed_identity_id string
+param account_kv_outputs_name string
 
 @secure()
 param secretparam_value string
@@ -23,19 +21,21 @@ param infra_outputs_azure_container_apps_environment_id string
 
 param infra_outputs_azure_container_registry_endpoint string
 
+param infra_outputs_azure_container_registry_managed_identity_id string
+
 param api_containerimage string
 
 param certificateName string
 
 param customDomain string
 
-resource infra_outputs_secret_output_account_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: infra_outputs_secret_output_account
+resource account_kv_outputs_name_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: account_kv_outputs_name
 }
 
-resource infra_outputs_secret_output_account_kv_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
-  name: 'connectionString'
-  parent: infra_outputs_secret_output_account_kv
+resource account_kv_outputs_name_kv_connectionstrings__account 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
+  name: 'connectionstrings--account'
+  parent: account_kv_outputs_name_kv
 }
 
 resource api 'Microsoft.App/containerApps@2024-03-01' = {
@@ -50,8 +50,8 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
         }
         {
           name: 'connectionstrings--account'
-          identity: infra_outputs_azure_container_registry_managed_identity_id
-          keyVaultUrl: infra_outputs_secret_output_account_kv_connectionString.properties.secretUri
+          identity: api_identity_outputs_id
+          keyVaultUrl: account_kv_outputs_name_kv_connectionstrings__account.properties.secretUri
         }
         {
           name: 'value'

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
@@ -46,7 +46,6 @@
         "params": {
           "infra_outputs_volumes_cache_0": "{infra.outputs.volumes_cache_0}",
           "cache_password_value": "{cache-password.value}",
-          "infra_outputs_azure_container_registry_managed_identity_id": "{infra.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
           "infra_outputs_azure_container_apps_environment_id": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
         }
       },
@@ -76,15 +75,20 @@
     },
     "account": {
       "type": "azure.bicep.v0",
-      "connectionString": "{account.secretOutputs.connectionString}",
+      "connectionString": "{account-kv.secrets.connectionstrings--account}",
       "path": "account.module.bicep",
       "params": {
-        "keyVaultName": "{infra.outputs.secret_output_account}"
+        "keyVaultName": "{account-kv.outputs.name}"
       }
+    },
+    "account-kv": {
+      "type": "azure.bicep.v0",
+      "connectionString": "{account-kv.outputs.vaultUri}",
+      "path": "account-kv.module.bicep"
     },
     "db": {
       "type": "value.v0",
-      "connectionString": "{account.secretOutputs.connectionString}"
+      "connectionString": "{account-kv.secrets.connectionstrings--account};Database=db"
     },
     "storage": {
       "type": "azure.bicep.v0",
@@ -104,9 +108,9 @@
         "type": "azure.bicep.v0",
         "path": "pythonapp.module.bicep",
         "params": {
-          "infra_outputs_azure_container_registry_managed_identity_id": "{infra.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
           "infra_outputs_azure_container_apps_environment_id": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
           "infra_outputs_azure_container_registry_endpoint": "{infra.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+          "infra_outputs_azure_container_registry_managed_identity_id": "{infra.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
           "pythonapp_containerimage": "{pythonapp.containerImage}"
         }
       }
@@ -123,11 +127,11 @@
           "api_containerport": "{api.containerPort}",
           "storage_outputs_blobendpoint": "{storage.outputs.blobEndpoint}",
           "cache_password_value": "{cache-password.value}",
-          "infra_outputs_secret_output_account": "{infra.outputs.secret_output_account}",
-          "infra_outputs_azure_container_registry_managed_identity_id": "{infra.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+          "account_kv_outputs_name": "{account-kv.outputs.name}",
           "secretparam_value": "{secretparam.value}",
           "infra_outputs_azure_container_apps_environment_id": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
           "infra_outputs_azure_container_registry_endpoint": "{infra.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+          "infra_outputs_azure_container_registry_managed_identity_id": "{infra.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
           "api_containerimage": "{api.containerImage}",
           "certificateName": "{certificateName.value}",
           "customDomain": "{customDomain.value}"
@@ -168,6 +172,14 @@
       "path": "api-roles-storage.module.bicep",
       "params": {
         "storage_outputs_name": "{storage.outputs.name}",
+        "principalId": "{api-identity.outputs.principalId}"
+      }
+    },
+    "api-roles-account-kv": {
+      "type": "azure.bicep.v0",
+      "path": "api-roles-account-kv.module.bicep",
+      "params": {
+        "account_kv_outputs_name": "{account-kv.outputs.name}",
         "principalId": "{api-identity.outputs.principalId}"
       }
     },

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/cache.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/cache.module.bicep
@@ -6,8 +6,6 @@ param infra_outputs_volumes_cache_0 string
 @secure()
 param cache_password_value string
 
-param infra_outputs_azure_container_registry_managed_identity_id string
-
 param infra_outputs_azure_container_apps_environment_id string
 
 resource cache 'Microsoft.App/containerApps@2024-03-01' = {
@@ -65,12 +63,6 @@ resource cache 'Microsoft.App/containerApps@2024-03-01' = {
           storageName: infra_outputs_volumes_cache_0
         }
       ]
-    }
-  }
-  identity: {
-    type: 'UserAssigned'
-    userAssignedIdentities: {
-      '${infra_outputs_azure_container_registry_managed_identity_id}': { }
     }
   }
 }

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/infra.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/infra.module.bicep
@@ -119,33 +119,7 @@ resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/stora
   parent: cae
 }
 
-resource kv_secret_output_account 'Microsoft.KeyVault/vaults@2023-07-01' = {
-  name: take('kvsecretoutputaccount-${uniqueString(resourceGroup().id)}', 24)
-  location: location
-  properties: {
-    tenantId: tenant().tenantId
-    sku: {
-      family: 'A'
-      name: 'standard'
-    }
-    enableRbacAuthorization: true
-  }
-  tags: tags
-}
-
-resource kv_secret_output_account_mi_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(kv_secret_output_account.id, mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
-  properties: {
-    principalId: mi.properties.principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
-    principalType: 'ServicePrincipal'
-  }
-  scope: kv_secret_output_account
-}
-
 output volumes_cache_0 string = managedStorage_volumes_cache_0.name
-
-output secret_output_account string = kv_secret_output_account.name
 
 output MANAGED_IDENTITY_NAME string = mi.name
 

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/pythonapp.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/pythonapp.module.bicep
@@ -36,6 +36,7 @@ resource pythonapp 'Microsoft.App/containerApps@2024-03-01' = {
     }
   }
   identity: {
+    type: 'UserAssigned'
     userAssignedIdentities: {
       '${infra_outputs_azure_container_registry_managed_identity_id}': { }
     }

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/pythonapp.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/pythonapp.module.bicep
@@ -1,11 +1,11 @@
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param infra_outputs_azure_container_registry_managed_identity_id string
-
 param infra_outputs_azure_container_apps_environment_id string
 
 param infra_outputs_azure_container_registry_endpoint string
+
+param infra_outputs_azure_container_registry_managed_identity_id string
 
 param pythonapp_containerimage string
 
@@ -36,7 +36,6 @@ resource pythonapp 'Microsoft.App/containerApps@2024-03-01' = {
     }
   }
   identity: {
-    type: 'UserAssigned'
     userAssignedIdentities: {
       '${infra_outputs_azure_container_registry_managed_identity_id}': { }
     }

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj
@@ -17,7 +17,6 @@
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.CosmosDB" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
-    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.AppContainers" />
 
     <ProjectReference Include="..\CosmosEndToEnd.ApiService\CosmosEndToEnd.ApiService.csproj" />
   </ItemGroup>

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj
@@ -17,6 +17,7 @@
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.CosmosDB" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.AppContainers" />
 
     <ProjectReference Include="..\CosmosEndToEnd.ApiService\CosmosEndToEnd.ApiService.csproj" />
   </ItemGroup>

--- a/playground/DatabaseMigration/DatabaseMigration.AppHost/aspire-manifest.json
+++ b/playground/DatabaseMigration/DatabaseMigration.AppHost/aspire-manifest.json
@@ -20,7 +20,7 @@
     },
     "db1": {
       "type": "value.v0",
-      "connectionString": "{sql1.connectionString};Database=db1"
+      "connectionString": "{sql1.connectionString};Initial Catalog=db1"
     },
     "api": {
       "type": "project.v0",

--- a/playground/Elasticsearch/Elasticsearch.AppHost/aspire-manifest.json
+++ b/playground/Elasticsearch/Elasticsearch.AppHost/aspire-manifest.json
@@ -4,7 +4,7 @@
     "elasticsearch": {
       "type": "container.v0",
       "connectionString": "http://elastic:{elasticsearch-password.value}@{elasticsearch.bindings.http.host}:{elasticsearch.bindings.http.port}",
-      "image": "docker.io/library/elasticsearch:8.17.0",
+      "image": "docker.io/library/elasticsearch:8.17.3",
       "volumes": [
         {
           "name": "elasticsearch.apphost-7490553fdf-elasticsearch-data",

--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/aspire-manifest.json
@@ -14,7 +14,7 @@
     },
     "db": {
       "type": "value.v0",
-      "connectionString": "{sql.connectionString};Database=db"
+      "connectionString": "{sql.connectionString};Initial Catalog=db"
     },
     "insertionrows": {
       "type": "parameter.v0",
@@ -24,6 +24,10 @@
           "type": "string"
         }
       }
+    },
+    "cs": {
+      "type": "value.v0",
+      "connectionString": "sql={db.connectionString};rows={insertionrows.value}"
     },
     "api": {
       "type": "project.v0",
@@ -35,6 +39,7 @@
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
         "HTTP_PORTS": "{api.bindings.http.targetPort}",
         "InsertionRows": "{insertionrows.value}",
+        "ConnectionStrings__cs": "{cs.connectionString}",
         "ConnectionStrings__db": "{db.connectionString}"
       },
       "bindings": {

--- a/playground/Qdrant/Qdrant.AppHost/aspire-manifest.json
+++ b/playground/Qdrant/Qdrant.AppHost/aspire-manifest.json
@@ -4,7 +4,7 @@
     "qdrant": {
       "type": "container.v0",
       "connectionString": "Endpoint={qdrant.bindings.grpc.url};Key={qdrant-Key.value}",
-      "image": "docker.io/qdrant/qdrant:v1.12.1",
+      "image": "docker.io/qdrant/qdrant:v1.13.4",
       "volumes": [
         {
           "name": "qdrant-data",

--- a/playground/Stress/Stress.AppHost/aspire-manifest.json
+++ b/playground/Stress/Stress.AppHost/aspire-manifest.json
@@ -9,7 +9,8 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
-        "HTTP_PORTS": "{stress-apiservice.bindings.http.targetPort};{stress-apiservice.bindings.http-5181.targetPort};{stress-apiservice.bindings.http-5182.targetPort};{stress-apiservice.bindings.http-5183.targetPort};{stress-apiservice.bindings.http-5184.targetPort};{stress-apiservice.bindings.http-5185.targetPort};{stress-apiservice.bindings.http-5186.targetPort};{stress-apiservice.bindings.http-5187.targetPort};{stress-apiservice.bindings.http-5188.targetPort};{stress-apiservice.bindings.http-5189.targetPort};{stress-apiservice.bindings.http-5190.targetPort};{stress-apiservice.bindings.http-5191.targetPort};{stress-apiservice.bindings.http-5192.targetPort};{stress-apiservice.bindings.http-5193.targetPort};{stress-apiservice.bindings.http-5194.targetPort};{stress-apiservice.bindings.http-5195.targetPort};{stress-apiservice.bindings.http-5196.targetPort};{stress-apiservice.bindings.http-5197.targetPort};{stress-apiservice.bindings.http-5198.targetPort};{stress-apiservice.bindings.http-5199.targetPort};{stress-apiservice.bindings.http-5200.targetPort};{stress-apiservice.bindings.http-5201.targetPort};{stress-apiservice.bindings.http-5202.targetPort};{stress-apiservice.bindings.http-5203.targetPort};{stress-apiservice.bindings.http-5204.targetPort};{stress-apiservice.bindings.http-5205.targetPort};{stress-apiservice.bindings.http-5206.targetPort};{stress-apiservice.bindings.http-5207.targetPort};{stress-apiservice.bindings.http-5208.targetPort};{stress-apiservice.bindings.http-5209.targetPort};{stress-apiservice.bindings.http-5210.targetPort}"
+        "HTTP_PORTS": "{stress-apiservice.bindings.http.targetPort};{stress-apiservice.bindings.http-5181.targetPort};{stress-apiservice.bindings.http-5182.targetPort};{stress-apiservice.bindings.http-5183.targetPort};{stress-apiservice.bindings.http-5184.targetPort};{stress-apiservice.bindings.http-5185.targetPort};{stress-apiservice.bindings.http-5186.targetPort};{stress-apiservice.bindings.http-5187.targetPort};{stress-apiservice.bindings.http-5188.targetPort};{stress-apiservice.bindings.http-5189.targetPort};{stress-apiservice.bindings.http-5190.targetPort};{stress-apiservice.bindings.http-5191.targetPort};{stress-apiservice.bindings.http-5192.targetPort};{stress-apiservice.bindings.http-5193.targetPort};{stress-apiservice.bindings.http-5194.targetPort};{stress-apiservice.bindings.http-5195.targetPort};{stress-apiservice.bindings.http-5196.targetPort};{stress-apiservice.bindings.http-5197.targetPort};{stress-apiservice.bindings.http-5198.targetPort};{stress-apiservice.bindings.http-5199.targetPort};{stress-apiservice.bindings.http-5200.targetPort};{stress-apiservice.bindings.http-5201.targetPort};{stress-apiservice.bindings.http-5202.targetPort};{stress-apiservice.bindings.http-5203.targetPort};{stress-apiservice.bindings.http-5204.targetPort};{stress-apiservice.bindings.http-5205.targetPort};{stress-apiservice.bindings.http-5206.targetPort};{stress-apiservice.bindings.http-5207.targetPort};{stress-apiservice.bindings.http-5208.targetPort};{stress-apiservice.bindings.http-5209.targetPort};{stress-apiservice.bindings.http-5210.targetPort}",
+        "OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE": "true"
       },
       "bindings": {
         "http": {
@@ -258,69 +259,6 @@
       }
     },
     "empty-0002": {
-      "type": "project.v0",
-      "path": "../Stress.Empty/Stress.Empty.csproj",
-      "env": {
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
-      }
-    },
-    "empty-0003": {
-      "type": "project.v0",
-      "path": "../Stress.Empty/Stress.Empty.csproj",
-      "env": {
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
-      }
-    },
-    "empty-0004": {
-      "type": "project.v0",
-      "path": "../Stress.Empty/Stress.Empty.csproj",
-      "env": {
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
-      }
-    },
-    "empty-0005": {
-      "type": "project.v0",
-      "path": "../Stress.Empty/Stress.Empty.csproj",
-      "env": {
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
-      }
-    },
-    "empty-0006": {
-      "type": "project.v0",
-      "path": "../Stress.Empty/Stress.Empty.csproj",
-      "env": {
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
-      }
-    },
-    "empty-0007": {
-      "type": "project.v0",
-      "path": "../Stress.Empty/Stress.Empty.csproj",
-      "env": {
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
-      }
-    },
-    "empty-0008": {
-      "type": "project.v0",
-      "path": "../Stress.Empty/Stress.Empty.csproj",
-      "env": {
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
-      }
-    },
-    "empty-0009": {
       "type": "project.v0",
       "path": "../Stress.Empty/Stress.Empty.csproj",
       "env": {

--- a/playground/TestShop/TestShop.AppHost/aspire-manifest.json
+++ b/playground/TestShop/TestShop.AppHost/aspire-manifest.json
@@ -68,7 +68,8 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
         "HTTP_PORTS": "{catalogdbapp.bindings.http.targetPort}",
-        "ConnectionStrings__catalogdb": "{catalogdb.connectionString}"
+        "ConnectionStrings__catalogdb": "{catalogdb.connectionString}",
+        "DatabaseResetKey": "6b85bcc5-617c-488b-b62f-f6134cf8a7d6"
       },
       "bindings": {
         "http": {

--- a/playground/bicep/BicepSample.AppHost/aspire-manifest.json
+++ b/playground/bicep/BicepSample.AppHost/aspire-manifest.json
@@ -99,17 +99,26 @@
     },
     "postgres2": {
       "type": "azure.bicep.v0",
-      "connectionString": "{postgres2.secretOutputs.connectionString}",
+      "connectionString": "{postgres2-kv.secrets.connectionstrings--postgres2}",
       "path": "postgres2.module.bicep",
       "params": {
         "administratorLogin": "{administratorLogin.value}",
         "administratorLoginPassword": "{administratorLoginPassword.value}",
-        "keyVaultName": ""
+        "keyVaultName": "{postgres2-kv.outputs.name}"
+      }
+    },
+    "postgres2-kv": {
+      "type": "azure.bicep.v0",
+      "connectionString": "{postgres2-kv.outputs.vaultUri}",
+      "path": "postgres2-kv.module.bicep",
+      "params": {
+        "principalType": "",
+        "principalId": ""
       }
     },
     "db2": {
       "type": "value.v0",
-      "connectionString": "{postgres2.secretOutputs.db2-connectionString}"
+      "connectionString": "{postgres2-kv.secrets.connectionstrings--db2}"
     },
     "cosmos": {
       "type": "azure.bicep.v0",
@@ -121,7 +130,7 @@
     },
     "db3": {
       "type": "value.v0",
-      "connectionString": "{cosmos.outputs.connectionString}"
+      "connectionString": "AccountEndpoint={cosmos.outputs.connectionString};Database=db3"
     },
     "lawkspc": {
       "type": "azure.bicep.v0",

--- a/playground/bicep/BicepSample.AppHost/postgres2-kv.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/postgres2-kv.module.bicep
@@ -1,0 +1,38 @@
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param principalType string
+
+param principalId string
+
+resource postgres2_kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: take('postgres2kv-${uniqueString(resourceGroup().id)}', 24)
+  location: location
+  properties: {
+    tenantId: tenant().tenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    enableRbacAuthorization: true
+  }
+  tags: {
+    'aspire-resource-name': 'postgres2-kv'
+  }
+}
+
+resource postgres2_kv_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(postgres2_kv.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+    principalType: principalType
+  }
+  scope: postgres2_kv
+}
+
+output vaultUri string = postgres2_kv.properties.vaultUri
+
+output name string = postgres2_kv.name
+
+output id string = postgres2_kv.id

--- a/playground/bicep/BicepSample.AppHost/postgres2.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/postgres2.module.bicep
@@ -59,7 +59,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  name: 'connectionString'
+  name: 'connectionstrings--postgres2'
   properties: {
     value: 'Host=${postgres2.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'
   }
@@ -67,7 +67,7 @@ resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
 }
 
 resource db2_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  name: 'db2-connectionString'
+  name: 'connectionstrings--db2'
   properties: {
     value: 'Host=${postgres2.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=db2'
   }

--- a/playground/bicep/BicepSample.AppHost/sql.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/sql.module.bicep
@@ -41,3 +41,5 @@ resource db 'Microsoft.Sql/servers/databases@2021-11-01' = {
 }
 
 output sqlServerFqdn string = sql.properties.fullyQualifiedDomainName
+
+output name string = sql.name

--- a/playground/cdk/CdkSample.AppHost/aspire-manifest.json
+++ b/playground/cdk/CdkSample.AppHost/aspire-manifest.json
@@ -11,7 +11,7 @@
     },
     "cosmosdb": {
       "type": "value.v0",
-      "connectionString": "{cosmos.outputs.connectionString}"
+      "connectionString": "AccountEndpoint={cosmos.outputs.connectionString};Database=cosmosdb"
     },
     "storagesku": {
       "type": "parameter.v0",
@@ -108,17 +108,26 @@
     },
     "pgsql": {
       "type": "azure.bicep.v0",
-      "connectionString": "{pgsql.secretOutputs.connectionString}",
+      "connectionString": "{pgsql-kv.secrets.connectionstrings--pgsql}",
       "path": "pgsql.module.bicep",
       "params": {
         "administratorLogin": "{pgsqlAdministratorLogin.value}",
         "administratorLoginPassword": "{pgsqlAdministratorLoginPassword.value}",
-        "keyVaultName": ""
+        "keyVaultName": "{pgsql-kv.outputs.name}"
+      }
+    },
+    "pgsql-kv": {
+      "type": "azure.bicep.v0",
+      "connectionString": "{pgsql-kv.outputs.vaultUri}",
+      "path": "pgsql-kv.module.bicep",
+      "params": {
+        "principalType": "",
+        "principalId": ""
       }
     },
     "pgsqldb": {
       "type": "value.v0",
-      "connectionString": "{pgsql.secretOutputs.pgsqldb-connectionString}"
+      "connectionString": "{pgsql-kv.secrets.connectionstrings--pgsqldb}"
     },
     "pgsql2": {
       "type": "azure.bicep.v0",

--- a/playground/cdk/CdkSample.AppHost/mykv.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/mykv.module.bicep
@@ -45,3 +45,5 @@ resource mysecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
 output vaultUri string = mykv.properties.vaultUri
 
 output name string = mykv.name
+
+output id string = mykv.id

--- a/playground/cdk/CdkSample.AppHost/pgsql-kv.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/pgsql-kv.module.bicep
@@ -5,8 +5,8 @@ param principalType string
 
 param principalId string
 
-resource kv3 'Microsoft.KeyVault/vaults@2023-07-01' = {
-  name: take('kv3-${uniqueString(resourceGroup().id)}', 24)
+resource pgsql_kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: take('pgsqlkv-${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
     tenantId: tenant().tenantId
@@ -17,22 +17,22 @@ resource kv3 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enableRbacAuthorization: true
   }
   tags: {
-    'aspire-resource-name': 'kv3'
+    'aspire-resource-name': 'pgsql-kv'
   }
 }
 
-resource kv3_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(kv3.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
+resource pgsql_kv_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(pgsql_kv.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
   properties: {
     principalId: principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
     principalType: principalType
   }
-  scope: kv3
+  scope: pgsql_kv
 }
 
-output vaultUri string = kv3.properties.vaultUri
+output vaultUri string = pgsql_kv.properties.vaultUri
 
-output name string = kv3.name
+output name string = pgsql_kv.name
 
-output id string = kv3.id
+output id string = pgsql_kv.id

--- a/playground/cdk/CdkSample.AppHost/pgsql.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/pgsql.module.bicep
@@ -59,7 +59,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  name: 'connectionString'
+  name: 'connectionstrings--pgsql'
   properties: {
     value: 'Host=${pgsql.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'
   }
@@ -67,7 +67,7 @@ resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
 }
 
 resource pgsqldb_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  name: 'pgsqldb-connectionString'
+  name: 'connectionstrings--pgsqldb'
   properties: {
     value: 'Host=${pgsql.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=pgsqldb'
   }

--- a/playground/cdk/CdkSample.AppHost/sql.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/sql.module.bicep
@@ -41,3 +41,5 @@ resource sqldb 'Microsoft.Sql/servers/databases@2021-11-01' = {
 }
 
 output sqlServerFqdn string = sql.properties.fullyQualifiedDomainName
+
+output name string = sql.name

--- a/playground/kafka/KafkaBasic.AppHost/aspire-manifest.json
+++ b/playground/kafka/KafkaBasic.AppHost/aspire-manifest.json
@@ -4,7 +4,7 @@
     "kafka": {
       "type": "container.v0",
       "connectionString": "{kafka.bindings.tcp.host}:{kafka.bindings.tcp.port}",
-      "image": "docker.io/confluentinc/confluent-local:7.8.0",
+      "image": "docker.io/confluentinc/confluent-local:7.9.0",
       "env": {
         "KAFKA_LISTENERS": "PLAINTEXT://localhost:29092,CONTROLLER://localhost:29093,PLAINTEXT_HOST://0.0.0.0:9092,PLAINTEXT_INTERNAL://0.0.0.0:9093",
         "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP": "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT",
@@ -54,7 +54,7 @@
     "kafka2": {
       "type": "container.v0",
       "connectionString": "{kafka2.bindings.tcp.host}:{kafka2.bindings.tcp.port}",
-      "image": "docker.io/confluentinc/confluent-local:7.8.0",
+      "image": "docker.io/confluentinc/confluent-local:7.9.0",
       "env": {
         "KAFKA_LISTENERS": "PLAINTEXT://localhost:29092,CONTROLLER://localhost:29093,PLAINTEXT_HOST://0.0.0.0:9092,PLAINTEXT_INTERNAL://0.0.0.0:9093",
         "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP": "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT",

--- a/playground/keycloak/Keycloak.AppHost/aspire-manifest.json
+++ b/playground/keycloak/Keycloak.AppHost/aspire-manifest.json
@@ -3,7 +3,7 @@
   "resources": {
     "keycloak": {
       "type": "container.v0",
-      "image": "quay.io/keycloak/keycloak:26.0",
+      "image": "quay.io/keycloak/keycloak:26.1",
       "args": [
         "start",
         "--import-realm"

--- a/playground/milvus/MilvusPlayground.AppHost/aspire-manifest.json
+++ b/playground/milvus/MilvusPlayground.AppHost/aspire-manifest.json
@@ -4,7 +4,7 @@
     "milvus": {
       "type": "container.v0",
       "connectionString": "Endpoint={milvus.bindings.grpc.url};Key=root:{milvus-key.value}",
-      "image": "docker.io/milvusdb/milvus:v2.4.13",
+      "image": "docker.io/milvusdb/milvus:v2.5.5",
       "args": [
         "milvus",
         "run",

--- a/playground/mysql/MySqlDb.AppHost/aspire-manifest.json
+++ b/playground/mysql/MySqlDb.AppHost/aspire-manifest.json
@@ -4,7 +4,7 @@
     "mysql": {
       "type": "container.v0",
       "connectionString": "Server={mysql.bindings.tcp.host};Port={mysql.bindings.tcp.port};User ID=root;Password={mysql-password.value}",
-      "image": "docker.io/library/mysql:9.1",
+      "image": "docker.io/library/mysql:9.2",
       "bindMounts": [
         {
           "source": "../MySql.ApiService/data",

--- a/playground/waitfor/WaitForSandbox.AppHost/aspire-manifest.json
+++ b/playground/waitfor/WaitForSandbox.AppHost/aspire-manifest.json
@@ -3,17 +3,26 @@
   "resources": {
     "pg": {
       "type": "azure.bicep.v0",
-      "connectionString": "{pg.secretOutputs.connectionString}",
+      "connectionString": "{pg-kv.secrets.connectionstrings--pg}",
       "path": "pg.module.bicep",
       "params": {
         "administratorLogin": "{pg-username.value}",
         "administratorLoginPassword": "{pg-password.value}",
-        "keyVaultName": ""
+        "keyVaultName": "{pg-kv.outputs.name}"
+      }
+    },
+    "pg-kv": {
+      "type": "azure.bicep.v0",
+      "connectionString": "{pg-kv.outputs.vaultUri}",
+      "path": "pg-kv.module.bicep",
+      "params": {
+        "principalType": "",
+        "principalId": ""
       }
     },
     "db": {
       "type": "value.v0",
-      "connectionString": "{pg.secretOutputs.db-connectionString}"
+      "connectionString": "{pg-kv.secrets.connectionstrings--db}"
     },
     "dbsetup": {
       "type": "project.v0",

--- a/playground/waitfor/WaitForSandbox.AppHost/pg-kv.module.bicep
+++ b/playground/waitfor/WaitForSandbox.AppHost/pg-kv.module.bicep
@@ -5,8 +5,8 @@ param principalType string
 
 param principalId string
 
-resource kv3 'Microsoft.KeyVault/vaults@2023-07-01' = {
-  name: take('kv3-${uniqueString(resourceGroup().id)}', 24)
+resource pg_kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: take('pgkv-${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
     tenantId: tenant().tenantId
@@ -17,22 +17,22 @@ resource kv3 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enableRbacAuthorization: true
   }
   tags: {
-    'aspire-resource-name': 'kv3'
+    'aspire-resource-name': 'pg-kv'
   }
 }
 
-resource kv3_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(kv3.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
+resource pg_kv_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(pg_kv.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
   properties: {
     principalId: principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
     principalType: principalType
   }
-  scope: kv3
+  scope: pg_kv
 }
 
-output vaultUri string = kv3.properties.vaultUri
+output vaultUri string = pg_kv.properties.vaultUri
 
-output name string = kv3.name
+output name string = pg_kv.name
 
-output id string = kv3.id
+output id string = pg_kv.id

--- a/playground/waitfor/WaitForSandbox.AppHost/pg.module.bicep
+++ b/playground/waitfor/WaitForSandbox.AppHost/pg.module.bicep
@@ -59,7 +59,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  name: 'connectionString'
+  name: 'connectionstrings--pg'
   properties: {
     value: 'Host=${pg.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'
   }
@@ -67,7 +67,7 @@ resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
 }
 
 resource db_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  name: 'db-connectionString'
+  name: 'connectionstrings--db'
   properties: {
     value: 'Host=${pg.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=db'
   }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -55,8 +55,6 @@ public class AzureContainerAppEnvironmentResource(string name, Action<AzureResou
 
     internal Dictionary<string, BicepOutputReference> VolumeNames { get; } = [];
 
-    internal Dictionary<string, BicepOutputReference> SecretKeyVaultNames { get; } = [];
-
     IManifestExpressionProvider IAzureContainerAppEnvironment.ContainerAppEnvironmentId => ContainerAppEnvironmentId;
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.ContainerAppDomain => ContainerAppDomain;
@@ -73,17 +71,7 @@ public class AzureContainerAppEnvironmentResource(string name, Action<AzureResou
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.GetSecretOutputKeyVault(AzureBicepResource resource)
     {
-        // REVIEW: Should we use the same naming algorithm as azd?
-        var outputName = $"secret_output_{resource.Name}";
-
-        if (!SecretKeyVaultNames.TryGetValue(outputName, out var outputReference))
-        {
-            outputReference = new BicepOutputReference(outputName, this);
-
-            SecretKeyVaultNames[outputName] = outputReference;
-        }
-
-        return outputReference;
+        throw new NotSupportedException("Key vault secrets are not supported in this environment. Please create a key vault resource directly.");
     }
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.GetVolumeStorage(IResource resource, ContainerMountType type, string volumeIndex)

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -65,8 +65,6 @@ public class AzureContainerAppEnvironmentResource(string name, Action<AzureResou
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.ContainerRegistryManagedIdentityId => ContainerRegistryManagedIdentityId;
 
-    IManifestExpressionProvider IAzureContainerAppEnvironment.ManagedIdentityId => ManagedIdentityId;
-
     IManifestExpressionProvider IAzureContainerAppEnvironment.LogAnalyticsWorkspaceId => LogAnalyticsWorkspaceId;
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.PrincipalName => PrincipalName;

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -71,7 +71,7 @@ public class AzureContainerAppEnvironmentResource(string name, Action<AzureResou
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.GetSecretOutputKeyVault(AzureBicepResource resource)
     {
-        throw new NotSupportedException("Key vault secrets are not supported in this environment. Please create a key vault resource directly.");
+        throw new NotSupportedException("Automatic Key vault generation is not supported in this environment. Please create a key vault resource directly.");
     }
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.GetVolumeStorage(IResource resource, ContainerMountType type, string volumeIndex)

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -799,14 +799,14 @@ internal sealed class AzureContainerAppsInfrastructure(
 
             private BicepValue<string> AllocateKeyVaultSecretUriReference(IKeyVaultSecretReference secretOutputReference)
             {
-                if (!KeyVaultRefs.TryGetValue(secretOutputReference.KeyVaultResource.Name, out var kv))
+                if (!KeyVaultRefs.TryGetValue(secretOutputReference.Resource.Name, out var kv))
                 {
                     // We resolve the keyvault that represents the storage for secret outputs
-                    var parameter = AllocateParameter(secretOutputReference.KeyVaultResource.NameOutputReference);
+                    var parameter = AllocateParameter(secretOutputReference.Resource.NameOutputReference);
                     kv = KeyVaultService.FromExisting($"{parameter.BicepIdentifier}_kv");
                     kv.Name = parameter;
 
-                    KeyVaultRefs[secretOutputReference.KeyVaultResource.Name] = kv;
+                    KeyVaultRefs[secretOutputReference.Resource.Name] = kv;
                 }
 
                 if (!KeyVaultSecretRefs.TryGetValue(secretOutputReference.ValueExpression, out var secret))

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -195,12 +195,7 @@ internal sealed class AzureContainerAppsInfrastructure(
 
                     var id = BicepFunction.Interpolate($"{containerAppIdentityId}").Compile().ToString();
 
-                    containerAppResource.Identity = new ManagedServiceIdentity()
-                    {
-                        ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned,
-                        UserAssignedIdentities = []
-                    };
-
+                    containerAppResource.Identity.ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned;
                     containerAppResource.Identity.UserAssignedIdentities[id] = new UserAssignedIdentityDetails();
 
                     EnvironmentVariables.Add(new ContainerAppEnvironmentVariable { Name = "AZURE_CLIENT_ID", Value = appIdentityResource.ClientId.AsProvisioningParameter(c) });
@@ -961,15 +956,10 @@ internal sealed class AzureContainerAppsInfrastructure(
                     return;
                 }
 
-                app.Identity ??= new ManagedServiceIdentity()
-                {
-                    ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned,
-                    UserAssignedIdentities = []
-                };
-
                 // REVIEW: This is is a little hacky, we should probably have a better way to do this
                 var id = BicepFunction.Interpolate($"{_containerRegistryManagedIdentityIdParameter}").Compile().ToString();
 
+                app.Identity.ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned;
                 app.Identity.UserAssignedIdentities[id] = new UserAssignedIdentityDetails();
             }
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -87,8 +87,8 @@ internal sealed class AzureContainerAppsInfrastructure(
             // HACK: This forces parameters to be resolved for any AzureProvisioningResource
             r.GetBicepTemplateFile();
 
-            // REVIEW: the secret key vault resources aren't coupled to the container app environment. This
-            // is a side effect from how azd worked. We can move them to another service in the future.
+            // This will throw an exception if there's no value specified, in this new mode, we don't no longer support
+            // automagic secret key vault references.
             SetKnownParameterValue(r, AzureBicepResource.KnownParameters.KeyVaultName, environment.GetSecretOutputKeyVault);
 
             // Set the known parameters for the container app environment

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -190,7 +190,16 @@ internal sealed class AzureContainerAppsInfrastructure(
                 if (resource.TryGetLastAnnotation<AppIdentityAnnotation>(out var appIdentityAnnotation))
                 {
                     var appIdentityResource = appIdentityAnnotation.IdentityResource;
-                    var id = BicepFunction.Interpolate($"{appIdentityResource.Id.AsProvisioningParameter(c)}").Compile().ToString();
+
+                    containerAppIdentityId = appIdentityResource.Id.AsProvisioningParameter(c);
+
+                    var id = BicepFunction.Interpolate($"{containerAppIdentityId}").Compile().ToString();
+
+                    containerAppResource.Identity = new ManagedServiceIdentity()
+                    {
+                        ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned,
+                        UserAssignedIdentities = []
+                    };
 
                     containerAppResource.Identity.UserAssignedIdentities[id] = new UserAssignedIdentityDetails();
 

--- a/src/Aspire.Hosting.Azure.AppContainers/IAzureContainerAppEnvironment.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/IAzureContainerAppEnvironment.cs
@@ -11,7 +11,6 @@ internal interface IAzureContainerAppEnvironment
     IManifestExpressionProvider ContainerAppDomain { get; }
     IManifestExpressionProvider ContainerRegistryUrl { get; }
     IManifestExpressionProvider ContainerRegistryManagedIdentityId { get; }
-    IManifestExpressionProvider ManagedIdentityId { get; }
     IManifestExpressionProvider LogAnalyticsWorkspaceId { get; }
     IManifestExpressionProvider PrincipalName { get; }
     IManifestExpressionProvider ContainerAppEnvironmentName { get; }

--- a/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
+++ b/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.KeyVault\Aspire.Hosting.Azure.KeyVault.csproj" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" />

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -357,7 +357,7 @@ public static class AzureCosmosExtensions
 
         var azureResource = builder.Resource;
         azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecretReference(
-            $"{azureResource.Name}--connectionString");
+            $"connectionstrings--{azureResource.Name}");
 
         builder.WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, keyVaultBuilder.Resource.NameOutputReference);
 
@@ -444,7 +444,7 @@ public static class AzureCosmosExtensions
             var secret = new KeyVaultSecret("connectionString")
             {
                 Parent = keyVault,
-                Name = $"{azureResource.Name}--connectionString",
+                Name = $"connectionstrings--{azureResource.Name}",
                 Properties = new SecretProperties
                 {
                     Value = BicepFunction.Interpolate($"AccountEndpoint={cosmosAccount.DocumentEndpoint};AccountKey={cosmosAccount.GetKeys().PrimaryMasterKey}")

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -346,11 +346,11 @@ public static class AzureCosmosExtensions
     }
 
     /// <summary>
-    /// 
+    /// Configures the resource to use access key authentication with Azure Cosmos DB.
     /// </summary>
-    /// <param name="builder"></param>
-    /// <param name="keyVaultBuilder"></param>
-    /// <returns></returns>
+    /// <param name="builder">The Azure Cosmos DB resource builder.</param>
+    /// <param name="keyVaultBuilder">The Azure Key Vault resource builder where the connection string used to connect to this AzureCosmosDBResource will be stored.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> builder.</returns>
     public static IResourceBuilder<AzureCosmosDBResource> WithAccessKeyAuthentication(this IResourceBuilder<AzureCosmosDBResource> builder, IResourceBuilder<IKeyVaultResource> keyVaultBuilder)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -41,7 +41,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     ///
     /// This is set when access key authentication is used. The connection string is stored in a secret in the Azure Key Vault.
     /// </summary>
-    internal BicepSecretOutputReference? ConnectionStringSecretOutput { get; set; }
+    internal IKeyVaultSecretReference? ConnectionStringSecretOutput { get; set; }
 
     private BicepOutputReference NameOutputReference => new("name", this);
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -37,7 +37,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     public BicepOutputReference ConnectionStringOutput => new("connectionString", this);
 
     /// <summary>
-    /// Gets the "connectionString" secret output reference from the bicep template for the Azure Redis resource.
+    /// Gets the "connectionString" secret reference from the key vault associated with this resource.
     ///
     /// This is set when access key authentication is used. The connection string is stored in a secret in the Azure Key Vault.
     /// </summary>

--- a/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
+++ b/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
@@ -18,4 +18,8 @@
     <PackageReference Include="Azure.Provisioning.KeyVault" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Azure.Provisioning.KeyVault;
 using Azure.Provisioning.Primitives;
-using Azure.Security.KeyVault.Secrets;
 
 namespace Aspire.Hosting.Azure;
 
@@ -40,16 +39,13 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     BicepOutputReference IKeyVaultResource.VaultUriOutputReference => VaultUri;
     BicepOutputReference IKeyVaultResource.IdOutputReference => Id;
 
-    // For testing purposes only
-    internal Dictionary<string, string> Secrets { get; } = [];
-
     // In run mode, this is set to the secret client used to access the Azure Key Vault.
-    internal SecretClient? SecretClient { get; set; }
+    internal Func<string, CancellationToken, Task<string?>>? SecretResolver { get; set; }
 
-    SecretClient? IKeyVaultResource.SecretClient
+    Func<string, CancellationToken, Task<string?>>? IKeyVaultResource.SecretResolver
     {
-        get => SecretClient;
-        set => SecretClient = value;
+        get => SecretResolver;
+        set => SecretResolver = value;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -19,7 +19,7 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     /// <summary>
     /// Gets the "vaultUri" output reference for the Azure Key Vault resource.
     /// </summary>
-    public BicepOutputReference VaultUri => new("vaultUri", this);
+    public BicepOutputReference VaultUriOutputReference => new("vaultUri", this);
 
     /// <summary>
     /// Gets the "name" output reference for the Azure Key Vault resource.
@@ -29,22 +29,26 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     /// <summary>
     /// Gets the resource identifier of the Azure Key Vault resource.
     /// </summary>
-    public BicepOutputReference Id => new("id", this);
+    public BicepOutputReference IdOutputReference => new("id", this);
 
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Key Vault resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{VaultUri}");
+        ReferenceExpression.Create($"{VaultUriOutputReference}");
 
     /// <summary>
     /// The secrets for the Azure Key Vault resource. Used in run mode to resolve
     /// </summary>
-    public Dictionary<string, string> Secrets { get; } = [];
+    internal Dictionary<string, string> Secrets { get; } = [];
 
-    IDictionary<string, string> IKeyVaultResource.Secrets => Secrets;
+    internal SecretClient? SecretClient { get; set; }
 
-    SecretClient? IKeyVaultResource.SecretClient { get; set; }
+    SecretClient? IKeyVaultResource.SecretClient
+    {
+        get => SecretClient;
+        set => SecretClient = value;
+    }
 
     /// <summary>
     /// Gets a secret reference for the specified secret name.

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -13,20 +13,43 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="configureInfrastructure">Callback to configure the Azure resources.</param>
 public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure)
-    : AzureProvisioningResource(name, configureInfrastructure), IResourceWithConnectionString
+    : AzureProvisioningResource(name, configureInfrastructure), IResourceWithConnectionString, IKeyVaultResource
 {
     /// <summary>
     /// Gets the "vaultUri" output reference for the Azure Key Vault resource.
     /// </summary>
     public BicepOutputReference VaultUri => new("vaultUri", this);
 
-    private BicepOutputReference NameOutputReference => new("name", this);
+    /// <summary>
+    /// Gets the "name" output reference for the Azure Key Vault resource.
+    /// </summary>
+    public BicepOutputReference NameOutputReference => new("name", this);
 
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Key Vault resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create($"{VaultUri}");
+
+    /// <summary>
+    /// The secrets for the Azure Key Vault resource. Used in run mode to resolve
+    /// </summary>
+    public Dictionary<string, string> Secrets { get; } = [];
+
+    IDictionary<string, string> IKeyVaultResource.Secrets => Secrets;
+
+    /// <summary>
+    /// Gets a secret reference for the specified secret name.
+    /// </summary>
+    /// <param name="secretName"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    public IKeyVaultSecretReference GetSecretReference(string secretName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(secretName, nameof(secretName));
+
+        return new AzureKeyVaultSecretReference(secretName, this);
+    }
 
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)
@@ -35,5 +58,35 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
         store.Name = NameOutputReference.AsProvisioningParameter(infra);
         infra.Add(store);
         return store;
+    }
+}
+
+/// <summary>
+/// Represents a reference to a secret in an Azure Key Vault resource.
+/// </summary>
+/// <param name="secretName">The name of the secret.</param>
+/// <param name="azureKeyVaultResource">The Azure Key Vault resource.</param>
+public sealed class AzureKeyVaultSecretReference(string secretName, IKeyVaultResource azureKeyVaultResource) : IKeyVaultSecretReference, IValueProvider, IManifestExpressionProvider
+{
+    /// <summary>
+    /// Gets the name of the secret.
+    /// </summary>
+    public string SecretName => secretName;
+
+    /// <summary>
+    /// Gets the Azure Key Vault resource.
+    /// </summary>
+    public IKeyVaultResource KeyVaultResource => azureKeyVaultResource;
+
+    string IManifestExpressionProvider.ValueExpression => $"{{{azureKeyVaultResource.Name}.secrets.{SecretName}}}";
+
+    ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken)
+    {
+        if (azureKeyVaultResource.Secrets.TryGetValue(secretName, out var secretValue))
+        {
+            return new(secretValue);
+        }
+
+        throw new InvalidOperationException($"Secret '{secretName}' not found in Key Vault '{azureKeyVaultResource.Name}'.");
     }
 }

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -19,7 +19,7 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     /// <summary>
     /// Gets the "vaultUri" output reference for the Azure Key Vault resource.
     /// </summary>
-    public BicepOutputReference VaultUriOutputReference => new("vaultUri", this);
+    public BicepOutputReference VaultUri => new("vaultUri", this);
 
     /// <summary>
     /// Gets the "name" output reference for the Azure Key Vault resource.
@@ -29,13 +29,16 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     /// <summary>
     /// Gets the resource identifier of the Azure Key Vault resource.
     /// </summary>
-    public BicepOutputReference IdOutputReference => new("id", this);
+    public BicepOutputReference Id => new("id", this);
 
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Key Vault resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{VaultUriOutputReference}");
+        ReferenceExpression.Create($"{VaultUri}");
+
+    BicepOutputReference IKeyVaultResource.VaultUriOutputReference => VaultUri;
+    BicepOutputReference IKeyVaultResource.IdOutputReference => Id;
 
     /// <summary>
     /// The secrets for the Azure Key Vault resource. Used in run mode to resolve

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -40,11 +40,10 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     BicepOutputReference IKeyVaultResource.VaultUriOutputReference => VaultUri;
     BicepOutputReference IKeyVaultResource.IdOutputReference => Id;
 
-    /// <summary>
-    /// The secrets for the Azure Key Vault resource. Used in run mode to resolve
-    /// </summary>
+    // For testing purposes only
     internal Dictionary<string, string> Secrets { get; } = [];
 
+    // In run mode, this is set to the secret client used to access the Azure Key Vault.
     internal SecretClient? SecretClient { get; set; }
 
     SecretClient? IKeyVaultResource.SecretClient

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -65,6 +65,7 @@ public static class AzureKeyVaultResourceExtensions
 
             // We need to output name to externalize role assignments.
             infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = keyVault.Name });
+            infrastructure.Add(new ProvisioningOutput("id", typeof(string)) { Value = keyVault.Id });
 
             if (infrastructure.AspireResource.TryGetLastAnnotation<AppliedRoleAssignmentsAnnotation>(out var appliedRoleAssignments))
             {

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents a reference to a secret in an Azure Key Vault resource.
+/// </summary>
+/// <param name="secretName">The name of the secret.</param>
+/// <param name="azureKeyVaultResource">The Azure Key Vault resource.</param>
+public sealed class AzureKeyVaultSecretReference(string secretName, IKeyVaultResource azureKeyVaultResource) : IKeyVaultSecretReference, IValueProvider, IManifestExpressionProvider
+{
+    /// <summary>
+    /// Gets the name of the secret.
+    /// </summary>
+    public string SecretName => secretName;
+
+    /// <summary>
+    /// Gets the Azure Key Vault resource.
+    /// </summary>
+    public IKeyVaultResource KeyVaultResource => azureKeyVaultResource;
+
+    string IManifestExpressionProvider.ValueExpression => $"{{{azureKeyVaultResource.Name}.secrets.{SecretName}}}";
+
+    async ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken)
+    {
+        if (azureKeyVaultResource.Secrets.TryGetValue(secretName, out var secretValue))
+        {
+            return new(secretValue);
+        }
+
+        if (azureKeyVaultResource.SecretClient is { } client)
+        {
+            var secret = await client.GetSecretAsync(secretName, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var response = secret.Value;
+            return response.Value;
+        }
+
+        throw new InvalidOperationException($"Secret '{secretName}' not found in Key Vault '{azureKeyVaultResource.Name}'.");
+    }
+}

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
@@ -20,7 +20,7 @@ public sealed class AzureKeyVaultSecretReference(string secretName, AzureKeyVaul
     /// <summary>
     /// Gets the Azure Key Vault resource.
     /// </summary>
-    public IKeyVaultResource KeyVaultResource => azureKeyVaultResource;
+    public IKeyVaultResource Resource => azureKeyVaultResource;
 
     string IManifestExpressionProvider.ValueExpression => $"{{{azureKeyVaultResource.Name}.secrets.{SecretName}}}";
 

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="secretName">The name of the secret.</param>
 /// <param name="azureKeyVaultResource">The Azure Key Vault resource.</param>
-public sealed class AzureKeyVaultSecretReference(string secretName, IKeyVaultResource azureKeyVaultResource) : IKeyVaultSecretReference, IValueProvider, IManifestExpressionProvider
+public sealed class AzureKeyVaultSecretReference(string secretName, AzureKeyVaultResource azureKeyVaultResource) : IKeyVaultSecretReference, IValueProvider, IManifestExpressionProvider
 {
     /// <summary>
     /// Gets the name of the secret.
@@ -28,7 +28,7 @@ public sealed class AzureKeyVaultSecretReference(string secretName, IKeyVaultRes
     {
         if (azureKeyVaultResource.Secrets.TryGetValue(secretName, out var secretValue))
         {
-            return new(secretValue);
+            return secretValue;
         }
 
         if (azureKeyVaultResource.SecretClient is { } client)

--- a/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.PostgreSQL\Aspire.Hosting.PostgreSQL.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.KeyVault\Aspire.Hosting.Azure.KeyVault.csproj" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.PostgreSql" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -319,7 +319,7 @@ public static class AzurePostgresExtensions
             ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder.ApplicationBuilder, $"{builder.Resource.Name}-password");
         builder.WithParameter("administratorLoginPassword", azureResource.PasswordParameter);
 
-        azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecretReference($"{builder.Resource.Name}--connectionString");
+        azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecretReference($"connectionstrings--{builder.Resource.Name}");
 
         builder.WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, keyVaultBuilder.Resource.NameOutputReference);
 
@@ -445,7 +445,7 @@ public static class AzurePostgresExtensions
             var secret = new KeyVaultSecret("connectionString")
             {
                 Parent = keyVault,
-                Name = $"{azureResource.Name}--connectionString",
+                Name = $"connectionstrings--{azureResource.Name}",
                 Properties = new SecretProperties
                 {
                     Value = BicepFunction.Interpolate($"Host={postgres.FullyQualifiedDomainName};Username={administratorLogin};Password={administratorLoginPassword}")
@@ -458,7 +458,7 @@ public static class AzurePostgresExtensions
                 var dbSecret = new KeyVaultSecret(Infrastructure.NormalizeBicepIdentifier(database.Key + "_connectionString"))
                 {
                     Parent = keyVault,
-                    Name = AzurePostgresFlexibleServerResource.GetDatabaseKeyVaultSecretName(azureResource.Name, database.Key),
+                    Name = AzurePostgresFlexibleServerResource.GetDatabaseKeyVaultSecretName(database.Key),
                     Properties = new SecretProperties
                     {
                         Value = BicepFunction.Interpolate($"Host={postgres.FullyQualifiedDomainName};Username={administratorLogin};Password={administratorLoginPassword};Database={database.Value}")

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -118,7 +118,7 @@ public static class AzurePostgresExtensions
     /// This requires changes to the application code to use an azure credential to authenticate with the resource. See
     /// https://learn.microsoft.com/azure/postgresql/flexible-server/how-to-connect-with-managed-identity#connect-using-managed-identity-in-c for more information.
     ///
-    /// You can use the <see cref="WithPasswordAuthentication(IResourceBuilder{AzurePostgresFlexibleServerResource}, IResourceBuilder{AzureKeyVaultResource}, IResourceBuilder{ParameterResource}?, IResourceBuilder{ParameterResource}?)"/> method to configure the resource to use password authentication.
+    /// You can use the <see cref="WithPasswordAuthentication(IResourceBuilder{AzurePostgresFlexibleServerResource}, IResourceBuilder{IKeyVaultResource}, IResourceBuilder{ParameterResource}?, IResourceBuilder{ParameterResource}?)"/> method to configure the resource to use password authentication.
     /// </remarks>
     /// <example>
     /// The following example creates an Azure PostgreSQL Flexible Server resource and referencing that resource in a .NET project.
@@ -303,7 +303,7 @@ public static class AzurePostgresExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> builder.</returns>
     public static IResourceBuilder<AzurePostgresFlexibleServerResource> WithPasswordAuthentication(
         this IResourceBuilder<AzurePostgresFlexibleServerResource> builder,
-        IResourceBuilder<AzureKeyVaultResource> keyVaultBuilder,
+        IResourceBuilder<IKeyVaultResource> keyVaultBuilder,
         IResourceBuilder<ParameterResource>? userName = null,
         IResourceBuilder<ParameterResource>? password = null)
     {
@@ -319,7 +319,7 @@ public static class AzurePostgresExtensions
             ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder.ApplicationBuilder, $"{builder.Resource.Name}-password");
         builder.WithParameter("administratorLoginPassword", azureResource.PasswordParameter);
 
-        azureResource.ConnectionStringSecretOutput = new AzureKeyVaultSecretReference($"{builder.Resource.Name}--connectionString", keyVaultBuilder.Resource);
+        azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecretReference($"{builder.Resource.Name}--connectionString");
 
         builder.WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, keyVaultBuilder.Resource.NameOutputReference);
 

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -118,7 +118,7 @@ public static class AzurePostgresExtensions
     /// This requires changes to the application code to use an azure credential to authenticate with the resource. See
     /// https://learn.microsoft.com/azure/postgresql/flexible-server/how-to-connect-with-managed-identity#connect-using-managed-identity-in-c for more information.
     ///
-    /// You can use the <see cref="WithPasswordAuthentication"/> method to configure the resource to use password authentication.
+    /// You can use the <see cref="WithPasswordAuthentication(IResourceBuilder{AzurePostgresFlexibleServerResource}, IResourceBuilder{AzureKeyVaultResource}, IResourceBuilder{ParameterResource}?, IResourceBuilder{ParameterResource}?)"/> method to configure the resource to use password authentication.
     /// </remarks>
     /// <example>
     /// The following example creates an Azure PostgreSQL Flexible Server resource and referencing that resource in a .NET project.
@@ -286,6 +286,29 @@ public static class AzurePostgresExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        var kv = builder.ApplicationBuilder.AddAzureKeyVault($"{builder.Resource.Name}-kv")
+                                           .WithParentRelationship(builder.Resource);
+
+        return builder.WithPasswordAuthentication(kv, userName, password);
+    }
+
+    /// <summary>
+    /// Configures the resource to use password authentication for Azure PostgreSQL Flexible Server.
+    /// This overload is used when the PostgreSQL resource is created in a container and the password is stored in an Azure Key Vault secret.
+    /// </summary>
+    /// <param name="builder">The Azure PostgreSQL server resource builder.</param>
+    /// <param name="keyVaultBuilder">The Azure Key Vault resource builder.</param>
+    /// <param name="userName">The parameter used to provide the user name for the PostgreSQL resource. If <see langword="null"/> a default value will be used.</param>
+    /// <param name="password">The parameter used to provide the administrator password for the PostgreSQL resource. If <see langword="null"/> a random password will be generated.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> builder.</returns>
+    public static IResourceBuilder<AzurePostgresFlexibleServerResource> WithPasswordAuthentication(
+        this IResourceBuilder<AzurePostgresFlexibleServerResource> builder,
+        IResourceBuilder<AzureKeyVaultResource> keyVaultBuilder,
+        IResourceBuilder<ParameterResource>? userName = null,
+        IResourceBuilder<ParameterResource>? password = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
         var azureResource = builder.Resource;
 
         azureResource.UserNameParameter = userName?.Resource ??
@@ -296,7 +319,9 @@ public static class AzurePostgresExtensions
             ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder.ApplicationBuilder, $"{builder.Resource.Name}-password");
         builder.WithParameter("administratorLoginPassword", azureResource.PasswordParameter);
 
-        azureResource.ConnectionStringSecretOutput = new BicepSecretOutputReference("connectionString", azureResource);
+        azureResource.ConnectionStringSecretOutput = new AzureKeyVaultSecretReference($"{builder.Resource.Name}--connectionString", keyVaultBuilder.Resource);
+
+        builder.WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, keyVaultBuilder.Resource.NameOutputReference);
 
         // If someone already called RunAsContainer - we need to reset the username/password parameters on the InnerResource
         var containerResource = azureResource.InnerResource;
@@ -420,7 +445,7 @@ public static class AzurePostgresExtensions
             var secret = new KeyVaultSecret("connectionString")
             {
                 Parent = keyVault,
-                Name = "connectionString",
+                Name = $"{azureResource.Name}--connectionString",
                 Properties = new SecretProperties
                 {
                     Value = BicepFunction.Interpolate($"Host={postgres.FullyQualifiedDomainName};Username={administratorLogin};Password={administratorLoginPassword}")
@@ -433,7 +458,7 @@ public static class AzurePostgresExtensions
                 var dbSecret = new KeyVaultSecret(Infrastructure.NormalizeBicepIdentifier(database.Key + "_connectionString"))
                 {
                     Parent = keyVault,
-                    Name = AzurePostgresFlexibleServerResource.GetDatabaseKeyVaultSecretName(database.Key),
+                    Name = AzurePostgresFlexibleServerResource.GetDatabaseKeyVaultSecretName(azureResource.Name, database.Key),
                     Properties = new SecretProperties
                     {
                         Value = BicepFunction.Interpolate($"Host={postgres.FullyQualifiedDomainName};Username={administratorLogin};Password={administratorLoginPassword};Database={database.Value}")

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -99,13 +99,13 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
         // Note that the bicep template puts each database's connection string in a KeyVault secret.
         if (InnerResource is null && ConnectionStringSecretOutput is not null)
         {
-            return ReferenceExpression.Create($"{ConnectionStringSecretOutput.Resource.GetSecretReference(GetDatabaseKeyVaultSecretName(Name, databaseResourceName))}");
+            return ReferenceExpression.Create($"{ConnectionStringSecretOutput.Resource.GetSecretReference(GetDatabaseKeyVaultSecretName(databaseResourceName))}");
         }
 
         return ReferenceExpression.Create($"{this};Database={databaseName}");
     }
 
-    internal static string GetDatabaseKeyVaultSecretName(string name, string databaseResourceName) => $"{name}--{databaseResourceName}-connectionString";
+    internal static string GetDatabaseKeyVaultSecretName(string databaseResourceName) => $"connectionstrings--{databaseResourceName}";
 
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -99,7 +99,7 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
         // Note that the bicep template puts each database's connection string in a KeyVault secret.
         if (InnerResource is null && ConnectionStringSecretOutput is not null)
         {
-            return ReferenceExpression.Create($"{ConnectionStringSecretOutput.KeyVaultResource.GetSecretReference(GetDatabaseKeyVaultSecretName(Name, databaseResourceName))}");
+            return ReferenceExpression.Create($"{ConnectionStringSecretOutput.Resource.GetSecretReference(GetDatabaseKeyVaultSecretName(Name, databaseResourceName))}");
         }
 
         return ReferenceExpression.Create($"{this};Database={databaseName}");

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -33,7 +33,7 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
     ///
     /// This is set when password authentication is used. The connection string is stored in a secret in the Azure Key Vault.
     /// </summary>
-    internal BicepSecretOutputReference? ConnectionStringSecretOutput { get; set; }
+    internal IKeyVaultSecretReference? ConnectionStringSecretOutput { get; set; }
 
     private BicepOutputReference NameOutputReference => new("name", this);
 
@@ -99,13 +99,13 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
         // Note that the bicep template puts each database's connection string in a KeyVault secret.
         if (InnerResource is null && ConnectionStringSecretOutput is not null)
         {
-            return ReferenceExpression.Create($"{new BicepSecretOutputReference(GetDatabaseKeyVaultSecretName(databaseResourceName), this)}");
+            return ReferenceExpression.Create($"{ConnectionStringSecretOutput.KeyVaultResource.GetSecretReference(GetDatabaseKeyVaultSecretName(Name, databaseResourceName))}");
         }
 
         return ReferenceExpression.Create($"{this};Database={databaseName}");
     }
 
-    internal static string GetDatabaseKeyVaultSecretName(string databaseResourceName) => $"{databaseResourceName}-connectionString";
+    internal static string GetDatabaseKeyVaultSecretName(string name, string databaseResourceName) => $"{name}--{databaseResourceName}-connectionString";
 
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)

--- a/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
+++ b/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Redis\Aspire.Hosting.Redis.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure.KeyVault\Aspire.Hosting.Azure.KeyVault.csproj" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.Redis" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
@@ -25,7 +25,7 @@ public class AzureRedisCacheResource(string name, Action<AzureResourceInfrastruc
     private BicepOutputReference ConnectionStringOutput => new("connectionString", this);
 
     /// <summary>
-    /// Gets the "connectionString" secret output reference from the bicep template for the Azure Redis resource.
+    /// Gets the "connectionString" secret reference from the key vault associated with this resource.
     ///
     /// This is set when access key authentication is used. The connection string is stored in a secret in the Azure Key Vault.
     /// </summary>

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
@@ -29,7 +29,7 @@ public class AzureRedisCacheResource(string name, Action<AzureResourceInfrastruc
     ///
     /// This is set when access key authentication is used. The connection string is stored in a secret in the Azure Key Vault.
     /// </summary>
-    internal BicepSecretOutputReference? ConnectionStringSecretOutput { get; set; }
+    internal IKeyVaultSecretReference? ConnectionStringSecretOutput { get; set; }
 
     private BicepOutputReference NameOutputReference => new("name", this);
 

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -210,7 +210,7 @@ public static class AzureRedisExtensions
         ArgumentNullException.ThrowIfNull(keyVaultBuilder);
 
         var azureResource = builder.Resource;
-        azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecretReference($"{azureResource.Name}--connectionString");
+        azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecretReference($"connectionstrings--{azureResource.Name}");
         builder.WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, keyVaultBuilder.Resource.NameOutputReference);
 
         // remove role assignment annotations when using access key authentication so an empty roles bicep module isn't generated
@@ -263,7 +263,7 @@ public static class AzureRedisExtensions
             var secret = new KeyVaultSecret("connectionString")
             {
                 Parent = keyVault,
-                Name = $"{redisResource.Name}--connectionString",
+                Name = $"connectionstrings-{redisResource.Name}",
                 Properties = new SecretProperties
                 {
                     Value = BicepFunction.Interpolate($"{redis.HostName},ssl=true,password={redis.GetKeys().PrimaryKey}")

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -263,7 +263,7 @@ public static class AzureRedisExtensions
             var secret = new KeyVaultSecret("connectionString")
             {
                 Parent = keyVault,
-                Name = $"connectionstrings-{redisResource.Name}",
+                Name = $"connectionstrings--{redisResource.Name}",
                 Properties = new SecretProperties
                 {
                     Value = BicepFunction.Interpolate($"{redis.HostName},ssl=true,password={redis.GetKeys().PrimaryKey}")

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -202,7 +202,7 @@ public static class AzureRedisExtensions
     /// Configures the resource to use access key authentication for Azure Cache for Redis.
     /// </summary>
     /// <param name="builder">The Azure Cache for Redis resource builder.</param>
-    /// <param name="keyVaultBuilder">The Azure Key Vault resource builder.</param>
+    /// <param name="keyVaultBuilder">The Azure Key Vault resource builder where the connection string used to connect to this AzureRedisCacheResource will be stored.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> builder.</returns>
     public static IResourceBuilder<AzureRedisCacheResource> WithAccessKeyAuthentication(this IResourceBuilder<AzureRedisCacheResource> builder, IResourceBuilder<IKeyVaultResource> keyVaultBuilder)
     {

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -96,7 +96,7 @@ public static class AzureRedisExtensions
     /// This requires changes to the application code to use an azure credential to authenticate with the resource. See
     /// https://github.com/Azure/Microsoft.Azure.StackExchangeRedis for more information.
     ///
-    /// You can use the <see cref="WithAccessKeyAuthentication"/> method to configure the resource to use access key authentication.
+    /// You can use the <see cref="WithAccessKeyAuthentication(IResourceBuilder{AzureRedisCacheResource}, IResourceBuilder{IKeyVaultResource})"/> method to configure the resource to use access key authentication.
     /// </remarks>
     /// <example>
     /// The following example creates an Azure Cache for Redis resource and referencing that resource in a .NET project.
@@ -192,8 +192,26 @@ public static class AzureRedisExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        var kv = builder.ApplicationBuilder.AddAzureKeyVault($"{builder.Resource.Name}-kv")
+                                           .WithParentRelationship(builder.Resource);
+
+        return builder.WithAccessKeyAuthentication(kv);
+    }
+
+    /// <summary>
+    /// Configures the resource to use access key authentication for Azure Cache for Redis.
+    /// </summary>
+    /// <param name="builder">The Azure Cache for Redis resource builder.</param>
+    /// <param name="keyVaultBuilder">The Azure Key Vault resource builder.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> builder.</returns>
+    public static IResourceBuilder<AzureRedisCacheResource> WithAccessKeyAuthentication(this IResourceBuilder<AzureRedisCacheResource> builder, IResourceBuilder<IKeyVaultResource> keyVaultBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(keyVaultBuilder);
+
         var azureResource = builder.Resource;
-        azureResource.ConnectionStringSecretOutput = new BicepSecretOutputReference("connectionString", azureResource);
+        azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecretReference($"{azureResource.Name}--connectionString");
+        builder.WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, keyVaultBuilder.Resource.NameOutputReference);
 
         // remove role assignment annotations when using access key authentication so an empty roles bicep module isn't generated
         var roleAssignmentAnnotations = azureResource.Annotations.OfType<DefaultRoleAssignmentsAnnotation>().ToArray();
@@ -245,7 +263,7 @@ public static class AzureRedisExtensions
             var secret = new KeyVaultSecret("connectionString")
             {
                 Parent = keyVault,
-                Name = "connectionString",
+                Name = $"{redisResource.Name}--connectionString",
                 Properties = new SecretProperties
                 {
                     Value = BicepFunction.Interpolate($"{redis.HostName},ssl=true,password={redis.GetKeys().PrimaryKey}")

--- a/src/Aspire.Hosting.Azure/AzurePublisher.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisher.cs
@@ -105,7 +105,7 @@ internal sealed class AzurePublisher(
 
                         if (!p.Secret && p.Default is not null)
                         {
-                            pp.Value = p.Value;
+                        pp.Value = p.Value;
                         }
 
                         // Map the parameter to the Bicep parameter

--- a/src/Aspire.Hosting.Azure/AzurePublisher.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisher.cs
@@ -105,7 +105,7 @@ internal sealed class AzurePublisher(
 
                         if (!p.Secret && p.Default is not null)
                         {
-                        pp.Value = p.Value;
+                            pp.Value = p.Value;
                         }
 
                         // Map the parameter to the Bicep parameter

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -355,7 +355,7 @@ internal sealed class AzureResourcePreparer(
 
         if (value is IKeyVaultSecretReference keyVaultSecretReference)
         {
-            azureReferences.Add(keyVaultSecretReference.KeyVaultResource);
+            azureReferences.Add(keyVaultSecretReference.Resource);
             return;
         }
 

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -353,6 +353,12 @@ internal sealed class AzureResourcePreparer(
             return;
         }
 
+        if (value is IKeyVaultSecretReference keyVaultSecretReference)
+        {
+            azureReferences.Add(keyVaultSecretReference.KeyVaultResource);
+            return;
+        }
+
         if (value is ReferenceExpression expr)
         {
             foreach (var vp in expr.ValueProviders)

--- a/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
@@ -12,22 +12,22 @@ namespace Aspire.Hosting.Azure;
 public interface IKeyVaultResource : IResource, IAzureResource
 {
     /// <summary>
-    /// Gets the "vaultUri" output reference for the Azure Key Vault resource.
+    /// Gets the output reference that represents the vault uri for the Azure Key Vault resource.
     /// </summary>
     BicepOutputReference VaultUriOutputReference { get; }
 
     /// <summary>
-    /// Gets the "name" output reference for the Azure Key Vault resource.
+    /// Gets the output reference that represents the name of Azure Key Vault resource.
     /// </summary>
     BicepOutputReference NameOutputReference { get; }
 
     /// <summary>
-    /// Gets the resource identifier of the Azure Key Vault resource.
+    /// the output reference that represents the resource id for the Azure Key Vault resource.
     /// </summary>
     BicepOutputReference IdOutputReference { get; }
 
     /// <summary>
-    /// The secret client used to access the Azure Key Vault at runtime.
+    /// The secret client used to access the Azure Key Vault in run mode.
     /// </summary>
     SecretClient? SecretClient { get; set; }
 

--- a/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents a resource that represents an Azure Key Vault.
+/// </summary>
+public interface IKeyVaultResource : IResource, IAzureResource
+{
+    /// <summary>
+    /// Gets the "vaultUri" output reference for the Azure Key Vault resource.
+    /// </summary>
+    BicepOutputReference VaultUri { get; }
+
+    /// <summary>
+    /// Gets the "name" output reference for the Azure Key Vault resource.
+    /// </summary>
+    BicepOutputReference NameOutputReference { get; }
+
+    /// <summary>
+    /// The secrets for the Azure Key Vault resource. Used in run mode to resolve
+    /// the secrets from the Key Vault.
+    /// </summary>
+    IDictionary<string, string> Secrets { get; }
+
+    /// <summary>
+    /// Gets a secret reference for the specified secret name.
+    /// </summary>
+    /// <param name="secretName">The name of the secret.</param>
+    /// <returns>A reference to the secret.</returns>
+    IKeyVaultSecretReference GetSecretReference(string secretName);
+}

--- a/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
@@ -14,7 +14,7 @@ public interface IKeyVaultResource : IResource, IAzureResource
     /// <summary>
     /// Gets the "vaultUri" output reference for the Azure Key Vault resource.
     /// </summary>
-    BicepOutputReference VaultUri { get; }
+    BicepOutputReference VaultUriOutputReference { get; }
 
     /// <summary>
     /// Gets the "name" output reference for the Azure Key Vault resource.
@@ -24,13 +24,7 @@ public interface IKeyVaultResource : IResource, IAzureResource
     /// <summary>
     /// Gets the resource identifier of the Azure Key Vault resource.
     /// </summary>
-    BicepOutputReference Id { get; }
-
-    /// <summary>
-    /// The secrets for the Azure Key Vault resource. Used in run mode to resolve
-    /// the secrets from the Key Vault.
-    /// </summary>
-    IDictionary<string, string> Secrets { get; }
+    BicepOutputReference IdOutputReference { get; }
 
     /// <summary>
     /// The secret client used to access the Azure Key Vault at runtime.

--- a/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Azure.Security.KeyVault.Secrets;
 
 namespace Aspire.Hosting.Azure;
 
@@ -27,9 +26,9 @@ public interface IKeyVaultResource : IResource, IAzureResource
     BicepOutputReference IdOutputReference { get; }
 
     /// <summary>
-    /// The secret client used to access the Azure Key Vault in run mode.
+    /// Gets or sets the secret resolver function used to resolve secrets at runtime.
     /// </summary>
-    SecretClient? SecretClient { get; set; }
+    Func<string, CancellationToken, Task<string?>>? SecretResolver { get; set; }
 
     /// <summary>
     /// Gets a secret reference for the specified secret name.

--- a/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Azure.Security.KeyVault.Secrets;
 
 namespace Aspire.Hosting.Azure;
 
@@ -21,10 +22,20 @@ public interface IKeyVaultResource : IResource, IAzureResource
     BicepOutputReference NameOutputReference { get; }
 
     /// <summary>
+    /// Gets the resource identifier of the Azure Key Vault resource.
+    /// </summary>
+    BicepOutputReference Id { get; }
+
+    /// <summary>
     /// The secrets for the Azure Key Vault resource. Used in run mode to resolve
     /// the secrets from the Key Vault.
     /// </summary>
     IDictionary<string, string> Secrets { get; }
+
+    /// <summary>
+    /// The secret client used to access the Azure Key Vault at runtime.
+    /// </summary>
+    SecretClient? SecretClient { get; set; }
 
     /// <summary>
     /// Gets a secret reference for the specified secret name.

--- a/src/Aspire.Hosting.Azure/IKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure/IKeyVaultSecretReference.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents a reference to a secret in an Azure Key Vault resource.
+/// </summary>
+public interface IKeyVaultSecretReference : IValueProvider, IManifestExpressionProvider
+{
+    /// <summary>
+    /// Gets the name of the secret.
+    /// </summary>
+    string SecretName { get; }
+
+    /// <summary>
+    /// Gets the Azure Key Vault resource.
+    /// </summary>
+    IKeyVaultResource KeyVaultResource { get; }
+}

--- a/src/Aspire.Hosting.Azure/IKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure/IKeyVaultSecretReference.cs
@@ -18,5 +18,5 @@ public interface IKeyVaultSecretReference : IValueProvider, IManifestExpressionP
     /// <summary>
     /// Gets the Azure Key Vault resource.
     /// </summary>
-    IKeyVaultResource KeyVaultResource { get; }
+    IKeyVaultResource Resource { get; }
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -276,11 +276,11 @@ internal sealed class BicepProvisioner(
         if (resource is IKeyVaultResource kvr)
         {
             // Outputs should be resolved above
-            var id = await kvr.Id.GetValueAsync(cancellationToken).ConfigureAwait(false);
-            var vaultUri = await kvr.VaultUri.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            var id = resource.Outputs[kvr.Id.Name] as string ?? throw new InvalidOperationException($"Key vault {kvr.Id.Name} not found in outputs.");
+            var vaultUri = resource.Outputs[kvr.VaultUri.Name] as string ?? throw new InvalidOperationException($"Key vault {kvr.VaultUri.Name} not found in outputs.");
 
             // Set the client for resolving secrets at runtime
-            kvr.SecretClient = new SecretClient(new(vaultUri!), context.Credential);
+            kvr.SecretClient = new SecretClient(new(vaultUri), context.Credential);
 
             // We don't need to do this every deployment
             // Make sure we can access the key vault so we can get the secrets at runtime
@@ -288,7 +288,7 @@ internal sealed class BicepProvisioner(
             // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#key-vault-reader
             var roleDefinitionId = CreateRoleDefinitionId(context.Subscription, "21090545-7ca7-4776-b22c-e363652d74d2");
 
-            await DoRoleAssignmentAsync(context.ArmClient, ResourceIdentifier.Parse(id!), context.Principal.Id, roleDefinitionId, cancellationToken).ConfigureAwait(false);
+            await DoRoleAssignmentAsync(context.ArmClient, ResourceIdentifier.Parse(id), context.Principal.Id, roleDefinitionId, cancellationToken).ConfigureAwait(false);
         }
 
         await notificationService.PublishUpdateAsync(resource, state =>

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -9,11 +9,8 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
 using Azure;
 using Azure.Core;
-using Azure.ResourceManager.KeyVault;
-using Azure.ResourceManager.KeyVault.Models;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
-using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -143,63 +140,6 @@ internal sealed class BicepProvisioner(
         // to populate them only after calling GetBicepTemplateFile.
         PopulateWellKnownParameters(resource, context);
 
-        KeyVaultResource? keyVault = null;
-
-        if (resource.Parameters.ContainsKey(AzureBicepResource.KnownParameters.KeyVaultName))
-        {
-            // This could be done as a bicep template that imports the other bicep template but this is
-            // quick and dirty for now
-            var keyVaults = resourceGroup.GetKeyVaults();
-
-            // Check to see if there's a key vault for this resource already
-            await foreach (var kv in keyVaults.GetAllAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
-            {
-                if (kv.Data.Tags.TryGetValue("aspire-secret-store", out var secretStore) && secretStore == resource.Name)
-                {
-                    resourceLogger.LogInformation("Found key vault {vaultName} for resource {resource} in {location}...", kv.Data.Name, resource.Name, context.Location);
-
-                    keyVault = kv;
-                    break;
-                }
-            }
-
-            if (keyVault is null)
-            {
-                await notificationService.PublishUpdateAsync(resource, state => state with
-                {
-                    State = new("Provisioning Keyvault", KnownResourceStateStyles.Info)
-
-                }).ConfigureAwait(false);
-
-                // A vault's name must be between 3-24 alphanumeric characters. The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens.
-                // Follow this link for more information: https://go.microsoft.com/fwlink/?linkid=2147742
-                var vaultName = $"v{Guid.NewGuid().ToString("N")[0..20]}";
-
-                resourceLogger.LogInformation("Creating key vault {vaultName} for resource {resource} in {location}...", vaultName, resource.Name, context.Location);
-
-                var properties = new KeyVaultProperties(context.Subscription.Data.TenantId!.Value, new KeyVaultSku(KeyVaultSkuFamily.A, KeyVaultSkuName.Standard))
-                {
-                    EnabledForTemplateDeployment = true,
-                    EnableRbacAuthorization = true
-                };
-                var kvParameters = new KeyVaultCreateOrUpdateContent(context.Location, properties);
-                kvParameters.Tags.Add("aspire-secret-store", resource.Name);
-
-                var kvOperation = await keyVaults.CreateOrUpdateAsync(WaitUntil.Completed, vaultName, kvParameters, cancellationToken).ConfigureAwait(false);
-                keyVault = kvOperation.Value;
-
-                resourceLogger.LogInformation("Key vault {vaultName} created.", keyVault.Data.Name);
-
-                // Key Vault Administrator
-                // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#key-vault-administrator
-                var roleDefinitionId = CreateRoleDefinitionId(context.Subscription, "00482a5a-887f-4fb3-b363-3b7fe8e74483");
-
-                await DoRoleAssignmentAsync(context.ArmClient, keyVault.Id, context.Principal.Id, roleDefinitionId, cancellationToken).ConfigureAwait(false);
-            }
-
-            resource.Parameters[AzureBicepResource.KnownParameters.KeyVaultName] = keyVault.Data.Name;
-        }
-
         // Use the azure CLI to run the bicep compiler to transpile the bicep file to a ARM JSON file
         var armTemplateContents = new StringBuilder();
         var templateSpec = new ProcessSpec(azPath)
@@ -328,27 +268,6 @@ internal sealed class BicepProvisioner(
                 // TODO: Handle complex output types
                 // Populate the resource outputs
                 resource.Outputs[item.Key] = item.Value?.Prop("value").ToString();
-            }
-        }
-
-        // Populate secret outputs from key vault (if any)
-        if (keyVault is not null)
-        {
-            var configOutputs = resourceConfig.Prop("SecretOutputs");
-
-            var client = new SecretClient(keyVault.Data.Properties.VaultUri, context.Credential);
-
-            await foreach (var item in keyVault.GetKeyVaultSecrets().GetAllAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
-            {
-                var response = await client.GetSecretAsync(item.Data.Name, cancellationToken: cancellationToken).ConfigureAwait(false);
-                var secret = response.Value;
-                resource.SecretOutputs[item.Data.Name] = secret.Value;
-            }
-
-            foreach (var item in resource.SecretOutputs)
-            {
-                // Save them to configuration
-                configOutputs[item.Key] = resource.SecretOutputs[item.Key];
             }
         }
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -276,8 +276,8 @@ internal sealed class BicepProvisioner(
         if (resource is IKeyVaultResource kvr)
         {
             // Outputs should be resolved above
-            var id = resource.Outputs[kvr.Id.Name] as string ?? throw new InvalidOperationException($"Key vault {kvr.Id.Name} not found in outputs.");
-            var vaultUri = resource.Outputs[kvr.VaultUri.Name] as string ?? throw new InvalidOperationException($"Key vault {kvr.VaultUri.Name} not found in outputs.");
+            var id = resource.Outputs[kvr.IdOutputReference.Name] as string ?? throw new InvalidOperationException($"{kvr.IdOutputReference.Name} not found in outputs.");
+            var vaultUri = resource.Outputs[kvr.VaultUriOutputReference.Name] as string ?? throw new InvalidOperationException($"{kvr.VaultUriOutputReference.Name} not found in outputs.");
 
             // Set the client for resolving secrets at runtime
             kvr.SecretClient = new SecretClient(new(vaultUri), context.Credential);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -1250,6 +1250,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             output vaultUri string = mykv.properties.vaultUri
 
             output name string = mykv.name
+
+            output id string = mykv.id
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);
@@ -1280,11 +1282,11 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-
+            
             param principalType string
-
+            
             param principalId string
-
+            
             resource mykv 'Microsoft.KeyVault/vaults@2023-07-01' = {
               name: take('mykv-${uniqueString(resourceGroup().id)}', 24)
               location: location
@@ -1300,7 +1302,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 'aspire-resource-name': 'mykv'
               }
             }
-
+            
             resource mykv_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
               name: guid(mykv.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
               properties: {
@@ -1310,10 +1312,12 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
               scope: mykv
             }
-
+            
             output vaultUri string = mykv.properties.vaultUri
-
+            
             output name string = mykv.name
+            
+            output id string = mykv.id
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -266,14 +266,14 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
         var kv = builder.CreateResourceBuilder<AzureKeyVaultResource>(kvName);
 
-        kv.Resource.Secrets["cosmos--connectionString"] = "mycosmosconnectionstring";
+        kv.Resource.Secrets["connectionstrings--cosmos"] = "mycosmosconnectionstring";
 
         var manifest = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
         var expectedManifest = $$"""
                                {
                                  "type": "azure.bicep.v0",
-                                 "connectionString": "{{{kvName}}.secrets.cosmos--connectionString}",
+                                 "connectionString": "{{{kvName}}.secrets.connectionstrings--cosmos}",
                                  "path": "cosmos.module.bicep",
                                  "params": {
                                    "keyVaultName": "{{{kvName}}.outputs.name}"
@@ -345,7 +345,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             }
             
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'cosmos--connectionString'
+              name: 'connectionstrings--cosmos'
               properties: {
                 value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'
               }
@@ -506,14 +506,14 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
         var kv = builder.CreateResourceBuilder<AzureKeyVaultResource>("cosmos-kv");
 
-        kv.Resource.Secrets["cosmos--connectionString"] = "mycosmosconnectionstring";
+        kv.Resource.Secrets["connectionstrings--cosmos"] = "mycosmosconnectionstring";
 
         var manifest = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
         var expectedManifest = """
                                {
                                  "type": "azure.bicep.v0",
-                                 "connectionString": "{cosmos-kv.secrets.cosmos--connectionString}",
+                                 "connectionString": "{cosmos-kv.secrets.connectionstrings--cosmos}",
                                  "path": "cosmos.module.bicep",
                                  "params": {
                                    "keyVaultName": "{cosmos-kv.outputs.name}"
@@ -586,7 +586,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             }
             
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'cosmos--connectionString'
+              name: 'connectionstrings--cosmos'
               properties: {
                 value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'
               }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -251,28 +251,33 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var db = cosmos.AddCosmosDatabase("db", databaseName: "mydatabase");
         db.AddContainer("container", "mypartitionkeypath", containerName: "mycontainer");
 
-        cosmos.Resource.SecretOutputs["connectionString"] = "mycosmosconnectionstring";
+        var kv = builder.CreateResourceBuilder<AzureKeyVaultResource>("cosmos-kv");
+
+        kv.Resource.Secrets["cosmos--connectionString"] = "mycosmosconnectionstring";
 
         var manifest = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
         var expectedManifest = """
                                {
                                  "type": "azure.bicep.v0",
-                                 "connectionString": "{cosmos.secretOutputs.connectionString}",
+                                 "connectionString": "{cosmos-kv.secrets.cosmos--connectionString}",
                                  "path": "cosmos.module.bicep",
                                  "params": {
-                                   "keyVaultName": ""
+                                   "keyVaultName": "{cosmos-kv.outputs.name}"
                                  }
                                }
                                """;
+        var m = manifest.ManifestNode.ToString();
+        output.WriteLine(m);
+
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
         var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-
+            
             param keyVaultName string
-
+            
             resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
               name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
               location: location
@@ -294,7 +299,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 'aspire-resource-name': 'cosmos'
               }
             }
-
+            
             resource db 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
               name: 'mydatabase'
               location: location
@@ -305,7 +310,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
               parent: cosmos
             }
-
+            
             resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
               name: 'mycontainer'
               location: location
@@ -321,13 +326,13 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
               parent: db
             }
-
+            
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
-
+            
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'connectionString'
+              name: 'cosmos--connectionString'
               properties: {
                 value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'
               }
@@ -486,28 +491,34 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var db = cosmos.AddCosmosDatabase("mydatabase");
         db.AddContainer("mycontainer", "mypartitionkeypath");
 
-        cosmos.Resource.SecretOutputs["connectionString"] = "mycosmosconnectionstring";
+        var kv = builder.CreateResourceBuilder<AzureKeyVaultResource>("cosmos-kv");
+
+        kv.Resource.Secrets["cosmos--connectionString"] = "mycosmosconnectionstring";
 
         var manifest = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
         var expectedManifest = """
                                {
                                  "type": "azure.bicep.v0",
-                                 "connectionString": "{cosmos.secretOutputs.connectionString}",
+                                 "connectionString": "{cosmos-kv.secrets.cosmos--connectionString}",
                                  "path": "cosmos.module.bicep",
                                  "params": {
-                                   "keyVaultName": ""
+                                   "keyVaultName": "{cosmos-kv.outputs.name}"
                                  }
                                }
                                """;
-        Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
+
+        var m = manifest.ManifestNode.ToString();
+
+        output.WriteLine(m);
+        Assert.Equal(expectedManifest, m);
 
         var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-
+            
             param keyVaultName string
-
+            
             resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
               name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
               location: location
@@ -529,7 +540,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 'aspire-resource-name': 'cosmos'
               }
             }
-
+            
             resource mydatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
               name: 'mydatabase'
               location: location
@@ -540,7 +551,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
               parent: cosmos
             }
-
+            
             resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
               name: 'mycontainer'
               location: location
@@ -556,13 +567,13 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
               parent: mydatabase
             }
-
+            
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
-
+            
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'connectionString'
+              name: 'cosmos--connectionString'
               properties: {
                 value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'
               }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -182,6 +182,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
+            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }
@@ -306,6 +307,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
+            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }
@@ -419,6 +421,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
+            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }
@@ -513,6 +516,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
+            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }
@@ -2342,6 +2346,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
+            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -53,7 +53,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -65,11 +64,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -88,12 +85,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 1
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -140,9 +131,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -154,15 +145,15 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param outputs_azure_container_registry_endpoint string
-
+        
+        param outputs_azure_container_registry_managed_identity_id string
+        
         param api_containerimage string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -190,7 +181,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
-            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }
@@ -236,9 +226,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "path": "api.module.bicep",
           "params": {
             "api_containerport": "{api.containerPort}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -250,17 +240,17 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
+        
         param api_containerport string
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param outputs_azure_container_registry_endpoint string
-
+        
+        param outputs_azure_container_registry_managed_identity_id string
+        
         param api_containerimage string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -315,7 +305,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
-            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }
@@ -370,9 +359,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}",
             "env": "{env.value}"
           }
@@ -385,17 +374,17 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param outputs_azure_container_registry_endpoint string
-
+        
+        param outputs_azure_container_registry_managed_identity_id string
+        
         param api_containerimage string
-
+        
         param env string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -429,7 +418,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
-            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }
@@ -673,11 +661,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -708,7 +694,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           identity: {
             type: 'UserAssigned'
             userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
+              '': { }
             }
           }
         }
@@ -802,14 +788,14 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             "api_containerport": "{api.containerPort}",
             "mydb_outputs_connectionstring": "{mydb.outputs.connectionString}",
             "storage_outputs_blobendpoint": "{storage.outputs.blobEndpoint}",
-            "pg_secretoutputs": "{pg.secretOutputs}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+            "pg_kv_outputs_name": "{pg-kv.outputs.name}",
             "value0_value": "{value0.value}",
             "value1_value": "{value1.value}",
             "cs_connectionstring": "{cs.connectionString}",
             "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -837,40 +823,40 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         param api_identity_outputs_clientid string
 
         param api_containerport string
-
+        
         param mydb_outputs_connectionstring string
-
+        
         param storage_outputs_blobendpoint string
-
-        param pg_secretoutputs string
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
+        param pg_kv_outputs_name string
+        
         @secure()
         param value0_value string
-
+        
         param value1_value string
-
+        
         @secure()
         param cs_connectionstring string
-
+        
         param outputs_azure_container_apps_environment_default_domain string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param outputs_azure_container_registry_endpoint string
-
+        
+        param outputs_azure_container_registry_managed_identity_id string
+        
         param api_containerimage string
-
-        resource pg_secretoutputs_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-          name: pg_secretoutputs
+        
+        resource pg_kv_outputs_name_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+          name: pg_kv_outputs_name
         }
-
-        resource pg_secretoutputs_kv_db_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
-          name: 'db-connectionString'
-          parent: pg_secretoutputs_kv
+        
+        resource pg_kv_outputs_name_kv_pg__db_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
+          name: 'pg--db-connectionString'
+          parent: pg_kv_outputs_name_kv
         }
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -879,8 +865,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               secrets: [
                 {
                   name: 'connectionstrings--db'
-                  identity: outputs_azure_container_registry_managed_identity_id
-                  keyVaultUrl: pg_secretoutputs_kv_db_connectionString.properties.secretUri
+                  identity: api_roles_outputs_id
+                  keyVaultUrl: pg_kv_outputs_name_kv_pg__db_connectionString.properties.secretUri
                 }
                 {
                   name: 'secretval'
@@ -1044,9 +1030,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         }
 
         output id string = api_identity.id
-
+        
         output clientId string = api_identity.properties.clientId
-
+        
         output principalId string = api_identity.properties.principalId
 
         output principalName string = api_identity.name
@@ -1800,8 +1786,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "api_roles_outputs_id": "{api-roles.outputs.id}",
+            "api_roles_outputs_clientid": "{api-roles.outputs.clientId}",
+            "mydb_kv_outputs_name": "{mydb-kv.outputs.name}",
             "mydb_secretoutputs": "{mydb.secretOutputs}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "mydb_secretoutputs_connectionstring": "{mydb.secretOutputs.connectionString}",
             "mydb_secretoutputs_connectionstring1": "{mydb.secretOutputs.connectionString1}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
@@ -1815,28 +1803,41 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
+        
+        param api_roles_outputs_id string
+        
+        param api_roles_outputs_clientid string
+        
+        param mydb_kv_outputs_name string
+        
         param mydb_secretoutputs string
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         @secure()
         param mydb_secretoutputs_connectionstring string
-
+        
         @secure()
         param mydb_secretoutputs_connectionstring1 string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
+        resource mydb_kv_outputs_name_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+          name: mydb_kv_outputs_name
+        }
+        
         resource mydb_secretoutputs_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
           name: mydb_secretoutputs
         }
-
+        
+        resource mydb_kv_outputs_name_kv_mydb__connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
+          name: 'mydb--connectionString'
+          parent: mydb_kv_outputs_name_kv
+        }
+        
         resource mydb_secretoutputs_kv_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
           name: 'connectionString'
           parent: mydb_secretoutputs_kv
         }
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -1845,22 +1846,22 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               secrets: [
                 {
                   name: 'connectionstrings--mydb'
-                  identity: outputs_azure_container_registry_managed_identity_id
-                  keyVaultUrl: mydb_secretoutputs_kv_connectionString.properties.secretUri
+                  identity: api_roles_outputs_id
+                  keyVaultUrl: mydb_kv_outputs_name_kv_mydb__connectionString.properties.secretUri
                 }
                 {
                   name: 'connectionstring'
-                  identity: outputs_azure_container_registry_managed_identity_id
+                  identity: api_roles_outputs_id
                   keyVaultUrl: mydb_secretoutputs_kv_connectionString.properties.secretUri
                 }
                 {
                   name: 'secret0'
-                  identity: outputs_azure_container_registry_managed_identity_id
+                  identity: api_roles_outputs_id
                   keyVaultUrl: mydb_secretoutputs_kv_connectionString.properties.secretUri
                 }
                 {
                   name: 'secret1'
-                  identity: outputs_azure_container_registry_managed_identity_id
+                  identity: api_roles_outputs_id
                   keyVaultUrl: mydb_secretoutputs_kv_connectionString.properties.secretUri
                 }
                 {
@@ -1897,6 +1898,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                       name: 'complex'
                       secretRef: 'complex'
                     }
+                    {
+                      name: 'AZURE_CLIENT_ID'
+                      value: api_roles_outputs_clientid
+                    }
                   ]
                 }
               ]
@@ -1908,7 +1913,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           identity: {
             type: 'UserAssigned'
             userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
+              '${api_roles_outputs_id}': { }
+              '': { }
             }
           }
         }
@@ -3347,33 +3353,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           parent: cae
         }
         
-        resource kv_secret_output_pg 'Microsoft.KeyVault/vaults@2023-07-01' = {
-          name: take('kvsecretoutputpg-${uniqueString(resourceGroup().id)}', 24)
-          location: location
-          properties: {
-            tenantId: tenant().tenantId
-            sku: {
-              family: 'A'
-              name: 'standard'
-            }
-            enableRbacAuthorization: true
-          }
-          tags: tags
-        }
-        
-        resource kv_secret_output_pg_mi_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-          name: guid(kv_secret_output_pg.id, mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
-          properties: {
-            principalId: mi.properties.principalId
-            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
-            principalType: 'ServicePrincipal'
-          }
-          scope: kv_secret_output_pg
-        }
-        
         output volumes_cache_0 string = managedStorage_volumes_cache_0.name
-        
-        output secret_output_pg string = kv_secret_output_pg.name
         
         output MANAGED_IDENTITY_NAME string = mi.name
         

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -837,8 +837,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           name: pg_kv_outputs_name
         }
         
-        resource pg_kv_outputs_name_kv_pg__db_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
-          name: 'pg--db-connectionString'
+        resource pg_kv_outputs_name_kv_connectionstrings__db 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
+          name: 'connectionstrings--db'
           parent: pg_kv_outputs_name_kv
         }
         
@@ -851,7 +851,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 {
                   name: 'connectionstrings--db'
                   identity: api_identity_outputs_id
-                  keyVaultUrl: pg_kv_outputs_name_kv_pg__db_connectionString.properties.secretUri
+                  keyVaultUrl: pg_kv_outputs_name_kv_connectionstrings__db.properties.secretUri
                 }
                 {
                   name: 'secretval'
@@ -1768,8 +1768,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           name: mydb_secretoutputs
         }
         
-        resource mydb_kv_outputs_name_kv_mydb__connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
-          name: 'mydb--connectionString'
+        resource mydb_kv_outputs_name_kv_connectionstrings__mydb 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
+          name: 'connectionstrings--mydb'
           parent: mydb_kv_outputs_name_kv
         }
         
@@ -1787,7 +1787,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 {
                   name: 'connectionstrings--mydb'
                   identity: api_identity_outputs_id
-                  keyVaultUrl: mydb_kv_outputs_name_kv_mydb__connectionString.properties.secretUri
+                  keyVaultUrl: mydb_kv_outputs_name_kv_connectionstrings__mydb.properties.secretUri
                 }
                 {
                   name: 'connectionstring'

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -462,9 +462,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -476,15 +476,15 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param outputs_azure_container_registry_endpoint string
-
+        
+        param outputs_azure_container_registry_managed_identity_id string
+        
         param api_containerimage string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -512,7 +512,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
-            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }
@@ -569,7 +568,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "value": "{value.value}",
             "minReplicas": "{minReplicas.value}"
@@ -583,15 +581,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param value string
-
+        
         param minReplicas string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -616,12 +612,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: minReplicas
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -689,12 +679,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 1
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '': { }
             }
           }
         }
@@ -817,11 +801,11 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
+        
         param api_identity_outputs_id string
-
+        
         param api_identity_outputs_clientid string
-
+        
         param api_containerport string
         
         param mydb_outputs_connectionstring string
@@ -865,7 +849,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               secrets: [
                 {
                   name: 'connectionstrings--db'
-                  identity: api_roles_outputs_id
+                  identity: api_identity_outputs_id
                   keyVaultUrl: pg_kv_outputs_name_kv_pg__db_connectionString.properties.secretUri
                 }
                 {
@@ -1126,14 +1110,14 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             "api_containerport": "{api.containerPort}",
             "mydb_outputs_connectionstring": "{mydb.outputs.connectionString}",
             "storage_outputs_blobendpoint": "{storage.outputs.blobEndpoint}",
-            "cae_outputs_secret_output_pg": "{cae.outputs.secret_output_pg}",
-            "cae_outputs_azure_container_registry_managed_identity_id": "{cae.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+            "pg_kv_outputs_name": "{pg-kv.outputs.name}",
             "value0_value": "{value0.value}",
             "value1_value": "{value1.value}",
             "cs_connectionstring": "{cs.connectionString}",
             "cae_outputs_azure_container_apps_environment_default_domain": "{cae.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "cae_outputs_azure_container_apps_environment_id": "{cae.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "cae_outputs_azure_container_registry_endpoint": "{cae.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "cae_outputs_azure_container_registry_managed_identity_id": "{cae.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -1217,7 +1201,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -1229,11 +1212,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -1252,12 +1233,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 0
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -1306,7 +1281,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "certificateName": "{certificateName.value}",
             "customDomain": "{customDomain.value}"
@@ -1320,15 +1294,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param certificateName string
-
+        
         param customDomain string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -1359,12 +1331,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 1
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -1415,7 +1381,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "initialCertificateName": "{initialCertificateName.value}",
             "customDomain": "{customDomain.value}",
@@ -1430,17 +1395,15 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param initialCertificateName string
-
+        
         param customDomain string
-
+        
         param expectedCertificateName string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -1471,12 +1434,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 1
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -1529,7 +1486,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "certificateName1": "{certificateName1.value}",
             "customDomain1": "{customDomain1.value}",
@@ -1545,19 +1501,17 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param certificateName1 string
-
+        
         param customDomain1 string
-
+        
         param certificateName2 string
-
+        
         param customDomain2 string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -1593,12 +1547,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 1
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -1646,7 +1594,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             "api_volumes_0_storage": "{api.volumes.0.storage}",
             "api_volumes_1_storage": "{api.volumes.1.storage}",
             "api_bindmounts_0_storage": "{api.bindMounts.0.storage}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -1658,17 +1605,15 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
+        
         param api_volumes_0_storage string
-
+        
         param api_volumes_1_storage string
-
+        
         param api_bindmounts_0_storage string
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -1718,12 +1663,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                   storageName: api_bindmounts_0_storage
                 }
               ]
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -1786,8 +1725,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "api_roles_outputs_id": "{api-roles.outputs.id}",
-            "api_roles_outputs_clientid": "{api-roles.outputs.clientId}",
+            "api_identity_outputs_id": "{api-identity.outputs.id}",
+            "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
             "mydb_kv_outputs_name": "{mydb-kv.outputs.name}",
             "mydb_secretoutputs": "{mydb.secretOutputs}",
             "mydb_secretoutputs_connectionstring": "{mydb.secretOutputs.connectionString}",
@@ -1804,9 +1743,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param api_roles_outputs_id string
+        param api_identity_outputs_id string
         
-        param api_roles_outputs_clientid string
+        param api_identity_outputs_clientid string
         
         param mydb_kv_outputs_name string
         
@@ -1846,22 +1785,22 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               secrets: [
                 {
                   name: 'connectionstrings--mydb'
-                  identity: api_roles_outputs_id
+                  identity: api_identity_outputs_id
                   keyVaultUrl: mydb_kv_outputs_name_kv_mydb__connectionString.properties.secretUri
                 }
                 {
                   name: 'connectionstring'
-                  identity: api_roles_outputs_id
+                  identity: api_identity_outputs_id
                   keyVaultUrl: mydb_secretoutputs_kv_connectionString.properties.secretUri
                 }
                 {
                   name: 'secret0'
-                  identity: api_roles_outputs_id
+                  identity: api_identity_outputs_id
                   keyVaultUrl: mydb_secretoutputs_kv_connectionString.properties.secretUri
                 }
                 {
                   name: 'secret1'
-                  identity: api_roles_outputs_id
+                  identity: api_identity_outputs_id
                   keyVaultUrl: mydb_secretoutputs_kv_connectionString.properties.secretUri
                 }
                 {
@@ -1900,7 +1839,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                     }
                     {
                       name: 'AZURE_CLIENT_ID'
-                      value: api_roles_outputs_clientid
+                      value: api_identity_outputs_clientid
                     }
                   ]
                 }
@@ -1913,8 +1852,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           identity: {
             type: 'UserAssigned'
             userAssignedIdentities: {
-              '${api_roles_outputs_id}': { }
-              '': { }
+              '${api_identity_outputs_id}': { }
             }
           }
         }
@@ -1953,11 +1891,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         resource api1 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api1-my'
           location: location
@@ -1976,12 +1912,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 1
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -2038,7 +1968,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -2050,11 +1979,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -2078,12 +2005,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 1
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -2127,7 +2048,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -2139,11 +2059,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -2173,12 +2091,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 1
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -2223,7 +2135,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -2235,11 +2146,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -2263,12 +2172,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               scale: {
                 minReplicas: 1
               }
-            }
-          }
-          identity: {
-            type: 'UserAssigned'
-            userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -2313,9 +2216,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "path": "api.module.bicep",
           "params": {
             "api_containerport": "{api.containerPort}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -2327,17 +2230,17 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-
+        
         param api_containerport string
-
-        param outputs_azure_container_registry_managed_identity_id string
-
+        
         param outputs_azure_container_apps_environment_id string
-
+        
         param outputs_azure_container_registry_endpoint string
-
+        
+        param outputs_azure_container_registry_managed_identity_id string
+        
         param api_containerimage string
-
+        
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -2396,7 +2299,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
           }
           identity: {
-            type: 'UserAssigned'
             userAssignedIdentities: {
               '${outputs_azure_container_registry_managed_identity_id}': { }
             }
@@ -2452,14 +2354,16 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               "params": {
                 "api_identity_outputs_id": "{api-identity.outputs.id}",
                 "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
-                "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
                 "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
                 "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+                "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
                 "api_containerimage": "{api.containerImage}"
               }
             }
             """;
-        Assert.Equal(expectedManifest, manifest.ToString());
+        var m = manifest.ToString();
+        output.WriteLine(m);
+        Assert.Equal(expectedManifest, m);
 
         var expectedIdentityManifest =
             """
@@ -2490,19 +2394,19 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-
+            
             param api_identity_outputs_id string
-
+            
             param api_identity_outputs_clientid string
-
-            param outputs_azure_container_registry_managed_identity_id string
-
+            
             param outputs_azure_container_apps_environment_id string
-
+            
             param outputs_azure_container_registry_endpoint string
-
+            
+            param outputs_azure_container_registry_managed_identity_id string
+            
             param api_containerimage string
-
+            
             resource api 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'api'
               location: location
@@ -2652,14 +2556,16 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 "api_identity_outputs_id": "{api-identity.outputs.id}",
                 "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
                 "cosmos_outputs_connectionstring": "{cosmos.outputs.connectionString}",
-                "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
                 "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
                 "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+                "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
                 "api_containerimage": "{api.containerImage}"
               }
             }
             """;
-        Assert.Equal(expectedManifest, manifest.ToString());
+        var m = manifest.ToString();
+        output.WriteLine(m);
+        Assert.Equal(expectedManifest, m);
 
         var expectedIdentityManifest =
             """
@@ -2690,21 +2596,21 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-
+            
             param api_identity_outputs_id string
-
+            
             param api_identity_outputs_clientid string
-
+            
             param cosmos_outputs_connectionstring string
-
-            param outputs_azure_container_registry_managed_identity_id string
-
+            
             param outputs_azure_container_apps_environment_id string
-
+            
             param outputs_azure_container_registry_endpoint string
-
+            
+            param outputs_azure_container_registry_managed_identity_id string
+            
             param api_containerimage string
-
+            
             resource api 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'api'
               location: location
@@ -2860,14 +2766,16 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 "api_identity_outputs_id": "{api-identity.outputs.id}",
                 "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
                 "redis_outputs_connectionstring": "{redis.outputs.connectionString}",
-                "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
                 "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
                 "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+                "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
                 "api_containerimage": "{api.containerImage}"
               }
             }
             """;
-        Assert.Equal(expectedManifest, manifest.ToString());
+        var m = manifest.ToString();
+        output.WriteLine(m);
+        Assert.Equal(expectedManifest, m);
 
         var expectedIdentityManifest =
             """
@@ -2899,21 +2807,21 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-
+            
             param api_identity_outputs_id string
-
+            
             param api_identity_outputs_clientid string
-
+            
             param redis_outputs_connectionstring string
-
-            param outputs_azure_container_registry_managed_identity_id string
-
+            
             param outputs_azure_container_apps_environment_id string
-
+            
             param outputs_azure_container_registry_endpoint string
-
+            
+            param outputs_azure_container_registry_managed_identity_id string
+            
             param api_containerimage string
-
+            
             resource api 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'api'
               location: location
@@ -3182,6 +3090,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         {
             foreach (var param in resource.Parameters)
             {
+                if (param.Key == AzureBicepResource.KnownParameters.KeyVaultName)
+                {
+                    // Skip kv since we fill it in by default
+                    continue;
+                }
+
                 if (AzureBicepResource.KnownParameters.IsKnownParameterName(param.Key))
                 {
                     Assert.Equal(string.Empty, param.Value);

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
@@ -180,7 +180,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
         var expectedManifest = $$"""
             {
               "type": "azure.bicep.v0",
-              "connectionString": "{{{kvName}}.secrets.postgres-data--connectionString}",
+              "connectionString": "{{{kvName}}.secrets.connectionstrings--postgres-data}",
               "path": "postgres-data.module.bicep",
               "params": {
                 "administratorLogin": "{{{userName?.Resource.Name ?? "postgres-data-username"}}.value}",
@@ -265,7 +265,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
             }
             
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'postgres-data--connectionString'
+              name: 'connectionstrings--postgres-data'
               properties: {
                 value: 'Host=${postgres_data.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'
               }
@@ -273,7 +273,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
             }
             
             resource db1_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'postgres-data--db1-connectionString'
+              name: 'connectionstrings--db1'
               properties: {
                 value: 'Host=${postgres_data.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=db1Name'
               }

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
@@ -88,25 +88,25 @@ public class AzurePublisherTests(ITestOutputHelper output)
             targetScope = 'subscription'
 
             param environmentName string
-
+            
             param location string
-
+            
             param principalId string
-
+            
             param storageSku string = 'Standard_LRS'
-
+            
             param skuDescription string = 'The sku is '
-
+            
             var tags = {
               'aspire-env-name': environmentName
             }
-
+            
             resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
               name: 'rg-${environmentName}'
               location: location
               tags: tags
             }
-
+            
             module acaEnv 'acaEnv/acaEnv.bicep' = {
               name: 'acaEnv'
               scope: rg
@@ -115,7 +115,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 userPrincipalId: principalId
               }
             }
-
+            
             module pg 'pg/pg.bicep' = {
               name: 'pg'
               scope: rg
@@ -123,7 +123,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-
+            
             module account 'account/account.bicep' = {
               name: 'account'
               scope: rg
@@ -131,7 +131,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-
+            
             module storage 'storage/storage.bicep' = {
               name: 'storage'
               scope: rg
@@ -141,7 +141,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 sku_description: '${skuDescription} ${storageSku}'
               }
             }
-
+            
             module mod 'mod/mod.bicep' = {
               name: 'mod'
               scope: rg
@@ -150,7 +150,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 pgdb: '${pg.outputs.connectionString};Database=pgdb'
               }
             }
-
+            
             module myapp_identity 'myapp-identity/myapp-identity.bicep' = {
               name: 'myapp-identity'
               scope: rg
@@ -158,7 +158,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-
+            
             module myapp_roles_account 'myapp-roles-account/myapp-roles-account.bicep' = {
               name: 'myapp-roles-account'
               scope: rg
@@ -168,7 +168,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 principalId: myapp_identity.outputs.principalId
               }
             }
-
+            
             module fe_identity 'fe-identity/fe-identity.bicep' = {
               name: 'fe-identity'
               scope: rg
@@ -176,7 +176,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-
+            
             module fe_roles_storage 'fe-roles-storage/fe-roles-storage.bicep' = {
               name: 'fe-roles-storage'
               scope: rg
@@ -186,24 +186,24 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 principalId: fe_identity.outputs.principalId
               }
             }
-
+            
             output myapp_identity_id string = myapp_identity.outputs.id
-
+            
             output myapp_identity_clientId string = myapp_identity.outputs.clientId
-
+            
             output account_connectionString string = account.outputs.connectionString
-
-            output acaEnv_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = acaEnv.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
-
+            
             output acaEnv_AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = acaEnv.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
-
+            
             output fe_identity_id string = fe_identity.outputs.id
-
+            
             output fe_identity_clientId string = fe_identity.outputs.clientId
-
+            
             output storage_blobEndpoint string = storage.outputs.blobEndpoint
-
+            
             output acaEnv_AZURE_CONTAINER_REGISTRY_ENDPOINT string = acaEnv.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+            
+            output acaEnv_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = acaEnv.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
             """;
         output.WriteLine(content);
         Assert.Equal(expectedBicep, content, ignoreAllWhiteSpace: true, ignoreLineEndingDifferences: true);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -114,7 +114,7 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
         var expectedManifest = $$"""
             {
               "type": "azure.bicep.v0",
-              "connectionString": "{{{kvName}}.secrets.redis-cache--connectionString}",
+              "connectionString": "{{{kvName}}.secrets.connectionstrings--redis-cache}",
               "path": "redis-cache.module.bicep",
               "params": {
                 "keyVaultName": "{{{kvName}}.outputs.name}"
@@ -153,7 +153,7 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
             }
             
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'redis-cache--connectionString'
+              name: 'connectionstrings--redis-cache'
               properties: {
                 value: '${redis_cache.properties.hostName},ssl=true,password=${redis_cache.listKeys().primaryKey}'
               }

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1336,41 +1336,42 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
         var expectedManifest = """
             {
               "type": "azure.bicep.v1",
-              "connectionString": "{redis.secretOutputs.connectionString}",
+              "connectionString": "{redis-kv.secrets.redis--connectionString}",
               "path": "redis.module.bicep",
               "params": {
-                "keyVaultName": ""
+                "keyVaultName": "{redis-kv.outputs.name}"
               },
               "scope": {
                 "resourceGroup": "existingResourceGroupName"
               }
             }
             """;
-
-        Assert.Equal(expectedManifest, ManifestNode.ToString());
+        var m = ManifestNode.ToString();
+        output.WriteLine(m);
+        Assert.Equal(expectedManifest, m);
 
         var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-
+            
             param keyVaultName string
-
+            
             resource redis 'Microsoft.Cache/redis@2024-03-01' existing = {
               name: 'existingResourceName'
             }
-
+            
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
-
+            
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'connectionString'
+              name: 'redis--connectionString'
               properties: {
                 value: '${redis.properties.hostName},ssl=true,password=${redis.listKeys().primaryKey}'
               }
               parent: keyVault
             }
-
+            
             output name string = redis.name
             """;
 
@@ -1614,31 +1615,33 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
         var expectedManifest = """
             {
               "type": "azure.bicep.v1",
-              "connectionString": "{cosmos.secretOutputs.connectionString}",
+              "connectionString": "{cosmos-kv.secrets.cosmos--connectionString}",
               "path": "cosmos.module.bicep",
               "params": {
-                "existingResourceName": "{existingResourceName.value}",
-                "keyVaultName": ""
+                "keyVaultName": "{cosmos-kv.outputs.name}",
+                "existingResourceName": "{existingResourceName.value}"
               },
               "scope": {
                 "resourceGroup": "{existingResourceGroupName.value}"
               }
             }
             """;
-        Assert.Equal(expectedManifest, ManifestNode.ToString());
+        var m = ManifestNode.ToString();
+        output.WriteLine(m);
+        Assert.Equal(expectedManifest, m);
 
         var expectedBicep = """
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
-
+            
             param existingResourceName string
-
+            
             param keyVaultName string
-
+            
             resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' existing = {
               name: existingResourceName
             }
-
+            
             resource mydb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
               name: 'mydb'
               location: location
@@ -1649,7 +1652,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
               }
               parent: cosmos
             }
-
+            
             resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
               name: 'container'
               location: location
@@ -1665,19 +1668,19 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
               }
               parent: mydb
             }
-
+            
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
-
+            
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'connectionString'
+              name: 'cosmos--connectionString'
               properties: {
                 value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'
               }
               parent: keyVault
             }
-
+            
             output name string = existingResourceName
             """;
 

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -852,7 +852,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
         var expectedManifest = """
             {
               "type": "azure.bicep.v1",
-              "connectionString": "{postgresSql-kv.secrets.postgresSql--connectionString}",
+              "connectionString": "{postgresSql-kv.secrets.connectionstrings--postgresSql}",
               "path": "postgresSql.module.bicep",
               "params": {
                 "administratorLogin": "{existingUserName.value}",
@@ -901,7 +901,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
             
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'postgresSql--connectionString'
+              name: 'connectionstrings--postgresSql'
               properties: {
                 value: 'Host=${postgresSql.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'
               }
@@ -1338,7 +1338,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
         var expectedManifest = """
             {
               "type": "azure.bicep.v1",
-              "connectionString": "{redis-kv.secrets.redis--connectionString}",
+              "connectionString": "{redis-kv.secrets.connectionstrings--redis}",
               "path": "redis.module.bicep",
               "params": {
                 "keyVaultName": "{redis-kv.outputs.name}"
@@ -1367,7 +1367,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
             
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'redis--connectionString'
+              name: 'connectionstrings--redis'
               properties: {
                 value: '${redis.properties.hostName},ssl=true,password=${redis.listKeys().primaryKey}'
               }
@@ -1617,7 +1617,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
         var expectedManifest = """
             {
               "type": "azure.bicep.v1",
-              "connectionString": "{cosmos-kv.secrets.cosmos--connectionString}",
+              "connectionString": "{cosmos-kv.secrets.connectionstrings--cosmos}",
               "path": "cosmos.module.bicep",
               "params": {
                 "keyVaultName": "{cosmos-kv.outputs.name}",
@@ -1676,7 +1676,7 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
             
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-              name: 'cosmos--connectionString'
+              name: 'connectionstrings--cosmos'
               properties: {
                 value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'
               }

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -703,6 +703,8 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             output vaultUri string = keyVault.properties.vaultUri
 
             output name string = existingResourceName
+
+            output id string = keyVault.id
             """;
 
         output.WriteLine(BicepText);


### PR DESCRIPTION
## Description

- This is a replacement for the magic secret outputs implementation. Resources that support keys push those keys into an explicitly defined per resource key vault and now into any key vault that is provided. The IKeyVaultSecretReference is a new primitive reference type that can is understood natively by compute environments like ACA and the azure preparer.

Fixes #8134

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)): https://github.com/dotnet/docs-aspire/issues/2889
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
