### PR TITLE
Template tests: Add retries to handle browser failures

### DIFF
--- a/tests/Aspire.Templates.Tests/StarterTemplateRunTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateRunTestsBase.cs
@@ -83,17 +83,17 @@ public abstract class StarterTemplateRunTestsBase<T> : TemplateTestsBase, IClass
 
     public static async Task CheckWebFrontendWorksAsync(IBrowserContext context, string url, ITestOutputHelper testOutput, string logPath, bool hasRedisCache = false)
     {
-        var page = await context.NewPageWithLoggingAsync(testOutput);
+        var pageWrapper = await context.NewPageWithLoggingAsync(testOutput);
 
         try
         {
             // Enabling routing disables the http cache
-            await page.RouteAsync("**", async route => await route.ContinueAsync());
-            await page.GotoAsync(url);
+            await pageWrapper.Page.RouteAsync("**", async route => await route.ContinueAsync());
+            await pageWrapper.Page.GotoAsync(url);
 
-            await page.GetByRole(AriaRole.Link, new PageGetByRoleOptions { Name = "Weather" }).ClickAsync();
+            await pageWrapper.Page.GetByRole(AriaRole.Link, new PageGetByRoleOptions { Name = "Weather" }).ClickAsync();
 
-            var tableLoc = page.Locator("//table[//thead/tr/th/text()='Date']");
+            var tableLoc = pageWrapper.Page.Locator("//table[//thead/tr/th/text()='Date']");
             await Expect(tableLoc).ToBeVisibleAsync();
 
             if (hasRedisCache)
@@ -102,7 +102,7 @@ public abstract class StarterTemplateRunTestsBase<T> : TemplateTestsBase, IClass
                 var firstLoadText = string.Join(',', (await GetAndValidateCellTexts(tableLoc)).SelectMany(r => r));
                 await Task.Delay(10_000);
 
-                await page.ReloadAsync(new PageReloadOptions { WaitUntil = WaitUntilState.Load });
+                await pageWrapper.Page.ReloadAsync(new PageReloadOptions { WaitUntil = WaitUntilState.Load });
 
                 var secondLoadText = string.Join(',', (await GetAndValidateCellTexts(tableLoc)).SelectMany(r => r));
                 Assert.NotEqual(firstLoadText, secondLoadText);
@@ -112,7 +112,7 @@ public abstract class StarterTemplateRunTestsBase<T> : TemplateTestsBase, IClass
         {
             testOutput.WriteLine($"Error: {ex}");
             string screenshotPath = Path.Combine(logPath, "webfrontend-fail.png");
-            await page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath });
+            await pageWrapper.Page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath });
             throw;
         }
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.TestUtilities;
-using Xunit;
 
 namespace Aspire.Templates.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
-[ActiveIssue("https://github.com/dotnet/aspire/issues/8191")]
 public class StarterTemplateWithRedisCacheTests : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.TestUtilities;
-using Xunit;
 
 namespace Aspire.Templates.Tests;
 
 [RequiresDocker("Needs docker to start redis cache")]
 [RequiresSSLCertificate]
-[ActiveIssue("https://github.com/dotnet/aspire/issues/8191")]
 public class StarterTemplateWithRedisCacheTests_PreviousTFM : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture_PreviousTFM>
 {
     protected override int DashboardResourcesWaitTimeoutSecs => 300;

--- a/tests/Shared/Playwright/WrapperForIPage.cs
+++ b/tests/Shared/Playwright/WrapperForIPage.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Playwright;
+
+// Used to wrap IPage and flag console errors and page errors
+public class WrapperForIPage
+{
+    public IPage Page { get; init; }
+    public bool HasErrors { get; private set; }
+    private readonly ITestOutputHelper _testOutput;
+
+    public WrapperForIPage(IPage page, ITestOutputHelper testOutput)
+    {
+        Page = page;
+        _testOutput = testOutput;
+
+        page.Console += (_, e) =>
+        {
+            _testOutput.WriteLine($"[browser-console] {e.Text}");
+            HasErrors = e.Text.Contains("Error: WebSocket closed with status code") || e.Text.Contains("net::ERR_NETWORK_CHANGED");
+        };
+        page.PageError += (_, e) =>
+        {
+            _testOutput.WriteLine($"[browser-error] {e}");
+            HasErrors = true;
+        };
+    }
+
+    public Task<IResponse?> ReloadAsync(PageReloadOptions? options = null)
+    {
+        HasErrors = false;
+        return Page.ReloadAsync(options);
+    }
+
+    public Task<IResponse?> GotoAsync(string url, PageGotoOptions? options = null)
+    {
+        HasErrors = false;
+        return Page.GotoAsync(url, options);
+    }
+}

--- a/tests/Shared/TemplatesTesting/Aspire.Shared.TemplatesTesting.targets
+++ b/tests/Shared/TemplatesTesting/Aspire.Shared.TemplatesTesting.targets
@@ -10,6 +10,8 @@
     <_DataFile Include="$(MSBuildThisFileDirectory)data\**\*" Link="testassets\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Include="@(_DataFile)" />
 
+    <PackageReference Include="Polly.Core" />
+
     <!-- needed for the RequiresDocker attribute, and discoverer -->
     <ProjectReference Include="$(RepoRoot)tests\Aspire.TestUtilities\Aspire.TestUtilities.csproj" />
   </ItemGroup>

--- a/tests/Shared/TemplatesTesting/AspireProject.cs
+++ b/tests/Shared/TemplatesTesting/AspireProject.cs
@@ -343,7 +343,11 @@ public partial class AspireProject : IAsyncDisposable
             .AddRetry(new()
             {
                 MaxRetryAttempts = 3,
-                ShouldHandle = new PredicateBuilder().Handle<PlaywrightException>(ex => ex.Message.Contains("net::ERR_NETWORK_CHANGED", StringComparison.OrdinalIgnoreCase)),
+                ShouldHandle = new PredicateBuilder().Handle<PlaywrightException>(ex =>
+                {
+                    return ex.Message.Contains("net::ERR_NETWORK_CHANGED", StringComparison.OrdinalIgnoreCase) ||
+                            ex.Message.Contains("net::ERR_SOCKET_NOT_CONNECTED", StringComparison.OrdinalIgnoreCase);
+                }),
                 OnRetry = (args) =>
                 {
                     _testOutput.WriteLine($"Reloading dashboard page due to {args.Outcome.Exception?.Message}");

--- a/tests/Shared/TemplatesTesting/TestExtensions.cs
+++ b/tests/Shared/TemplatesTesting/TestExtensions.cs
@@ -10,13 +10,10 @@ namespace Aspire.Templates.Tests;
 
 public static class TestExtensions
 {
-    public static async Task<IPage> NewPageWithLoggingAsync(this IBrowserContext context, ITestOutputHelper testOutput)
+    public static async Task<WrapperForIPage> NewPageWithLoggingAsync(this IBrowserContext context, ITestOutputHelper testOutput)
     {
         var page = await context.NewPageAsync();
-        page.Console += (_, e) => testOutput.WriteLine($"[browser-console] {e.Text}");
-        page.Crash += (_, _) => testOutput.WriteLine("******************* browser-crash *******************");
-        page.PageError += (_, e) => testOutput.WriteLine($"[browser-page-error] *********** {e}");
-        return page;
+        return new WrapperForIPage(page, testOutput);
     }
 
     public static bool TryGetHasExited(this Process process)


### PR DESCRIPTION
Template tests: Reload playwright page if it fails to load

Loading the page can sometimes fail with errors like
`[browser-console] Failed to load resource: net::ERR_NETWORK_CHANGED`,
or the websocket getting disconnected, causing the tests to fail. This
commit add retries for such cases.

Fixes https://github.com/dotnet/aspire/issues/8191