### PR TITLE
Filter https service discovery variables.

### DIFF
--- a/playground/publishers/Publishers.AppHost/docker-compose.yaml
+++ b/playground/publishers/Publishers.AppHost/docker-compose.yaml
@@ -67,7 +67,6 @@ services:
       P2: "${PARAM2}"
       P3: "${PARAM3}"
       services__api__http__0: "http://api:8005"
-      services__api__https__0: "https://api:8007"
     ports:
       - "8011:8010"
       - "8013:8012"


### PR DESCRIPTION
Fixes: #8332

This PR adds a hack in to filter out emission of `https` service discovery variables in Docker Compose. This is because we don't yet do anything around configuring TLS with Docker Compose either in terms of having a certificate file injected into the container or setting up some kind of proxy.

As a result, the webfrontend in the default template can't talk to the API because it preferences HTTPS because the variable is there.