### PR TITLE
Add error handling for package updates in workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -30,7 +30,8 @@ jobs:
         run: dotnet tool install --global dotnet-outdated-tool
 
       - name: Update packages
-        run: dotnet outdated --no-restore -u ./Aspire.sln
+        continue-on-error: true
+        run: dotnet outdated --no-restore -u ./Aspire.sln || echo "Some dependencies could not be updated, but continuing workflow."
 
       - name: Revert all changes except Directory.Packages.props
         run: |


### PR DESCRIPTION
## Description

Sometimes dotnet outdated tool can return an error exit code if one of the dependencies failed to be updated (could be for different reasons). This change makes it so that even if some dependencies are unable to be updated, the workflow will continue to run and update the rest of the dependencies.

cc: @eerhardt @radical 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
