### PR TITLE
Add minimal dotnet watch support to CLI

### DIFF
--- a/playground/waitfor/WaitForSandbox.ApiService/Program.cs
+++ b/playground/waitfor/WaitForSandbox.ApiService/Program.cs
@@ -19,6 +19,7 @@ app.MapGet("/", async (MyDbContext dbContext) =>
     // since we've proven connectivity to the others for now.
     var entry = new Entry();
     await dbContext.Entries.AddAsync(entry);
+    await dbContext.Entries.AddAsync(entry);
     await dbContext.SaveChangesAsync();
 
     var entries = await dbContext.Entries.ToListAsync();

--- a/playground/waitfor/WaitForSandbox.ApiService/Program.cs
+++ b/playground/waitfor/WaitForSandbox.ApiService/Program.cs
@@ -19,7 +19,6 @@ app.MapGet("/", async (MyDbContext dbContext) =>
     // since we've proven connectivity to the others for now.
     var entry = new Entry();
     await dbContext.Entries.AddAsync(entry);
-    await dbContext.Entries.AddAsync(entry);
     await dbContext.SaveChangesAsync();
 
     var entries = await dbContext.Entries.ToListAsync();

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -15,9 +15,10 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 {
     internal Func<int> GetCurrentProcessId { get; set; } = () => Environment.ProcessId;
 
-    public async Task<int> RunAsync(FileInfo projectFile, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
+    public async Task<int> RunAsync(FileInfo projectFile, bool watch, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
     {
-        string[] cliArgs = ["run", "--project", projectFile.FullName, "--", ..args];
+        var watchOrRunCommand = watch ? "watch" : "run";
+        string[] cliArgs = [watchOrRunCommand, "--project", projectFile.FullName, "--", ..args];
         return await ExecuteAsync(
             args: cliArgs,
             env: env,

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -128,6 +128,9 @@ public class Program
         projectOption.Validators.Add(ValidateProjectOption);
         command.Options.Add(projectOption);
 
+        var watchOption = new Option<bool>("--watch", "-w");
+        command.Options.Add(watchOption);
+
         command.SetAction(async (parseResult, ct) => {
             using var app = BuildApplication(parseResult);
             _ = app.RunAsync(ct);
@@ -158,8 +161,11 @@ public class Program
 
             var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();
 
+            var watch = parseResult.GetValue<bool>("--watch");
+
             var pendingRun = runner.RunAsync(
                 effectiveAppHostProjectFile,
+                watch,
                 Array.Empty<string>(),
                 env,
                 backchannelCompletitionSource,
@@ -344,6 +350,7 @@ public class Program
                         var backchannelCompletionSource = new TaskCompletionSource<AppHostBackchannel>();
                         var pendingInspectRun = runner.RunAsync(
                             effectiveAppHostProjectFile,
+                            false,
                             ["--operation", "inspect"],
                             null,
                             backchannelCompletionSource,
@@ -386,6 +393,7 @@ public class Program
                 .StartAsync($":hammer_and_wrench:  Building artifacts for '{publisher}' publisher...", async context => {
                     var pendingRun = runner.RunAsync(
                         effectiveAppHostProjectFile,
+                        false,
                         ["--publisher", publisher ?? "manifest", "--output-path", fullyQualifiedOutputPath],
                         env,
                         null, // TODO: We will use a backchannel here soon but null for now.


### PR DESCRIPTION
Introduce support for a watch mode in the CLI, allowing for continuous monitoring of project changes.

DRAFT because this currently isn't working because dotnet watch doesn't seem to be able to successfully rebuild the API service project:

![image](https://github.com/user-attachments/assets/4b70a36b-d73e-414b-b6ae-a3a145b5aa6d)

Also noticed that when I launch the WaitForSandbox in dotnet watch mode the API service project doesn't start (works if you start it auotmatically). So there are probably a few underlying issues here with watch support.

Fixes: #7897 