### PR TITLE
[CI] Fix pipeline tests on rolling builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build with packages
         env:
           CI: false
-        run: ./build.sh -restore -build -ci -pack -testnobuild /bl /p:InstallBrowsersForPlaywright=false
+        run: ./build.sh -restore -build -ci -pack /bl /p:InstallBrowsersForPlaywright=false /p:SkipTestProjects=true
 
       - name: Upload built NuGets
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -4,7 +4,7 @@
     <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)playground\**\*.csproj" />
-    <ProjectToBuild Include="$(RepoRoot)tests\**\*.csproj" Condition="'$(TestNoBuild)' != 'true'" />
+    <ProjectToBuild Include="$(RepoRoot)tests\**\*.csproj" />
   </ItemGroup>
 
   <!-- When building from source, we want to use the live repo contents as opposed to cloning the repo. -->

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -4,7 +4,11 @@
     <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)playground\**\*.csproj" />
-    <ProjectToBuild Include="$(RepoRoot)tests\**\*.csproj" />
+
+    <!-- `$(SkipTestProjects)` allows skipping test projects from being
+          included in the build at all. This is useful for cases like when we are
+          just building the packages, and don't need to build the test projects. -->
+    <ProjectToBuild Include="$(RepoRoot)tests\**\*.csproj" Condition="'$(SkipTestProjects)' != 'true'" />
   </ItemGroup>
 
   <!-- When building from source, we want to use the live repo contents as opposed to cloning the repo. -->

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -96,7 +96,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "verbosity"              { $arguments += " -$argument " + $($PSBoundParameters[$argument]) }
     "configuration"          { $configuration = (Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])); $arguments += " -configuration $configuration" }
     "arch"                   { $arguments += " /p:TargetArchitecture=$($PSBoundParameters[$argument])" }
-    "testnobuild"                   { $arguments += " /p:VSTestNoBuild=true" }
+    "testnobuild"            { $arguments += " /p:VSTestNoBuild=true" }
     default                  { $arguments += " /p:$argument=$($PSBoundParameters[$argument])" }
   }
 }

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -96,6 +96,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "verbosity"              { $arguments += " -$argument " + $($PSBoundParameters[$argument]) }
     "configuration"          { $configuration = (Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])); $arguments += " -configuration $configuration" }
     "arch"                   { $arguments += " /p:TargetArchitecture=$($PSBoundParameters[$argument])" }
+    "testnobuild"                   { $arguments += " /p:VSTestNoBuild=true" }
     default                  { $arguments += " /p:$argument=$($PSBoundParameters[$argument])" }
   }
 }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -132,7 +132,7 @@ while [[ $# > 0 ]]; do
       ;;
 
      -testnobuild)
-      arguments="$arguments /p:TestNoBuild=true"
+      arguments="$arguments /p:VSTestNoBuild=true"
       shift 1
       ;;
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.Common.Tests;
+using Xunit;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
@@ -7,6 +7,7 @@ namespace Aspire.Templates.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
+[Active("https://github.com/dotnet/aspire/issues/8191")]
 public class StarterTemplateWithRedisCacheTests : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
@@ -7,7 +7,7 @@ namespace Aspire.Templates.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
-[Active("https://github.com/dotnet/aspire/issues/8191")]
+[ActiveIssue("https://github.com/dotnet/aspire/issues/8191")]
 public class StarterTemplateWithRedisCacheTests : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.Common.Tests;
+using Xunit;
 
 namespace Aspire.Templates.Tests;
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
@@ -7,7 +7,7 @@ namespace Aspire.Templates.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
-[Active("https://github.com/dotnet/aspire/issues/8191")]
+[ActiveIssue("https://github.com/dotnet/aspire/issues/8191")]
 public class StarterTemplateWithRedisCacheTests_PreviousTFM : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture_PreviousTFM>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
@@ -7,6 +7,7 @@ namespace Aspire.Templates.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
+[Active("https://github.com/dotnet/aspire/issues/8191")]
 public class StarterTemplateWithRedisCacheTests_PreviousTFM : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture_PreviousTFM>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;


### PR DESCRIPTION
Use `$(VSTestNoBuild)` property which is used by vstest instead of
arbitrary `$(TestNoBuild)`. VSTest prevents a build of the test projects
when the property is `true`.

This fixes the running tests on Azdo pipeline builds by not skipping the test projects completely when `-testnobuild` is used.

Fixes https://github.com/dotnet/aspire/issues/8330 .
