### PR TITLE
Allow sorting by timestamp in structured logs and traces

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -143,7 +143,7 @@
                                         <AspireTemplateColumn ColumnId="@LogLevelColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
                                             <LogLevelColumnDisplay LogEntry="@context" />
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.TimeStamp, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
+                                        <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.TimeStamp, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true" Sortable="true" SortBy="@_timestampSort">
                                             @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.TimeStamp, MillisecondsDisplay.Truncated)
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@MessageColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -91,7 +91,7 @@
                                     OnRowClick="@(r => r.ExecuteOnDefault(d => NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(d.TraceId))))"
                                     Class="main-grid enable-row-click">
                         <ChildContent>
-                            <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
+                            <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true" Sortable="true" SortBy="@_timestampSort">
                                 @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)
                             </AspireTemplateColumn>
                             <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@(trace => GetNameTooltip(trace))">

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -40,6 +40,7 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
     private AspirePageContentLayout? _contentLayout;
     private FluentDataGrid<OtlpTrace> _dataGrid = null!;
     private GridColumnManager _manager = null!;
+    private readonly GridSort<OtlpTrace> _timestampSort = GridSort<OtlpTrace>.ByDescending(e => e.TimeStamp).ThenAscending(p => p.FullName, StringComparers.OtlpFieldValue);
 
     private ColumnResizeLabels _resizeLabels = ColumnResizeLabels.Default;
     private ColumnSortLabels _sortLabels = ColumnSortLabels.Default;
@@ -115,7 +116,7 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
     {
         TracesViewModel.StartIndex = request.StartIndex;
         TracesViewModel.Count = request.Count ?? DashboardUIHelpers.DefaultDataGridResultCount;
-        var traces = TracesViewModel.GetTraces();
+        var traces = TracesViewModel.GetTraces(request.ApplySorting);
 
         if (traces.IsFull && !TelemetryRepository.HasDisplayedMaxTraceLimitMessage)
         {

--- a/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
@@ -74,7 +74,7 @@ public class StructuredLogsViewModel
         _logs = null;
     }
 
-    public PagedResult<OtlpLogEntry> GetLogs()
+    public PagedResult<OtlpLogEntry> GetLogs(Func<IQueryable<OtlpLogEntry>, IQueryable<OtlpLogEntry>> sortFunction)
     {
         var logs = _logs;
         if (logs == null)
@@ -95,7 +95,8 @@ public class StructuredLogsViewModel
                 ApplicationKey = ApplicationKey,
                 StartIndex = StartIndex,
                 Count = Count,
-                Filters = filters
+                Filters = filters,
+                SortFunction = sortFunction,
             });
         }
 

--- a/src/Aspire.Dashboard/Model/TracesViewModel.cs
+++ b/src/Aspire.Dashboard/Model/TracesViewModel.cs
@@ -72,7 +72,7 @@ public class TracesViewModel
         _traces = null;
     }
 
-    public PagedResult<OtlpTrace> GetTraces()
+    public PagedResult<OtlpTrace> GetTraces(Func<IQueryable<OtlpTrace>, IQueryable<OtlpTrace>> sortFunction)
     {
         var traces = _traces;
         if (traces == null)
@@ -85,7 +85,8 @@ public class TracesViewModel
                 FilterText = FilterText,
                 StartIndex = StartIndex,
                 Count = Count,
-                Filters = filters
+                Filters = filters,
+                SortFunction = sortFunction
             });
 
             traces = result.PagedResult;

--- a/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
@@ -12,5 +12,5 @@ public sealed class GetLogsContext
     public required int StartIndex { get; init; }
     public required int Count { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
-    public required Func<IQueryable<OtlpLogEntry>, IQueryable<OtlpLogEntry>> SortFunction { get; init; }
+    public Func<IQueryable<OtlpLogEntry>, IQueryable<OtlpLogEntry>>? SortFunction { get; init; }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Otlp.Model;
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
@@ -11,4 +12,5 @@ public sealed class GetLogsContext
     public required int StartIndex { get; init; }
     public required int Count { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
+    public required Func<IQueryable<OtlpLogEntry>, IQueryable<OtlpLogEntry>> SortFunction { get; init; }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Otlp.Model;
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
@@ -12,4 +13,5 @@ public sealed class GetTracesRequest
     public required int Count { get; init; }
     public required string FilterText { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
+    public required Func<IQueryable<OtlpTrace>, IQueryable<OtlpTrace>> SortFunction { get; init; }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
@@ -13,5 +13,5 @@ public sealed class GetTracesRequest
     public required int Count { get; init; }
     public required string FilterText { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
-    public required Func<IQueryable<OtlpTrace>, IQueryable<OtlpTrace>> SortFunction { get; init; }
+    public Func<IQueryable<OtlpTrace>, IQueryable<OtlpTrace>>? SortFunction { get; init; }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -410,7 +410,7 @@ public sealed class TelemetryRepository
                 results = filter.Apply(results);
             }
 
-            return OtlpHelpers.GetItems(results, context.StartIndex, context.Count, _logs.IsFull);
+            return OtlpHelpers.GetItems(results, context.StartIndex, context.Count, _logs.IsFull, context.SortFunction);
         }
         finally
         {
@@ -536,7 +536,7 @@ public sealed class TelemetryRepository
             // Traces can be modified as new spans are added. Copy traces before returning results to avoid concurrency issues.
             var copyFunc = static (OtlpTrace t) => OtlpTrace.Clone(t);
 
-            var pagedResults = OtlpHelpers.GetItems(results, context.StartIndex, context.Count, _traces.IsFull, copyFunc);
+            var pagedResults = OtlpHelpers.GetItems(results, context.StartIndex, context.Count, _traces.IsFull, copyFunc, context.SortFunction);
             var maxDuration = pagedResults.TotalItemCount > 0 ? results.Max(r => r.Duration) : default;
 
             return new GetTracesResponse


### PR DESCRIPTION
## Description

Adds the ability to sort by timestamp for traces and structured logs. For this, I had to extend `OtlpHelpers.GetItems` to also accept a sorting function as is provided to us in `GetData` in the data grids.

![image](https://github.com/user-attachments/assets/698222a3-186b-42e2-b0a9-433d84d93dbc)

Fixes #4190

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
