### PR TITLE
Revert "Clean up build scripts"

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,6 +2,18 @@
   "version": 1,
   "isRoot": true,
   "tools": {
+    "dotnet-coverage": {
+      "version": "17.13.1",
+      "commands": [
+        "dotnet-coverage"
+      ]
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.2.4",
+      "commands": [
+        "reportgenerator"
+      ]
+    },
     "PowerShell": {
       "version": "7.5.0",
       "commands": [

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -9,6 +9,10 @@ Param(
   [switch]$testnobuild,
   [ValidateSet("x86","x64","arm","arm64")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
 
+  # Run tests with code coverage
+  [Parameter(ParameterSetName='CommandLine')]
+  [switch] $testCoverage,
+
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -39,6 +43,7 @@ function Get-Help() {
   Write-Host "  -sign                   Sign build outputs."
   Write-Host "  -test (-t)              Incrementally builds and runs tests."
   Write-Host "                          Use in conjunction with -testnobuild to only run tests."
+  Write-Host "  -testCoverage           Run unit tests and capture code coverage information."
   Write-Host ""
 
   Write-Host "Libraries settings:"
@@ -77,7 +82,7 @@ if ($vs) {
 }
 
 # Check if an action is passed in
-$actions = "b","build","r","restore","rebuild","sign","testnobuild","publish","clean","t","test"
+$actions = "b","build","r","restore","rebuild","sign","testnobuild","publish","clean"
 $actionPassedIn = @(Compare-Object -ReferenceObject @($PSBoundParameters.Keys) -DifferenceObject $actions -ExcludeDifferent -IncludeEqual).Length -ne 0
 if ($null -ne $properties -and $actionPassedIn -ne $true) {
   $actionPassedIn = @(Compare-Object -ReferenceObject $properties -DifferenceObject $actions.ForEach({ "-" + $_ }) -ExcludeDifferent -IncludeEqual).Length -ne 0
@@ -91,6 +96,7 @@ foreach ($argument in $PSBoundParameters.Keys)
 {
   switch($argument)
   {
+    "testCoverage"           { <# this argument is handled in this script only #> }
     "os"                     { $arguments += " /p:TargetOS=$($PSBoundParameters[$argument])" }
     "properties"             { $arguments += " " + $properties }
     "verbosity"              { $arguments += " -$argument " + $($PSBoundParameters[$argument]) }
@@ -106,3 +112,35 @@ if ($env:TreatWarningsAsErrors -eq 'false') {
 
 Write-Host "& `"$PSScriptRoot/common/build.ps1`" $arguments"
 Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $arguments"
+
+
+# Perform code coverage as the last operation, this enables the following scenarios:
+#   .\build.cmd -restore -build -c Release -testCoverage
+if ($testCoverage) {
+  try {
+    # Install required toolset
+    . $PSScriptRoot/common/tools.ps1
+    InitializeDotNetCli -install $true | Out-Null
+
+    Push-Location $PSScriptRoot/../
+
+    $testResultPath = "./artifacts/TestResults/$configuration";
+
+    # Run tests and collect code coverage
+    ./.dotnet/dotnet dotnet-coverage collect --settings ./eng/CodeCoverage.config --output $testResultPath/local.cobertura.xml "build.cmd -test -configuration $configuration"
+
+    # Generate the code coverage report and open it in the browser
+    ./.dotnet/dotnet reportgenerator -reports:$testResultPath/*.cobertura.xml -targetdir:$testResultPath/CoverageResultsHtml -reporttypes:HtmlInline_AzurePipelines
+    Start-Process $testResultPath/CoverageResultsHtml/index.html
+  }
+  catch {
+    Write-Host $_.Exception.Message -Foreground "Red"
+    Write-Host $_.ScriptStackTrace -Foreground "DarkGray"
+    exit $global:LASTEXITCODE;
+  }
+  finally {
+    Pop-Location
+  }
+}
+
+exit 0

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -41,6 +41,7 @@ usage()
   echo "  --sign                     Sign build outputs."
   echo "  --test (-t)                Incrementally builds and runs tests."
   echo "                             Use in conjunction with --testnobuild to only run tests."
+  echo "  --testCoverage             Run unit tests and capture code coverage information."
   echo ""
 
   echo "Libraries settings:"
@@ -54,9 +55,10 @@ usage()
 
 arguments=''
 extraargs=''
+testCoverage=false
 
 # Check if an action is passed in
-declare -a actions=("b" "build" "r" "restore" "rebuild" "testnobuild" "sign" "publish" "clean" "t" "test")
+declare -a actions=("b" "build" "r" "restore" "rebuild" "testnobuild" "sign" "publish" "clean")
 actInt=($(comm -12 <(printf '%s\n' "${actions[@]/#/-}" | sort) <(printf '%s\n' "${@/#--/-}" | sort)))
 
 while [[ $# > 0 ]]; do
@@ -136,6 +138,10 @@ while [[ $# > 0 ]]; do
       shift 1
       ;;
 
+    -testcoverage)
+      testCoverage=true
+      ;;
+
      *)
       extraargs="$extraargs $1"
       shift 1
@@ -153,3 +159,24 @@ fi
 
 arguments="$arguments $extraargs"
 "$scriptroot/common/build.sh" $arguments
+
+
+# Perform code coverage as the last operation, this enables the following scenarios:
+#   .\build.sh --restore --build --c Release --testCoverage
+if [[ "$testCoverage" == true ]]; then
+  # Install required toolset
+  . "$DIR/common/tools.sh"
+  InitializeDotNetCli true > /dev/null
+
+  repoRoot=$(realpath $DIR/../)
+  testResultPath="$repoRoot/artifacts/TestResults/$configuration"
+
+  # Run tests and collect code coverage
+  $repoRoot/.dotnet/dotnet 'dotnet-coverage' collect --settings $repoRoot/eng/CodeCoverage.config --output $testResultPath/local.cobertura.xml "$repoRoot/build.sh --test --configuration $configuration"
+
+  # Generate the code coverage report and open it in the browser
+  $repoRoot/.dotnet/dotnet reportgenerator -reports:$testResultPath/*.cobertura.xml -targetdir:$testResultPath/CoverageResultsHtml -reporttypes:HtmlInline_AzurePipelines
+  echo ""
+  echo -e "\e[32mCode coverage results:\e[0m $testResultPath/CoverageResultsHtml/index.html"
+  echo ""
+fi


### PR DESCRIPTION
Reverting #8265 as that accidentally broke the build given we also needed to do some cleanup on the AzDO pipeline side in order to be able to fully remove code coverage. 

FYI: @RussKie @radical @davidfowl 