### PR TITLE
Remove verb from annotation name

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
@@ -73,7 +73,7 @@ public sealed class ContainerDirectory : ContainerFileSystemItem
 /// Represents a callback annotation that specifies files and folders that should be created or updated in a container.
 /// </summary>
 [DebuggerDisplay("Type = {GetType().Name,nw}, DestinationPath = {DestinationPath}")]
-public sealed class ContainerCreateFilesCallbackAnnotation : IResourceAnnotation
+public sealed class ContainerFileSystemCallbackAnnotation : IResourceAnnotation
 {
     /// <summary>
     /// The (absolute) base path to create the new file (and any parent directories) in the container.
@@ -106,13 +106,13 @@ public sealed class ContainerCreateFilesCallbackAnnotation : IResourceAnnotation
     /// <summary>
     /// The callback to be executed when the container is created. Should return a tree of <see cref="ContainerFileSystemItem"/> entries to create (or update) in the container.
     /// </summary>
-    public required Func<ContainerCreateFilesCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> Callback { get; init; }
+    public required Func<ContainerFileSystemCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> Callback { get; init; }
 }
 
 /// <summary>
-/// Represents the context for a <see cref="ContainerCreateFilesCallbackAnnotation"/> callback.
+/// Represents the context for a <see cref="ContainerFileSystemCallbackAnnotation"/> callback.
 /// </summary>
-public sealed class ContainerCreateFilesCallbackContext
+public sealed class ContainerFileSystemCallbackContext
 {
     /// <summary>
     /// A <see cref="IServiceProvider"/> that can be used to resolve services in the callback.

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -747,7 +747,7 @@ public static class ContainerResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(destinationPath);
         ArgumentNullException.ThrowIfNull(entries);
 
-        var annotation = new ContainerCreateFilesCallbackAnnotation
+        var annotation = new ContainerFileSystemCallbackAnnotation
         {
             DestinationPath = destinationPath,
             Callback = (_, _) => Task.FromResult(entries),
@@ -814,13 +814,13 @@ public static class ContainerResourceBuilderExtensions
     /// });
     /// </code>
     /// </example>
-    public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, Func<ContainerCreateFilesCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> callback, int defaultOwner = 0, int defaultGroup = 0, UnixFileMode? umask = null) where T : ContainerResource
+    public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, Func<ContainerFileSystemCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> callback, int defaultOwner = 0, int defaultGroup = 0, UnixFileMode? umask = null) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(destinationPath);
         ArgumentNullException.ThrowIfNull(callback);
 
-        var annotation = new ContainerCreateFilesCallbackAnnotation
+        var annotation = new ContainerFileSystemCallbackAnnotation
         {
             DestinationPath = destinationPath,
             Callback = callback,

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1595,7 +1595,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
     {
         var createFiles = new List<ContainerCreateFileSystem>();
 
-        if (modelResource.TryGetAnnotationsOfType<ContainerCreateFilesCallbackAnnotation>(out var createFileAnnotations))
+        if (modelResource.TryGetAnnotationsOfType<ContainerFileSystemCallbackAnnotation>(out var createFileAnnotations))
         {
             foreach (var a in createFileAnnotations)
             {

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -381,7 +381,7 @@ public class AddPostgresTests
         await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
 
         var container = builder.Resources.Single(r => r.Name == "mypostgres-pgadmin");
-        var createFile = container.Annotations.OfType<ContainerCreateFilesCallbackAnnotation>().Single();
+        var createFile = container.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/pgadmin4", createFile.DestinationPath);
     }
@@ -472,7 +472,7 @@ public class AddPostgresTests
 
         var pgadmin = builder.Resources.Single(r => r.Name.EndsWith("-pgadmin"));
 
-        var createServers = pgadmin.Annotations.OfType<ContainerCreateFilesCallbackAnnotation>().Single();
+        var createServers = pgadmin.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/pgadmin4", createServers.DestinationPath);
         Assert.Null(createServers.Umask);
@@ -543,7 +543,7 @@ public class AddPostgresTests
         await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
 
         var pgweb = builder.Resources.Single(r => r.Name.EndsWith("-pgweb"));
-        var createBookmarks = pgweb.Annotations.OfType<ContainerCreateFilesCallbackAnnotation>().Single();
+        var createBookmarks = pgweb.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
 
         Assert.Equal("/", createBookmarks.DestinationPath);
         Assert.Null(createBookmarks.Umask);


### PR DESCRIPTION
## Description

Renames the new annotation `ContainerCreateFilesCallbackAnnotation` to `ContainerFileSystemCallbackAnnotation`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
