### PR TITLE
[tests] Run Hosting.Docker.Tests on the pipeline

### DIFF
--- a/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
+++ b/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
@@ -6,6 +6,9 @@
       $(NoWarn);
       ASPIREHOSTINGPYTHON001;
     </NoWarn>
+    <!-- required because DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile needs
+    the TestingAppHost1 -->
+    <RunTestsOnHelix>false</RunTestsOnHelix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.. so they can run out of the repo allowing
`Aspire.Hosting.Docker.Tests.DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile` to access the `TestingAppHost1` project.

This changed in https://github.com/dotnet/aspire/pull/8264 .

Fixes https://github.com/dotnet/aspire/issues/8325 .

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
