### PR TITLE
Fix container shutdown issue with apphost termination

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -9,7 +9,7 @@ using StreamJsonRpc;
 
 namespace Aspire.Cli.Backchannel;
 
-internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, CliRpcTarget target) : IDisposable
+internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, CliRpcTarget target)
 {
     private readonly TaskCompletionSource<JsonRpc> _rpcTaskCompletionSource = new();
     private Process? _process;
@@ -112,18 +112,6 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         await foreach (var state in resourceStates.WithCancellation(cancellationToken))
         {
             yield return state;
-        }
-    }
-
-    public void Dispose()
-    {
-        try
-        {
-            _process?.Kill();
-        }
-        catch (Exception ex)
-        {
-            logger.LogTrace(ex, "Process kill failed. This may be expected if the process has already exited.");
         }
     }
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -418,7 +418,7 @@ public class Program
                             backchannelCompletionSource,
                             ct).ConfigureAwait(false);
 
-                        using var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
+                        var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
                         var publishers = await backchannel.GetPublishersAsync(ct).ConfigureAwait(false);
 
                         return publishers;
@@ -473,7 +473,7 @@ public class Program
                         backchannelCompletionSource,
                         ct);
 
-                    using var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
+                    var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
 
                     launchingAppHostTask.Value = 100;
                     launchingAppHostTask.StopTask();

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -655,7 +655,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var unhealthyEvent = await app.ResourceNotifications.WaitForResourceAsync("resource", e => e.Snapshot.HealthStatus == HealthStatus.Unhealthy).DefaultTimeout();
         Assert.Equal(HealthStatus.Unhealthy, unhealthyEvent.Snapshot.HealthStatus);
 
-        await app.StopAsync().DefaultTimeout();
+        await app.StopAsync().TimeoutAfter(TestConstants.LongTimeoutTimeSpan);
     }
 
     private sealed class ParentResource(string name) : Resource(name)

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -46,7 +46,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var healthyEvent = await app.ResourceNotifications.WaitForResourceHealthyAsync("resource").DefaultTimeout();
         Assert.Equal(HealthStatus.Healthy, healthyEvent.Snapshot.HealthStatus);
 
-        await app.StopAsync().DefaultTimeout();
+        await app.StopAsync().TimeoutAfter(TestConstants.LongTimeoutTimeSpan);
 
         Assert.Contains(testSink.Writes, w => w.Message == "Resource 'resource' has no health checks to monitor.");
     }


### PR DESCRIPTION
Addressed a problem where containers did not shut down cleanly when the apphost was terminated. Removed the Dispose method to prevent forced termination of the process, allowing for a more graceful shutdown. This means that DCP processes hang-around to do their clean-up after the AppHost gets the propogated CTRL-C.