### PR TITLE
Rename publisher methods for clarity and add overloads for defaults

### DIFF
--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -9,9 +9,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureContainerAppEnvironment("env");
 
-builder.AddDockerComposePublisher("docker-compose");
+builder.AddDockerComposePublisher();
 
-builder.AddKubernetesPublisher("k8s");
+builder.AddKubernetesPublisher();
 
 #pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 

--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -9,9 +9,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureContainerAppEnvironment("env");
 
-builder.AddDockerCompose("docker-compose");
+builder.AddDockerComposePublisher("docker-compose");
 
-builder.AddKubernetes("k8s");
+builder.AddKubernetesPublisher("k8s");
 
 #pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 

--- a/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
@@ -21,4 +21,15 @@ public static class AzurePublisherExtensions
     {
         builder.AddPublisher<AzurePublisher, AzurePublisherOptions>(name, configureOptions);
     }
+
+    /// <summary>
+    /// Adds an Azure Container Apps publisher to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
+    /// <param name="configureOptions">Callback to configure Azure Container Apps publisher options.</param>
+    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    public static void AddAzurePublisher(this IDistributedApplicationBuilder builder, Action<AzurePublisherOptions>? configureOptions = null)
+    {
+        builder.AddPublisher<AzurePublisher, AzurePublisherOptions>("azure", configureOptions);
+    }
 }

--- a/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
@@ -14,8 +14,18 @@ public static class DockerComposePublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
-    public static void AddDockerCompose(this IDistributedApplicationBuilder builder, string name, Action<DockerComposePublisherOptions>? configureOptions = null)
+    public static void AddDockerComposePublisher(this IDistributedApplicationBuilder builder, string name, Action<DockerComposePublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>(name, configureOptions);
+    }
+
+    /// <summary>
+    /// Adds a Docker Compose publisher to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
+    /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
+    public static void AddDockerComposePublisher(this IDistributedApplicationBuilder builder, Action<DockerComposePublisherOptions>? configureOptions = null)
+    {
+        builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>("docker-compose", configureOptions);
     }
 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
@@ -14,8 +14,18 @@ public static class KubernetesPublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
-    public static void AddKubernetes(this IDistributedApplicationBuilder builder, string name, Action<KubernetesPublisherOptions>? configureOptions = null)
+    public static void AddKubernetesPublisher(this IDistributedApplicationBuilder builder, string name, Action<KubernetesPublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>(name, configureOptions);
+    }
+
+    /// <summary>
+    /// Adds a Kubernetes publisher to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
+    /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
+    public static void AddKubernetesPublisher(this IDistributedApplicationBuilder builder, Action<KubernetesPublisherOptions>? configureOptions = null)
+    {
+        builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>("kubernetes", configureOptions);
     }
 }


### PR DESCRIPTION
Rename methods for Docker Compose and Kubernetes publishers to improve clarity and add overloads for default configurations. This enhances usability and maintains consistency across publisher methods.

Fixes #8110