### PR TITLE
Fix Azure SqlServer deployment with ACA environment

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzdAzureContainerAppEnvironment.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzdAzureContainerAppEnvironment.cs
@@ -20,9 +20,9 @@ internal sealed class AzdAzureContainerAppEnvironment : IAzureContainerAppEnviro
 
     public IManifestExpressionProvider ContainerRegistryManagedIdentityId => AzureContainerAppsEnvironment.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID;
 
-    public IManifestExpressionProvider ManagedIdentityId => ContainerRegistryManagedIdentityId;
-
     public IManifestExpressionProvider LogAnalyticsWorkspaceId => AzureContainerAppsEnvironment.AZURE_LOG_ANALYTICS_WORKSPACE_ID;
+
+    public IManifestExpressionProvider PrincipalId => AzureContainerAppsEnvironment.MANAGED_IDENTITY_PRINCIPAL_ID;
 
     public IManifestExpressionProvider PrincipalName => AzureContainerAppsEnvironment.MANAGED_IDENTITY_NAME;
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -24,11 +24,6 @@ public class AzureContainerAppEnvironmentResource(string name, Action<AzureResou
     public BicepOutputReference ContainerAppDomain => new("AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN", this);
 
     /// <summary>
-    /// Gets the managed identity ID associated with the Container App Environment.
-    /// </summary>
-    public BicepOutputReference ManagedIdentityId => new("AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID", this);
-
-    /// <summary>
     /// Gets the URL endpoint of the associated Azure Container Registry.
     /// </summary>
     public BicepOutputReference ContainerRegistryUrl => new("AZURE_CONTAINER_REGISTRY_ENDPOINT", this);
@@ -49,6 +44,11 @@ public class AzureContainerAppEnvironmentResource(string name, Action<AzureResou
     public BicepOutputReference PrincipalName => new("MANAGED_IDENTITY_NAME", this);
 
     /// <summary>
+    /// Gets the principal ID of the managed identity.
+    /// </summary>
+    public BicepOutputReference PrincipalId => new("MANAGED_IDENTITY_PRINCIPAL_ID", this);
+
+    /// <summary>
     /// Gets the name of the Container App Environment.
     /// </summary>
     public BicepOutputReference ContainerAppEnvironmentName => new("AZURE_CONTAINER_APPS_ENVIRONMENT_NAME", this);
@@ -64,6 +64,8 @@ public class AzureContainerAppEnvironmentResource(string name, Action<AzureResou
     IManifestExpressionProvider IAzureContainerAppEnvironment.ContainerRegistryManagedIdentityId => ContainerRegistryManagedIdentityId;
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.LogAnalyticsWorkspaceId => LogAnalyticsWorkspaceId;
+
+    IManifestExpressionProvider IAzureContainerAppEnvironment.PrincipalId => PrincipalId;
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.PrincipalName => PrincipalName;
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -92,7 +92,7 @@ internal sealed class AzureContainerAppsInfrastructure(
             SetKnownParameterValue(r, AzureBicepResource.KnownParameters.KeyVaultName, environment.GetSecretOutputKeyVault);
 
             // Set the known parameters for the container app environment
-            SetKnownParameterValue(r, AzureBicepResource.KnownParameters.PrincipalId, _ => environment.ContainerRegistryManagedIdentityId);
+            SetKnownParameterValue(r, AzureBicepResource.KnownParameters.PrincipalId, _ => environment.PrincipalId);
             SetKnownParameterValue(r, AzureBicepResource.KnownParameters.PrincipalType, _ => "ServicePrincipal");
             SetKnownParameterValue(r, AzureBicepResource.KnownParameters.PrincipalName, _ => environment.PrincipalName);
             SetKnownParameterValue(r, AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, _ => environment.LogAnalyticsWorkspaceId);

--- a/src/Aspire.Hosting.Azure.AppContainers/IAzureContainerAppEnvironment.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/IAzureContainerAppEnvironment.cs
@@ -12,6 +12,7 @@ internal interface IAzureContainerAppEnvironment
     IManifestExpressionProvider ContainerRegistryUrl { get; }
     IManifestExpressionProvider ContainerRegistryManagedIdentityId { get; }
     IManifestExpressionProvider LogAnalyticsWorkspaceId { get; }
+    IManifestExpressionProvider PrincipalId { get; }
     IManifestExpressionProvider PrincipalName { get; }
     IManifestExpressionProvider ContainerAppEnvironmentName { get; }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -3340,6 +3340,96 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         Assert.Equal(expectedBicep, bicep);
     }
 
+    // see https://github.com/dotnet/aspire/issues/8381 for more information on this scenario
+    // Azure SqlServer needs an admin when it is first provisioned. To supply this, we use the
+    // principalId from the Azure Container App Environment.
+    [Fact]
+    public async Task AddContainerAppEnvironmentWorksWithSqlServer()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureContainerAppEnvironment("env");
+
+        var sql = builder.AddAzureSqlServer("sql");
+        var db = sql.AddDatabase("db");
+
+        builder.AddContainer("cache", "redis")
+               .WithReference(db);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var (manifest, bicep) = await GetManifestWithBicep(sql.Resource);
+
+        var m = manifest.ToString();
+
+        var expectedManifest =
+        """
+        {
+          "type": "azure.bicep.v0",
+          "connectionString": "Server=tcp:{sql.outputs.sqlServerFqdn},1433;Encrypt=True;Authentication=\u0022Active Directory Default\u0022",
+          "path": "sql.module.bicep",
+          "params": {
+            "principalId": "{env.outputs.MANAGED_IDENTITY_PRINCIPAL_ID}",
+            "principalName": "{env.outputs.MANAGED_IDENTITY_NAME}"
+          }
+        }
+        """;
+        Assert.Equal(expectedManifest, m);
+
+        var expectedBicep =
+        """
+        @description('The location for the resource(s) to be deployed.')
+        param location string = resourceGroup().location
+
+        param principalId string
+
+        param principalName string
+
+        resource sql 'Microsoft.Sql/servers@2021-11-01' = {
+          name: take('sql-${uniqueString(resourceGroup().id)}', 63)
+          location: location
+          properties: {
+            administrators: {
+              administratorType: 'ActiveDirectory'
+              login: principalName
+              sid: principalId
+              tenantId: subscription().tenantId
+              azureADOnlyAuthentication: true
+            }
+            minimalTlsVersion: '1.2'
+            publicNetworkAccess: 'Enabled'
+            version: '12.0'
+          }
+          tags: {
+            'aspire-resource-name': 'sql'
+          }
+        }
+
+        resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {
+          name: 'AllowAllAzureIps'
+          properties: {
+            endIpAddress: '0.0.0.0'
+            startIpAddress: '0.0.0.0'
+          }
+          parent: sql
+        }
+
+        resource db 'Microsoft.Sql/servers/databases@2021-11-01' = {
+          name: 'db'
+          location: location
+          parent: sql
+        }
+
+        output sqlServerFqdn string = sql.properties.fullyQualifiedDomainName
+
+        output name string = sql.name
+        """;
+        output.WriteLine(bicep);
+        Assert.Equal(expectedBicep, bicep);
+    }
+
     private static Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource) =>
         AzureManifestUtils.GetManifestWithBicep(resource, skipPreparer: true);
 


### PR DESCRIPTION
## Description

Azure SqlServer needs an admin when it is first provisioned. To supply this, we use the principalId from the Azure Container App Environment. But today the ACA environment is filling it with the wrong ID - it is using the managedIdentity.Id and not PrincipalId.

To fix this, fill in the empty principalId parameters with the correct principalId

Contributes to #8381

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
