### PR TITLE
Add an animation to reset button

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -128,7 +128,7 @@ class ResourceGraph {
     }
 
     resetZoomAndPan() {
-        this.svg.call(this.zoom.transform, d3.zoomIdentity);
+        this.svg.transition().call(this.zoom.transform, d3.zoomIdentity);
     }
 
     zoomIn() {


### PR DESCRIPTION
Zoom in and out buttons on the resource graph have a 0.5s animation of zooming.
PR adds the same 0.5s animation to reset screen position so reset feels less abrupt.