### PR TITLE
[CI] Bump number of retries for downloading dotnet-install.sh

### DIFF
--- a/tests/Shared/InstallSdk.targets
+++ b/tests/Shared/InstallSdk.targets
@@ -36,7 +36,7 @@
 
     <DownloadFile SourceUrl="https://dot.net/v1/$(_DotNetInstallScriptName)"
                   DestinationFolder="$(ArtifactsObjDir)"
-                  Retries="3"
+                  Retries="6"
                   Condition="!Exists($(_DotNetInstallScriptPath))"/>
 
     <RemoveDir Directories="$(SdkTargetDir)" />


### PR DESCRIPTION
This is to work around failures like:
```
  ** Installing sdk 8.0.406 for template tests into /home/runner/work/aspire/aspire/artifacts/bin/dotnet-8/
/home/runner/work/aspire/aspire/tests/Shared/InstallSdk.targets(37,5): error MSB3923: Failed to download file "https://dot.net/v1/dotnet-install.sh".  The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing. ---> A task was canceled. ---> A task was canceled.
```

The timeout is from the `DownloadFile` task which we can't control
Instead, we are bumping the number of retries here from 3 to 6.

Related dnceng issue: https://github.com/dotnet/dnceng/issues/3824
Fixes https://github.com/dotnet/aspire/issues/8263
