### PR TITLE
Only add .msi in Signing.props when missing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -3,7 +3,9 @@
   <ItemGroup>
     <FileExtensionSignInfo Update=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Update=".zip" CertificateName="None" />
-    <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
+
+    <!-- add missing entry for .msi, this can be removed once aspire uses arcade 10.0 -->
+    <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" Condition="!@(FileExtensionSignInfo->AnyHaveMetadataValue('Identity', '.msi'))" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
arcade 10.0 which is used in the VMR build added .msi to FileExtensionSignInfo so the aspire build now complains about a duplicate entry. Only add the entry if it's not already there.
