### PR TITLE
Add Xunit.Abstractions as global using for tests

### DIFF
--- a/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Cli.Tests;
 

--- a/tests/Aspire.Components.Common.Tests/RequiresDockerDiscoverer.cs
+++ b/tests/Aspire.Components.Common.Tests/RequiresDockerDiscoverer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.XUnitExtensions;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Aspire.Components.Common.Tests;

--- a/tests/Aspire.Components.Common.Tests/RequiresPlaywrightDiscoverer.cs
+++ b/tests/Aspire.Components.Common.Tests/RequiresPlaywrightDiscoverer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.XUnitExtensions;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Aspire.Components.Common.Tests;

--- a/tests/Aspire.Components.Common.Tests/RequiresSSLCertificateDiscoverer.cs
+++ b/tests/Aspire.Components.Common.Tests/RequiresSSLCertificateDiscoverer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.XUnitExtensions;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Aspire.Components.Common.Tests;

--- a/tests/Aspire.Components.Common.Tests/RequiresToolsDiscoverer.cs
+++ b/tests/Aspire.Components.Common.Tests/RequiresToolsDiscoverer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.XUnitExtensions;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Aspire.Components.Common.Tests;

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Metrics;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Confluent.Kafka.Tests;
 

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Confluent.Kafka.Tests;
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -19,7 +19,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Components.Tests.Pages;
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/LoginTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/LoginTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Components.Tests.Pages;
 

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/IntegrationTestHelpers.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Components.Tests.Shared;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
@@ -19,7 +19,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
-using Xunit.Abstractions;
 using DashboardServiceBase = Aspire.ResourceService.Proto.V1.DashboardService.DashboardServiceBase;
 
 namespace Aspire.Dashboard.Tests.Integration;

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
@@ -8,7 +8,6 @@ using Aspire.Hosting;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpCorsHttpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpCorsHttpServiceTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Aspire.Hosting;
 using Microsoft.AspNetCore.InternalTesting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
@@ -16,7 +16,6 @@ using OpenTelemetry.Proto.Collector.Metrics.V1;
 using OpenTelemetry.Proto.Collector.Trace.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/ResponseCompressionTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ResponseCompressionTests.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.InternalTesting;
 using System.Net;
 using System.Net.Http.Headers;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -18,7 +18,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration;
 

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Proto.Logs.V1;
 using Xunit;
-using Xunit.Abstractions;
 using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;

--- a/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
+++ b/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
@@ -33,6 +33,10 @@
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(_BuildForTestsRunningOutsideOfRepo)' == 'true'">
     <None Include="..\testproject\**\*" Link="$(DeployOutsideOfRepoSupportFilesDir)%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\.editorconfig" Link="$(DeployOutsideOfRepoSupportFilesDir)..\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
-using Xunit.Abstractions;
 using Aspire.TestProject;
 using Aspire.Templates.Tests;
 

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
-using Xunit.Abstractions;
 using Aspire.TestProject;
 using Aspire.Templates.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -17,7 +17,6 @@ using Azure.Provisioning.Search;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -15,7 +15,6 @@ using Azure.Provisioning.Primitives;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Polly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -8,7 +8,6 @@ using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -14,7 +14,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -10,7 +10,6 @@ using Aspire.Hosting.Utils;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.cs
@@ -5,7 +5,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.AppContainers;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -6,7 +6,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
@@ -5,7 +5,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSignalREmulatorFunctionalTest.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSignalREmulatorFunctionalTest.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Polly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 public class AzureSignalREmulatorFunctionalTest(ITestOutputHelper testOutputHelper)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSignalRExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSignalRExtensionsTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.Utils;
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageEmulatorFunctionalTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
@@ -7,7 +7,6 @@ using Aspire.Hosting.Utils;
 using Azure.Provisioning.WebPubSub;
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
@@ -15,7 +15,6 @@ using Azure.Provisioning.SignalR;
 using Azure.Provisioning.WebPubSub;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -10,7 +10,6 @@ using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Containers.Tests;
 

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Docker.Tests;
 

--- a/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Polly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Elasticsearch.Tests;
 

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Hosting;
 using Polly;
 using StackExchange.Redis;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Garnet.Tests;
 

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Polly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Kafka.Tests;
 

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Milvus.Client;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Milvus.Tests;
 

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -9,7 +9,6 @@ using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Xunit;
-using Xunit.Abstractions;
 using Polly;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Diagnostics.HealthChecks;

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -16,7 +16,6 @@ using Microsoft.Extensions.Hosting;
 using MySqlConnector;
 using Polly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.MySql.Tests;
 

--- a/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Utils;
 using Xunit;
-using Xunit.Abstractions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using NATS.Client.Core;

--- a/tests/Aspire.Hosting.NodeJs.Tests/NodeAppFixture.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/NodeAppFixture.cs
@@ -6,7 +6,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
 using Aspire.Hosting.Utils;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Aspire.Hosting.NodeJs.Tests;

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Polly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Oracle.Tests;
 

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.Hosting;
 using Npgsql;
 using Polly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.PostgreSQL.Tests;
 

--- a/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
@@ -7,7 +7,6 @@ using Aspire.Hosting.Utils;
 using Aspire.Hosting.Tests.Utils;
 using System.Diagnostics;
 using Aspire.Components.Common.Tests;
-using Xunit.Abstractions;
 using Aspire.Hosting.ApplicationModel;
 using System.Runtime.CompilerServices;
 

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -13,7 +13,6 @@ using Polly;
 using Qdrant.Client;
 using Qdrant.Client.Grpc;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Qdrant.Tests;
 

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.RabbitMQ.Tests;
 

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -14,7 +14,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using StackExchange.Redis;
 using Xunit;
-using Xunit.Abstractions;
 using Aspire.Hosting.Tests.Dcp;
 using System.Text.Json.Nodes;
 using Aspire.Hosting;

--- a/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
@@ -7,7 +7,6 @@ using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Seq.Tests;
 

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Polly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.SqlServer.Tests;
 

--- a/tests/Aspire.Hosting.Testing.Tests/ResourceLoggerForwarderServiceTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/ResourceLoggerForwarderServiceTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using Projects;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Testing.Tests;
 

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Testing.Tests;
 

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostBackchannelTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.Threading;
 using StreamJsonRpc;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Backchannel;
 

--- a/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
@@ -5,7 +5,6 @@ using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests.Codespaces;
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Xunit;
-using Xunit.Abstractions;
 using Aspire.Hosting.Devcontainers;
 
 namespace Aspire.Hosting.Tests.Dashboard;

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Aspire.Hosting.Tests.Dashboard;

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
-using Xunit.Abstractions;
 using DashboardService = Aspire.Hosting.Dashboard.DashboardService;
 using Resource = Aspire.Hosting.ApplicationModel.Resource;
 

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -24,7 +24,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 using TestConstants = Microsoft.AspNetCore.InternalTesting.TestConstants;
 

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests.Health;
 

--- a/tests/Aspire.Hosting.Tests/HealthCheckTests.cs
+++ b/tests/Aspire.Hosting.Tests/HealthCheckTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests;
 

--- a/tests/Aspire.Hosting.Tests/OperationModesTests.cs
+++ b/tests/Aspire.Hosting.Tests/OperationModesTests.cs
@@ -7,7 +7,6 @@ using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests;
 

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
@@ -8,7 +8,6 @@ using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests.Publishing;
 

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -6,7 +6,6 @@ using Aspire.Hosting.Orchestrator;
 using Aspire.Hosting.Testing;
 using Aspire.Hosting.Tests.Dcp;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Utils;
 

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests;
 

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -5,7 +5,6 @@ using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests;
 

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using StackExchange.Redis;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Valkey.Tests;
 

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Trace;
 using Oracle.ManagedDataAccess.OpenTelemetry;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Oracle.EntityFrameworkCore.Tests;
 

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests_TypeSpecificConfig.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests_TypeSpecificConfig.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Components.Common.Tests;
 using Microsoft.Extensions.Configuration;
-using Xunit.Abstractions;
 
 namespace Aspire.Oracle.EntityFrameworkCore.Tests;
 

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/EnrichOracleDatabaseTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/EnrichOracleDatabaseTests.cs
@@ -13,7 +13,6 @@ using OpenTelemetry.Trace;
 using Oracle.EntityFrameworkCore;
 using Oracle.EntityFrameworkCore.Infrastructure.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Oracle.EntityFrameworkCore.Tests;
 

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
@@ -5,7 +5,6 @@ using Aspire.Components.Common.Tests;
 using DotNet.Testcontainers.Builders;
 using Testcontainers.Oracle;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Oracle.EntityFrameworkCore.Tests;
 

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -14,7 +14,6 @@ using Polly.Timeout;
 using SamplesIntegrationTests;
 using SamplesIntegrationTests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Aspire.Playground.Tests;

--- a/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
+++ b/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
@@ -6,7 +6,6 @@ using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SamplesIntegrationTests.Infrastructure;
-using Xunit.Abstractions;
 
 namespace SamplesIntegrationTests;
 

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -7,7 +7,6 @@ using Aspire.Components.Common.Tests;
 using SamplesIntegrationTests;
 using SamplesIntegrationTests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Playground.Tests;
 

--- a/tests/Aspire.Templates.Tests/AppHostTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/AppHostTemplateTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
-using Xunit.Abstractions;
 using System.Text.RegularExpressions;
 
 namespace Aspire.Templates.Tests;

--- a/tests/Aspire.Templates.Tests/BuildAndRunStarterTemplateBuiltInTest.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunStarterTemplateBuiltInTest.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Components.Common.Tests;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
@@ -4,7 +4,6 @@
 using System.Text.RegularExpressions;
 using Aspire.Components.Common.Tests;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/EmptyTemplateRunFixture.cs
+++ b/tests/Aspire.Templates.Tests/EmptyTemplateRunFixture.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
-
 namespace Aspire.Templates.Tests;
 
 /// <summary>

--- a/tests/Aspire.Templates.Tests/EmptyTemplateRunTests.cs
+++ b/tests/Aspire.Templates.Tests/EmptyTemplateRunTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Components.Common.Tests;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Components.Common.Tests;
 using Microsoft.Playwright;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateFixture.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateFixture.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
-
 namespace Aspire.Templates.Tests;
 
 /// <summary>

--- a/tests/Aspire.Templates.Tests/StarterTemplateFixture_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateFixture_PreviousTFM.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
-
 namespace Aspire.Templates.Tests;
 
 public sealed class StarterTemplateFixture_PreviousTFM : TemplateAppFixture

--- a/tests/Aspire.Templates.Tests/StarterTemplateProjectNamesTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateProjectNamesTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Components.Common.Tests;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateRunTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateRunTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.Common.Tests;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateRunTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateRunTestsBase.cs
@@ -4,7 +4,6 @@
 using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 using Xunit;
-using Xunit.Abstractions;
 using Aspire.Hosting.Redis;
 using System.Net.Http.Json;
 using Aspire.Components.Common.Tests;

--- a/tests/Aspire.Templates.Tests/StarterTemplateRunTests_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateRunTests_PreviousTFM.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.Common.Tests;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheFixture.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheFixture.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
-
 namespace Aspire.Templates.Tests;
 
 /// <summary>

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheFixture_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheFixture_PreviousTFM.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
-
 namespace Aspire.Templates.Tests;
 
 public sealed class StarterTemplateWithRedisCacheFixture_PreviousTFM : TemplateAppFixture

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.Common.Tests;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.Common.Tests;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/TemplateAppFixture.cs
+++ b/tests/Aspire.Templates.Tests/TemplateAppFixture.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
@@ -7,7 +7,6 @@ using System.Xml;
 using Aspire.Components.Common.Tests;
 using Microsoft.Playwright;
 using Xunit;
-using Xunit.Abstractions;
 using static Aspire.Templates.Tests.TestExtensions;
 
 namespace Aspire.Templates.Tests;

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <Using Include="Xunit.Abstractions" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
-    <Using Include="Xunit.Abstractions" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
+++ b/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Utils;
 

--- a/tests/Shared/Logging/XunitLoggerFactoryExtensions.cs
+++ b/tests/Shared/Logging/XunitLoggerFactoryExtensions.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Microsoft.Extensions.Logging;

--- a/tests/Shared/Logging/XunitLoggerProvider.cs
+++ b/tests/Shared/Logging/XunitLoggerProvider.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using System.Text;
-using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.Logging.Testing;
 

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -55,6 +55,10 @@
     <PackageReference Include="@(AspireProjectOrPackageReference)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(IncludeTestPackages)' == 'true'">
+    <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TestsRunningOutsideOfRepo)' == 'true' and '$(RepoRoot)' == '' and '$(IncludeTestPackages)' == 'true'" Label="Test packages">
     <!-- in-repo-builds use Arcade which adds these package references for test projects implicitly.
          But when they are built without Arcade outside the repo, these need to be added

--- a/tests/Shared/TemplatesTesting/AspireProject.cs
+++ b/tests/Shared/TemplatesTesting/AspireProject.cs
@@ -7,7 +7,6 @@ using System.Text.RegularExpressions;
 using Aspire.Components.Common.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Playwright;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Aspire.Templates.Tests;

--- a/tests/Shared/TemplatesTesting/DotNetCommand.cs
+++ b/tests/Shared/TemplatesTesting/DotNetCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
-
 namespace Aspire.Templates.Tests;
 
 public class DotNetCommand : ToolCommand

--- a/tests/Shared/TemplatesTesting/DotNetNewCommand.cs
+++ b/tests/Shared/TemplatesTesting/DotNetNewCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
-
 namespace Aspire.Templates.Tests;
 
 public class DotNetNewCommand : DotNetCommand

--- a/tests/Shared/TemplatesTesting/ProjectInfo.cs
+++ b/tests/Shared/TemplatesTesting/ProjectInfo.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Shared/TemplatesTesting/RunCommand.cs
+++ b/tests/Shared/TemplatesTesting/RunCommand.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
-
 namespace Aspire.Templates.Tests;
 
 public class RunCommand : DotNetCommand

--- a/tests/Shared/TemplatesTesting/TestExtensions.cs
+++ b/tests/Shared/TemplatesTesting/TestExtensions.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Playwright;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Aspire.Templates.Tests;

--- a/tests/Shared/TemplatesTesting/TestOutputWrapper.cs
+++ b/tests/Shared/TemplatesTesting/TestOutputWrapper.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
 using Xunit.Sdk;
 using System.Globalization;
 

--- a/tests/Shared/TemplatesTesting/ToolCommand.cs
+++ b/tests/Shared/TemplatesTesting/ToolCommand.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using Xunit.Abstractions;
 
 namespace Aspire.Templates.Tests;
 


### PR DESCRIPTION
This will make the diff less noisy for the migration to xunit.v3, and this PR on itself is still easy and straightforward to review.