### PR TITLE
Make manifest publisher available to aspire publish command.

### DIFF
--- a/playground/waitfor/WaitForSandbox.AppHost/pg-kv-roles.module.bicep
+++ b/playground/waitfor/WaitForSandbox.AppHost/pg-kv-roles.module.bicep
@@ -11,11 +11,11 @@ resource pg_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: pg_kv_outputs_name
 }
 
-resource pg_kv_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(pg_kv.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
+resource pg_kv_KeyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(pg_kv.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6'))
   properties: {
     principalId: principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
     principalType: principalType
   }
   scope: pg_kv

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -400,12 +400,6 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
                 logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
                 return;
             }
-            catch (SocketException ex) when (process.HasExited && process.ExitCode == 0)
-            {
-                logger.LogInformation(ex, "AppHost process exited successfully without opening a backchannel, this can occur in publish mode.");
-                backchannelCompletionSource.SetResult(backchannel); // We return the backchannel here anyway.
-                return;
-            }
             catch (SocketException ex) when (process.HasExited && process.ExitCode != 0)
             {
                 logger.LogError(ex, "AppHost process has exited. Unable to connect to backchannel at {SocketPath}", socketPath);

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -366,7 +366,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         // Publishing support
         Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.MutateHttp2TransportAsync);
-        _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, ManifestPublisher>("manifest");
+        this.AddPublisher<ManifestPublisher, PublishingOptions>("manifest");
         _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, DockerContainerRuntime>("docker");
         _innerBuilder.Services.AddKeyedSingleton<IContainerRuntime, PodmanContainerRuntime>("podman");
         _innerBuilder.Services.AddSingleton<IResourceContainerImageBuilder, ResourceContainerImageBuilder>();

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -40,13 +40,13 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
             // compatibility with AZD, but also support manifest publishing via the Aspire CLI
             // where the output path is a directory (since not all publishers use a manifest).
             _options.Value.OutputPath = Path.Combine(_options.Value.OutputPath, "aspire-manifest.json");
-            var parentDirectory = Directory.GetParent(_options.Value.OutputPath);
-            
-            if (!Directory.Exists(parentDirectory!.FullName))
-            {
-                // Create the directory if it does not exist
-                Directory.CreateDirectory(parentDirectory.FullName);
-            }
+        }
+
+        var parentDirectory = Directory.GetParent(_options.Value.OutputPath);
+        if (!Directory.Exists(parentDirectory!.FullName))
+        {
+            // Create the directory if it does not exist
+            Directory.CreateDirectory(parentDirectory.FullName);
         }
 
         using var stream = new FileStream(_options.Value.OutputPath, FileMode.Create);

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -37,7 +37,7 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
             // If the manifest path ends with .json we assume that the output path was specified
             // as a filename. If not, we assume that the output path was specified as a directory
             // and append aspire-manifest.json to the path. This is so that we retain backwards
-            // compatability with AZD, but also support manifest publishing via the Aspire CLI
+            // compatibility with AZD, but also support manifest publishing via the Aspire CLI
             // where the output path is a directory (since not all publishers use a manifest).
             _options.Value.OutputPath = Path.Combine(_options.Value.OutputPath, "aspire-manifest.json");
             var parentDirectory = Directory.GetParent(_options.Value.OutputPath);

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -32,6 +32,23 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
                 );
         }
 
+        if (!_options.Value.OutputPath.EndsWith(".json"))
+        {
+            // If the manifest path ends with .json we assume that the output path was specified
+            // as a filename. If not, we assume that the output path was specified as a directory
+            // and append aspire-manifest.json to the path. This is so that we retain backwards
+            // compatability with AZD, but also support manifest publishing via the Aspire CLI
+            // where the output path is a directory (since not all publishers use a manifest).
+            _options.Value.OutputPath = Path.Combine(_options.Value.OutputPath, "aspire-manifest.json");
+            var parentDirectory = Directory.GetParent(_options.Value.OutputPath);
+            
+            if (!Directory.Exists(parentDirectory!.FullName))
+            {
+                // Create the directory if it does not exist
+                Directory.CreateDirectory(parentDirectory.FullName);
+            }
+        }
+
         using var stream = new FileStream(_options.Value.OutputPath, FileMode.Create);
         using var jsonWriter = JsonWriter ?? new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
 
@@ -44,6 +61,7 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
     protected async Task WriteManifestAsync(DistributedApplicationModel model, Utf8JsonWriter jsonWriter, CancellationToken cancellationToken)
     {
         var manifestPath = _options.Value.OutputPath ?? throw new DistributedApplicationException("The '--output-path [path]' option was not specified even though '--publisher manifest' argument was used.");
+
         var context = new ManifestPublishingContext(_executionContext, manifestPath, jsonWriter, cancellationToken);
 
         await context.WriteModel(model, cancellationToken).ConfigureAwait(false);

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostBackchannelTests.cs
@@ -171,6 +171,7 @@ public class AppHostBackchannelTests(ITestOutputHelper outputHelper)
 
         Assert.Collection(
             publishers,
+            x => Assert.Equal("manifest", x),
             x => Assert.Equal("dummy1", x),
             x => Assert.Equal("dummy2", x)
             );
@@ -215,6 +216,7 @@ public class AppHostBackchannelTests(ITestOutputHelper outputHelper)
 
         Assert.Collection(
             publishers,
+            x => Assert.Equal("manifest", x),
             x => Assert.Equal("dummy1", x),
             x => Assert.Equal("dummy2", x)
             );

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -534,7 +534,7 @@ public class ManifestGenerationTests
 
     private static string[] GetManifestArgs()
     {
-        var manifestPath = Path.GetTempFileName();
+        var manifestPath = Path.Combine(Path.GetTempPath(), "tempmanifests", Guid.NewGuid().ToString(), "manifest.json");
         return ["--publisher", "manifest", "--output-path", manifestPath];
     }
 }


### PR DESCRIPTION
Fixes: #8254

A few things needed to be done here. Firstly we needed to register the manifest publisher like we do other publishers. Secondly need to handle the fact that the manifest publisher when invoked via dotnet run on the apphost takes an output path with a filename, not a directory.

This PR detects when a filename is being used and if not interprets the path as a directory (its a file if it has a .json extension).

Finally, the manifest publisher is pretty quick at the moment because it doesn't do image builds. As a result the apphost process exits before the backchannel can be established. So I revised the code in the CLI runner to accommodate a fast running publisher.