### PR TITLE
Add Before/After Publish Events

### DIFF
--- a/src/Aspire.Hosting/Publishing/AfterPublishEvent.cs
+++ b/src/Aspire.Hosting/Publishing/AfterPublishEvent.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+
+namespace Aspire.Hosting.Publishing;
+
+/// <summary>
+/// This event is published after the distributed application is published.
+/// </summary>
+/// <param name="services">The <see cref="IServiceProvider"/> for the app host.</param>
+/// <param name="model">The <see cref="DistributedApplicationModel"/>.</param>
+public sealed class AfterPublishEvent(IServiceProvider services, DistributedApplicationModel model) : IDistributedApplicationEvent
+{
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> for the app host.
+    /// </summary>
+    public IServiceProvider Services { get; } = services;
+
+    /// <summary>
+    /// The <see cref="DistributedApplicationModel"/> instance.
+    /// </summary>
+    public DistributedApplicationModel Model { get; } = model;
+}

--- a/src/Aspire.Hosting/Publishing/BeforePublishEvent.cs
+++ b/src/Aspire.Hosting/Publishing/BeforePublishEvent.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+
+namespace Aspire.Hosting.Publishing;
+
+/// <summary>
+/// This event is published before the distributed application is published.
+/// </summary>
+/// <param name="services">The <see cref="IServiceProvider"/> for the app host.</param>
+/// <param name="model">The <see cref="DistributedApplicationModel"/>.</param>
+public sealed class BeforePublishEvent(IServiceProvider services, DistributedApplicationModel model) : IDistributedApplicationEvent
+{
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> for the app host.
+    /// </summary>
+    public IServiceProvider Services { get; } = services;
+
+    /// <summary>
+    /// The <see cref="DistributedApplicationModel"/> instance.
+    /// </summary>
+    public DistributedApplicationModel Model { get; } = model;
+}


### PR DESCRIPTION
Introduce events that are published before and after the distributed application is published, enhancing the eventing capabilities of the application.