### PR TITLE
Automatically determine default template version from CLI version

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Diagnostics;
 using System.Text;
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -475,7 +476,7 @@ public class Program
             }
             else
             {
-                return "9.2.0"; // HACK: Need to get this from the CLI version.
+                return VersionHelper.GetDefaultTemplateVersion();
             }
         };
         command.Options.Add(templateVersionOption);

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Utils;
+
+internal static class VersionHelper
+{
+    public static string GetDefaultTemplateVersion()
+    {
+        // Write some code that gets the informational assembly version of the current assembly and returns it as a string.
+        var assembly = typeof(VersionHelper).Assembly;
+        var informationalVersion = assembly
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+            .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+            .FirstOrDefault()?.InformationalVersion;
+
+        return informationalVersion ?? throw new InvalidOperationException("Unable to retrieve the assembly version.");
+    }
+}


### PR DESCRIPTION
Implement a method to retrieve the default template version based on the CLI's informational version, replacing the hardcoded value.

Fixes #8198