### PR TITLE
[Docs] Small typos in CreateBuilder method signature documentation

### DIFF
--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -99,7 +99,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// method will be called as a top-level statement in the application's entry-point.
     /// </para>
     /// <para>
-    /// Note that the <paramref name="args"/> parameter is a <see langword="string"/> is essential in allowing the application
+    /// Note that the <paramref name="args"/> parameter is a <see langword="string"/> and is essential in allowing the application
     /// host to work with deployment tools because arguments are used to tell the application host that it
     /// is in publish mode. If <paramref name="args"/> is not provided the application will not work with
     /// deployment tools. It is also possible to provide arguments using the <see cref="CreateBuilder(Aspire.Hosting.DistributedApplicationOptions)"/>
@@ -153,15 +153,15 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// <remarks>
     /// <para>
     /// The <see cref="DistributedApplication.CreateBuilder(DistributedApplicationOptions)"/> method provides
-    /// greater control over the behavior of the distributed application at runtime. For example using providing
-    /// a <paramref name="options"/> argument allows developers to force all container images to be loaded
+    /// greater control over the behavior of the distributed application at runtime. For example providing
+    /// an <paramref name="options"/> argument allows developers to force all container images to be loaded
     /// from a specified container registry by using the <see cref="DistributedApplicationOptions.ContainerRegistryOverride"/>
-    /// property, or disable the dashboard by using the <see cref="DistributedApplicationOptions.DisableDashboard"/>
+    /// property, or disabling the dashboard by using the <see cref="DistributedApplicationOptions.DisableDashboard"/>
     /// property. Refer to the <see cref="DistributedApplicationOptions"/> class for more details on
     /// each option that may be provided.
     /// </para>
     /// <para>
-    /// When supplying a custom <see cref="DistributedApplicationOptions"/> it is commended to populate the
+    /// When supplying a custom <see cref="DistributedApplicationOptions"/> it is recommended to populate the
     /// <see cref="DistributedApplicationOptions.Args"/> property to ensure that the app host continues to function
     /// correctly when used with deployment tools that need to enable publish mode.
     /// </para>


### PR DESCRIPTION
## Description

Corrected a few typos regarding the `DistributedApplicationOptions` parameter of the `DistributedApplication.CreateBuilder` method and use case examples in the API signature documentation. Very small changes but this XML documentation has wide reach as it is present in the top level builder via VS intellisense.

Fixes # (issue)
- n/a - _will create one if desired_ :)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
