### PR TITLE
Bootstrapping container builds for `aspire build` / `aspire publish`.

### DIFF
--- a/playground/publishers/Publishers.AppHost/docker-compose.yaml
+++ b/playground/publishers/Publishers.AppHost/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   pg:
-    image: "docker.io/library/postgres:17.2"
+    image: "${PG_IMAGE}"
     environment:
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
@@ -40,7 +40,7 @@ services:
     networks:
       - "aspire"
   sqlserver:
-    image: "mcr.microsoft.com/mssql/server:2022-latest"
+    image: "${SQLSERVER_IMAGE}"
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "${SQLSERVER_PASSWORD}"

--- a/playground/publishers/Publishers.AppHost/docker-compose.yaml
+++ b/playground/publishers/Publishers.AppHost/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   pg:
-    image: "${PG_IMAGE}"
+    image: "docker.io/library/postgres:17.2"
     environment:
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
@@ -17,7 +17,7 @@ services:
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
       OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "in_memory"
       ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
-      HTTP_PORTS: "8002"
+      HTTP_PORTS: "8001"
       ConnectionStrings__db: "Host=pg;Port=5432;Username=postgres;Password=${PG_PASSWORD};Database=db"
     ports:
       - "8002:8001"
@@ -31,7 +31,7 @@ services:
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
       OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "in_memory"
       ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
-      HTTP_PORTS: "8006"
+      HTTP_PORTS: "8005"
       ConnectionStrings__db: "Host=pg;Port=5432;Username=postgres;Password=${PG_PASSWORD};Database=db"
       ConnectionStrings__azdb: "${AZPG_OUTPUTS_CONNECTIONSTRING};Database=azdb"
     ports:
@@ -40,7 +40,7 @@ services:
     networks:
       - "aspire"
   sqlserver:
-    image: "${SQLSERVER_IMAGE}"
+    image: "mcr.microsoft.com/mssql/server:2022-latest"
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "${SQLSERVER_PASSWORD}"
@@ -60,7 +60,7 @@ services:
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
       OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "in_memory"
       ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
-      HTTP_PORTS: "8011"
+      HTTP_PORTS: "8010"
       ConnectionStrings__sqldb: "Server=sqlserver,1433;User ID=sa;Password=${SQLSERVER_PASSWORD};TrustServerCertificate=true;Initial Catalog=sqldb"
       P0: "${PARAM0}"
       P1: "${PARAM1}"

--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -96,6 +96,25 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         return publishers;
     }
 
+    public async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
+    {
+        var rpc = await _rpcTaskCompletionSource.Task;
+
+        logger.LogDebug("Requesting publishing activities.");
+
+        var resourceStates = await rpc.InvokeWithCancellationAsync<IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)>>(
+            "GetPublishingActivitiesAsync",
+            Array.Empty<object>(),
+            cancellationToken);
+
+        logger.LogDebug("Received publishing activities.");
+
+        await foreach (var state in resourceStates.WithCancellation(cancellationToken))
+        {
+            yield return state;
+        }
+    }
+
     public void Dispose()
     {
         try

--- a/src/Aspire.Hosting.Docker/DockerComposePublisher.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisher.cs
@@ -20,7 +20,9 @@ internal sealed class DockerComposePublisher(
     [ServiceKey]string name,
     IOptionsMonitor<DockerComposePublisherOptions> options,
     ILogger<DockerComposePublisher> logger,
-    DistributedApplicationExecutionContext executionContext) : IDistributedApplicationPublisher
+    DistributedApplicationExecutionContext executionContext,
+    IResourceContainerImageBuilder imageBuilder
+    ) : IDistributedApplicationPublisher
 {
     /// <summary>
     /// Publishes a distributed application model using the Docker Compose publisher implementation.
@@ -45,7 +47,7 @@ internal sealed class DockerComposePublisher(
             );
         }
 
-        var context = new DockerComposePublishingContext(executionContext, publisherOptions, logger, cancellationToken);
+        var context = new DockerComposePublishingContext(executionContext, publisherOptions, imageBuilder, logger, cancellationToken);
 
         await context.WriteModelAsync(model).ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -22,9 +22,12 @@ namespace Aspire.Hosting.Docker;
 internal sealed class DockerComposePublishingContext(
     DistributedApplicationExecutionContext executionContext,
     DockerComposePublisherOptions publisherOptions,
+    IResourceContainerImageBuilder imageBuilder,
     ILogger logger,
     CancellationToken cancellationToken = default)
 {
+    public readonly IResourceContainerImageBuilder ImageBuilder = imageBuilder;
+
     public readonly PortAllocator PortAllocator = new();
     private readonly Dictionary<string, (string Description, string? DefaultValue)> _env = [];
     private readonly Dictionary<IResource, ComposeServiceContext> _composeServices = [];
@@ -86,7 +89,7 @@ internal sealed class DockerComposePublishingContext(
 
             var composeServiceContext = await ProcessResourceAsync(resource).ConfigureAwait(false);
 
-            var composeService = composeServiceContext.BuildComposeService();
+            var composeService = await composeServiceContext.BuildComposeServiceAsync(cancellationToken).ConfigureAwait(false);
 
             HandleComposeFileVolumes(composeServiceContext, composeFile);
 
@@ -175,12 +178,11 @@ internal sealed class DockerComposePublishingContext(
         private List<string> Commands { get; } = [];
         public List<Volume> Volumes { get; } = [];
 
-        public Service BuildComposeService()
+        public async Task<Service> BuildComposeServiceAsync(CancellationToken cancellationToken)
         {
-            if (!TryGetContainerImageName(resource, out var containerImageName))
-            {
-                composePublishingContext.Logger.FailedToGetContainerImage(resource.Name);
-            }
+            var image = await composePublishingContext.ImageBuilder.BuildImageAsync(resource, cancellationToken).ConfigureAwait(false);
+            var imageEnvName = $"{resource.Name.ToUpperInvariant().Replace("-", "_")}_IMAGE";
+            composePublishingContext.AddEnv(imageEnvName, $"Container image name for {resource.Name}", image);
 
             var composeService = new Service
             {
@@ -191,7 +193,7 @@ internal sealed class DockerComposePublishingContext(
             AddEnvironmentVariablesAndCommandLineArgs(composeService);
             AddPorts(composeService);
             AddVolumes(composeService);
-            SetContainerImage(containerImageName, composeService);
+            SetContainerImage($"${{{imageEnvName}}}", composeService);
 
             return composeService;
         }
@@ -231,25 +233,6 @@ internal sealed class DockerComposePublishingContext(
             {
                 composeService.Image = containerImageName;
             }
-        }
-
-        private bool TryGetContainerImageName(IResource resourceInstance, out string? containerImageName)
-        {
-            // If the resource has a Dockerfile build annotation, we don't have the image name
-            // it will come as a parameter
-            if (resourceInstance.TryGetLastAnnotation<DockerfileBuildAnnotation>(out _) || resourceInstance is ProjectResource)
-            {
-                var imageEnvName = $"{resourceInstance.Name.ToUpperInvariant().Replace("-", "_")}_IMAGE";
-
-                composePublishingContext.AddEnv(imageEnvName,
-                                                $"Container image name for {resourceInstance.Name}",
-                                                $"{resourceInstance.Name}:latest");
-
-                containerImageName = $"${{{imageEnvName}}}";
-                return false;
-            }
-
-            return resourceInstance.TryGetContainerImageName(out containerImageName);
         }
 
         public async Task ProcessResourceAsync(DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Backchannel/BackchannelService.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelService.cs
@@ -20,7 +20,6 @@ internal sealed class BackchannelService(ILogger<BackchannelService> logger, ICo
     {
         try
         {
-
             var unixSocketPath = configuration.GetValue<string>(UnixSocketPathEnvironmentVariable);
 
             if (string.IsNullOrEmpty(unixSocketPath))

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -251,6 +251,11 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             return new AspireStore(Path.Combine(aspireDir, ".aspire"));
         });
 
+        // Shared DCP things (even though DCP isn't used in 'publish' and 'inspect' mode
+        // we still honour the DCP options around container runtime selection.
+        _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DcpOptions>, ConfigureDefaultDcpOptions>());
+        _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DcpOptions>, ValidateDcpOptions>());
+
         // Aspire CLI support
         _innerBuilder.Services.AddHostedService<CliOrphanDetector>();
         _innerBuilder.Services.AddSingleton<BackchannelService>();
@@ -339,8 +344,6 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             _innerBuilder.Services.AddSingleton<DcpExecutorEvents>();
             _innerBuilder.Services.AddSingleton<DcpHost>();
             _innerBuilder.Services.AddSingleton<IDcpDependencyCheckService, DcpDependencyCheck>();
-            _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DcpOptions>, ConfigureDefaultDcpOptions>());
-            _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DcpOptions>, ValidateDcpOptions>());
             _innerBuilder.Services.AddSingleton<DcpNameGenerator>();
 
             // We need a unique path per application instance
@@ -361,6 +364,9 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         // Publishing support
         Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.MutateHttp2TransportAsync);
         _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, ManifestPublisher>("manifest");
+        _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, DockerContainerRuntime>("docker");
+        _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, PodmanContainerRuntime>("podman");
+        _innerBuilder.Services.AddSingleton<IResourceContainerImageBuilder, ResourceContainerImageBuilder>();
 
         Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.ExcludeDashboardFromManifestAsync);
 

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -367,6 +367,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, DockerContainerRuntime>("docker");
         _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, PodmanContainerRuntime>("podman");
         _innerBuilder.Services.AddSingleton<IResourceContainerImageBuilder, ResourceContainerImageBuilder>();
+        _innerBuilder.Services.AddSingleton<PublishingActivityProgressReporter>();
+        _innerBuilder.Services.AddSingleton<IPublishingActivityProgressReporter, PublishingActivityProgressReporter>(sp => sp.GetRequiredService<PublishingActivityProgressReporter>());
 
         Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.ExcludeDashboardFromManifestAsync);
 

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -17,7 +17,7 @@ internal sealed class DistributedApplicationRunner(ILogger<DistributedApplicatio
         {
             var publishingActivity = await activityReporter.CreateActivityAsync(
                 "publishing-artifacts",
-                "Publishing artifacts",
+                $"Executing publisher {executionContext.PublisherName}",
                 isPrimary: true,
                 stoppingToken).ConfigureAwait(false);
 

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -5,18 +5,38 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
-internal sealed class DistributedApplicationRunner(IHostApplicationLifetime lifetime, DistributedApplicationExecutionContext executionContext, DistributedApplicationModel model, IServiceProvider serviceProvider) : BackgroundService
+internal sealed class DistributedApplicationRunner(ILogger<DistributedApplicationRunner> logger, IHostApplicationLifetime lifetime, DistributedApplicationExecutionContext executionContext, DistributedApplicationModel model, IServiceProvider serviceProvider, IPublishingActivityProgressReporter activityReporter) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (executionContext.IsPublishMode)
         {
-            var publisher = serviceProvider.GetRequiredKeyedService<IDistributedApplicationPublisher>(executionContext.PublisherName);
-            await publisher.PublishAsync(model, stoppingToken).ConfigureAwait(false);
-            lifetime.StopApplication();
+            var publishingActivity = await activityReporter.CreateActivityAsync(
+                "docker-compose",
+                "Docker Compose artifacts",
+                isPrimary: true,
+                stoppingToken).ConfigureAwait(false);
+
+            try
+            {
+                var publisher = serviceProvider.GetRequiredKeyedService<IDistributedApplicationPublisher>(executionContext.PublisherName);
+                await publisher.PublishAsync(model, stoppingToken).ConfigureAwait(false);
+
+                publishingActivity.IsComplete = true;
+                await activityReporter.UpdateActivityAsync(publishingActivity, stoppingToken).ConfigureAwait(false);
+
+                lifetime.StopApplication();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to publish the distributed application.");
+                publishingActivity.IsError = true;
+                await activityReporter.UpdateActivityAsync(publishingActivity, stoppingToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -16,8 +16,8 @@ internal sealed class DistributedApplicationRunner(ILogger<DistributedApplicatio
         if (executionContext.IsPublishMode)
         {
             var publishingActivity = await activityReporter.CreateActivityAsync(
-                "docker-compose",
-                "Docker Compose artifacts",
+                "publishing-artifacts",
+                "Publishing artifacts",
                 isPrimary: true,
                 stoppingToken).ConfigureAwait(false);
 

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -22,12 +22,10 @@ internal sealed class DockerContainerRuntime(ILogger<DockerContainerRuntime> log
         startInfo.ArgumentList.Add(dockerfilePath);
         startInfo.ArgumentList.Add("--tag");
         startInfo.ArgumentList.Add(imageName);
-        startInfo.ArgumentList.Add("--output");
-        startInfo.ArgumentList.Add("type=oci");
         startInfo.ArgumentList.Add("--quiet");
         startInfo.ArgumentList.Add(contextPath);
 
-        logger.LogInformation("Running Docker CLI with arguments: {Arguments}", startInfo.ArgumentList);
+        logger.LogInformation("Running Docker CLI with arguments: {ArgumentList}", startInfo.ArgumentList);
 
         using var process = Process.Start(startInfo);
 

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Publishing;
+
+internal sealed class DockerContainerRuntime(ILogger<DockerContainerRuntime> logger) : IContainerRuntime
+{
+    private async Task<(int ExitCode, string? Output)> RunDockerBuildAsync(string contextPath, string dockerfilePath, CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "docker",
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        };
+
+        startInfo.ArgumentList.Add("build");
+        startInfo.ArgumentList.Add("--file");
+        startInfo.ArgumentList.Add(dockerfilePath);
+        startInfo.ArgumentList.Add("--quiet");
+        startInfo.ArgumentList.Add(contextPath);
+
+        logger.LogInformation("Running Docker CLI with arguments: {Arguments}", startInfo.ArgumentList);
+
+        using var process = Process.Start(startInfo);
+
+        if (process is null)
+        {
+            throw new DistributedApplicationException("Failed to start Docker CLI.");
+        }
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            var stderr = process.StandardError.ReadToEnd();
+            var stdout = process.StandardOutput.ReadToEnd();
+
+            logger.LogError(
+                "Docker CLI failed with exit code {ExitCode}. Output: {Stdout}, Error: {Stderr}",
+                process.ExitCode,
+                stdout,
+                stderr);
+
+            return (process.ExitCode, null);
+        }
+        else
+        {
+            var stdout = process.StandardOutput.ReadToEnd();
+            logger.LogInformation("Docker CLI succeeded. Output: {Stdout}", stdout);
+            return (process.ExitCode, stdout);
+        }
+    }
+
+    public async Task<string> BuildAsync(IResource resource, CancellationToken cancellationToken)
+    {
+        if (resource.TryGetLastAnnotation<DockerfileBuildAnnotation>(out var dockerfileAnnotation))
+        {
+            var result = await RunDockerBuildAsync(
+                dockerfileAnnotation.ContextPath,
+                dockerfileAnnotation.DockerfilePath,
+                cancellationToken).ConfigureAwait(false);
+
+            if (result.ExitCode == 0)
+            {
+                return result.Output!;
+            }
+            else
+            {
+                throw new DistributedApplicationException($"Docker build failed with exit code {result.ExitCode}.");
+            }
+        }
+        else
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -22,6 +22,8 @@ internal sealed class DockerContainerRuntime(ILogger<DockerContainerRuntime> log
         startInfo.ArgumentList.Add(dockerfilePath);
         startInfo.ArgumentList.Add("--tag");
         startInfo.ArgumentList.Add(imageName);
+        startInfo.ArgumentList.Add("--output");
+        startInfo.ArgumentList.Add("type=oci");
         startInfo.ArgumentList.Add("--quiet");
         startInfo.ArgumentList.Add(contextPath);
 

--- a/src/Aspire.Hosting/Publishing/IContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/IContainerRuntime.cs
@@ -1,11 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.ApplicationModel;
-
 namespace Aspire.Hosting.Publishing;
 
 internal interface IContainerRuntime
 {
-    public Task<string> BuildAsync(IResource resource, CancellationToken cancellationToken);
+    public Task<string> BuildImageAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Hosting/Publishing/IContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/IContainerRuntime.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Publishing;
+
+internal interface IContainerRuntime
+{
+    public Task<string> BuildAsync(IResource resource, CancellationToken cancellationToken);
+}

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -1,12 +1,76 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
 namespace Aspire.Hosting.Publishing;
 
-internal sealed class PodmanContainerRuntime : IContainerRuntime
+internal sealed class PodmanContainerRuntime(ILogger<PodmanContainerRuntime> logger) : IContainerRuntime
 {
-    public Task<string> BuildImageAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
+    private async Task<(int ExitCode, string? Output)> RunDockerBuildAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "podman",
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        };
+
+        startInfo.ArgumentList.Add("build");
+        startInfo.ArgumentList.Add("--file");
+        startInfo.ArgumentList.Add(dockerfilePath);
+        startInfo.ArgumentList.Add("--tag");
+        startInfo.ArgumentList.Add(imageName);
+        startInfo.ArgumentList.Add("--quiet");
+        startInfo.ArgumentList.Add(contextPath);
+
+        logger.LogInformation("Running Podman CLI with arguments: {Arguments}", startInfo.ArgumentList);
+
+        using var process = Process.Start(startInfo);
+
+        if (process is null)
+        {
+            throw new DistributedApplicationException("Failed to start Podman CLI.");
+        }
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            var stderr = process.StandardError.ReadToEnd();
+            var stdout = process.StandardOutput.ReadToEnd();
+
+            logger.LogError(
+                "Podman CLI failed with exit code {ExitCode}. Output: {Stdout}, Error: {Stderr}",
+                process.ExitCode,
+                stdout,
+                stderr);
+
+            return (process.ExitCode, null);
+        }
+        else
+        {
+            var stdout = process.StandardOutput.ReadToEnd();
+            logger.LogInformation("Podman CLI succeeded. Output: {Stdout}", stdout);
+            return (process.ExitCode, stdout);
+        }
     }
-}
+
+    public async Task<string> BuildImageAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
+    {
+        var result = await RunDockerBuildAsync(
+            contextPath,
+            dockerfilePath,
+            imageName,
+            cancellationToken).ConfigureAwait(false);
+
+        if (result.ExitCode == 0)
+        {
+            return result.Output!;
+        }
+        else
+        {
+            throw new DistributedApplicationException($"Docker build failed with exit code {result.ExitCode}.");
+        }
+    }}

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -1,13 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.ApplicationModel;
-
 namespace Aspire.Hosting.Publishing;
 
 internal sealed class PodmanContainerRuntime : IContainerRuntime
 {
-    public Task<string> BuildAsync(IResource resource, CancellationToken cancellationToken)
+    public Task<string> BuildImageAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Publishing;
+
+internal sealed class PodmanContainerRuntime : IContainerRuntime
+{
+    public Task<string> BuildAsync(IResource resource, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+
+namespace Aspire.Hosting.Publishing;
+
+/// <summary>
+/// Represents a publishing activity.
+/// </summary>
+public sealed class PublishingActivity
+{
+    internal PublishingActivity(string id, string initialStatusText, bool isPrimary = false)
+    {
+        Id = id;
+        StatusMessage = initialStatusText;
+        IsPrimary = isPrimary;
+    }
+
+    /// <summary>
+    /// Unique Id of the publishing activity.
+    /// </summary>
+    public string Id { get; private set; }
+
+    /// <summary>
+    /// Status message of the publishing activity.
+    /// </summary>
+    public string StatusMessage { get; set; }
+
+    /// <summary>
+    /// Indicates whether the publishing activity is complete.
+    /// </summary>
+    public bool IsComplete { get; set; }
+
+    /// <summary>
+    /// Indicates whether the publishing activity is the primary activity.
+    /// </summary>
+    public bool IsPrimary { get; private set; }
+
+    /// <summary>
+    /// Indicates whether the publishing activity has encountered an error.
+    /// </summary>
+    public bool IsError { get; set; }
+
+}
+
+/// <summary>
+/// Interface for reporting publishing activity progress.
+/// </summary>
+public interface IPublishingActivityProgressReporter
+{
+    /// <summary>
+    /// Creates a new publishing activity with the specified ID.
+    /// </summary>
+    /// <param name="id">Unique Id of the publishing activity.</param>
+    /// <param name="initialStatusText"></param>
+    /// <param name="isPrimary">Indicates that this activity is the primary activity.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The publishing activity</returns>
+    /// <remarks>
+    /// When an activity is created the <paramref name="isPrimary"/> flag indicates whether this
+    /// activity is the primary activity. When the primary activity is completed any laumcher
+    /// which is reading activities will stop listening for updates.
+    /// </remarks>
+    Task<PublishingActivity> CreateActivityAsync(string id, string initialStatusText, bool isPrimary, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Updates the status of an existing publishing activity.
+    /// </summary>
+    /// <param name="publishingActivity">The activity with updated properties.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    Task UpdateActivityAsync(PublishingActivity publishingActivity, CancellationToken cancellationToken);
+}
+
+internal sealed class PublishingActivityProgressReporter : IPublishingActivityProgressReporter
+{
+    public async Task<PublishingActivity> CreateActivityAsync(string id, string initialStatusText, bool isPrimary, CancellationToken cancellationToken)
+    {
+        var publishingActivity = new PublishingActivity(id, initialStatusText, isPrimary);
+        await ActivitiyUpdated.Writer.WriteAsync(publishingActivity, cancellationToken).ConfigureAwait(false);
+        return publishingActivity;
+    }
+
+    public async Task UpdateActivityAsync(PublishingActivity publishingActivity, CancellationToken cancellationToken)
+    {
+        await ActivitiyUpdated.Writer.WriteAsync(publishingActivity, cancellationToken).ConfigureAwait(false);
+
+        if (publishingActivity.IsPrimary && (publishingActivity.IsComplete || publishingActivity.IsError))
+        {
+            // If the activity is complete or an error and it is the primary activity,
+            // we can stop listening for updates.
+            ActivitiyUpdated.Writer.Complete();
+        }
+    }
+
+    internal Channel<PublishingActivity> ActivitiyUpdated { get; } = Channel.CreateUnbounded<PublishingActivity>();
+}

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -110,6 +110,7 @@ internal sealed class ResourceContainerImageBuilder(
         startInfo.ArgumentList.Add("Release");
         startInfo.ArgumentList.Add("--output");
         startInfo.ArgumentList.Add(temporaryOutputPath);
+        startInfo.ArgumentList.Add("--no-bulid");
         startInfo.ArgumentList.Add("/t:PublishContainer");
         startInfo.ArgumentList.Add($"/p:ContainerRepository={resource.Name}");
 

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -118,10 +118,6 @@ internal sealed class ResourceContainerImageBuilder(
             process.Id
             );
 
-        logger.LogInformation("Waiting for 1 minute");
-        await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken).ConfigureAwait(false);
-        logger.LogInformation("Finished waiting for 1 minute");
-
         await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 
         if (process.ExitCode != 0)

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Publishing;
+
+/// <summary>
+/// Provides a service to publishers for building containers that represent a resource.
+/// </summary>
+public interface IResourceContainerImageBuilder
+{
+    /// <summary>
+    /// Builds a container that represents the specified resource.
+    /// </summary>
+    /// <param name="resource">The resource to build.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>String representing the container image.</returns>
+    Task<string> BuildImageAsync(IResource resource, CancellationToken cancellationToken);
+}
+
+internal sealed class ResourceContainerImageBuilder(ILogger<ResourceContainerImageBuilder> logger, IOptions<DcpOptions> dcpOptions, IServiceProvider serviceProvider) : IResourceContainerImageBuilder
+{
+    public async Task<string> BuildImageAsync(IResource resource, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Building container image for resource {Resource}", resource.Name);
+
+        if (resource is IProjectMetadata)
+        {
+            var image = await BuildProjectContainerImageAsync(resource, cancellationToken).ConfigureAwait(false);
+            return image;
+        }
+        else if (resource is ContainerResource)
+        {
+            var image = await BuildContainerImageAsync(resource, cancellationToken).ConfigureAwait(false);
+            return image;
+        }
+        else
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private Task<string> BuildProjectContainerImageAsync(IResource resource, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    private async Task<string> BuildContainerImageAsync(IResource resource, CancellationToken cancellationToken)
+    {
+        var containerRuntime = dcpOptions.Value.ContainerRuntime switch
+        {
+            "podman" => serviceProvider.GetRequiredKeyedService<IContainerRuntime>("podman"),
+            _ => serviceProvider.GetRequiredKeyedService<IContainerRuntime>("docker")
+        };
+
+        var image = await containerRuntime.BuildAsync(resource, cancellationToken).ConfigureAwait(false);
+        return image;
+    }
+}

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -43,7 +43,7 @@ internal sealed class ResourceContainerImageBuilder(
                 cancellationToken).ConfigureAwait(false);
             return image;
         }
-        else if (resource.TryGetLastAnnotation<ContainerImageAnnotation>(out var contaimerImageAnnotation))
+        else if (resource.TryGetLastAnnotation<ContainerImageAnnotation>(out var containerImageAnnotation))
         {
             if (resource.TryGetLastAnnotation<DockerfileBuildAnnotation>(out var dockerfileBuildAnnotation))
             {
@@ -52,14 +52,18 @@ internal sealed class ResourceContainerImageBuilder(
                     resource.Name,
                     dockerfileBuildAnnotation.ContextPath,
                     dockerfileBuildAnnotation.DockerfilePath,
-                    contaimerImageAnnotation.Image,
+                    containerImageAnnotation.Image,
                     cancellationToken).ConfigureAwait(false);
                 return image;
             }
             else
             {
-                // ... except in this case where there is nothing to build, so we just return the image name.
-                return contaimerImageAnnotation.Image;
+                if (!resource.TryGetContainerImageName(out var containerImageName))
+                {
+                    throw new DistributedApplicationException($"Could not get container image name for resource '{resource.Name}'.");
+                }
+
+                return containerImageName;
             }
         }
         else

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -41,7 +41,7 @@ internal sealed class ResourceContainerImageBuilder(ILogger<ResourceContainerIma
         }
         else
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException($"The resource type '{resource.GetType().Name}' is not supported.");
         }
     }
 

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -162,8 +162,8 @@ internal sealed class ResourceContainerImageBuilder(
         {
             var containerRuntime = dcpOptions.Value.ContainerRuntime switch
             {
-                "podman" => serviceProvider.GetRequiredKeyedService<IContainerRuntime>("podman"),
-                _ => serviceProvider.GetRequiredKeyedService<IContainerRuntime>("docker")
+                string rt => serviceProvider.GetRequiredKeyedService<IContainerRuntime>(rt),
+                null => serviceProvider.GetRequiredKeyedService<IContainerRuntime>("docker")
             };
 
             var image = await containerRuntime.BuildImageAsync(

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -118,6 +118,10 @@ internal sealed class ResourceContainerImageBuilder(
             process.Id
             );
 
+        logger.LogInformation("Waiting for 1 minute");
+        await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken).ConfigureAwait(false);
+        logger.LogInformation("Finished waiting for 1 minute");
+
         await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 
         if (process.ExitCode != 0)

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -87,16 +87,6 @@ internal sealed class ResourceContainerImageBuilder(
             throw new DistributedApplicationException($"The resource '{projectMetadata}' does not have a project metadata annotation.");
         }
 
-        var temporaryOutputPath = Path.Combine(
-            Path.GetTempPath(),
-            Path.GetRandomFileName());
-
-        Directory.CreateDirectory(temporaryOutputPath);
-
-        logger.LogInformation(
-            "Creating temporary output path: {TemporaryOutputPath}",
-            temporaryOutputPath);
-
         var startInfo = new ProcessStartInfo
         {
             FileName = "dotnet",
@@ -108,9 +98,6 @@ internal sealed class ResourceContainerImageBuilder(
         startInfo.ArgumentList.Add(projectMetadata.ProjectPath);
         startInfo.ArgumentList.Add("--configuration");
         startInfo.ArgumentList.Add("Release");
-        startInfo.ArgumentList.Add("--output");
-        startInfo.ArgumentList.Add(temporaryOutputPath);
-        startInfo.ArgumentList.Add("--no-bulid");
         startInfo.ArgumentList.Add("/t:PublishContainer");
         startInfo.ArgumentList.Add($"/p:ContainerRepository={resource.Name}");
 
@@ -157,12 +144,6 @@ internal sealed class ResourceContainerImageBuilder(
             logger.LogError(
                 ".NET CLI completed with exit code: {ExitCode}",
                 process.ExitCode);
-
-            Directory.Delete(temporaryOutputPath, true);
-
-            logger.LogInformation(
-                "Deleted temporary output path: {TemporaryOutputPath}",
-                temporaryOutputPath);
 
             return $"{resource.Name}:latest";
         }

--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -6,6 +6,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Testing;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -23,7 +24,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync(includeSecrets: true);
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync(includeSecrets: true);
 
         builder.Configuration["Parameters:secret"] = "open sesame from env";
         var parameter = builder.AddParameter("secret", secret: true);
@@ -57,7 +58,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
             logging.AddXunit(testOutputHelper);
         });
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         builder.AddContainer("testcontainer", "testimage")
                .WithHttpEndpoint(targetPort: 80)
@@ -93,7 +94,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var dockerFile = builder.AddDockerfile(resourceName, tempContextPath, tempDockerfilePath);
 
@@ -111,7 +112,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var dockerFile = builder.AddContainer(resourceName, "someimagename")
             .WithDockerfile(tempContextPath, tempDockerfilePath);
@@ -126,7 +127,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var dockerFile = builder.AddContainer("testcontainer", "someimagename")
             .WithDockerfile(tempContextPath, tempDockerfilePath);
@@ -146,7 +147,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var dockerFile = builder.AddContainer("testcontainer", "someimagename")
             .WithDockerfile(tempContextPath, tempDockerfilePath);
@@ -169,7 +170,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         builder.AddContainer("testcontainer", "testimage")
                .WithHttpEndpoint(targetPort: 80)
@@ -203,7 +204,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         builder.AddDockerfile("testcontainer", tempContextPath, tempDockerfilePath)
                .WithHttpEndpoint(targetPort: 80);
@@ -231,7 +232,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task WithDockerfileResultsInBuildAttributeBeingAddedToManifest()
     {
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -279,7 +280,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task AddDockerfileResultsInBuildAttributeBeingAddedToManifest()
     {
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -326,7 +327,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task WithDockerfileWithBuildSecretResultsInManifestReferencingSecretParameter()
     {
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -372,7 +373,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task AddDockerfileWithBuildSecretResultsInManifestReferencingSecretParameter()
     {
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -421,7 +422,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         builder.Configuration["Parameters:message"] = "hello";
         var parameter = builder.AddParameter("message");
@@ -492,7 +493,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         builder.Configuration["Parameters:message"] = "hello";
         var parameter = builder.AddParameter("message");
@@ -609,7 +610,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var container = builder.AddContainer("mycontainer", "myimage")
                                .WithDockerfile(tempContextPath);
@@ -625,7 +626,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var container = builder.AddDockerfile("mycontainer", tempContextPath);
 
@@ -640,7 +641,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var container = builder.AddContainer("mycontainer", "myimage")
                                .WithDockerfile(tempContextPath, "Dockerfile");
@@ -656,7 +657,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var container = builder.AddDockerfile("mycontainer", tempContextPath, "Dockerfile");
 
@@ -671,7 +672,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync("Otherdockerfile");
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync("Otherdockerfile");
 
         var container = builder.AddContainer("mycontainer", "myimage")
                                .WithDockerfile(tempContextPath, "Otherdockerfile");
@@ -687,7 +688,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync("Otherdockerfile");
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync("Otherdockerfile");
 
         var container = builder.AddDockerfile("mycontainer", tempContextPath, "Otherdockerfile");
 
@@ -702,7 +703,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var container = builder.AddContainer("mycontainer", "myimage")
                                .WithDockerfile(tempContextPath, tempDockerfilePath);
@@ -718,34 +719,13 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
         var container = builder.AddDockerfile("mycontainer", tempContextPath, tempDockerfilePath);
 
         var annotation = Assert.Single(container.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
         Assert.Equal(tempContextPath, annotation.ContextPath);
         Assert.Equal(tempDockerfilePath, annotation.DockerfilePath);
-    }
-
-    private static async Task<(string ContextPath, string DockerfilePath)> CreateTemporaryDockerfileAsync(string dockerfileName = "Dockerfile", bool createDockerfile = true, bool includeSecrets = false)
-    {
-        var tempContextPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(tempContextPath);
-
-        var tempDockerfilePath = Path.Combine(tempContextPath, dockerfileName);
-
-        if (createDockerfile)
-        {
-            var dockerfileTemplate = includeSecrets ? HelloWorldDockerfileWithSecrets : HelloWorldDockerfile;
-            // We apply this random value to the Dockerfile to make sure that we get a clean
-            // build each time with no possible caching.
-            var cacheBuster = Guid.NewGuid();
-            var dockerfileContent = dockerfileTemplate.Replace("!!!CACHEBUSTER!!!", cacheBuster.ToString());
-
-            await File.WriteAllTextAsync(tempDockerfilePath, dockerfileContent);
-        }
-
-        return (tempContextPath, tempDockerfilePath);
     }
 
     private static async Task WaitForResourceAsync(DistributedApplication app, string resourceName, string resourceState, TimeSpan? timeout = null)
@@ -755,33 +735,4 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
 
     private const string DefaultMessage = "aspire!";
 
-    private const string HelloWorldDockerfile = $$"""
-        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS builder
-        ARG MESSAGE=aspire!
-        RUN mkdir -p /usr/share/nginx/html
-        RUN echo !!!CACHEBUSTER!!! > /usr/share/nginx/html/cachebuster.txt
-        RUN echo ${MESSAGE} > /usr/share/nginx/html/aspire.html
-
-        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS runner
-        ARG MESSAGE
-        RUN mkdir -p /usr/share/nginx/html
-        COPY --from=builder /usr/share/nginx/html/cachebuster.txt /usr/share/nginx/html
-        COPY --from=builder /usr/share/nginx/html/aspire.html /usr/share/nginx/html
-        """;
-
-    private const string HelloWorldDockerfileWithSecrets = $$"""
-        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS builder
-        ARG MESSAGE=aspire!
-        RUN mkdir -p /usr/share/nginx/html
-        RUN echo !!!CACHEBUSTER!!! > /usr/share/nginx/html/cachebuster.txt
-        RUN echo ${MESSAGE} > /usr/share/nginx/html/aspire.html
-
-        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS runner
-        ARG MESSAGE
-        RUN mkdir -p /usr/share/nginx/html
-        COPY --from=builder /usr/share/nginx/html/cachebuster.txt /usr/share/nginx/html
-        COPY --from=builder /usr/share/nginx/html/aspire.html /usr/share/nginx/html
-        RUN --mount=type=secret,id=ENV_SECRET cp /run/secrets/ENV_SECRET /usr/share/nginx/html/ENV_SECRET.txt
-        RUN chmod -R 777 /usr/share/nginx/html
-        """;
 }

--- a/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
+++ b/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
@@ -12,7 +12,6 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Docker\Aspire.Hosting.Docker.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
-    <ProjectReference Include="..\TestingAppHost1\TestingAppHost1.MyWebApp\TestingAppHost1.MyWebApp.csproj" IsAspireProjectResource="false"  />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
+++ b/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Docker\Aspire.Hosting.Docker.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
+    <ProjectReference Include="..\TestingAppHost1\TestingAppHost1.AppHost\TestingAppHost1.AppHost.csproj" IsAspireProjectResource="false"  />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
+++ b/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Docker\Aspire.Hosting.Docker.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
-    <ProjectReference Include="..\TestingAppHost1\TestingAppHost1.AppHost\TestingAppHost1.AppHost.csproj" IsAspireProjectResource="false"  />
+    <ProjectReference Include="..\TestingAppHost1\TestingAppHost1.MyWebApp\TestingAppHost1.MyWebApp.csproj" IsAspireProjectResource="false"  />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -116,9 +116,6 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
             # Parameter param2
             PARAM2=default
 
-            # Container image name for myapp
-            MYAPP_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0
-
             # Container image name for project1
             PROJECT1_IMAGE=project1:latest
 

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -10,12 +10,14 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
 using Xunit.Abstractions;
+using Aspire.Components.Common.Tests;
 
 namespace Aspire.Hosting.Docker.Tests;
 
 public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
 {
     [Fact]
+    [RequiresDocker]
     public async Task PublishAsync_GeneratesValidDockerComposeFile()
     {
         using var tempDir = new TempDirectory();

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -38,7 +38,10 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
                          .WithReference(cs)
                          .WithArgs("--cs", cs.Resource);
 
-        builder.AddProject<Projects.TestingAppHost1_MyWebApp>("project1", launchProfileName: null)
+        builder.AddProject(
+            "project1",
+            "..\\TestingAppHost1\\TestingAppHost1.MyWebApp\\TestingAppHost1.MyWebApp.csproj",
+            launchProfileName: null)
             .WithReference(api.GetEndpoint("http"));
 
         var app = builder.Build();

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -112,7 +112,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
             PARAM2=default
 
             # Container image name for myapp
-            MYAPP_IMAGE=mcr.microsoft.com/dotnet/aspnet
+            MYAPP_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0
 
             # Container image name for project1
             PROJECT1_IMAGE=project1:latest

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -4,6 +4,7 @@
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
+using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -37,7 +38,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
                          .WithReference(cs)
                          .WithArgs("--cs", cs.Resource);
 
-        builder.AddProject<TestProject>("project1", launchProfileName: null)
+        builder.AddProject<Projects.TestingAppHost1_MyWebApp>("project1", launchProfileName: null)
             .WithReference(api.GetEndpoint("http"));
 
         var app = builder.Build();
@@ -48,7 +49,9 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
 
         var publisher = new DockerComposePublisher("test", options,
             NullLogger<DockerComposePublisher>.Instance,
-            builder.ExecutionContext);
+            builder.ExecutionContext,
+            app.Services.GetRequiredService<IResourceContainerImageBuilder>()
+            );
 
         // Act
         await publisher.PublishAsync(model, default);
@@ -107,6 +110,9 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
 
             # Parameter param2
             PARAM2=default
+
+            # Container image name for myapp
+            MYAPP_IMAGE=mcr.microsoft.com/dotnet/aspnet
 
             # Container image name for project1
             PROJECT1_IMAGE=project1:latest

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -609,7 +609,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var healthyEvent = await app.ResourceNotifications.WaitForResourceHealthyAsync("resource").DefaultTimeout();
         Assert.Equal(HealthStatus.Healthy, healthyEvent.Snapshot.HealthStatus);
 
-        await app.StopAsync().DefaultTimeout();
+        await app.StopAsync().TimeoutAfter(TestConstants.LongTimeoutTimeSpan);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -358,7 +358,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(resource.Resource, @event.Resource);
 
         await pendingStart.DefaultTimeout();
-        await app.StopAsync().DefaultTimeout();
+        await app.StopAsync().TimeoutAfter(TestConstants.LongTimeoutTimeSpan);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -242,7 +242,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
             },
             "Wait for healthy delay.", logger);
 
-        await app.StopAsync(abortTokenSource.Token).DefaultTimeout();
+        await app.StopAsync(abortTokenSource.Token).TimeoutAfter(TestConstants.LongTimeoutTimeSpan);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -561,7 +561,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(childReadyEvent.Resource, child.Resource);
 
         await pendingStart; // already has a timeout
-        await app.StopAsync().DefaultTimeout();
+        await app.StopAsync().TimeoutAfter(TestConstants.LongTimeoutTimeSpan);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Helpers/NoopPublisher.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/NoopPublisher.cs
@@ -2,16 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Publishing;
-using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting.Tests.Helpers;
-internal sealed class NoopPublisher(IHostApplicationLifetime lifetime) : IDistributedApplicationPublisher
+internal sealed class NoopPublisher : IDistributedApplicationPublisher
 {
-    private readonly IHostApplicationLifetime _lifetime = lifetime;
-
     public Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {
-        _lifetime.StopApplication();
         return Task.CompletedTask;
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
@@ -25,7 +25,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
         var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageBuilder>();
-        _ = await imageBuilder.BuildImageAsync(servicea.Resource, cts.Token);
+        await imageBuilder.BuildImageAsync(servicea.Resource, cts.Token);
     }
 
     [Fact]
@@ -41,6 +41,6 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
         var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageBuilder>();
-        _ = await imageBuilder.BuildImageAsync(servicea.Resource, cts.Token);
+        await imageBuilder.BuildImageAsync(servicea.Resource, cts.Token);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
@@ -14,6 +15,7 @@ namespace Aspire.Hosting.Tests.Publishing;
 public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 {
     [Fact]
+    [RequiresDocker]
     public async Task CanBuildImageFromProjectResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -27,6 +29,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
+    [RequiresDocker]
     public async Task CanBuildImageFromDockerfileResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Hosting.Tests.Publishing;
+
+public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task CanBuildImageFromProjectResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
+        var servicea = builder.AddProject<Projects.ServiceA>("servicea");
+
+        using var app = builder.Build();
+
+        using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
+        var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageBuilder>();
+        _ = await imageBuilder.BuildImageAsync(servicea.Resource, cts.Token);
+    }
+
+    [Fact]
+    public async Task CanBuildImageFromDockerfileResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
+
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var servicea = builder.AddDockerfile("container", tempContextPath, tempDockerfilePath);
+
+        using var app = builder.Build();
+
+        using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
+        var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageBuilder>();
+        _ = await imageBuilder.BuildImageAsync(servicea.Resource, cts.Token);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Utils/DockerfileUtils.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/DockerfileUtils.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Tests.Utils;
+
+public static class DockerfileUtils
+{
+    public const string HelloWorldDockerfile = $$"""
+        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS builder
+        ARG MESSAGE=aspire!
+        RUN mkdir -p /usr/share/nginx/html
+        RUN echo !!!CACHEBUSTER!!! > /usr/share/nginx/html/cachebuster.txt
+        RUN echo ${MESSAGE} > /usr/share/nginx/html/aspire.html
+
+        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS runner
+        ARG MESSAGE
+        RUN mkdir -p /usr/share/nginx/html
+        COPY --from=builder /usr/share/nginx/html/cachebuster.txt /usr/share/nginx/html
+        COPY --from=builder /usr/share/nginx/html/aspire.html /usr/share/nginx/html
+        """;
+
+    public const string HelloWorldDockerfileWithSecrets = $$"""
+        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS builder
+        ARG MESSAGE=aspire!
+        RUN mkdir -p /usr/share/nginx/html
+        RUN echo !!!CACHEBUSTER!!! > /usr/share/nginx/html/cachebuster.txt
+        RUN echo ${MESSAGE} > /usr/share/nginx/html/aspire.html
+
+        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS runner
+        ARG MESSAGE
+        RUN mkdir -p /usr/share/nginx/html
+        COPY --from=builder /usr/share/nginx/html/cachebuster.txt /usr/share/nginx/html
+        COPY --from=builder /usr/share/nginx/html/aspire.html /usr/share/nginx/html
+        RUN --mount=type=secret,id=ENV_SECRET cp /run/secrets/ENV_SECRET /usr/share/nginx/html/ENV_SECRET.txt
+        RUN chmod -R 777 /usr/share/nginx/html
+        """;
+
+    public static async Task<(string ContextPath, string DockerfilePath)> CreateTemporaryDockerfileAsync(string dockerfileName = "Dockerfile", bool createDockerfile = true, bool includeSecrets = false)
+    {
+        var tempContextPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempContextPath);
+
+        var tempDockerfilePath = Path.Combine(tempContextPath, dockerfileName);
+
+        if (createDockerfile)
+        {
+            var dockerfileTemplate = includeSecrets ? HelloWorldDockerfileWithSecrets : HelloWorldDockerfile;
+            // We apply this random value to the Dockerfile to make sure that we get a clean
+            // build each time with no possible caching.
+            var cacheBuster = Guid.NewGuid();
+            var dockerfileContent = dockerfileTemplate.Replace("!!!CACHEBUSTER!!!", cacheBuster.ToString());
+
+            await File.WriteAllTextAsync(tempDockerfilePath, dockerfileContent);
+        }
+
+        return (tempContextPath, tempDockerfilePath);
+    }
+}


### PR DESCRIPTION
This PR introduces the plumbing necessaryo support the `aspire build` / `aspire publish` commands producing container images from resources in the application model.

There are a few scenarios it will support:

1. Building .NET projects
2. Building resources that have a Dockerfile annotation.

There are a few moving parts:

- [x] A new interface called `IContainerRuntime`. This represents either docker or podman capabiltiies at publish time and we pick the right implementation based on DCP options.
- [x] IResourceContainerImageBuilder which is the main interface that publishers use when they encounter a resource for which they need to produce a container image. They pass in the resource and we give them back a string identifying that container image.
- [x] progress reporter thingo (not present yet); an API that publishers, and anything in the publishing pipeline can use to capture an async task and use to report back via the back channel the status of sub-tasks.