### PR TITLE
Support Azure SqlServer role assignments on app specific managed identity

### DIFF
--- a/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/aspire-manifest.json
@@ -33,7 +33,7 @@
     },
     "db2": {
       "type": "value.v0",
-      "connectionString": "{sql2.connectionString};Database=db2"
+      "connectionString": "{sql2.connectionString};Initial Catalog=db2"
     },
     "dbsetup": {
       "type": "project.v0",

--- a/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/sql1.module.bicep
+++ b/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/sql1.module.bicep
@@ -41,3 +41,5 @@ resource db1 'Microsoft.Sql/servers/databases@2021-11-01' = {
 }
 
 output sqlServerFqdn string = sql1.properties.fullyQualifiedDomainName
+
+output name string = sql1.name

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -1397,6 +1397,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             }
 
             output sqlServerFqdn string = sql.properties.fullyQualifiedDomainName
+
+            output name string = sql.name
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);
@@ -1478,6 +1480,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             }
 
             output sqlServerFqdn string = sql.properties.fullyQualifiedDomainName
+
+            output name string = sql.name
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
@@ -130,6 +130,8 @@ public class AzureResourceOptionsTests(ITestOutputHelper output)
                 }
 
                 output sqlServerFqdn string = sql_server.properties.fullyQualifiedDomainName
+
+                output name string = sql_server.name
                 """;
             output.WriteLine(actualBicep);
             Assert.Equal(expectedBicep, actualBicep);

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -1169,6 +1169,8 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
 
             output sqlServerFqdn string = sqlServer.properties.fullyQualifiedDomainName
+
+            output name string = existingResourceName
             """;
 
         output.WriteLine(BicepText);
@@ -1243,6 +1245,8 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             }
 
             output sqlServerFqdn string = sqlServer.properties.fullyQualifiedDomainName
+
+            output name string = existingResourceName
             """;
 
         output.WriteLine(BicepText);

--- a/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
@@ -389,6 +389,43 @@ public class RoleAssignmentTests(ITestOutputHelper output)
             includePrincipalName: true);
     }
 
+    [Fact]
+    public Task SqlSupport()
+    {
+        return RoleAssignmentTest("sql",
+            builder =>
+            {
+                var redis = builder.AddAzureSqlServer("sql");
+
+                builder.AddProject<Project>("api", launchProfileName: null)
+                    .WithReference(redis);
+            },
+            """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param sql_outputs_name string
+
+            param principalId string
+
+            param principalName string
+
+            resource sql 'Microsoft.Sql/servers@2021-11-01' existing = {
+              name: sql_outputs_name
+            }
+            
+            resource sql_admin 'Microsoft.Sql/servers/administrators@2021-11-01' = {
+              name: 'ActiveDirectory'
+              properties: {
+                login: principalName
+                sid: principalId
+              }
+              parent: sql
+            }
+            """,
+            includePrincipalName: true);
+    }
+
     private async Task RoleAssignmentTest(
         string azureResourceName,
         Action<IDistributedApplicationBuilder> configureBuilder,


### PR DESCRIPTION
## Description

Adding role assignment support for PostgreSQL following the pattern set in #8140

Fix #6161

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship!!
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - ongoing
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] No
        - Link to aspire-docs issue [[New article]: Aspire 9.2 Azure WithRoleAssignments docs (dotnet/docs-aspire#2788)](https://github.com/dotnet/docs-aspire/issues/2788)
