### PR TITLE
Add cert trusting logic to aspire CLI.

### DIFF
--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -29,6 +29,30 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             cancellationToken: cancellationToken);
     }
 
+    public async Task<int> CheckHttpCertificateAsync(CancellationToken cancellationToken)
+    {
+        string[] cliArgs = ["dev-certs", "https", "--check"];
+        return await ExecuteAsync(
+            args: cliArgs,
+            env: null,
+            workingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
+            backchannelCompletionSource: null,
+            streamsCallback: null,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<int> TrustHttpCertificateAsync(CancellationToken cancellationToken)
+    {
+        string[] cliArgs = ["dev-certs", "https", "--trust"];
+        return await ExecuteAsync(
+            args: cliArgs,
+            env: null,
+            workingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
+            backchannelCompletionSource: null,
+            streamsCallback: null,
+            cancellationToken: cancellationToken);
+    }
+
     public async Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, CancellationToken cancellationToken)
     {
         List<string> cliArgs = ["new", "install", $"{packageName}::{version}"];

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -31,7 +31,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> CheckHttpCertificateAsync(CancellationToken cancellationToken)
     {
-        string[] cliArgs = ["dev-certs", "https", "--check"];
+        string[] cliArgs = ["dev-certs", "https", "--check", "--trust"];
         return await ExecuteAsync(
             args: cliArgs,
             env: null,

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -13,4 +13,5 @@ internal static class ExitCodeConstants
     public const int FailedToAddPackage = 5;
     public const int FailedToBuildArtifacts = 6;
     public const int FailedToFindProject = 7;
+    public const int FailedToTrustCertificates = 8;
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -302,7 +302,7 @@ public class Program
 
             if (trustExitCode != 0)
             {
-                throw new InvalidOperationException("Failed to trust certificates, trust command failed with exit code: {trustExitCode}");
+                throw new InvalidOperationException($"Failed to trust certificates, trust command failed with exit code: {trustExitCode}");
             }
         }
     }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -160,6 +160,16 @@ public class Program
                 env["ASPIRE_WAIT_FOR_DEBUGGER"] = "true";
             }
 
+            try
+            {
+                await EnsureCertificatesTrustedAsync(runner, ct);
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down:  An error occurred while trusting the certificates: {ex.Message}[/]");
+                return ExitCodeConstants.FailedToTrustCertificates;
+            }
+
             var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();
 
             var watch = parseResult.GetValue<bool>("--watch");
@@ -266,6 +276,35 @@ public class Program
         });
 
         parentCommand.Subcommands.Add(command);
+    }
+
+    private static async Task EnsureCertificatesTrustedAsync(DotNetCliRunner runner, CancellationToken cancellationToken)
+    {
+        var checkExitCode = await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots3)
+            .SpinnerStyle(Style.Parse("purple"))
+            .StartAsync(
+                ":locked_with_key: Checking certificates...",
+                async (context) => {
+                    return await runner.CheckHttpCertificateAsync(cancellationToken);
+                });
+
+        if (checkExitCode != 0)
+        {
+            var trustExitCode = await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots3)
+                .SpinnerStyle(Style.Parse("purple"))
+                .StartAsync(
+                    ":locked_with_key: Trusting certificates...",
+                    async (context) => {
+                        return await runner.TrustHttpCertificateAsync(cancellationToken);
+                    });
+
+            if (trustExitCode != 0)
+            {
+                throw new InvalidOperationException("Failed to trust certificates, trust command failed with exit code: {trustExitCode}");
+            }
+        }
     }
 
     private static FileInfo? UseOrFindAppHostProjectFile(FileInfo? projectFile)
@@ -606,10 +645,18 @@ public class Program
                 AnsiConsole.MarkupLine($"[red bold]:thumbs_down: Project creation failed with exit code {newProjectExitCode}. For more information run with --debug switch.[/]");
                 return ExitCodeConstants.FailedToCreateNewProject;
             }
-            else
+
+            try
             {
-                AnsiConsole.MarkupLine($":thumbs_up: Project created successfully in {outputPath}.");
+                await EnsureCertificatesTrustedAsync(cliRunner, ct);
             }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down:  An error occurred while trusting the certificates: {ex.Message}[/]");
+                return ExitCodeConstants.FailedToTrustCertificates;
+            }
+
+            AnsiConsole.MarkupLine($":thumbs_up: Project created successfully in {outputPath}.");
 
             return ExitCodeConstants.Success;
         });


### PR DESCRIPTION
Fixes: #8347

This fixes a papercut that folks using .NET Aspire via the CLI might experience. If you've never used .NET before and you just download the CLi and create a project, before that project can work the ASP.NET dev certs need to be trusted.

This automatically checks and trusts the certs anytime you run the `aspire new` or the `aspire run` command.

The command takes a fraction of a second to run so doesn't appreciably slow down execution time in either case.