### PR TITLE
Remove ConfigureAwait from the Cli

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -473,7 +473,7 @@ dotnet_diagnostic.IDE0161.severity = silent
 # IDE0005: Remove unused usings. Ignore for shared src files since imports for those depend on the projects in which they are included.
 dotnet_diagnostic.IDE0005.severity = silent
 
-[{*.razor.cs,src/Aspire.Dashboard/Components/**.cs}]
+[{*.razor.cs,src/Aspire.Dashboard/Components/**.cs,src/Aspire.Cli/**.cs}]
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = silent
 

--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -14,46 +14,46 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async Task<long> PingAsync(long timestamp, CancellationToken cancellationToken)
     {
-        var rpc = await _rpcTaskCompletionSource.Task.ConfigureAwait(false);
+        var rpc = await _rpcTaskCompletionSource.Task;
 
         logger.LogDebug("Sent ping with timestamp {Timestamp}", timestamp);
 
         var responseTimestamp = await rpc.InvokeWithCancellationAsync<long>(
             "PingAsync",
             [timestamp],
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken);
 
         return responseTimestamp;
     }
 
     public async Task<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)> GetDashboardUrlsAsync(CancellationToken cancellationToken)
     {
-        var rpc = await _rpcTaskCompletionSource.Task.ConfigureAwait(false);
+        var rpc = await _rpcTaskCompletionSource.Task;
 
         logger.LogDebug("Requesting dashboard URL");
 
         var url = await rpc.InvokeWithCancellationAsync<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)>(
             "GetDashboardUrlsAsync",
             Array.Empty<object>(),
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken);
 
         return url;
     }
 
     public async IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> GetResourceStatesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
     {
-        var rpc = await _rpcTaskCompletionSource.Task.ConfigureAwait(false);
+        var rpc = await _rpcTaskCompletionSource.Task;
 
         logger.LogDebug("Requesting resource states");
 
         var resourceStates = await rpc.InvokeWithCancellationAsync<IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)>>(
             "GetResourceStatesAsync",
             Array.Empty<object>(),
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken);
 
         logger.LogDebug("Received resource states async enumerable");
 
-        await foreach (var state in resourceStates.WithCancellation(cancellationToken).ConfigureAwait(false))
+        await foreach (var state in resourceStates.WithCancellation(cancellationToken))
         {
             yield return state;
         }
@@ -69,7 +69,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         logger.LogDebug("Connecting to AppHost backchannel at {SocketPath}", socketPath);
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(socketPath);
-        await socket.ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
+        await socket.ConnectAsync(endpoint, cancellationToken);
         logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
 
         var stream = new NetworkStream(socket, true);

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -24,7 +24,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             workingDirectory: projectFile.Directory!,
             backchannelCompletionSource: backchannelCompletionSource,
             streamsCallback: null,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+            cancellationToken: cancellationToken);
     }
 
     public async Task<int> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, CancellationToken cancellationToken)
@@ -48,7 +48,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             workingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
             backchannelCompletionSource: null,
             streamsCallback: null,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+            cancellationToken: cancellationToken);
     }
 
     public async Task<int> NewProjectAsync(string templateName, string name, string outputPath, CancellationToken cancellationToken)
@@ -60,7 +60,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             workingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
             backchannelCompletionSource: null,
             streamsCallback: null,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+            cancellationToken: cancellationToken);
     }
 
     internal static string GetBackchannelSocketPath()
@@ -133,16 +133,16 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
                     process.StandardOutput,
                     "stdout",
                     process,
-                    cancellationToken).ConfigureAwait(false);
-                }, cancellationToken).ConfigureAwait(false);
+                    cancellationToken);
+                }, cancellationToken);
 
             var pendingStderrStreamForwarder = Task.Run(async () => {
                 await ForwardStreamToLoggerAsync(
                     process.StandardError,
                     "stderr",
                     process,
-                    cancellationToken).ConfigureAwait(false);
-                }, cancellationToken).ConfigureAwait(false);
+                    cancellationToken);
+                }, cancellationToken);
         }
 
         if (!started)
@@ -161,7 +161,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
         logger.LogDebug("Waiting for dotnet process to exit with PID: {ProcessId}", process.Id);
 
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        await process.WaitForExitAsync(cancellationToken);
 
         if (!process.HasExited)
         {
@@ -185,7 +185,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
             while (!cancellationToken.IsCancellationRequested && !reader.EndOfStream)
             {
-                var line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+                var line = await reader.ReadLineAsync(cancellationToken);
                 logger.LogDebug(
                     "dotnet({ProcessId}) {Identifier}: {Line}",
                     process.Id,
@@ -210,7 +210,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             try
             {
                 logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts++);
-                await backchannel.ConnectAsync(socketPath, cancellationToken).ConfigureAwait(false);
+                await backchannel.ConnectAsync(socketPath, cancellationToken);
                 backchannelCompletionSource.SetResult(backchannel);
                 logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
                 return;
@@ -221,7 +221,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
                 logger.LogTrace(ex, "Failed to connect to AppHost backchannel (attempt {Attempt})", connectionAttempts);
             }
 
-        } while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false));
+        } while (await timer.WaitForNextTickAsync(cancellationToken));
     }
 
     public async Task<int> AddPackageAsync(FileInfo projectFilepath, string packageName, string packageVersion, CancellationToken cancellationToken)
@@ -243,7 +243,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             workingDirectory: projectFilepath.Directory!,
             backchannelCompletionSource: null,
             streamsCallback: (_, _, _) => { },
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+            cancellationToken: cancellationToken);
 
         if (result != 0)
         {
@@ -296,7 +296,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
                 stdout = output.ReadToEnd();
                 stderr = output.ReadToEnd();
             },
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+            cancellationToken: cancellationToken);
 
         if (result != 0)
         {

--- a/src/Aspire.Cli/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGetPackageCache.cs
@@ -33,7 +33,7 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNe
                 skip,
                 source,
                 cancellationToken
-                ).ConfigureAwait(false);
+                );
 
             if (result.ExitCode != 0)
             {

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
@@ -130,7 +130,7 @@ public class Program
 
         command.SetAction(async (parseResult, ct) => {
             using var app = BuildApplication(parseResult);
-            _ = app.RunAsync(ct).ConfigureAwait(false);
+            _ = app.RunAsync(ct);
 
             var runner = app.Services.GetRequiredService<DotNetCliRunner>();
             var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
@@ -158,7 +158,7 @@ public class Program
                 Array.Empty<string>(),
                 env,
                 backchannelCompletitionSource,
-                ct).ConfigureAwait(false);
+                ct);
 
             if (useRichConsole)
             {
@@ -168,16 +168,16 @@ public class Program
                                                    .Spinner(Spinner.Known.Dots3)
                                                    .SpinnerStyle(Style.Parse("purple"))
                                                    .StartAsync(":linked_paperclips:  Starting Aspire app host...", async context => {
-                                                        return await backchannelCompletitionSource.Task.ConfigureAwait(false);
-                                                   }).ConfigureAwait(true);
+                                                        return await backchannelCompletitionSource.Task;
+                                                   });
 
                 // We wait for the first update of the console model via RPC from the AppHost.
                 var dashboardUrls = await AnsiConsole.Status()
                                                     .Spinner(Spinner.Known.Dots3)
                                                     .SpinnerStyle(Style.Parse("purple"))
                                                     .StartAsync(":chart_increasing:  Starting Aspire dashboard...", async context => {
-                                                        return await backchannel.GetDashboardUrlsAsync(ct).ConfigureAwait(false);
-                                                    }).ConfigureAwait(true);
+                                                        return await backchannel.GetDashboardUrlsAsync(ct);
+                                                    });
 
                 AnsiConsole.WriteLine();
                 AnsiConsole.MarkupLine($"[green bold]Dashboard[/]:");
@@ -201,7 +201,7 @@ public class Program
 
                     var resourceStates = backchannel.GetResourceStatesAsync(ct);
 
-                    await foreach(var resourceState in resourceStates.ConfigureAwait(false))
+                    await foreach(var resourceState in resourceStates)
                     {
                         knownResources[resourceState.Resource] = resourceState;
 
@@ -240,7 +240,7 @@ public class Program
                         context.Refresh();
                     }
 
-                }).ConfigureAwait(true);
+                });
 
                 return await pendingRun;
             }
@@ -307,7 +307,7 @@ public class Program
 
         command.SetAction(async (parseResult, ct) => {
             using var app = BuildApplication(parseResult);
-            _ = app.RunAsync(ct).ConfigureAwait(false);
+            _ = app.RunAsync(ct);
 
             var runner = app.Services.GetRequiredService<DotNetCliRunner>();
             var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
@@ -333,10 +333,10 @@ public class Program
                         ["--publisher", publisher ?? "manifest", "--output-path", fullyQualifiedOutputPath],
                         env,
                         null, // TODO: We will use a backchannel here soon but null for now.
-                        ct).ConfigureAwait(false);
+                        ct);
 
                     return await pendingRun;
-                }).ConfigureAwait(false);
+                });
 
             if (exitCode != 0)
             {
@@ -427,7 +427,7 @@ public class Program
         command.SetAction(async (parseResult, ct) => {
             using var app = BuildApplication(parseResult);
             var cliRunner = app.Services.GetRequiredService<DotNetCliRunner>();
-            _ = app.RunAsync(ct).ConfigureAwait(false);
+            _ = app.RunAsync(ct);
 
             var templateVersion = parseResult.GetValue<string>("--version");
             var source = parseResult.GetValue<string?>("--source");
@@ -438,8 +438,8 @@ public class Program
                 .StartAsync(
                     ":ice:  Getting latest templates...",
                     async context => {
-                        return await cliRunner.InstallTemplateAsync("Aspire.ProjectTemplates", templateVersion!, source, true, ct).ConfigureAwait(false);
-                    }).ConfigureAwait(false);
+                        return await cliRunner.InstallTemplateAsync("Aspire.ProjectTemplates", templateVersion!, source, true, ct);
+                    });
 
             if (templateInstallExitCode != 0)
             {
@@ -474,8 +474,8 @@ public class Program
                     templateName,
                     name,
                     outputPath,
-                    ct).ConfigureAwait(false);
-                }).ConfigureAwait(false);
+                    ct);
+                });
 
             if (newProjectExitCode != 0)
             {
@@ -589,7 +589,7 @@ public class Program
                 var packages = await AnsiConsole.Status().StartAsync(
                     "Searching for Aspire packages...",
                     context => integrationLookup.GetPackagesAsync(effectiveAppHostProjectFile, prerelease, source, ct)
-                    ).ConfigureAwait(false);
+                    );
 
                 var packagesWithShortName = packages.Select(p => GenerateFriendlyName(p));
 
@@ -619,11 +619,11 @@ public class Program
                             selectedNuGetPackage.Package.Id,
                             selectedNuGetPackage.Package.Version,
                             ct
-                            ).ConfigureAwait(false);
+                            );
 
                         return addPackageResult == 0 ? ExitCodeConstants.Success : ExitCodeConstants.FailedToAddPackage;
-                    }                
-                ).ConfigureAwait(false);
+                    }
+                );
 
                 return addPackageResult;
             }
@@ -637,12 +637,12 @@ public class Program
         parentCommand.Subcommands.Add(command);
     }
 
-    public static async Task<int> Main(string[] args)
+    public static Task<int> Main(string[] args)
     {
         System.Console.OutputEncoding = Encoding.UTF8;
         var rootCommand = GetRootCommand();
         var config = new CommandLineConfiguration(rootCommand);
         config.EnableDefaultExceptionHandler = true;
-        return await config.InvokeAsync(args).ConfigureAwait(false);
+        return config.InvokeAsync(args);
     }
 }


### PR DESCRIPTION
## Description

Since the CLI is a console application, requiring ConfigureAwait everywhere isn't necessary.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
