### PR TITLE
Fix Functions connection key for Azure Table Storage

### DIFF
--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/aspire-manifest.json
@@ -64,7 +64,7 @@
         "AzureWebJobsStorage__tableServiceUri": "{funcstorage67c6c.outputs.tableEndpoint}",
         "Aspire__Azure__Storage__Blobs__AzureWebJobsStorage__ServiceUri": "{funcstorage67c6c.outputs.blobEndpoint}",
         "Aspire__Azure__Storage__Queues__AzureWebJobsStorage__ServiceUri": "{funcstorage67c6c.outputs.queueEndpoint}",
-        "Aspire__Azure__Storage__Tables__AzureWebJobsStorage__ServiceUri": "{funcstorage67c6c.outputs.tableEndpoint}",
+        "Aspire__Azure__Data__Tables__AzureWebJobsStorage__ServiceUri": "{funcstorage67c6c.outputs.tableEndpoint}",
         "myhub__fullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
         "Aspire__Azure__Messaging__EventHubs__EventHubProducerClient__myhub__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
         "Aspire__Azure__Messaging__EventHubs__EventHubConsumerClient__myhub__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
@@ -21,7 +21,7 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
 
     internal const string BlobsConnectionKeyPrefix = "Aspire__Azure__Storage__Blobs";
     internal const string QueuesConnectionKeyPrefix = "Aspire__Azure__Storage__Queues";
-    internal const string TablesConnectionKeyPrefix = "Aspire__Azure__Storage__Tables";
+    internal const string TablesConnectionKeyPrefix = "Aspire__Azure__Data__Tables";
 
     /// <summary>
     /// Gets the "blobEndpoint" output reference from the bicep template for the Azure Storage resource.

--- a/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
@@ -117,7 +117,7 @@ public class ResourceWithAzureFunctionsConfigTests
         Assert.True(target.ContainsKey("myconnection"));
         Assert.True(target.ContainsKey("Aspire__Azure__Storage__Blobs__myconnection__ConnectionString"));
         Assert.True(target.ContainsKey("Aspire__Azure__Storage__Queues__myconnection__ConnectionString"));
-        Assert.True(target.ContainsKey("Aspire__Azure__Storage__Tables__myconnection__ConnectionString"));
+        Assert.True(target.ContainsKey("Aspire__Azure__Data__Tables__myconnection__ConnectionString"));
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class ResourceWithAzureFunctionsConfigTests
         Assert.True(target.ContainsKey("myconnection__tableServiceUri"));
         Assert.True(target.ContainsKey("Aspire__Azure__Storage__Blobs__myconnection__ServiceUri"));
         Assert.True(target.ContainsKey("Aspire__Azure__Storage__Queues__myconnection__ServiceUri"));
-        Assert.True(target.ContainsKey("Aspire__Azure__Storage__Tables__myconnection__ServiceUri"));
+        Assert.True(target.ContainsKey("Aspire__Azure__Data__Tables__myconnection__ServiceUri"));
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class ResourceWithAzureFunctionsConfigTests
 
         // Assert
         Assert.True(target.ContainsKey("mytables"));
-        Assert.True(target.ContainsKey("Aspire__Azure__Storage__Tables__mytables__ConnectionString"));
+        Assert.True(target.ContainsKey("Aspire__Azure__Data__Tables__mytables__ConnectionString"));
     }
 
     [Fact]


### PR DESCRIPTION
We were injecting the connection info for the table resource into the wrong position.