### PR TITLE
[SignalR-Playground] Ignore null fields when serializing negotiate response

### DIFF
--- a/playground/signalr/SignalRServerlessWeb/Program.cs
+++ b/playground/signalr/SignalRServerlessWeb/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.Management;
@@ -37,6 +38,10 @@ app.UseRouting();
 
 app.UseAuthorization();
 
+var jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+{
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+};
 app.MapPost($"{hubName}/negotiate", async (string? userId) =>
 {
     var negotiateResponse = await hubContext.NegotiateAsync(new NegotiationOptions
@@ -44,7 +49,7 @@ app.MapPost($"{hubName}/negotiate", async (string? userId) =>
         UserId = userId ?? "user1"
     });
 
-    return Results.Ok(negotiateResponse);
+    return Results.Json(negotiateResponse, jsonSerializerOptions);
 });
 
 app.MapRazorPages();

--- a/playground/signalr/SignalRServerlessWeb/Program.cs
+++ b/playground/signalr/SignalRServerlessWeb/Program.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.Management;
@@ -6,6 +5,10 @@ using Microsoft.Azure.SignalR.Management;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+});
 
 var serviceManager = new ServiceManagerBuilder()
         .WithOptions(option =>
@@ -41,10 +44,7 @@ app.MapPost($"{hubName}/negotiate", async (string? userId) =>
         UserId = userId ?? "user1"
     });
 
-    return Results.Json(negotiateResponse, new JsonSerializerOptions(JsonSerializerDefaults.Web)
-    {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    });
+    return Results.Ok(negotiateResponse);
 });
 
 app.MapRazorPages();

--- a/playground/signalr/SignalRServerlessWeb/Program.cs
+++ b/playground/signalr/SignalRServerlessWeb/Program.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR.Management;
 
@@ -39,7 +41,10 @@ app.MapPost($"{hubName}/negotiate", async (string? userId) =>
         UserId = userId ?? "user1"
     });
 
-    return Results.Ok(negotiateResponse);
+    return Results.Json(negotiateResponse, new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    });
 });
 
 app.MapRazorPages();

--- a/playground/signalr/SignalRServerlessWeb/Program.cs
+++ b/playground/signalr/SignalRServerlessWeb/Program.cs
@@ -6,10 +6,6 @@ using Microsoft.Azure.SignalR.Management;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
-builder.Services.ConfigureHttpJsonOptions(options =>
-{
-    options.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-});
 
 var serviceManager = new ServiceManagerBuilder()
         .WithOptions(option =>

--- a/playground/signalr/SignalRServerlessWeb/Program.cs
+++ b/playground/signalr/SignalRServerlessWeb/Program.cs
@@ -29,9 +29,7 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();
-
 app.UseRouting();
-
 app.UseAuthorization();
 
 var jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)


### PR DESCRIPTION
- Add a serializing option to ignore null fields for negotiate response as a workaround for this [bug](https://github.com/dotnet/aspnetcore/issues/60935) in SignalR Client .NET Library