### PR TITLE
Fixing pull request update action and exclusion logic for api Review

### DIFF
--- a/.github/workflows/generate-api-diffs.yml
+++ b/.github/workflows/generate-api-diffs.yml
@@ -19,13 +19,14 @@ jobs:
         run: |
           set +e
 
-          for proj in $(find src -name '*.csproj' ! -path 'src/Aspire.ProjectTemplates/**/*.csproj' ! -path 'src/Aspire.Cli/**/*.csproj'); do
+          # Find all csproj files excluding specific paths
+          find src -name '*.csproj' | grep -v 'Aspire.ProjectTemplates' | grep -v 'Aspire.Cli' | while read proj; do
             export CI=false && ./dotnet.sh build "$proj" -f net8.0 --configuration Release --no-incremental /t:"Build;GenAPIGenerateReferenceAssemblySource"
           done
         continue-on-error: true
 
       - name: Create or update pull request
-        uses: dotnet/actions-create-pull-request@v4
+        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update-api-diffs

--- a/.github/workflows/generate-api-diffs.yml
+++ b/.github/workflows/generate-api-diffs.yml
@@ -20,7 +20,7 @@ jobs:
           set +e
 
           # Find all csproj files excluding specific paths
-          find src -name '*.csproj' | grep -v 'Aspire.ProjectTemplates' | grep -v 'Aspire.Cli' | while read proj; do
+          find src -name '*.csproj' | egrep -v 'Aspire.ProjectTemplates|Aspire.Cli' | while read proj; do
             export CI=false && ./dotnet.sh build "$proj" -f net8.0 --configuration Release --no-incremental /t:"Build;GenAPIGenerateReferenceAssemblySource"
           done
         continue-on-error: true

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -39,7 +39,7 @@ jobs:
           git checkout -- .
 
       - name: Create Pull Request
-        uses: dotnet/actions-create-pull-request@v4
+        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update-dependencies


### PR DESCRIPTION
cc: @eerhardt @danmoseley @radical 


This fixes:

- Pull requests failing the action when updating an existing pull request by using a patched version of the action
- Corrected the logic of excluding multiple projects so API generation is skipped for them correctly.