### PR TITLE
Ensure WithHttpCommand adds HttpClientFactory

### DIFF
--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1508,6 +1508,8 @@ public static class ResourceBuilderExtensions
         var endpoint = endpointSelector()
             ?? throw new DistributedApplicationException($"Could not create HTTP command for resource '{builder.Resource.Name}' as the endpoint selector returned null.");
 
+        builder.ApplicationBuilder.Services.AddHttpClient();
+
         commandName ??= $"{endpoint.Resource.Name}-{endpoint.EndpointName}-http-{method.Method.ToLowerInvariant()}-{path}";
 
         var targetRunning = false;

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -12,6 +12,27 @@ namespace Aspire.Hosting.Tests;
 public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
+    public void WithHttpCommand_AddsHttpClientFactory()
+    {
+        // Arrange
+        var builder = DistributedApplication.CreateBuilder();
+
+        // Act
+        var resourceBuilder = builder.AddContainer("name", "image")
+            .WithHttpEndpoint()
+            .WithHttpCommand("/some-path", "Do The Thing");
+
+        using var app = builder.Build();
+
+        // Assert
+        var httpClientFactoryServiceDescriptor = builder.Services.FirstOrDefault(sd => sd.ServiceType == typeof(IHttpClientFactory));
+        Assert.NotNull(httpClientFactoryServiceDescriptor);
+
+        var httpClientFactory = app.Services.GetService<IHttpClientFactory>();
+        Assert.NotNull(httpClientFactory);
+    }
+
+    [Fact]
     public void WithHttpCommand_AddsResourceCommandAnnotation_WithDefaultValues()
     {
         // Arrange


### PR DESCRIPTION
## Description

Ensures that `IHttpClientFactory` is registered in the `DistributedApplication` DI container when `WithHttpCommand` is called.

Fixes #8270

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
