### PR TITLE
Fix DockerComposePublisher port rendering

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -353,7 +353,7 @@ internal sealed class DockerComposePublishingContext(
 
         private static string GetValue(EndpointMapping mapping, EndpointProperty property)
         {
-            var (scheme, host, internalPort, exposedPort, isHttpIngress) = mapping;
+            var (scheme, host, internalPort, _, isHttpIngress) = mapping;
 
             return property switch
             {
@@ -361,7 +361,7 @@ internal sealed class DockerComposePublishingContext(
                 EndpointProperty.Host or EndpointProperty.IPV4Host => GetHostValue(),
                 EndpointProperty.Port => internalPort.ToString(CultureInfo.InvariantCulture),
                 EndpointProperty.HostAndPort => GetHostValue(suffix: $":{internalPort}"),
-                EndpointProperty.TargetPort => $"{exposedPort}",
+                EndpointProperty.TargetPort => $"{internalPort}",
                 EndpointProperty.Scheme => scheme,
                 _ => throw new NotSupportedException(),
             };


### PR DESCRIPTION
Currently there is a problem with port rendering in the DockerComposePublisher where it emits the internal port as the externally facing port in the `docker-compose.yml` file. Basically the effect of this PR is:

Before:

```yaml
            services:
              resource:
                image: "mcr.microsoft.com/dotnet/aspnet:8.0"
                environment:
                  ASPNETCORE_ENVIRONMENT: "Development"
                  HTTP_PORT: "8001"
                ports:
                  - "8001:8000"
                networks:
                  - "aspire"
            networks:
              aspire:
                driver: "bridge"
```

After:

```yaml
            services:
              resource:
                image: "mcr.microsoft.com/dotnet/aspnet:8.0"
                environment:
                  ASPNETCORE_ENVIRONMENT: "Development"
                  HTTP_PORT: "8000"
                ports:
                  - "8001:8000"
                networks:
                  - "aspire"
            networks:
              aspire:
                driver: "bridge"
```