### PR TITLE
Added overload of AddConnectionString using the builder pattern to make it more approachable

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -251,5 +251,16 @@ public class ReferenceExpressionBuilder
         {
             builder.AppendFormatted(valueProvider);
         }
+
+        /// <summary>
+        /// Appends a formatted value to the expression. The value must implement <see cref="IValueProvider"/> and <see cref="IManifestExpressionProvider"/>.
+        /// </summary>
+        /// <param name="valueProvider">An instance of an object which implements <see cref="IValueProvider"/> and <see cref="IManifestExpressionProvider"/>.</param>
+        /// <exception cref="InvalidOperationException"></exception>
+        public void AppendFormatted<T>(IResourceBuilder<T> valueProvider)
+            where T : IResource, IValueProvider, IManifestExpressionProvider
+        {
+            builder.AppendFormatted(valueProvider.Resource);
+        }
     }
 }

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -64,7 +64,7 @@ public static class ConnectionStringBuilderExtensions
     ///
     /// var apiKey = builder.AddParameter("apiKey", secret: true);
     ///
-    /// var cs = builder.AddConnectionString("cs", b => b.AppendFormatted($"Endpoint=http://something;Key={apiKey}");
+    /// var cs = builder.AddConnectionString("cs", b => b.AppendFormatted($"Endpoint=http://something;Key={apiKey}"));
     ///
     /// var backend = builder
     ///     .AddProject&lt;Projects.Backend&gt;("backend")

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -64,7 +64,7 @@ public static class ConnectionStringBuilderExtensions
     ///
     /// var apiKey = builder.AddParameter("apiKey", secret: true);
     ///
-    /// var cs = builder.AddConnectionString("cs", b => b.AppendFormatted($"Endpoint=http://something;Key={apiKey}"));
+    /// var cs = builder.AddConnectionString("cs", b => b.Append($"Endpoint=http://something;Key={apiKey}"));
     ///
     /// var backend = builder
     ///     .AddProject&lt;Projects.Backend&gt;("backend")

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -247,7 +247,7 @@ public class WithReferenceTests
     }
 
     [Fact]
-    public async Task ConnectionStringResourceWithExpressiononnectionString()
+    public async Task ConnectionStringResourceWithExpressionConnectionString()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
@@ -255,9 +255,34 @@ public class WithReferenceTests
         var key = builder.AddParameter("key", "secretKey", secret: true);
 
         var cs = ReferenceExpression.Create($"Endpoint={endpoint};Key={key}");
-        
+
         // Get the service provider.
         var resource = builder.AddConnectionString("cs", cs);
+
+        var projectB = builder.AddProject<ProjectB>("projectb")
+                              .WithReference(resource);
+
+        // Call environment variable callbacks.
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
+
+        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
+        Assert.Equal(1, servicesKeysCount);
+        Assert.Equal("Endpoint=http://localhost:3452;Key=secretKey", config["ConnectionStrings__cs"]);
+    }
+
+    [Fact]
+    public async Task ConnectionStringResourceWithExpressionConnectionStringBuilder()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var endpoint = builder.AddParameter("endpoint", "http://localhost:3452");
+        var key = builder.AddParameter("key", "secretKey", secret: true);
+
+        // Get the service provider.
+        var resource = builder.AddConnectionString("cs", b =>
+        {
+            b.AppendFormatted($"Endpoint={endpoint};Key={key}");
+        });
 
         var projectB = builder.AddProject<ProjectB>("projectb")
                               .WithReference(resource);

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -281,7 +281,7 @@ public class WithReferenceTests
         // Get the service provider.
         var resource = builder.AddConnectionString("cs", b =>
         {
-            b.AppendFormatted($"Endpoint={endpoint};Key={key}");
+            b.Append($"Endpoint={endpoint};Key={key}");
         });
 
         var projectB = builder.AddProject<ProjectB>("projectb")


### PR DESCRIPTION
## Description

Added overload of `AddConnectionString` using the builder pattern to make it more approachable

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
