### PR TITLE
Add experimental attribute and suppress warnings

### DIFF
--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Docker;
 using Aspire.Hosting.Kubernetes;
@@ -13,11 +15,7 @@ builder.AddDockerComposePublisher();
 
 builder.AddKubernetesPublisher();
 
-#pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
 builder.AddAzurePublisher("azure");
-
-#pragma warning restore ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 var param0 = builder.AddParameter("param0");
 var param1 = builder.AddParameter("param1", secret: true);

--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREPUBLISHERS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREPUBLISHERS001
 
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Docker;

--- a/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
@@ -16,7 +16,7 @@ public static class AzurePublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Azure Container Apps publisher options.</param>
-    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static void AddAzurePublisher(this IDistributedApplicationBuilder builder, string name, Action<AzurePublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<AzurePublisher, AzurePublisherOptions>(name, configureOptions);

--- a/src/Aspire.Hosting.Docker/DockerComposePublisher.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisher.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
+#pragma warning disable ASPIREPUBLISHERS001
 
 namespace Aspire.Hosting.Docker;
 
@@ -16,7 +16,6 @@ public static class DockerComposePublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
-    [Experimental("ASPIREPUBLISHERS001")]
     public static void AddDockerComposePublisher(this IDistributedApplicationBuilder builder, string name, Action<DockerComposePublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>(name, configureOptions);
@@ -27,7 +26,6 @@ public static class DockerComposePublisherExtensions
     /// </summary>
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
-    [Experimental("ASPIREPUBLISHERS001")]
     public static void AddDockerComposePublisher(this IDistributedApplicationBuilder builder, Action<DockerComposePublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>("docker-compose", configureOptions);

--- a/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Hosting.Docker;
 
 /// <summary>
@@ -14,6 +16,7 @@ public static class DockerComposePublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
+    [Experimental("ASPIREPUBLISHERS001")]
     public static void AddDockerComposePublisher(this IDistributedApplicationBuilder builder, string name, Action<DockerComposePublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>(name, configureOptions);
@@ -24,6 +27,7 @@ public static class DockerComposePublisherExtensions
     /// </summary>
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
+    [Experimental("ASPIREPUBLISHERS001")]
     public static void AddDockerComposePublisher(this IDistributedApplicationBuilder builder, Action<DockerComposePublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>("docker-compose", configureOptions);

--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
 using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Docker.Resources;

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Hosting.Kubernetes;
 
 /// <summary>
@@ -14,6 +16,7 @@ public static class KubernetesPublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
+    [Experimental("ASPIREPUBLISHERS001")]
     public static void AddKubernetesPublisher(this IDistributedApplicationBuilder builder, string name, Action<KubernetesPublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>(name, configureOptions);
@@ -24,6 +27,7 @@ public static class KubernetesPublisherExtensions
     /// </summary>
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
+    [Experimental("ASPIREPUBLISHERS001")]
     public static void AddKubernetesPublisher(this IDistributedApplicationBuilder builder, Action<KubernetesPublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>("kubernetes", configureOptions);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
+#pragma warning disable ASPIREPUBLISHERS001
 
 namespace Aspire.Hosting.Kubernetes;
 
@@ -16,7 +16,6 @@ public static class KubernetesPublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
-    [Experimental("ASPIREPUBLISHERS001")]
     public static void AddKubernetesPublisher(this IDistributedApplicationBuilder builder, string name, Action<KubernetesPublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>(name, configureOptions);
@@ -27,7 +26,6 @@ public static class KubernetesPublisherExtensions
     /// </summary>
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
-    [Experimental("ASPIREPUBLISHERS001")]
     public static void AddKubernetesPublisher(this IDistributedApplicationBuilder builder, Action<KubernetesPublisherOptions>? configureOptions = null)
     {
         builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>("kubernetes", configureOptions);

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
 using System.Diagnostics;
 using System.Reflection;
 using System.Security.Cryptography;

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Publishing;

--- a/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
@@ -1,13 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting;
 
 /// <summary>
-/// TODO
+/// Extensions for adding a publisher to the distributed application.
 /// </summary>
 public static class PublisherDistributedApplicationBuilderExtensions
 {
@@ -19,6 +20,7 @@ public static class PublisherDistributedApplicationBuilderExtensions
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>. </param>
     /// <param name="name">The name of the publisher.</param>
     /// <param name="configureOptions">Callback to configure options for the publisher.</param>
+    [Experimental("ASPIREPUBLISHERS001")]
     public static void AddPublisher<TPublisher, TPublisherOptions>(this IDistributedApplicationBuilder builder, string name, Action<TPublisherOptions>? configureOptions = null)
         where TPublisher : class, IDistributedApplicationPublisher
         where TPublisherOptions : class

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
 
 namespace Aspire.Hosting.Publishing;
@@ -8,6 +11,7 @@ namespace Aspire.Hosting.Publishing;
 /// <summary>
 /// Represents a publishing activity.
 /// </summary>
+[Experimental("ASPIREPUBLISHERS001")]
 public sealed class PublishingActivity
 {
     internal PublishingActivity(string id, string initialStatusText, bool isPrimary = false)
@@ -47,6 +51,7 @@ public sealed class PublishingActivity
 /// <summary>
 /// Interface for reporting publishing activity progress.
 /// </summary>
+[Experimental("ASPIREPUBLISHERS001")]
 public interface IPublishingActivityProgressReporter
 {
     /// <summary>

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +16,7 @@ namespace Aspire.Hosting.Publishing;
 /// <summary>
 /// Provides a service to publishers for building containers that represent a resource.
 /// </summary>
+[Experimental("ASPIREPUBLISHERS001")]
 public interface IResourceContainerImageBuilder
 {
     /// <summary>

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostBackchannelTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
 using System.Net.Sockets;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Utils;

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;


### PR DESCRIPTION
Introduce an experimental attribute for publisher methods and disable related warnings in playground and tests to streamline development and evaluation.

Fixes: #8304