### PR TITLE
Add Cosmos database builder pattern for child containers

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
@@ -8,9 +8,9 @@ using Newtonsoft.Json;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
-builder.WithAzureCosmosDatabase("db")
-    .AddContainer("entries")
-    .AddContainer("users");
+builder.AddAzureCosmosDatabase("db")
+    .AddKeyedContainer("entries")
+    .AddKeyedContainer("users");
 builder.AddCosmosDbContext<TestCosmosContext>("db", configureDbContextOptions =>
 {
     configureDbContextOptions.RequestTimeout = TimeSpan.FromSeconds(120);

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
@@ -8,8 +8,9 @@ using Newtonsoft.Json;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
-builder.AddAzureCosmosDatabase("db");
-builder.AddAzureCosmosContainer("entries");
+builder.WithAzureCosmosDatabase("db")
+    .AddContainer("entries")
+    .AddContainer("users");
 builder.AddCosmosDbContext<TestCosmosContext>("db", configureDbContextOptions =>
 {
     configureDbContextOptions.RequestTimeout = TimeSpan.FromSeconds(120);
@@ -18,14 +19,13 @@ builder.AddCosmosDbContext<TestCosmosContext>("db", configureDbContextOptions =>
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
-app.MapGet("/", async (Database db, Container container) =>
+
+static async Task<object> AddAndGetStatus<T>(Container container, T newEntry)
 {
-    // Add an entry to the database on each request.
-    var newEntry = new Entry() { Id = Guid.NewGuid().ToString() };
     await container.CreateItemAsync(newEntry);
 
-    var entries = new List<Entry>();
-    var iterator = container.GetItemQueryIterator<Entry>(requestOptions: new QueryRequestOptions() { MaxItemCount = 5 });
+    var entries = new List<T>();
+    var iterator = container.GetItemQueryIterator<T>(requestOptions: new QueryRequestOptions() { MaxItemCount = 5 });
 
     var batchCount = 0;
     while (iterator.HasMoreResults)
@@ -40,10 +40,22 @@ app.MapGet("/", async (Database db, Container container) =>
 
     return new
     {
-        batchCount = batchCount,
+        batchCount,
         totalEntries = entries.Count,
-        entries = entries
+        entries
     };
+}
+
+app.MapGet("/", async ([FromKeyedServices("entries")] Container container) =>
+{
+    var newEntry = new Entry() { Id = Guid.NewGuid().ToString() };
+    return await AddAndGetStatus(container, newEntry);
+});
+
+app.MapGet("/users", async ([FromKeyedServices("users")] Container container) =>
+{
+    var newEntry = new User() { Id = $"user-{Guid.NewGuid()}" };
+    return await AddAndGetStatus(container, newEntry);
 });
 
 app.MapGet("/ef", async (TestCosmosContext context) =>
@@ -57,6 +69,12 @@ app.MapGet("/ef", async (TestCosmosContext context) =>
 });
 
 app.Run();
+
+public class User
+{
+    [JsonProperty("id")]
+    public string? Id { get; set; }
+}
 
 public class Entry
 {

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -9,14 +9,13 @@ var cosmos = builder.AddAzureCosmosDB("cosmos")
                 .RunAsPreviewEmulator(e => e.WithDataExplorer());
 
 var db = cosmos.AddCosmosDatabase("db");
-var entries = db.AddContainer("entries", "/id");
-var users = db.AddContainer("users", "/id");
+var entries = db.AddContainer("entries", "/id", "staging-entries");
+db.AddContainer("users", "/id");
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()
        .WithReference(db).WaitFor(db)
-       .WithReference(entries).WaitFor(entries)
-       .WithReference(users).WaitFor(users);
+       .WithReference(entries).WaitFor(entries);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -9,12 +9,14 @@ var cosmos = builder.AddAzureCosmosDB("cosmos")
                 .RunAsPreviewEmulator(e => e.WithDataExplorer());
 
 var db = cosmos.AddCosmosDatabase("db");
-var container = db.AddContainer("entries", "/id");
+var entries = db.AddContainer("entries", "/id");
+var users = db.AddContainer("users", "/id");
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()
        .WithReference(db).WaitFor(db)
-       .WithReference(container).WaitFor(container);
+       .WithReference(entries).WaitFor(entries)
+       .WithReference(users).WaitFor(users);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
@@ -46,6 +46,15 @@ public static class AspireMicrosoftAzureCosmosExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos" section.</remarks>
+    /// <remarks>
+    /// The <see cref="Container"/> is registered as a singleton in the services provided by
+    /// the <paramref name="builder"/> and does not reuse any existing <see cref="CosmosClient"/>
+    /// instances in the DI container. The connection string associated with the <paramref name="connectionName"/>
+    /// must contain the database name and container name or be set in the <paramref name="configureSettings" />
+    /// callback. To interact with multiple containers against the same database, use
+    /// <see cref="CosmosDatabaseBuilder"/> to register the database and then call
+    /// <see cref="CosmosDatabaseBuilder.AddKeyedContainer(string)"/> for each container.
+    /// </remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
     public static void AddAzureCosmosContainer(
         this IHostApplicationBuilder builder,
@@ -101,6 +110,15 @@ public static class AspireMicrosoftAzureCosmosExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
+    /// <remarks>
+    /// The <see cref="Container"/> is registered as a singleton in the services provided by
+    /// the <paramref name="builder"/> and does not reuse any existing <see cref="CosmosClient"/>
+    /// instances in the DI container. The connection string associated with the <paramref name="name"/>
+    /// must contain the database name and container name or be set in the <paramref name="configureSettings" />
+    /// callback. To interact with multiple containers against the same database, use
+    /// <see cref="CosmosDatabaseBuilder"/> to register the database and then call
+    /// <see cref="CosmosDatabaseBuilder.AddKeyedContainer(string)"/> for each container.
+    /// </remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
     public static void AddKeyedAzureCosmosContainer(
         this IHostApplicationBuilder builder,

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
@@ -39,39 +39,6 @@ public static class AspireMicrosoftAzureCosmosExtensions
     }
 
     /// <summary>
-    /// Registers the <see cref="Database"/> as a singleton in the services provided by the <paramref name="builder"/>.
-    /// </summary>
-    /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
-    /// <param name="connectionName">The connection name to use to find a connection string.</param>
-    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosSettings"/>. It's invoked after the settings are read from the configuration.</param>
-    /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos" section.</remarks>
-    /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
-    public static void AddAzureCosmosDatabase(
-        this IHostApplicationBuilder builder,
-        string connectionName,
-        Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
-        Action<CosmosClientOptions>? configureClientOptions = null)
-    {
-        var settings = builder.GetSettings(connectionName, configureSettings);
-        var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        builder.Services.AddSingleton(sp =>
-        {
-            if (string.IsNullOrEmpty(settings.DatabaseName))
-            {
-                throw new InvalidOperationException($"The connection string '{connectionName}' does not exist or is missing the database name.");
-            }
-            CosmosClient? client = null;
-            if (configureClientOptions is null)
-            {
-                client = sp.GetService<CosmosClient>();
-            }
-            client ??= GetCosmosClient(connectionName, settings, clientOptions);
-            return client.GetDatabase(settings.DatabaseName);
-        });
-    }
-
-    /// <summary>
     /// Registers the <see cref="Container"/> as a singleton in the services provided by the <paramref name="builder"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
@@ -94,12 +61,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
             {
                 throw new InvalidOperationException($"The connection string '{connectionName}' does not exist or is missing the container name or database name.");
             }
-            CosmosClient? client = null;
-            if (configureClientOptions is null)
-            {
-                client = sp.GetService<CosmosClient>();
-            }
-            client ??= GetCosmosClient(connectionName, settings, clientOptions);
+            var client = GetCosmosClient(connectionName, settings, clientOptions);
             return client.GetContainer(settings.DatabaseName, settings.ContainerName);
         });
     }
@@ -132,39 +94,6 @@ public static class AspireMicrosoftAzureCosmosExtensions
     }
 
     /// <summary>
-    /// Registers the <see cref="Database"/> as a singleton for given <paramref name="name" /> in the services provided by the <paramref name="builder"/>.
-    /// </summary>
-    /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
-    /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection string from the ConnectionStrings configuration section.</param>
-    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosSettings"/>. It's invoked after the settings are read from the configuration.</param>
-    /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
-    /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
-    public static void AddKeyedAzureCosmosDatabase(
-       this IHostApplicationBuilder builder,
-       string name,
-       Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
-       Action<CosmosClientOptions>? configureClientOptions = null)
-    {
-        var settings = builder.GetSettings(name, configureSettings);
-        var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        builder.Services.AddKeyedSingleton(name, (sp, key) =>
-        {
-            if (string.IsNullOrEmpty(settings.DatabaseName))
-            {
-                throw new InvalidOperationException($"The connection string '{name}' does not exist or is missing the database name.");
-            }
-            CosmosClient? client = null;
-            if (configureClientOptions is null)
-            {
-                client = sp.GetKeyedService<CosmosClient>(key);
-            }
-            client ??= GetCosmosClient(name, settings, clientOptions);
-            return client.GetDatabase(settings.DatabaseName);
-        });
-    }
-
-    /// <summary>
     /// Registers the <see cref="Container"/> as a singleton for given <paramref name="name" /> in the services provided by the <paramref name="builder"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
@@ -187,19 +116,14 @@ public static class AspireMicrosoftAzureCosmosExtensions
             {
                 throw new InvalidOperationException($"The connection string '{name}' does not exist or is missing the container name or database name.");
             }
-            CosmosClient? client = null;
-            if (configureClientOptions is null)
-            {
-                client = sp.GetKeyedService<CosmosClient>(key);
-            }
-            client ??= GetCosmosClient(name, settings, clientOptions);
+            var client = GetCosmosClient(name, settings, clientOptions);
             return client.GetContainer(settings.DatabaseName, settings.ContainerName);
         });
     }
 
     /// <summary>
-    /// Returns a <see cref="CosmosDatabaseBuilder"/> for the given connection name that can be used to
-    /// register multiple containers against the same database.
+    /// Registers the <see cref="Database"/> as a singleton the services provided by the <paramref name="builder"/>
+    /// and returns a <see cref="CosmosDatabaseBuilder"/> to support chaining multiple container registrations against the same database.
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
     /// <param name="connectionName">The connection name to use to find a connection string.</param>
@@ -207,7 +131,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
-    public static CosmosDatabaseBuilder WithAzureCosmosDatabase(
+    public static CosmosDatabaseBuilder AddAzureCosmosDatabase(
         this IHostApplicationBuilder builder,
         string connectionName,
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
@@ -215,25 +139,32 @@ public static class AspireMicrosoftAzureCosmosExtensions
     {
         var settings = builder.GetSettings(connectionName, configureSettings);
         var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        return new CosmosDatabaseBuilder(builder, connectionName, settings, clientOptions);
+        var cosmosDatabaseBuilder = new CosmosDatabaseBuilder(builder, connectionName, settings, clientOptions);
+        cosmosDatabaseBuilder.AddDatabase();
+        return cosmosDatabaseBuilder;
     }
 
     /// <summary>
-    /// Register a <see cref="Container"/> against the database managed with <see cref="CosmosDatabaseBuilder"/>.
-    /// This method can be called multiple times to register multiple containers against the same database.
+    /// Registers the <see cref="Database"/> as a singleton for given <paramref name="name" /> in the services provided by the <paramref name="builder"/>
+    /// and returns a <see cref="CosmosDatabaseBuilder"/> to support chaining multiple container registrations against the same database.
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
     /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection string from the ConnectionStrings configuration section.</param>
-    /// <returns>A <see cref="CosmosDatabaseBuilder"/> that can be used for further chaining.</returns>
-    /// <remarks>
-    /// Containers registered with this method will always use the account and database associated
-    /// with the parent <see cref="CosmosDatabaseBuilder"/>. The connection string for the container.
-    /// </remarks>
-    public static CosmosDatabaseBuilder AddContainer(
-        this CosmosDatabaseBuilder builder,
-        string name)
+    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosSettings"/>. It's invoked after the settings are read from the configuration.</param>
+    /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
+    /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
+    /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
+    public static CosmosDatabaseBuilder AddKeyedAzureCosmosDatabase(
+       this IHostApplicationBuilder builder,
+       string name,
+       Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
+       Action<CosmosClientOptions>? configureClientOptions = null)
     {
-        return builder.AddContainer(name);
+        var settings = builder.GetSettings(name, configureSettings);
+        var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
+        var cosmosDatabaseBuilder = new CosmosDatabaseBuilder(builder, name, settings, clientOptions);
+        cosmosDatabaseBuilder.AddKeyedDatabase();
+        return cosmosDatabaseBuilder;
     }
 
     internal static CosmosConnectionInfo? GetCosmosConnectionInfo(this IHostApplicationBuilder builder, string connectionName)

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/CosmosDatabaseBuilder.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/CosmosDatabaseBuilder.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Aspire.Microsoft.Azure.Cosmos;
+
+/// <summary>
+/// Represents a builder that can be used to register multiple container
+/// instances against the same Cosmos database connection.
+/// </summary>
+public sealed class CosmosDatabaseBuilder(
+    IHostApplicationBuilder hostBuilder,
+    string connectionName,
+    MicrosoftAzureCosmosSettings settings,
+    CosmosClientOptions clientOptions)
+{
+    private CosmosClient? _client;
+
+    internal CosmosDatabaseBuilder AddContainer(string name)
+    {
+        _client ??= AspireMicrosoftAzureCosmosExtensions.GetCosmosClient(connectionName, settings, clientOptions);
+
+        var connectionInfo = hostBuilder.GetCosmosConnectionInfo(name) ?? throw new InvalidOperationException($"The connection string '{name}' does not exist.");
+
+        hostBuilder.Services.AddKeyedSingleton(name, (sp, _) =>
+        {
+            if (string.IsNullOrEmpty(connectionInfo.ContainerName))
+            {
+                throw new InvalidOperationException(
+                    $"A Container could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{name}'");
+            }
+            return _client.GetContainer(settings.DatabaseName, connectionInfo.ContainerName);
+        });
+
+        return this;
+    }
+}


### PR DESCRIPTION
This PR introduces new APIs to the Azure Cosmos integration to support interacting with multiple containers against the same database. Our goal is to reuse client configuration for multiple containers. Our current set of APIs makes it possible to reuse client information if there is always one database -> one container.

```csharp
builder.AddAzureCosmosDatabase("db");
builder.AddAzureCosmosContainer("entries"); // Uses the same client that initialized "db"
```

This falls apart when there are multiple containers that are uniquely identified by their service key. In this case, we can assume that all containers share the same database but that might not always be the case.

```csharp
builder.AddAzureCosmosDatabase("cosmos1");
builder.AddAzureCosmosDatabase("cosmos2");
// Which database do these container have a relationship with?
builder.AddKeyedAzureCosmosContainer("users");
builder.AddKeyedAzureCosmosContainer("products");
builder.AddKeyedAzureCosmosContainer("orders");
```

The `WithCosmosDatabaseBuilder` API introduced here makes it possible to chain the database->container relationships:

```csharp
builder.WithAzureCosmosDatabase("cosmos1")
    .AddContainer("users")
    .AddContainer("orders");
builder.WithAzureCosmosDatabase("cosmos2")
    .AddContainer("products");
```

In application code, these services can be resolved as follows:

```
app.MapGet("/users", ([FromKeyedServices("users")] Container container) => { });
app.MapGet("/orders", ([FromKeyedServices("orders")] Container container) => { });
app.MapGet("/products", ([FromKeyedServices("products")] Container container) => { });
```