### PR TITLE
Refactor Azure Key Vault secret handling to use Bicep output references

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -711,11 +711,6 @@ internal sealed class AzureContainerAppsInfrastructure(
 
                 if (value is IKeyVaultSecretReference vaultSecretReference)
                 {
-                    if (parent is null)
-                    {
-                        return (AllocateKeyVaultSecretUriReference(vaultSecretReference), SecretType.KeyVault);
-                    }
-
                     return (AllocateParameter(vaultSecretReference, secretType: SecretType.KeyVault), SecretType.KeyVault);
                 }
 
@@ -784,32 +779,6 @@ internal sealed class AzureContainerAppsInfrastructure(
                     var secretBicepIdentifier = Infrastructure.NormalizeBicepIdentifier($"{kv.BicepIdentifier}_{secretOutputReference.Name}");
                     secret = KeyVaultSecret.FromExisting(secretBicepIdentifier);
                     secret.Name = secretOutputReference.Name;
-                    secret.Parent = kv;
-
-                    KeyVaultSecretRefs[secretOutputReference.ValueExpression] = secret;
-                }
-
-                return secret.Properties.SecretUri;
-            }
-
-            private BicepValue<string> AllocateKeyVaultSecretUriReference(IKeyVaultSecretReference secretOutputReference)
-            {
-                if (!KeyVaultRefs.TryGetValue(secretOutputReference.Resource.Name, out var kv))
-                {
-                    // We resolve the keyvault that represents the storage for secret outputs
-                    var parameter = AllocateParameter(secretOutputReference.Resource.NameOutputReference);
-                    kv = KeyVaultService.FromExisting($"{parameter.BicepIdentifier}_kv");
-                    kv.Name = parameter;
-
-                    KeyVaultRefs[secretOutputReference.Resource.Name] = kv;
-                }
-
-                if (!KeyVaultSecretRefs.TryGetValue(secretOutputReference.ValueExpression, out var secret))
-                {
-                    // Now we resolve the secret
-                    var secretBicepIdentifier = Infrastructure.NormalizeBicepIdentifier($"{kv.BicepIdentifier}_{secretOutputReference.SecretName}");
-                    secret = KeyVaultSecret.FromExisting(secretBicepIdentifier);
-                    secret.Name = secretOutputReference.SecretName;
                     secret.Parent = kv;
 
                     KeyVaultSecretRefs[secretOutputReference.ValueExpression] = secret;

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -41,9 +41,9 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     BicepOutputReference IKeyVaultResource.IdOutputReference => Id;
 
     // In run mode, this is set to the secret client used to access the Azure Key Vault.
-    internal Func<string, CancellationToken, Task<string?>>? SecretResolver { get; set; }
+    internal Func<IKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
 
-    Func<string, CancellationToken, Task<string?>>? IKeyVaultResource.SecretResolver
+    Func<IKeyVaultSecretReference, CancellationToken, Task<string?>>? IKeyVaultResource.SecretResolver
     {
         get => SecretResolver;
         set => SecretResolver = value;

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
@@ -26,18 +26,11 @@ internal sealed class AzureKeyVaultSecretReference(string secretName, BicepOutpu
 
     async ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken)
     {
-        var secretUri = await bicepOutputReference.GetValueAsync(cancellationToken).ConfigureAwait(false);
-
-        if (secretUri is null)
-        {
-            return null;
-        }
-
         if (Resource.SecretResolver is null)
         {
             throw new InvalidOperationException($"The secret resolver is not set for the Azure Key Vault resource '{Resource.Name}'.");
         }
 
-        return await Resource.SecretResolver(secretUri, cancellationToken).ConfigureAwait(false);
+        return await Resource.SecretResolver(this, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
@@ -28,7 +28,7 @@ public interface IKeyVaultResource : IResource, IAzureResource
     /// <summary>
     /// Gets or sets the secret resolver function used to resolve secrets at runtime.
     /// </summary>
-    Func<string, CancellationToken, Task<string?>>? SecretResolver { get; set; }
+    Func<IKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
 
     /// <summary>
     /// Gets a secret reference for the specified secret name.

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -279,9 +279,9 @@ internal sealed class BicepProvisioner(
 
             // Set the client for resolving secrets at runtime
             var client = new SecretClient(new(vaultUri), context.Credential);
-            kvr.SecretResolver = async (secretName, ct) =>
+            kvr.SecretResolver = async (secretReference, ct) =>
             {
-                var secret = await client.GetSecretAsync(secretName, cancellationToken: ct).ConfigureAwait(false);
+                var secret = await client.GetSecretAsync(secretReference.SecretName, cancellationToken: ct).ConfigureAwait(false);
                 return secret.Value.Value;
             };
         }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -271,9 +271,9 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             ["connectionstrings--cosmos"] = "mycosmosconnectionstring"
         };
 
-        kv.Resource.SecretResolver = (name, _) =>
+        kv.Resource.SecretResolver = (secretReference, _) =>
         {
-            if (!secrets.TryGetValue(name, out var value))
+            if (!secrets.TryGetValue(secretReference.SecretName, out var value))
             {
                 return Task.FromResult<string?>(null);
             }
@@ -286,7 +286,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var expectedManifest = $$"""
                                {
                                  "type": "azure.bicep.v0",
-                                 "connectionString": "{{{kvName}}.secrets.connectionstrings--cosmos}",
+                                 "connectionString": "{{{kvName}}.outputs.secrets_connectionstrings__cosmos_uri}",
                                  "path": "cosmos.module.bicep",
                                  "params": {
                                    "keyVaultName": "{{{kvName}}.outputs.name}"
@@ -537,9 +537,9 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             ["connectionstrings--cosmos"] = "mycosmosconnectionstring"
         };
 
-        kv.Resource.SecretResolver = (name, _) =>
+        kv.Resource.SecretResolver = (reference, _) =>
         {
-            if (!secrets.TryGetValue(name, out var value))
+            if (!secrets.TryGetValue(reference.SecretName, out var value))
             {
                 return Task.FromResult<string?>(null);
             }
@@ -552,7 +552,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var expectedManifest = $$"""
                                {
                                  "type": "azure.bicep.v0",
-                                 "connectionString": "{{{kvName}}.secrets.connectionstrings--cosmos}",
+                                 "connectionString": "{{{kvName}}.outputs.secrets_connectionstrings__cosmos_uri}",
                                  "path": "cosmos.module.bicep",
                                  "params": {
                                    "keyVaultName": "{{{kvName}}.outputs.name}"


### PR DESCRIPTION
## Description

Follow up from https://github.com/dotnet/aspire/pull/8171, treat KeyVaultReferences as secret uris. That removes the need for tools to understand it specifically (like azd) and in the future removes the need for multiple compute platforms to understand it.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
