### PR TITLE
Dashboard gracefully handles duplicate property names

### DIFF
--- a/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
@@ -341,7 +341,7 @@ internal sealed class DashboardClient : IDashboardClient
                                 foreach (var resource in response.InitialData.Resources)
                                 {
                                     // Add to map.
-                                    var viewModel = resource.ToViewModel(_timeProvider, _knownPropertyLookup);
+                                    var viewModel = resource.ToViewModel(_timeProvider, _knownPropertyLookup, _logger);
                                     _resourceByName[resource.Name] = viewModel;
 
                                     // Send this update to any subscribers too.
@@ -361,7 +361,7 @@ internal sealed class DashboardClient : IDashboardClient
                                     if (change.KindCase == WatchResourcesChange.KindOneofCase.Upsert)
                                     {
                                         // Upsert (i.e. add or replace)
-                                        var viewModel = change.Upsert.ToViewModel(_timeProvider, _knownPropertyLookup);
+                                        var viewModel = change.Upsert.ToViewModel(_timeProvider, _knownPropertyLookup, _logger);
                                         _resourceByName[change.Upsert.Name] = viewModel;
                                         changes.Add(new(ResourceViewModelChangeType.Upsert, viewModel));
                                     }
@@ -584,7 +584,7 @@ internal sealed class DashboardClient : IDashboardClient
             {
                 foreach (var data in initialData)
                 {
-                    _resourceByName[data.Name] = data.ToViewModel(_timeProvider, _knownPropertyLookup);
+                    _resourceByName[data.Name] = data.ToViewModel(_timeProvider, _knownPropertyLookup, _logger);
                 }
             }
         }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -48,14 +48,45 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var vm = resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup());
+        var vm = resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup(), NullLogger.Instance);
 
         // Assert
-        Assert.Collection(resource.Environment,
+        Assert.Collection(vm.Environment,
             e =>
             {
                 Assert.Empty(e.Name);
                 Assert.Equal("Value!", e.Value);
+            });
+    }
+
+    [Fact]
+    public void ToViewModel_DuplicatePropertyNames_Success()
+    {
+        // Arrange
+        var resource = new Resource
+        {
+            Name = "TestName-abc",
+            DisplayName = "TestName",
+            CreatedAt = Timestamp.FromDateTime(s_dateTime),
+            Properties =
+            {
+                new ResourceProperty { Name = "test", Value = Value.ForString("one!") },
+                new ResourceProperty { Name = "test", Value = Value.ForString("two!") }
+            }
+        };
+
+        // Act
+        var vm = resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup(), NullLogger.Instance);
+
+        // Assert
+        Assert.Collection(vm.Properties,
+            e =>
+            {
+                var (key, vm) = (e.Key, e.Value);
+
+                Assert.Equal("test", key);
+                Assert.Equal("test", vm.Name);
+                Assert.Equal("two!", vm.Value.StringValue);
             });
     }
 
@@ -69,7 +100,7 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var ex = Assert.Throws<InvalidOperationException>(() => resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup()));
+        var ex = Assert.Throws<InvalidOperationException>(() => resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup(), NullLogger.Instance));
 
         // Assert
         Assert.Equal(@"Error converting resource ""TestName-abc"" to ResourceViewModel.", ex.Message);
@@ -95,7 +126,7 @@ public sealed class ResourceViewModelTests
         var kp = new KnownProperty("foo", "bar");
 
         // Act
-        var viewModel = resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup(123, kp));
+        var viewModel = resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup(123, kp), NullLogger.Instance);
 
         // Assert
         Assert.Collection(


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/8311. Last value wins when there are duplicates.

Still need to look at what is happening in hosting that causes it to send duplicate property names.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
