### PR TITLE
Move extra URLs to stress, customize frontend endpoints

### DIFF
--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -70,7 +70,9 @@ serviceBuilder.WithHttpCommand("/log-message-limit", "Log message limit", comman
 serviceBuilder.WithHttpCommand("/multiple-traces-linked", "Multiple traces linked", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 serviceBuilder.WithHttpCommand("/overflow-counter", "Overflow counter", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 
-builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice");
+builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice")
+       .WithUrls(c => c.Urls.Add(new() { Url = "https://someplace.com", DisplayText = "Some place" }))
+       .WithUrl("https://someotherplace.com/some-path", "Some other place");
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -64,10 +64,10 @@ var basketService = builder.AddProject("basketservice", @"..\BasketService\Baske
 
 builder.AddProject<Projects.MyFrontend>("frontend")
        .WithExternalHttpEndpoints()
-       .WithUrls(c => c.Urls.Add(new() { Url = "https://someplace.com", DisplayText = "Some place" }))
-       .WithUrl("https://someotherplace.com/some-path", "Some other place")
        .WithReference(basketService)
-       .WithReference(catalogService);
+       .WithReference(catalogService)
+       .WithUrlForEndpoint("http", c => c.DisplayText = "Online store (http)")
+       .WithUrlForEndpoint("https", c => c.DisplayText = "Online store (https)");
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor", launchProfileName: "OrderProcessor")
        .WithReference(messaging).WaitFor(messaging);

--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -66,8 +66,7 @@ builder.AddProject<Projects.MyFrontend>("frontend")
        .WithExternalHttpEndpoints()
        .WithReference(basketService)
        .WithReference(catalogService)
-       .WithUrlForEndpoint("http", c => c.DisplayText = "Online store (http)")
-       .WithUrlForEndpoint("https", c => c.DisplayText = "Online store (https)");
+       .WithUrls(c => c.Urls.ForEach(u => u.DisplayText = $"Online store ({u.Endpoint?.EndpointName})"));
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor", launchProfileName: "OrderProcessor")
        .WithReference(messaging).WaitFor(messaging);


### PR DESCRIPTION
The extra URLs in test shop were annoying me so I moved them to stress playground.

Instead I customized frontend endpoints with a display name:

![image](https://github.com/user-attachments/assets/13346ca5-6eab-4c4e-9ac4-cbc9c414ba2e)