### PR TITLE
Mark AzurePublisherOptions as Experimental

### DIFF
--- a/src/Aspire.Hosting.Azure/AzurePublisher.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisher.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Azure.Provisioning;
@@ -13,6 +14,7 @@ using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Azure;
 
+[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
 internal sealed class AzurePublisher(
     [ServiceKey] string name,
     IOptionsMonitor<AzurePublisherOptions> options,

--- a/src/Aspire.Hosting.Azure/AzurePublisherOptions.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisherOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting.Azure;
@@ -8,6 +9,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Options which control generation of artifacts for deploying to Azure.
 /// </summary>
+[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
 public sealed class AzurePublisherOptions : PublishingOptions
 {
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;


### PR DESCRIPTION
See https://github.com/dotnet/aspire/pull/7811#discussion_r2004870333

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] No
        - Link to aspire-docs issue [[New article]: Add ASPIREAZURE001 to aspire/diagnostics docs (dotnet/docs-aspire#2882)](https://github.com/dotnet/docs-aspire/issues/2882)
