### PR TITLE
Obsolete EventHubs Emulator WithDataBindMount and WithDataVolume

### DIFF
--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -388,6 +388,7 @@ public static class AzureEventHubsExtensions
     /// <param name="builder">The builder for the <see cref="AzureEventHubsEmulatorResource"/>.</param>
     /// <param name="path">Relative path to the AppHost where emulator storage is persisted between runs. Defaults to the path '.eventhubs/{builder.Resource.Name}'</param>
     /// <returns>A builder for the <see cref="AzureEventHubsEmulatorResource"/>.</returns>
+    [Obsolete($"This method is obsolete because it doesn't work as intended and will be removed in a future version.")]
     public static IResourceBuilder<AzureEventHubsEmulatorResource> WithDataBindMount(this IResourceBuilder<AzureEventHubsEmulatorResource> builder, string? path = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -401,6 +402,7 @@ public static class AzureEventHubsExtensions
     /// <param name="builder">The builder for the <see cref="AzureEventHubsEmulatorResource"/>.</param>
     /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <returns>A builder for the <see cref="AzureEventHubsEmulatorResource"/>.</returns>
+    [Obsolete($"This method is obsolete because it doesn't work as intended and will be removed in a future version.")]
     public static IResourceBuilder<AzureEventHubsEmulatorResource> WithDataVolume(this IResourceBuilder<AzureEventHubsEmulatorResource> builder, string? name = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -158,7 +158,9 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         var eventHubs = builder.AddAzureEventHubs("eh").RunAsEmulator(configureContainer: builder =>
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             builder.WithDataBindMount();
+#pragma warning restore CS0618 // Type or member is obsolete
         });
 
         // Ignoring the annotation created for the custom Config.json file
@@ -175,7 +177,9 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         var eventHubs = builder.AddAzureEventHubs("eh").RunAsEmulator(configureContainer: builder =>
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             builder.WithDataBindMount("mydata");
+#pragma warning restore CS0618 // Type or member is obsolete
         });
 
         // Ignoring the annotation created for the custom Config.json file
@@ -192,7 +196,9 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         var eventHubs = builder.AddAzureEventHubs("eh").RunAsEmulator(configureContainer: builder =>
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             builder.WithDataVolume();
+#pragma warning restore CS0618 // Type or member is obsolete
         });
 
         // Ignoring the annotation created for the custom Config.json file
@@ -209,7 +215,9 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         var eventHubs = builder.AddAzureEventHubs("eh").RunAsEmulator(configureContainer: builder =>
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             builder.WithDataVolume("mydata");
+#pragma warning restore CS0618 // Type or member is obsolete
         });
 
         // Ignoring the annotation created for the custom Config.json file

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/EventHubsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/EventHubsPublicApiTests.cs
@@ -277,7 +277,9 @@ public class EventHubsPublicApiTests
     {
         IResourceBuilder<AzureEventHubsEmulatorResource> builder = null!;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => builder.WithDataBindMount();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(builder), exception.ParamName);
@@ -288,7 +290,9 @@ public class EventHubsPublicApiTests
     {
         IResourceBuilder<AzureEventHubsEmulatorResource> builder = null!;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => builder.WithDataVolume();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(builder), exception.ParamName);


### PR DESCRIPTION
These methods don't work correctly, so obsoleting and eventually removing them.

Fix #8008