### PR TITLE
[CI] Don't use short url for dotnet-install script

### DIFF
--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -96,6 +96,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/8326")]
     public async Task ResourcesWithHealthCheck_CreationErrorIsReported()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);

--- a/tests/Shared/InstallSdk.targets
+++ b/tests/Shared/InstallSdk.targets
@@ -34,7 +34,7 @@
              Condition="'$(SdkVersionToInstall)' == ''"
              Importance="High" />
 
-    <DownloadFile SourceUrl="https://dot.net/v1/$(_DotNetInstallScriptName)"
+    <DownloadFile SourceUrl="https://builds.dotnet.microsoft.com/dotnet/scripts/v1/$(_DotNetInstallScriptName)"
                   DestinationFolder="$(ArtifactsObjDir)"
                   Retries="6"
                   Condition="!Exists($(_DotNetInstallScriptPath))"/>


### PR DESCRIPTION
This should hopefully help side-step the cdn issues.
