### PR TITLE
Templates: Use latest OTel packages when targeting net9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -109,13 +109,13 @@
     <PackageVersion Include="StreamJsonRpc" Version="2.21.69" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="9.0.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryLTSVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryLTSVersion)" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryLTSVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="$(OpenTelemetryInstrumentationGrpcNetClientLTSVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryLTSVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryLTSVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryLTSVersion)" />
     <!-- build dependencies -->
     <PackageVersion Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="1.1.87-gba258badda" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,6 +72,14 @@
     <MicrosoftExtensionsHttpVersion>9.0.3</MicrosoftExtensionsHttpVersion>
     <SystemFormatsAsn1Version>9.0.3</SystemFormatsAsn1Version>
     <SystemTextJsonVersion>9.0.3</SystemTextJsonVersion>
+    <!-- OpenTelemetry (OTel) -->
+    <OpenTelemetryVersion>1.11.2</OpenTelemetryVersion>
+    <OpenTelemetryInstrumentationAspNetCoreVersion>1.11.1</OpenTelemetryInstrumentationAspNetCoreVersion>
+    <OpenTelemetryInstrumentationHttpVersion>1.11.1</OpenTelemetryInstrumentationHttpVersion>
+    <OpenTelemetryInstrumentationExtensionsHostingVersion>1.11.2</OpenTelemetryInstrumentationExtensionsHostingVersion>
+    <OpenTelemetryInstrumentationRuntimeVersion>1.11.1</OpenTelemetryInstrumentationRuntimeVersion>
+    <OpenTelemetryInstrumentationGrpcNetClientVersion>1.11.0-beta.2</OpenTelemetryInstrumentationGrpcNetClientVersion>
+    <OpenTelemetryExporterOpenTelemetryProtocolVersion>1.11.2</OpenTelemetryExporterOpenTelemetryProtocolVersion>
   </PropertyGroup>
   <!-- .NET 8.0 Package Versions -->
   <PropertyGroup Label="LTS">
@@ -103,5 +111,8 @@
     <MicrosoftExtensionsHttpLTSVersion>8.0.1</MicrosoftExtensionsHttpLTSVersion>
     <SystemFormatsAsn1LTSVersion>8.0.2</SystemFormatsAsn1LTSVersion>
     <SystemTextJsonLTSVersion>8.0.5</SystemTextJsonLTSVersion>
+    <!-- OpenTelemetry (OTel) -->
+    <OpenTelemetryLTSVersion>1.9.0</OpenTelemetryLTSVersion>
+    <OpenTelemetryInstrumentationGrpcNetClientLTSVersion>1.9.0-beta.1</OpenTelemetryInstrumentationGrpcNetClientLTSVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -78,7 +78,6 @@
     <OpenTelemetryInstrumentationHttpVersion>1.11.1</OpenTelemetryInstrumentationHttpVersion>
     <OpenTelemetryInstrumentationExtensionsHostingVersion>1.11.2</OpenTelemetryInstrumentationExtensionsHostingVersion>
     <OpenTelemetryInstrumentationRuntimeVersion>1.11.1</OpenTelemetryInstrumentationRuntimeVersion>
-    <OpenTelemetryInstrumentationGrpcNetClientVersion>1.11.0-beta.2</OpenTelemetryInstrumentationGrpcNetClientVersion>
     <OpenTelemetryExporterOpenTelemetryProtocolVersion>1.11.2</OpenTelemetryExporterOpenTelemetryProtocolVersion>
   </PropertyGroup>
   <!-- .NET 8.0 Package Versions -->

--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -53,7 +53,14 @@
                       Lines="$([System.IO.File]::ReadAllText('%(TemplateProjectFiles.FullPath)')
                                                  .Replace('!!REPLACE_WITH_LATEST_VERSION!!', '$(PackageVersion)')
                                                  .Replace('!!REPLACE_WITH_ASPNETCORE_9_VERSION!!', '$(MicrosoftAspNetCorePackageVersionForNet9)')
-                                                 .Replace('!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!', '$(MicrosoftExtensionsHttpResilienceVersion)'))"
+                                                 .Replace('!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!', '$(MicrosoftExtensionsHttpResilienceVersion)')
+                                                 .Replace('!!REPLACE_WITH_OTEL_LTS_VERSION!!', '$(OpenTelemetryLTSVersion)')
+                                                 .Replace('!!REPLACE_WITH_OTEL_VERSION!!', '$(OpenTelemetryVersion)')
+                                                 .Replace('!!REPLACE_WITH_OTEL_EXPORTER_VERSION!!', '$(OpenTelemetryExporterOpenTelemetryProtocolVersion)')
+                                                 .Replace('!!REPLACE_WITH_OTEL_HOSTING_VERSION!!', '$(OpenTelemetryInstrumentationExtensionsHostingVersion)')
+                                                 .Replace('!!REPLACE_WITH_OTEL_ASPNETCORE_VERSION!!', '$(OpenTelemetryInstrumentationAspNetCoreVersion)')
+                                                 .Replace('!!REPLACE_WITH_OTEL_HTTP_VERSION!!', '$(OpenTelemetryInstrumentationHttpVersion)')
+                                                 .Replace('!!REPLACE_WITH_OTEL_RUNTIME_VERSION!!', '$(OpenTelemetryInstrumentationRuntimeVersion)') )"
                       Overwrite="true" />
   </Target>
 

--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -55,7 +55,6 @@
                                                  .Replace('!!REPLACE_WITH_ASPNETCORE_9_VERSION!!', '$(MicrosoftAspNetCorePackageVersionForNet9)')
                                                  .Replace('!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!', '$(MicrosoftExtensionsHttpResilienceVersion)')
                                                  .Replace('!!REPLACE_WITH_OTEL_LTS_VERSION!!', '$(OpenTelemetryLTSVersion)')
-                                                 .Replace('!!REPLACE_WITH_OTEL_VERSION!!', '$(OpenTelemetryVersion)')
                                                  .Replace('!!REPLACE_WITH_OTEL_EXPORTER_VERSION!!', '$(OpenTelemetryExporterOpenTelemetryProtocolVersion)')
                                                  .Replace('!!REPLACE_WITH_OTEL_HOSTING_VERSION!!', '$(OpenTelemetryInstrumentationExtensionsHostingVersion)')
                                                  .Replace('!!REPLACE_WITH_OTEL_ASPNETCORE_VERSION!!', '$(OpenTelemetryInstrumentationAspNetCoreVersion)')

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/9.2/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/9.2/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
@@ -12,11 +12,16 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Extensions.Hosting" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Instrumentation.AspNetCore" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Instrumentation.Http" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Instrumentation.Runtime" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="!!REPLACE_WITH_OTEL_EXPORTER_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Extensions.Hosting" Version="!!REPLACE_WITH_OTEL_HOSTING_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Instrumentation.AspNetCore" Version="!!REPLACE_WITH_OTEL_ASPNETCORE_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Instrumentation.Http" Version="!!REPLACE_WITH_OTEL_HTTP_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Instrumentation.Runtime" Version="!!REPLACE_WITH_OTEL_RUNTIME_VERSION!!" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.2/Aspire.ServiceDefaults1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.2/Aspire.ServiceDefaults1.csproj
@@ -12,11 +12,16 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Extensions.Hosting" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Instrumentation.AspNetCore" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Instrumentation.Http" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Instrumentation.Runtime" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="!!REPLACE_WITH_OTEL_EXPORTER_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Extensions.Hosting" Version="!!REPLACE_WITH_OTEL_HOSTING_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Instrumentation.AspNetCore" Version="!!REPLACE_WITH_OTEL_ASPNETCORE_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Instrumentation.Http" Version="!!REPLACE_WITH_OTEL_HTTP_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Instrumentation.Runtime" Version="!!REPLACE_WITH_OTEL_RUNTIME_VERSION!!" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.ServiceDefaults/Aspire-StarterApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.ServiceDefaults/Aspire-StarterApplication.1.ServiceDefaults.csproj
@@ -12,11 +12,16 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Extensions.Hosting" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Instrumentation.AspNetCore" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Instrumentation.Http" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' == 'net8.0' " Include="OpenTelemetry.Instrumentation.Runtime" Version="!!REPLACE_WITH_OTEL_LTS_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="!!REPLACE_WITH_OTEL_EXPORTER_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Extensions.Hosting" Version="!!REPLACE_WITH_OTEL_HOSTING_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Instrumentation.AspNetCore" Version="!!REPLACE_WITH_OTEL_ASPNETCORE_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Instrumentation.Http" Version="!!REPLACE_WITH_OTEL_HTTP_VERSION!!" />
+    <PackageReference Condition=" '$(Framework)' != 'net8.0' " Include="OpenTelemetry.Instrumentation.Runtime" Version="!!REPLACE_WITH_OTEL_RUNTIME_VERSION!!" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

Templates now use latest OTel packages when project targets `net9.0`.

Contributes to #7123

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
