### PR TITLE
Retry both deletion and verification when restarting a resource

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1513,6 +1513,9 @@ internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
             {
                 string? uid = null;
 
+                // Make deletion part of the retry loop--we have seen cases during test execution when
+                // the deletion request completed with success code, but it was never "acted upon" by DCP.
+
                 try
                 {
                     var r = await _kubernetesService.DeleteAsync<T>(resourceName, cancellationToken: attemptCancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Description

This is an attempt to fix https://github.com/dotnet/aspire/issues/8084 and https://github.com/dotnet/aspire/issues/7836. From the logs I can see that Aspire app host submits a deletion request and receives a success-code response from DCP, but in DCP Executable controller logs there is no trace of this (deletion) request. My best theory to explain this is timing issue in the API server storage layer, but since the issue is hard to repro, I think this change is our best bet to move forward.

The diff may be confusing, but what I did is I moved the deletion of the resource to be included in the retry loop. Previously only the verification (polling for the object to verify it was deleted) was retried.

Fixes # (issue)
https://github.com/dotnet/aspire/issues/8084
https://github.com/dotnet/aspire/issues/7836

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
