### PR TITLE
Add new 3rd party dependencies to Signing.props to fix official build

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -21,6 +21,9 @@
     <FileSignInfo Include="Grpc.Net.Client.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Grpc.Net.ClientFactory.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Grpc.Net.Common.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MessagePack.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="MessagePack.Annotations.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Spectre.Console.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Fixes official build by adding recently added 3rd party dependencies to signing.props. cc: @mitchdenny @maddymontaquila @radical 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
