### PR TITLE
[cli] null check on project file logic

### DIFF
--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -11,6 +11,6 @@ internal static class ExitCodeConstants
     public const int FailedToInstallTemplates = 3;
     public const int FailedToCreateNewProject = 4;
     public const int FailedToAddPackage = 5;
-
     public const int FailedToBuildArtifacts = 6;
+    public const int FailedToFindProject = 7;
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
@@ -285,12 +285,12 @@ public class Program
             Debug.WriteLine(ex.Message);
             if (projectFilePaths.Length > 1)
             {
-                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and multiple *.csproj files were detected.[/]");
+                AnsiConsole.MarkupLine("[red bold]:police_car_light:  The --project option was not specified and multiple *.csproj files were detected.[/]");
                 
             }
             else
             {
-                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and no *.csproj files were detected.[/]");
+                AnsiConsole.MarkupLine("[red bold]:police_car_light:  The --project option was not specified and no *.csproj files were detected.[/]");
             }
             return null;
         };

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -135,6 +135,11 @@ public class Program
             var runner = app.Services.GetRequiredService<DotNetCliRunner>();
             var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
             var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
+            
+            if (effectiveAppHostProjectFile is null)
+            {
+                return ExitCodeConstants.FailedToFindProject;
+            }
 
             var env = new Dictionary<string, string>();
 
@@ -253,7 +258,7 @@ public class Program
         parentCommand.Subcommands.Add(command);
     }
 
-    private static FileInfo UseOrFindAppHostProjectFile(FileInfo? projectFile)
+    private static FileInfo? UseOrFindAppHostProjectFile(FileInfo? projectFile)
     {
         if (projectFile is not null)
         {
@@ -280,13 +285,14 @@ public class Program
             Debug.WriteLine(ex.Message);
             if (projectFilePaths.Length > 1)
             {
-                AnsiConsole.MarkupLine("[red bold]:thumbs_down:  The --project option was not specified and multiple *.csproj files were detected.[/]");
+                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and multiple *.csproj files were detected.[/]");
+                
             }
             else
             {
-                AnsiConsole.MarkupLine("[red bold]:thumbs_down:  The --project option was not specified and no *.csproj files were detected.[/]");
+                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and no *.csproj files were detected.[/]");
             }
-            return new FileInfo(Environment.CurrentDirectory);
+            return null;
         };
     }
 
@@ -313,6 +319,11 @@ public class Program
             var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
             var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
             
+            if (effectiveAppHostProjectFile is null)
+            {
+                return ExitCodeConstants.FailedToFindProject;
+            }
+
             var env = new Dictionary<string, string>();
 
             if (parseResult.GetValue<bool?>("--wait-for-debugger") ?? false)
@@ -479,7 +490,7 @@ public class Program
 
             if (newProjectExitCode != 0)
             {
-                AnsiConsole.MarkupLine($"[red bold]:thumbs_down:  Project creation failed with exit code {newProjectExitCode}. For more information run with --debug switch.[/]");
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: Project creation failed with exit code {newProjectExitCode}. For more information run with --debug switch.[/]");
                 return ExitCodeConstants.FailedToCreateNewProject;
             }
 
@@ -581,6 +592,11 @@ public class Program
 
                 var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
                 var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
+                
+                if (effectiveAppHostProjectFile is null)
+                {
+                    return ExitCodeConstants.FailedToFindProject;
+                }
 
                 var prerelease = parseResult.GetValue<bool>("--prerelease");
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -285,12 +285,12 @@ public class Program
             Debug.WriteLine(ex.Message);
             if (projectFilePaths.Length > 1)
             {
-                AnsiConsole.MarkupLine("[red bold]:police_car_light:  The --project option was not specified and multiple *.csproj files were detected.[/]");
+                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and multiple *.csproj files were detected.[/]");
                 
             }
             else
             {
-                AnsiConsole.MarkupLine("[red bold]:police_car_light:  The --project option was not specified and no *.csproj files were detected.[/]");
+                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and no *.csproj files were detected.[/]");
             }
             return null;
         };


### PR DESCRIPTION
## Description

If you ran `aspire run` without the proper project file info/if one is missing, it would return the working directory as FileInfo and keep executing after the error. I changed the FileInfo to nullable and returned null if it went down the exception path, and then created a new error code constant to reflect it and return.

I also changed the emoji to :police_car_light: - partly to see how it looks, but also so we can tell when an error is coming from a Validator SetError vs this function.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
