### PR TITLE
Remove IKeyVaultResource.IdOutputReference from public API

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/account-kv.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/account-kv.module.bicep
@@ -20,5 +20,3 @@ resource account_kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
 output vaultUri string = account_kv.properties.vaultUri
 
 output name string = account_kv.name
-
-output id string = account_kv.id

--- a/playground/bicep/BicepSample.AppHost/kv3.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/kv3.module.bicep
@@ -20,5 +20,3 @@ resource kv3 'Microsoft.KeyVault/vaults@2023-07-01' = {
 output vaultUri string = kv3.properties.vaultUri
 
 output name string = kv3.name
-
-output id string = kv3.id

--- a/playground/bicep/BicepSample.AppHost/postgres2-kv.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/postgres2-kv.module.bicep
@@ -20,5 +20,3 @@ resource postgres2_kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
 output vaultUri string = postgres2_kv.properties.vaultUri
 
 output name string = postgres2_kv.name
-
-output id string = postgres2_kv.id

--- a/playground/cdk/CdkSample.AppHost/mykv.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/mykv.module.bicep
@@ -31,5 +31,3 @@ resource mysecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
 output vaultUri string = mykv.properties.vaultUri
 
 output name string = mykv.name
-
-output id string = mykv.id

--- a/playground/cdk/CdkSample.AppHost/pgsql-kv.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/pgsql-kv.module.bicep
@@ -20,5 +20,3 @@ resource pgsql_kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
 output vaultUri string = pgsql_kv.properties.vaultUri
 
 output name string = pgsql_kv.name
-
-output id string = pgsql_kv.id

--- a/playground/waitfor/WaitForSandbox.AppHost/pg-kv.module.bicep
+++ b/playground/waitfor/WaitForSandbox.AppHost/pg-kv.module.bicep
@@ -20,5 +20,3 @@ resource pg_kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
 output vaultUri string = pg_kv.properties.vaultUri
 
 output name string = pg_kv.name
-
-output id string = pg_kv.id

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -26,18 +26,12 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     public BicepOutputReference NameOutputReference => new("name", this);
 
     /// <summary>
-    /// Gets the resource identifier of the Azure Key Vault resource.
-    /// </summary>
-    public BicepOutputReference Id => new("id", this);
-
-    /// <summary>
     /// Gets the connection string template for the manifest for the Azure Key Vault resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create($"{VaultUri}");
 
     BicepOutputReference IKeyVaultResource.VaultUriOutputReference => VaultUri;
-    BicepOutputReference IKeyVaultResource.IdOutputReference => Id;
 
     // In run mode, this is set to the secret client used to access the Azure Key Vault.
     internal Func<string, CancellationToken, Task<string?>>? SecretResolver { get; set; }

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -65,7 +65,6 @@ public static class AzureKeyVaultResourceExtensions
 
             // We need to output name to externalize role assignments.
             infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = keyVault.Name });
-            infrastructure.Add(new ProvisioningOutput("id", typeof(string)) { Value = keyVault.Id });
         };
 
         var resource = new AzureKeyVaultResource(name, configureInfrastructure);

--- a/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/IKeyVaultResource.cs
@@ -21,11 +21,6 @@ public interface IKeyVaultResource : IResource, IAzureResource
     BicepOutputReference NameOutputReference { get; }
 
     /// <summary>
-    /// the output reference that represents the resource id for the Azure Key Vault resource.
-    /// </summary>
-    BicepOutputReference IdOutputReference { get; }
-
-    /// <summary>
     /// Gets or sets the secret resolver function used to resolve secrets at runtime.
     /// </summary>
     Func<string, CancellationToken, Task<string?>>? SecretResolver { get; set; }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -1289,8 +1289,6 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             output vaultUri string = mykv.properties.vaultUri
 
             output name string = mykv.name
-
-            output id string = mykv.id
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);
@@ -1339,8 +1337,6 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             output vaultUri string = mykv.properties.vaultUri
 
             output name string = mykv.name
-
-            output id string = mykv.id
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -496,8 +496,6 @@ public class ExistingAzureResourceTests(ITestOutputHelper output)
             output vaultUri string = keyVault.properties.vaultUri
 
             output name string = existingResourceName
-
-            output id string = keyVault.id
             """;
 
         output.WriteLine(BicepText);


### PR DESCRIPTION
This property isn't used and can be removed.