### PR TITLE
Run only quarantined tests in outer loop

### DIFF
--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -44,6 +44,8 @@ jobs:
         run: ${{ env.DOTNET_SCRIPT }} dev-certs https --trust
 
       - name: Run quarantined tests
+        env:
+          CI: false
         run: |
           ${{ env.BUILD_SCRIPT }} -projects ${{ github.workspace }}/tests/Shared/SolutionTests.proj -restore -build -test -c Release /p:RunQuarantinedTests=true /bl:${{ github.workspace }}/artifacts/log/Release/test-quarantined.binlog
 

--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -1,0 +1,173 @@
+# Executes quarantined tests in the outerloop
+name: Outerloop Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 14 * * *' # 6am PST (14:00 UTC)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  test:
+    name: ${{ matrix.os.title }}
+    runs-on: ${{ matrix.os.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu-latest
+            title: Linux
+          - name: windows-latest
+            title: Windows
+    steps:
+      - name: Setup vars (Linux)
+        if: ${{ matrix.os.name == 'ubuntu-latest' }}
+        run: |
+          echo "DOTNET_SCRIPT=./dotnet.sh" >> $GITHUB_ENV
+          echo "BUILD_SCRIPT=./build.sh" >> $GITHUB_ENV
+
+      - name: Setup vars (Windows)
+        if: ${{ matrix.os.name == 'windows-latest' }}
+        run: |
+          echo "DOTNET_SCRIPT=.\dotnet.cmd" >> $env:GITHUB_ENV
+          echo "BUILD_SCRIPT=.\build.cmd" >> $env:GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Trust HTTPS development certificate (Linux)
+        if: matrix.os.name == 'ubuntu-latest'
+        run: ${{ env.DOTNET_SCRIPT }} dev-certs https --trust
+
+      - name: Run quarantined tests
+        run: |
+          ${{ env.BUILD_SCRIPT }} -projects ${{ github.workspace }}/tests/Shared/SolutionTests.proj -restore -build -test -c Release /p:RunQuarantinedTests=true /bl:${{ github.workspace }}/artifacts/log/Release/test-quarantined.binlog
+
+      - name: Keep only relevant test logs
+        if: always()
+        shell: pwsh
+        run: |
+          # Define the directory to search for log files
+          $logDirectory = "${{ github.workspace }}/artifacts/log/**/TestLogs"
+
+          # Define the text to search for in the log files
+          $searchText = "No test matches the given testcase filter"
+          $resultsFilePattern = "Results File: (.+)"
+
+          # Get all .log files in the specified directory and its subdirectories
+          $logFiles = Get-ChildItem -Path $logDirectory -Filter *.log -Recurse
+
+          foreach ($logFile in $logFiles) {
+              # Read the content of the log file
+              $content = Get-Content -Path $logFile.FullName
+
+              # Check if the content contains the specified text
+              if ($content -match $searchText) {
+                  # Remove the log file if it contains the specified text
+                  Remove-Item -Path $logFile.FullName -Force
+                  Write-Host "Removed file: $($logFile.FullName)"
+              }
+              else {
+                  # Extract paths from lines containing "Results File: <path>"
+                  foreach ($line in $content) {
+                      if ($line -match $resultsFilePattern) {
+                          $resultsFilePath = $matches[1]
+                          Write-Host "Found results file: $resultsFilePath"
+
+                          # Copy the results file to the TestLogs folder
+                          $destinationPath = (Split-Path -Path $logFile.FullName -Parent)
+                          Copy-Item -Path $resultsFilePath -Destination $destinationPath -Force
+                          Write-Host "Copied $resultsFilePath to $destinationPath"
+                      }
+                  }
+              }
+          }
+
+      - name: Process logs and post results
+        if: always()
+        shell: pwsh
+        run: |
+          $logDirectory = "${{ github.workspace }}/artifacts/log/**/TestLogs"
+          $trxFiles = Get-ChildItem -Path $logDirectory -Filter *.trx -Recurse
+
+          $testResults = @() # Initialize an array to store test results
+
+          foreach ($trxFile in $trxFiles) {
+              # Load the .trx file as XML
+              $xmlContent = [xml](Get-Content -Path $trxFile.FullName)
+
+              # Extract test results from the XML
+              foreach ($testResult in $xmlContent.TestRun.Results.UnitTestResult) {
+                  $testName = $testResult.testName
+                  $outcome = $testResult.outcome
+                  $duration = $testResult.duration
+
+                  # Map outcome to emoji
+                  switch ($outcome) {
+                      "Passed" { $emoji = "✔️" }
+                      "Failed" { $emoji = "❌" }
+                      default { $emoji = "❔" }
+                  }
+
+                  # Normalize the duration to a consistent format (hh:mm:ss.fff)
+                  $normalizedDuration = [TimeSpan]::Parse($duration).ToString("mm\:ss\.fff")
+
+                  # Add the test result to the array
+                  $testResults += [PSCustomObject]@{
+                      TestName    = $testName
+                      Outcome     = $outcome
+                      OutcomeIcon = $emoji
+                      Duration    = $normalizedDuration
+                  }
+              }
+          }
+
+          # Sort the test results by test name
+          $testResults = $testResults | Sort-Object -Property TestName
+
+          # Calculate summary statistics
+          $totalTests = $testResults.Count
+          $passedTests = ($testResults | Where-Object { $_.Outcome -eq "Passed" }).Count
+          $failedTests = ($testResults | Where-Object { $_.Outcome -eq "Failed" }).Count
+          $skippedTests = ($testResults | Where-Object { $_.Outcome -eq "NotExecuted" }).Count
+
+          # Add the summary to the annotation
+          $summary = "total: $totalTests, passed: $passedTests, failed: $failedTests, skipped: $skippedTests"
+          if ($failedTests -gt 0) {
+              Write-Host "::error::Tests Summary: $summary"
+          } else {
+              Write-Host "::notice::Tests Summary: $summary"
+          }
+
+          # Format the test results as a console-friendly table
+          $tableHeader = "{0,-16} {1,-150} {2,-20}" -f "Duration", "Test Name", "Result"
+          $tableSeparator = "-" * 185
+          $tableRows = $testResults | ForEach-Object { "{0,-16} {1,-150} {2,-20}" -f $_.Duration, $_.TestName, "$($_.OutcomeIcon) $($_.Outcome)" }
+          $table = "$tableHeader`n$tableSeparator`n" + ($tableRows -join "`n") + "`n$tableSeparator`n"
+          Write-Host "`nTest Results:`n`n$table"
+
+          # Optionally, save the results to a file for further processing
+          $outputPath = "${{ github.workspace }}/artifacts/log/Release/TestLogs/summary.log"
+          $table | Out-File -FilePath $outputPath -Encoding utf8
+          Write-Host "Test results saved to $outputPath"
+
+          # Windows-specific: Check for failed tests and set the exit code accordingly
+          # This is a workaround for the issue with the `exit` command in PowerShell
+          if ($failedTests -gt 0) {
+              Write-Host "::error::Build failed. Check errors above."
+              exit 1
+          }
+
+      - name: Upload logs, and test results
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: logs-${{ matrix.os.name }}
+          path: |
+            ${{ github.workspace }}/artifacts/log/*/*.binlog
+            ${{ github.workspace }}/artifacts/log/*/TestLogs/**
+          retention-days: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
     with:
       testShortName: ${{ matrix.shortname }}
       os: "ubuntu-latest"
+      extraTestArgs: "--filter \"(quarantined!=true)\""
 
   integrations_test_win:
     uses: ./.github/workflows/run-tests.yml
@@ -86,6 +87,7 @@ jobs:
     with:
       testShortName: ${{ matrix.shortname }}
       os: "windows-latest"
+      extraTestArgs: "--filter \"(quarantined!=true)\""
 
   templates_test_lin:
     name: Templates Linux
@@ -101,7 +103,7 @@ jobs:
       testSessionTimeoutMs: 1200000
       testHangTimeout: 12m
       # append '.' to the name so only the test class with exactly that name is run
-      extraTestArgs: "--filter FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}."
+      extraTestArgs: "--filter \"(quarantined!=true)&(FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}.\""
       requiresNugets: true
       requiresTestSdk: true
 
@@ -119,7 +121,7 @@ jobs:
       testSessionTimeoutMs: 1200000
       testHangTimeout: 12m
       # append '.' to the name so only the test class with exactly that name is run
-      extraTestArgs: "--filter FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}."
+      extraTestArgs: "--filter \"(quarantined!=true)&(FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}.\""
       requiresNugets: true
       requiresTestSdk: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
       testSessionTimeoutMs: 1200000
       testHangTimeout: 12m
       # append '.' to the name so only the test class with exactly that name is run
-      extraTestArgs: "--filter \"(quarantined!=true)&(FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}.\""
+      extraTestArgs: "--filter \"(quarantined!=true)&(FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}.)\""
       requiresNugets: true
       requiresTestSdk: true
 
@@ -121,7 +121,7 @@ jobs:
       testSessionTimeoutMs: 1200000
       testHangTimeout: 12m
       # append '.' to the name so only the test class with exactly that name is run
-      extraTestArgs: "--filter \"(quarantined!=true)&(FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}.\""
+      extraTestArgs: "--filter \"(quarantined!=true)&(FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}.)\""
       requiresNugets: true
       requiresTestSdk: true
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <Import Condition="'$(SampleProject)' == 'true' or '$(CI)' != 'true' " Project="eng\Versions.dev.targets" />
-  <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true' " Project="eng\Versions.targets" />
+  <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true' and '$(RunTestsOnGithubActions)' != 'true' " Project="eng\Versions.targets" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <Import Condition="'$(SampleProject)' == 'true' or '$(CI)' != 'true' " Project="eng\Versions.dev.targets" />
-  <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true' and '$(RunTestsOnGithubActions)' != 'true' " Project="eng\Versions.targets" />
+  <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true' " Project="eng\Versions.targets" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 

--- a/eng/Testing.props
+++ b/eng/Testing.props
@@ -1,0 +1,19 @@
+<Project>
+  <PropertyGroup Condition="'$(UseVSTestRunner)' != 'true'">
+    <_QuarantinedTestRunAdditionalArgs>-trait "quarantined=true"</_QuarantinedTestRunAdditionalArgs>
+    <_NonQuarantinedTestRunAdditionalArgs>-notrait "quarantined=true"</_NonQuarantinedTestRunAdditionalArgs>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseVSTestRunner)' == 'true'">
+    <_QuarantinedTestRunAdditionalArgs>--filter "quarantined=true"</_QuarantinedTestRunAdditionalArgs>
+    <_NonQuarantinedTestRunAdditionalArgs>--filter "quarantined!=true"</_NonQuarantinedTestRunAdditionalArgs>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <BlameHangTimeout Condition="'$(BlameHangTimeout)' == ''">10m</BlameHangTimeout>
+    <_BlameArgs>--blame --blame-hang-timeout $(BlameHangTimeout) --blame-crash</_BlameArgs>
+
+    <TestRunnerAdditionalArguments Condition="'$(RunQuarantinedTests)' == ''">$(TestRunnerAdditionalArguments) $(_NonQuarantinedTestRunAdditionalArgs) $(TestRunnerAdditionalArguments) $(_BlameArgs)</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments Condition="'$(RunQuarantinedTests)' == 'true'">$(TestRunnerAdditionalArguments) $(_QuarantinedTestRunAdditionalArgs) $(TestRunnerAdditionalArguments) $(_BlameArgs)</TestRunnerAdditionalArguments>
+  </PropertyGroup>
+</Project>

--- a/eng/Testing.targets
+++ b/eng/Testing.targets
@@ -1,0 +1,3 @@
+<Project>
+
+</Project>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -107,5 +107,3 @@ if ($env:TreatWarningsAsErrors -eq 'false') {
 
 Write-Host "& `"$PSScriptRoot/common/build.ps1`" $arguments"
 Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $arguments"
-
-exit 0

--- a/global.json
+++ b/global.json
@@ -22,9 +22,10 @@
     }
   },
   "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.7.0",
+    "Microsoft.Build.Traversal": "3.2.0",
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.25164.2",
     "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.25164.2",
-    "Microsoft.DotNet.SharedFramework.Sdk": "9.0.0-beta.25164.2",
-    "Microsoft.Build.NoTargets": "3.7.0"
+    "Microsoft.DotNet.SharedFramework.Sdk": "9.0.0-beta.25164.2"
   }
 }

--- a/tests/Aspire.Azure.Npgsql.Tests/PostgreSQLContainerFixture.cs
+++ b/tests/Aspire.Azure.Npgsql.Tests/PostgreSQLContainerFixture.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Postgres;
 using Aspire.TestUtilities;
 using Testcontainers.PostgreSql;

--- a/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
@@ -93,7 +93,7 @@ public class CliOrphanDetectorTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7920", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnGithubActions), nameof(PlatformDetection.IsWindows))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7920")]
     public async Task AppHostExitsWhenCliProcessPidDies()
     {
         using var fakeCliProcess = RemoteExecutor.Invoke(

--- a/tests/Aspire.Components.Common.Tests/ComponentTestConstants.cs
+++ b/tests/Aspire.Components.Common.Tests/ComponentTestConstants.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.TestUtilities;
+namespace Aspire.Components.Common.Tests;
 
 public static class ComponentTestConstants
 {

--- a/tests/Aspire.Confluent.Kafka.Tests/KafkaContainerFixture.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/KafkaContainerFixture.cs
@@ -10,6 +10,7 @@ using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
 using Testcontainers.Kafka;
 using Xunit;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.Confluent.Kafka.Tests;
 

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -12,6 +12,7 @@
     <InstallBrowsersForPlaywright Condition="'$(InstallBrowsersForPlaywright)' == '' and '$(OS)' == 'Windows_NT' and '$(ContinuousIntegrationBuild)' != 'true'">true</InstallBrowsersForPlaywright>
 
     <RunTestsOnHelix>false</RunTestsOnHelix>
+    <SkipTests Condition=" '$(OS)' != 'Windows_NT' and '$(RunTestsOnGithubActions)' != 'true' and '$(RunTestsOnHelix)' != 'true' ">true</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -12,7 +12,6 @@
     <InstallBrowsersForPlaywright Condition="'$(InstallBrowsersForPlaywright)' == '' and '$(OS)' == 'Windows_NT' and '$(ContinuousIntegrationBuild)' != 'true'">true</InstallBrowsersForPlaywright>
 
     <RunTestsOnHelix>false</RunTestsOnHelix>
-    <SkipTests Condition=" '$(OS)' != 'Windows_NT' and '$(RunTestsOnGithubActions)' != 'true' and '$(RunTestsOnHelix)' != 'true' ">true</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
+using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Playwright;
 using Xunit;
@@ -17,7 +18,7 @@ public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7943")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7943")]
     public async Task AppBar_Change_Theme()
     {
         // Arrange
@@ -64,7 +65,7 @@ public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7943")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7943")]
     public async Task AppBar_Change_Theme_ReloadPage()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -29,7 +29,7 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7921", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnGithubActions))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7921")]
     public async Task BrowserToken_LoginPage_Success_RedirectToResources()
     {
         // Arrange

--- a/tests/Aspire.Elastic.Clients.Elasticsearch.Tests/ElasticsearchContainerFixture.cs
+++ b/tests/Aspire.Elastic.Clients.Elasticsearch.Tests/ElasticsearchContainerFixture.cs
@@ -5,6 +5,7 @@ using Aspire.TestUtilities;
 using Aspire.Hosting.Elasticsearch;
 using Testcontainers.Elasticsearch;
 using Xunit;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.Elastic.Clients.Elasticsearch.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
@@ -267,7 +267,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7178")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7178")]
     public async Task AddAzureCosmosDB_RunAsEmulator_CreatesDatabase()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));

--- a/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
@@ -25,7 +25,7 @@ public class ElasticsearchFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/5821")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/5821")]
     public async Task VerifyElasticsearchResource()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
@@ -68,7 +68,7 @@ public class ElasticsearchFunctionalTests(ITestOutputHelper testOutputHelper)
     [InlineData(true)]
     [InlineData(false)]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7276")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7276")]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
@@ -231,7 +231,7 @@ public class ElasticsearchFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/5844")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/5844")]
     public async Task VerifyWaitForOnElasticsearchBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -103,7 +103,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
     [InlineData(true)]
     [InlineData(false)]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7293")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7293")]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var dbName = "testdb";
@@ -247,7 +247,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/5937")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/5937")]
     public async Task VerifyWithInitBindMount()
     {
         // Creates a script that should be executed when the container is initialized.

--- a/tests/Aspire.Hosting.NodeJs.Tests/NodeFunctionalTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/NodeFunctionalTests.cs
@@ -18,7 +18,7 @@ public class NodeFunctionalTests : IClassFixture<NodeAppFixture>
 
     [Fact]
     [RequiresTools(["node"])]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4508", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4508")]
     public async Task VerifyNodeAppWorks()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
@@ -30,7 +30,7 @@ public class NodeFunctionalTests : IClassFixture<NodeAppFixture>
 
     [Fact]
     [RequiresTools(["npm"])]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4508", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4508")]
     public async Task VerifyNpmAppWorks()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Aspire.Hosting.Oracle.Tests;
 
-[ActiveIssue("https://github.com/dotnet/aspire/issues/5362", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+[QuarantinedTest("https://github.com/dotnet/aspire/issues/5362")]
 public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     // Folders created for mounted folders need to be granted specific permissions

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 using Aspire.Hosting.Tests.Dcp;
 using System.Text.Json.Nodes;
 using Aspire.Hosting;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.Hosting.Redis.Tests;
 
@@ -24,7 +25,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7177")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7177")]
     public async Task VerifyWaitForOnRedisBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -123,7 +124,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7291")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7291")]
     public async Task VerifyDatabasesAreNotDuplicatedForPersistentRedisInsightContainer()
     {
         var randomResourceSuffix = Random.Shared.Next(10000).ToString();
@@ -228,7 +229,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/6099")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/6099")]
     public async Task VerifyWithRedisInsightImportDatabases()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
@@ -536,7 +537,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     [InlineData(false)]
     [InlineData(true)]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7176")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7176")]
     public async Task RedisInsightWithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -210,7 +210,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     [InlineData(false, true)]
     [InlineData(true, false)]
     [InlineData(true, true)]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7930", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnGithubActions), nameof(PlatformDetection.IsWindows))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7930")]
     public async Task ArgsPropagateToAppHostConfiguration(bool genericEntryPoint, bool directArgs)
     {
         string[] args = directArgs ? ["APP_HOST_ARG=42"] : [];

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -46,7 +46,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4650", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4650")]
     public async Task HttpClientGetTest()
     {
         // Wait for the application to be ready
@@ -69,7 +69,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4650")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4650")]
     public async Task SelectsFirstLaunchProfile()
     {
         var config = _app.Services.GetRequiredService<IConfiguration>();

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppContainers\Aspire.Hosting.Azure.AppContainers.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.NodeJs\Aspire.Hosting.NodeJs.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Testing\Aspire.Hosting.Testing.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\Aspire.TestUtilities\Aspire.TestUtilities.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\testproject\TestProject.AppHost\TestProject.AppHost.csproj" IsAspireProjectResource="false" />
   </ItemGroup>

--- a/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
+using Aspire.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -52,7 +53,7 @@ public class CodespacesUrlRewriterTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/6648")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/6648")]
     public async Task VerifyUrlsRewrittenWhenInCodespaces()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -962,6 +962,7 @@ public class DistributedApplicationTests
         }).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
     }
 
+    [Fact]
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/4599")]
     public async Task ProxylessAndProxiedEndpointBothWorkOnSameResource()
     {

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -311,7 +311,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task AllocatedPortsAssignedAfterHookRuns()
     {
         using var testProgram = CreateTestProgram("ports-assigned-after-hook-runs");
@@ -344,7 +344,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task TestServicesWithMultipleReplicas()
     {
         var replicaCount = 3;
@@ -401,7 +401,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task VerifyContainerArgs()
     {
         using var testProgram = CreateTestProgram("verify-container-args");
@@ -486,7 +486,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task VerifyContainerStopStartWorks()
     {
         using var testProgram = CreateTestProgram("container-start-stop", randomizePorts: false);
@@ -539,7 +539,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task VerifyExecutableStopStartWorks()
     {
         const string testName = "executable-start-stop";
@@ -574,7 +574,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task SpecifyingEnvPortInEndpointFlowsToEnv()
     {
         const string testName = "ports-flow-to-env";
@@ -631,7 +631,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task StartAsync_DashboardAuthConfig_PassedToDashboardProcess()
     {
         const string testName = "dashboard-auth-config";
@@ -672,7 +672,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task StartAsync_UnsecuredAllowAnonymous_PassedToDashboardProcess()
     {
         const string testName = "dashboard-allow-anonymous";
@@ -709,7 +709,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task VerifyDockerWithEntrypointWorks()
     {
         const string testName = "docker-entrypoint";
@@ -738,7 +738,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task VerifyDockerWithBindMountWorksWithAbsolutePaths()
     {
         const string testName = "docker-bindmount-absolute";
@@ -769,7 +769,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task VerifyDockerWithBindMountWorksWithRelativePaths()
     {
         const string testName = "docker-bindmount-relative";
@@ -800,7 +800,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task VerifyDockerWithVolumeWorksWithName()
     {
         const string testName = "docker-volume";
@@ -830,7 +830,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task KubernetesHasResourceNameForContainersAndExes()
     {
         const string testName = "kube-resource-names";
@@ -888,7 +888,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task ReplicasAndProxylessEndpointThrows()
     {
         const string testName = "replicas-no-proxyless-endpoints";
@@ -907,7 +907,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task ProxylessEndpointWithoutPortThrows()
     {
         const string testName = "proxyess-endpoint-without-port";
@@ -927,7 +927,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task ProxylessEndpointWorks()
     {
         const string testName = "proxyless-endpoint-works";
@@ -963,7 +963,7 @@ public class DistributedApplicationTests
     }
 
     [Fact(Skip = "https://github.com/dotnet/aspire/issues/4599")]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4599", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4599")]
     public async Task ProxylessAndProxiedEndpointBothWorkOnSameResource()
     {
         const string testName = "proxyless-and-proxied-endpoints";
@@ -1031,7 +1031,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task ProxylessContainerCanBeReferenced()
     {
         const string testName = "proxyless-container";
@@ -1137,7 +1137,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task ProxylessContainerWithoutPortThrows()
     {
         const string testName = "proxyless-container-without-ports";
@@ -1156,7 +1156,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task AfterResourcesCreatedLifecycleHookWorks()
     {
         const string testName = "lifecycle-hook-after-resource-created";

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -962,7 +962,6 @@ public class DistributedApplicationTests
         }).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
     }
 
-    [Fact(Skip = "https://github.com/dotnet/aspire/issues/4599")]
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/4599")]
     public async Task ProxylessAndProxiedEndpointBothWorkOnSameResource()
     {

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -4,6 +4,7 @@
 using System.Threading.Channels;
 using Aspire.Hosting.Health;
 using Aspire.Hosting.Utils;
+using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -96,7 +97,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/8326")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8326")]
     public async Task ResourcesWithHealthCheck_CreationErrorIsReported()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
@@ -137,7 +138,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/8103")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8103")]
     public async Task ResourcesWithHealthCheck_StopsAndRestartsMonitoringWithResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Redis;
 using Aspire.Hosting.Tests.Helpers;
 using Aspire.Hosting.Utils;
-using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;

--- a/tests/Aspire.Hosting.Tests/SlimTestProgramTests.cs
+++ b/tests/Aspire.Hosting.Tests/SlimTestProgramTests.cs
@@ -19,7 +19,7 @@ public class SlimTestProgramTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7923", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnGithubActions), nameof(PlatformDetection.IsWindows))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7923")]
     public async Task TestProjectStartsAndStopsCleanly()
     {
         var testProgram = _slimTestProgramFixture.TestProgram;
@@ -44,7 +44,7 @@ public class SlimTestProgramTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7923", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnGithubActions), nameof(PlatformDetection.IsWindows))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7923")]
     public async Task TestPortOnEndpointAnnotationAndAllocatedEndpointAnnotationMatch()
     {
         var testProgram = _slimTestProgramFixture.TestProgram;
@@ -63,7 +63,7 @@ public class SlimTestProgramTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/7923", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnGithubActions), nameof(PlatformDetection.IsWindows))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7923")]
     public async Task TestPortOnEndpointAnnotationAndAllocatedEndpointAnnotationMatchForReplicatedServices()
     {
         var testProgram = _slimTestProgramFixture.TestProgram;

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Orchestrator;
 using Aspire.Hosting.Testing;
 using Aspire.Hosting.Tests.Dcp;
-using Aspire.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Utils;

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
+using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -130,7 +131,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     [InlineData(404, false)]
     [InlineData(500, false)]
     [Theory]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/8194")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8194")]
     public async Task WithHttpCommand_ResultsInExpectedResultForStatusCode(int statusCode, bool expectSuccess)
     {
         // Arrange
@@ -261,7 +262,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/8192")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8192")]
     public async Task WithHttpCommand_CallsPrepareRequestCallback_BeforeSendingRequest()
     {
         // Arrange
@@ -306,7 +307,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/8200")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8200")]
     public async Task WithHttpCommand_CallsGetResponseCallback_AfterSendingRequest()
     {
         // Arrange
@@ -352,7 +353,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/8101")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8101")]
     public async Task WithHttpCommand_EnablesCommandOnceResourceIsRunning()
     {
         // Arrange

--- a/tests/Aspire.Milvus.Client.Tests/MilvusContainerFixture.cs
+++ b/tests/Aspire.Milvus.Client.Tests/MilvusContainerFixture.cs
@@ -5,6 +5,7 @@ using Aspire.TestUtilities;
 using Aspire.Hosting.Milvus;
 using Testcontainers.Milvus;
 using Xunit;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.Milvus.Client.Tests;
 

--- a/tests/Aspire.MongoDB.Driver.Tests/MongoDbContainerFixture.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/MongoDbContainerFixture.cs
@@ -5,6 +5,7 @@ using Aspire.TestUtilities;
 using Aspire.Hosting.MongoDB;
 using Testcontainers.MongoDb;
 using Xunit;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.MongoDB.Driver.Tests;
 

--- a/tests/Aspire.MySqlConnector.Tests/MySqlContainerFixture.cs
+++ b/tests/Aspire.MySqlConnector.Tests/MySqlContainerFixture.cs
@@ -5,6 +5,7 @@ using Aspire.TestUtilities;
 using Aspire.Hosting.MySql;
 using Testcontainers.MySql;
 using Xunit;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.MySqlConnector.Tests;
 

--- a/tests/Aspire.NATS.Net.Tests/NatsContainerFixture.cs
+++ b/tests/Aspire.NATS.Net.Tests/NatsContainerFixture.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Nats;
 using Aspire.TestUtilities;
 using Testcontainers.Nats;

--- a/tests/Aspire.Npgsql.Tests/PostgreSQLContainerFixture.cs
+++ b/tests/Aspire.Npgsql.Tests/PostgreSQLContainerFixture.cs
@@ -5,6 +5,7 @@ using Aspire.TestUtilities;
 using Aspire.Hosting.Postgres;
 using Testcontainers.PostgreSql;
 using Xunit;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.Npgsql.Tests;
 

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Aspire.TestUtilities;
 using DotNet.Testcontainers.Builders;
 using Testcontainers.Oracle;

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -31,7 +31,7 @@ public class AppHostTests
 
     [Theory]
     [MemberData(nameof(TestEndpoints))]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/6866")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/6866")]
     public async Task TestEndpointsReturnOk(TestEndpoints testEndpoints)
     {
         var appHostType = testEndpoints.AppHostType!;

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.Hosting.Tests\Utils\LoggerNotificationExtensions.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\FileUtil.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\PlatformDetection.cs" />
+    <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\QuarantinedTestTraitDiscoverer.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\Requires*.cs" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" />
   </ItemGroup>
@@ -88,6 +89,7 @@
     <None Include="$(RepoRoot)tests\Aspire.Hosting.Tests\Utils\LoggerNotificationExtensions.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\LoggerNotificationExtensions.cs" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\FileUtil.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\PlatformDetection.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(RepoRoot)tests\Aspire.TestUtilities\QuarantinedTestTraitDiscoverer.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\Requires*.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
 
     <None Include="..\helix\xunit.runner.json" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -30,7 +30,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/6867")]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/6867")]
     public async Task KafkaTest()
     {
         var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.KafkaBasic_AppHost), _testOutput);

--- a/tests/Aspire.Playground.Tests/QuarantinedTestAttribute.cs
+++ b/tests/Aspire.Playground.Tests/QuarantinedTestAttribute.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit.Sdk;
+
+namespace Aspire.TestUtilities;
+
+/// <summary>
+/// Marks a test as "quarantined" so that the build will sequester it and ignore failures.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute works by applying xUnit.net "Traits" based on the criteria specified in the attribute
+/// properties. Once these traits are applied, build scripts can include/exclude tests based on them.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [Fact]
+/// [QuarantinedTest]
+/// public void FlakyTest()
+/// {
+///     // Flakiness
+/// }
+/// </code>
+///
+/// <para>
+/// The above example generates the following facet:
+/// </para>
+///
+/// <list type="bullet">
+/// <item>
+///     <description><c>quarantined</c> = <c>true</c></description>
+/// </item>
+/// </list>
+/// </example>
+// NOTE: This is a duplicate of QuarantinedTestAttribute from Aspire.TestUtilities project, but because files are directly
+// linked into this project, we must adjust the containing assembly name.
+[TraitDiscoverer("Aspire.TestUtilities.QuarantinedTestTraitDiscoverer", "Aspire.Playground.Tests")]
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+public sealed class QuarantinedTestAttribute : Attribute, ITraitAttribute
+{
+    /// <summary>
+    /// Gets an optional reason for the quarantining, such as a link to a GitHub issue URL with more details as to why the test is quarantined.
+    /// </summary>
+    public string? Reason { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuarantinedTestAttribute"/> class with an optional <see cref="Reason"/>.
+    /// </summary>
+    /// <param name="reason">A reason that this test is quarantined.</param>
+    public QuarantinedTestAttribute(string? reason = null)
+    {
+        Reason = reason;
+    }
+}

--- a/tests/Aspire.Qdrant.Client.Tests/QdrantContainerFixture.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/QdrantContainerFixture.cs
@@ -6,6 +6,7 @@ using Aspire.Hosting.Qdrant;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using Xunit;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.Qdrant.Client.Tests;
 

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using Aspire.TestUtilities;
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting.RabbitMQ;
+using Aspire.TestUtilities;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/tests/Aspire.RabbitMQ.Client.Tests/RabbitMQContainerFixture.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/RabbitMQContainerFixture.cs
@@ -5,6 +5,7 @@ using Aspire.TestUtilities;
 using Aspire.Hosting.RabbitMQ;
 using Testcontainers.RabbitMq;
 using Xunit;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.RabbitMQ.Client.Tests;
 

--- a/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
@@ -5,6 +5,7 @@ using Aspire.TestUtilities;
 using Aspire.Hosting.Redis;
 using Testcontainers.Redis;
 using Xunit;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.StackExchange.Redis.Tests;
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.TestUtilities;
-using Xunit;
 
 namespace Aspire.Templates.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
-[ActiveIssue("https://github.com/dotnet/aspire/issues/8473", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnGithubActions))]
+[QuarantinedTest("https://github.com/dotnet/aspire/issues/8191")]
 public class StarterTemplateWithRedisCacheTests : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.TestUtilities;
-using Xunit;
 
 namespace Aspire.Templates.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
-[ActiveIssue("https://github.com/dotnet/aspire/issues/8473", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnGithubActions))]
+[QuarantinedTest("https://github.com/dotnet/aspire/issues/8191")]
 public class StarterTemplateWithRedisCacheTests_PreviousTFM : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture_PreviousTFM>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;

--- a/tests/Aspire.TestUtilities/QuarantinedTestAttribute.cs
+++ b/tests/Aspire.TestUtilities/QuarantinedTestAttribute.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit.Sdk;
+
+namespace Aspire.TestUtilities;
+
+/// <summary>
+/// Marks a test as "quarantined" so that the build will sequester it and ignore failures.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute works by applying xUnit.net "Traits" based on the criteria specified in the attribute
+/// properties. Once these traits are applied, build scripts can include/exclude tests based on them.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [Fact]
+/// [QuarantinedTest]
+/// public void FlakyTest()
+/// {
+///     // Flakiness
+/// }
+/// </code>
+///
+/// <para>
+/// The above example generates the following facet:
+/// </para>
+///
+/// <list type="bullet">
+/// <item>
+///     <description><c>quarantined</c> = <c>true</c></description>
+/// </item>
+/// </list>
+/// </example>
+[TraitDiscoverer("Aspire.TestUtilities.QuarantinedTestTraitDiscoverer", "Aspire.TestUtilities")]
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+public sealed class QuarantinedTestAttribute : Attribute, ITraitAttribute
+{
+    /// <summary>
+    /// Gets an optional reason for the quarantining, such as a link to a GitHub issue URL with more details as to why the test is quarantined.
+    /// </summary>
+    public string? Reason { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuarantinedTestAttribute"/> class with an optional <see cref="Reason"/>.
+    /// </summary>
+    /// <param name="reason">A reason that this test is quarantined.</param>
+    public QuarantinedTestAttribute(string? reason = null)
+    {
+        Reason = reason;
+    }
+}

--- a/tests/Aspire.TestUtilities/QuarantinedTestTraitDiscoverer.cs
+++ b/tests/Aspire.TestUtilities/QuarantinedTestTraitDiscoverer.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit.Sdk;
+
+// Do not change this namespace without changing the usage in QuarantinedTestAttribute
+namespace Aspire.TestUtilities;
+
+public sealed class QuarantinedTestTraitDiscoverer : ITraitDiscoverer
+{
+    public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+    {
+        if (traitAttribute is ReflectionAttributeInfo attribute && attribute.Attribute is QuarantinedTestAttribute)
+        {
+            yield return new KeyValuePair<string, string>("quarantined", "true");
+        }
+        else
+        {
+            throw new InvalidOperationException("The 'QuarantinedTest' attribute is only supported via reflection.");
+        }
+    }
+}

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
+  <Import Project="$(RepositoryEngineeringDir)Testing.props" />
   <Import Project="$(TestsSharedRepoTestingDir)Aspire.RepoTesting.props" />
 
   <PropertyGroup>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -27,7 +27,8 @@
     <None Include="$(XunitRunnerJson)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <Target Name="ZipTestArchive" AfterTargets="Build" Condition="'$(ArchiveTests)' == 'true' and '$(RunTestsOnHelix)' == 'true' and '$(IsCrossTargetingBuild)' != 'true'">
+  <Target Name="ZipTestArchive" AfterTargets="Build"
+          Condition="'$(ArchiveTests)' == 'true' and '$(RunTestsOnHelix)' == 'true' and '$(IsTestUtilityProject)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'">
     <Error Condition="'$(TestArchiveTestsDir)' == ''" Text="TestArchiveTestsDir property to archive the test folder must be set." />
     <PropertyGroup>
       <TestsArchiveSourceDir Condition="'$(TestsArchiveSourceDir)' == ''">$(OutDir)</TestsArchiveSourceDir>
@@ -79,4 +80,5 @@
   </Target>
 
   <Import Project="$(TestsSharedDir)Aspire.Templates.Testing.targets" Condition="'$(IsTemplateTestProject)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)Testing.targets" />
 </Project>

--- a/tests/Shared/SolutionTests.proj
+++ b/tests/Shared/SolutionTests.proj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.Build.Traversal">
+  <!--
+    This file is used to build all the eligible test projects in the repo.
+    It is used to execute the tests in the outer loop and in the CI pipeline.
+
+    Generally, this project should invoked in the following way:
+
+      ./build.cmd -projects ./tests/Shared/SolutionTests.proj -restore -build -test /p:RunQuarantinedTests=[true|false]
+
+   -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_TestProjectsToExclude Include="$(RepoRoot)tests\Shared\**\*Tests.csproj" />
+    <_TestProjectsToExclude Include="$(RepoRoot)tests\testproject\**\*Tests.csproj" />
+    <_TestProjectsToExclude Include="$(RepoRoot)tests\TestingAppHost1\**\*Tests.csproj" />
+
+    <!-- This runs in a separate job -->
+    <_TestProjectsToExclude Include="$(RepoRoot)tests\Aspire.Workload.Tests\**\*Tests.csproj" />
+
+    <_TestProjectsToInclude Include="$(RepoRoot)tests\Aspire.Hosting.Tests\*Tests.csproj" />
+
+    <!-- Add all the test projects we want to build as project references, so the traversal SDK can build them -->
+    <ProjectReference Include="@(_TestProjectsToInclude)"
+                      Exclude="@(_TestProjectsToExclude)" />
+  </ItemGroup>
+
+</Project>

--- a/tests/helix/send-to-helix-basictests.targets
+++ b/tests/helix/send-to-helix-basictests.targets
@@ -21,8 +21,8 @@
       <!-- needed for Aspire.Hosting.Container.Tests -->
       <HelixPreCommand Include="$(_EnvVarSetKeyword) DOCKER_BUILDKIT=1" />
 
-      <_TestRunCommandArguments Condition="'$(OS)' != 'Windows_NT'" Include="-- RunConfiguration.TestSessionTimeout=$TEST_TIMEOUT" />
-      <_TestRunCommandArguments Condition="'$(OS)' == 'Windows_NT'" Include="-- RunConfiguration.TestSessionTimeout=%TEST_TIMEOUT%" />
+      <_TestRunCommandArguments Condition="'$(OS)' != 'Windows_NT'" Include="--filter &quot;quarantined!=true&quot; -- RunConfiguration.TestSessionTimeout=$TEST_TIMEOUT" />
+      <_TestRunCommandArguments Condition="'$(OS)' == 'Windows_NT'" Include="--filter &quot;quarantined!=true&quot; -- RunConfiguration.TestSessionTimeout=%TEST_TIMEOUT%" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/tests/helix/send-to-helix-buildonhelixtests.targets
+++ b/tests/helix/send-to-helix-buildonhelixtests.targets
@@ -37,6 +37,8 @@
       <!-- Using `dotnet test` for the project directly here -->
       <_TestRunCommandArguments Include="dotnet test -s .runsettings --results-directory $(_HelixLogsPath) -v:n" />
       <_TestRunCommandArguments Include="@(_TestBlameArguments, ' ')" />
+
+      <_TestRunCommandArguments Include="--filter &quot;quarantined!=true&quot;" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/tests/helix/send-to-helix-endtoendtests.targets
+++ b/tests/helix/send-to-helix-endtoendtests.targets
@@ -21,7 +21,7 @@
            Text="Could not find EndToEnd tests at %24(_E2ETestsArchivePath)=$(_E2ETestsArchivePath)" />
 
     <ItemGroup>
-      <_TestRunCommandArguments Include="--filter scenario=$(_TestScenarioEnvVar)" />
+      <_TestRunCommandArguments Include="--filter &quot;(quarantined!=true)&amp;(scenario=$(_TestScenarioEnvVar))&quot;" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/tests/helix/send-to-helix-templatestests.targets
+++ b/tests/helix/send-to-helix-templatestests.targets
@@ -59,8 +59,8 @@
 
           To fix that, append '.' to the name so only the test class with exactly that name is run.
         -->
-        <PreCommands Condition="'$(OS)' == 'Windows_NT'">%(PreCommands) $(_ShellCommandSeparator) set &quot;TEST_ARGS=--filter category^^!=failing^&amp;FullyQualifiedName~%(Identity).&quot;</PreCommands>
-        <PreCommands Condition="'$(OS)' != 'Windows_NT'">%(PreCommands) $(_ShellCommandSeparator) export &quot;TEST_ARGS=--filter category!=failing&amp;FullyQualifiedName~%(Identity).&quot;</PreCommands>
+        <PreCommands Condition="'$(OS)' == 'Windows_NT'">%(PreCommands) $(_ShellCommandSeparator) set &quot;TEST_ARGS=--filter quarantined^^!=true^&amp;category^^!=failing^&amp;FullyQualifiedName~%(Identity).&quot;</PreCommands>
+        <PreCommands Condition="'$(OS)' != 'Windows_NT'">%(PreCommands) $(_ShellCommandSeparator) export &quot;TEST_ARGS=--filter quarantined!=true&amp;category!=failing&amp;FullyQualifiedName~%(Identity).&quot;</PreCommands>
 
         <Command>$(_TestRunCommand)</Command>
         <Timeout>$(_workItemTimeout)</Timeout>


### PR DESCRIPTION
Allow quarantine flaky tests, which excludes the test from being executed by the normal CI pipelines. The quarantined tests get executed on preset schedule by a cron job for some period of time, after which they could manually unquarantined, if their stability improves.

The quarantine attribute and the discoverer as well as some of the MSBuild infra are copied from dotnet/aspnetcore.

The test execution is implemented in an Arcade SDK way, which should make it easy to maintain and enhance, if required.

The quarantined test can be invoked with the following command:

    ./build.cmd -projects ./tests/Shared/SolutionTests.proj
                -restore -build -test
                /p:RunQuarantinedTests=true

Setting `RunQuarantinedTests=false` (which is default, so can be omitted) will execute all the non-quarantined tests.