### PR TITLE
Add resource to environment callback context

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/Program.cs
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/Program.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIREACADOMAINS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using Aspire.Hosting.Azure;
 using Azure.Provisioning.Storage;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -44,6 +45,13 @@ builder.AddProject<Projects.AzureContainerApps_ApiService>("api")
        .WithReference(redis)
        .WithReference(cosmosDb)
        .WithEnvironment("VALUE", param)
+       .WithEnvironment(context =>
+       {
+           if (context.Resource.TryGetLastAnnotation<AppIdentityAnnotation>(out var identity))
+           {
+               context.EnvironmentVariables["AZURE_PRINCIPAL_NAME"] = identity.IdentityResource.PrincipalName;
+           }
+       })
        .PublishAsAzureContainerApp((module, app) =>
        {
            app.ConfigureCustomDomain(customDomain, certificateName);

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
@@ -17,6 +17,8 @@ param account_kv_outputs_name string
 @secure()
 param secretparam_value string
 
+param api_identity_outputs_principalname string
+
 param infra_outputs_azure_container_apps_environment_id string
 
 param infra_outputs_azure_container_registry_endpoint string
@@ -120,6 +122,10 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'VALUE'
               secretRef: 'value'
+            }
+            {
+              name: 'AZURE_PRINCIPAL_NAME'
+              value: api_identity_outputs_principalname
             }
             {
               name: 'AZURE_CLIENT_ID'

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
@@ -129,6 +129,7 @@
           "cache_password_value": "{cache-password.value}",
           "account_kv_outputs_name": "{account-kv.outputs.name}",
           "secretparam_value": "{secretparam.value}",
+          "api_identity_outputs_principalname": "{api-identity.outputs.principalName}",
           "infra_outputs_azure_container_apps_environment_id": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
           "infra_outputs_azure_container_registry_endpoint": "{infra.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
           "infra_outputs_azure_container_registry_managed_identity_id": "{infra.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -146,7 +147,8 @@
         "ConnectionStrings__blobs": "{blobs.connectionString}",
         "ConnectionStrings__cache": "{cache.connectionString}",
         "ConnectionStrings__account": "{account.connectionString}",
-        "VALUE": "{secretparam.value}"
+        "VALUE": "{secretparam.value}",
+        "AZURE_PRINCIPAL_NAME": "{api-identity.outputs.principalName}"
       },
       "bindings": {
         "http": {

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -524,7 +524,7 @@ internal sealed class AzureContainerAppsInfrastructure(
             {
                 if (resource.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var environmentCallbacks))
                 {
-                    var context = new EnvironmentCallbackContext(executionContext, cancellationToken: cancellationToken);
+                    var context = new EnvironmentCallbackContext(executionContext, resource, cancellationToken: cancellationToken);
 
                     foreach (var c in environmentCallbacks)
                     {

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -281,7 +281,7 @@ internal sealed class AzureResourcePreparer(
 
         if (resource.TryGetEnvironmentVariables(out var environmentCallbacks))
         {
-            var context = new EnvironmentCallbackContext(executionContext, cancellationToken: cancellationToken);
+            var context = new EnvironmentCallbackContext(executionContext, resource, cancellationToken: cancellationToken);
 
             foreach (var c in environmentCallbacks)
             {

--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -309,7 +309,7 @@ internal sealed class DockerComposePublishingContext(
         {
             if (resource.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var environmentCallbacks))
             {
-                var context = new EnvironmentCallbackContext(executionContext, cancellationToken: cancellationToken);
+                var context = new EnvironmentCallbackContext(executionContext, resource, cancellationToken: cancellationToken);
 
                 foreach (var c in environmentCallbacks)
                 {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResourceContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResourceContext.cs
@@ -187,7 +187,7 @@ internal sealed class KubernetesResourceContext(
     {
         if (resource.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var environmentCallbacks))
         {
-            var context = new EnvironmentCallbackContext(executionContext, cancellationToken: cancellationToken);
+            var context = new EnvironmentCallbackContext(executionContext, resource, cancellationToken: cancellationToken);
 
             foreach (var c in environmentCallbacks)
             {

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
@@ -50,6 +50,7 @@ public class EnvironmentCallbackContext(DistributedApplicationExecutionContext e
     /// <remarks>
     /// This will be set to the resource in all cases where .NET Aspire invokes the callback.
     /// </remarks>
+    /// <exception cref="InvalidOperationException">Thrown when the EnvironmentCallbackContext was created without a specified resource.</exception>
     public IResource Resource => _resource ?? throw new InvalidOperationException($"{nameof(Resource)} is not set. This callback context is not associated with a resource.");
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
@@ -14,6 +14,21 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
 public class EnvironmentCallbackContext(DistributedApplicationExecutionContext executionContext, Dictionary<string, object>? environmentVariables = null, CancellationToken cancellationToken = default)
 {
+    private readonly IResource? _resource;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnvironmentCallbackContext"/> class.
+    /// </summary>
+    /// <param name="executionContext">The execution context for this invocation of the AppHost.</param>
+    /// <param name="resource">The resource associated with this callback context.</param>
+    /// <param name="environmentVariables">The environment variables associated with this execution.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    public EnvironmentCallbackContext(DistributedApplicationExecutionContext executionContext, IResource resource, Dictionary<string, object>? environmentVariables = null, CancellationToken cancellationToken = default)
+        : this(executionContext, environmentVariables, cancellationToken)
+    {
+        _resource = resource ?? throw new ArgumentNullException(nameof(resource));
+    }
+
     /// <summary>
     /// Gets the environment variables associated with the callback context.
     /// </summary>
@@ -28,6 +43,14 @@ public class EnvironmentCallbackContext(DistributedApplicationExecutionContext e
     /// An optional logger to use for logging.
     /// </summary>
     public ILogger Logger { get; set; } = NullLogger.Instance;
+
+    /// <summary>
+    /// The resource associated with this callback context.
+    /// </summary>
+    /// <remarks>
+    /// This will be set to the resource in all cases where .NET Aspire invokes the callback.
+    /// </remarks>
+    public IResource Resource => _resource ?? throw new InvalidOperationException($"{nameof(Resource)} is not set. This callback context is not associated with a resource.");
 
     /// <summary>
     /// Gets the execution context associated with this invocation of the AppHost.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -342,7 +342,7 @@ public static class ResourceExtensions
         if (resource.TryGetEnvironmentVariables(out var callbacks))
         {
             var config = new Dictionary<string, object>();
-            var context = new EnvironmentCallbackContext(executionContext, config, cancellationToken)
+            var context = new EnvironmentCallbackContext(executionContext, resource, config, cancellationToken)
             {
                 Logger = logger
             };

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -131,6 +131,8 @@ public class ExpressionResolverTests
         var test = builder.AddResource(new ContainerResource("testSource"))
             .WithEnvironment(env =>
             {
+                Assert.NotNull(env.Resource);
+
                 env.EnvironmentVariables["envname"] = new HostUrl(hostUrlVal);
             });
 

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -170,6 +170,8 @@ public class ResourceExtensionsTests
          .WithEnvironment("xpack.security.enabled", "true")
          .WithEnvironment(context =>
          {
+             Assert.NotNull(context.Resource);
+
              context.EnvironmentVariables["ELASTIC_PASSWORD"] = "p@ssw0rd1";
          });
 


### PR DESCRIPTION
## Description

When setting environment variables on a resource, it is useful to get the resource so you can grab annotations off of it to use in the environment settings.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
