### PR TITLE
Reduce default KeyVault role

### DIFF
--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -71,7 +71,7 @@ public static class AzureKeyVaultResourceExtensions
         var resource = new AzureKeyVaultResource(name, configureInfrastructure);
         return builder.AddResource(resource)
             .WithDefaultRoleAssignments(KeyVaultBuiltInRole.GetBuiltInRoleName,
-                KeyVaultBuiltInRole.KeyVaultAdministrator);
+                KeyVaultBuiltInRole.KeyVaultSecretsUser);
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -1361,11 +1361,11 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               name: mykv_outputs_name
             }
 
-            resource mykv_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-              name: guid(mykv.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
+            resource mykv_KeyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(mykv.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6'))
               properties: {
                 principalId: principalId
-                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
                 principalType: principalType
               }
               scope: mykv


### PR DESCRIPTION
## Description

KeyVaultAdministrator is too high of a priviledge role to use by default in applications. By default apps should not need to manage key vault settings, but instead just be able to read secrets. So instead, by default apps will get KeyVaultSecretsUser role and if an application needs a higher role, it can be configured easily by using WithRoleAssignments.

Fix #8218

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] Yes
        - Link to aspire-docs issue https://github.com/dotnet/docs-aspire/issues/2899
