### PR TITLE
Fix test failure due to missing entry in CPM file

### DIFF
--- a/tests/Shared/RepoTesting/Directory.Packages.Helix.props
+++ b/tests/Shared/RepoTesting/Directory.Packages.Helix.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Aspire.Azure.Security.KeyVault" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Confluent.Kafka" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Elastic.Clients.Elasticsearch" Version="$(PackageVersion)" />
 


### PR DESCRIPTION
## Description

When we run the tests in helix, we run against our built packages as opposed to package versions. A recent change modified one of our test playground apps to use a new project reference (which in Helix is treated as a package version) but that new package wasn't added to the Helix-specific CPM file, causing the test to fail and break the build in Helix. This pull request includes an update to the `tests/Shared/RepoTesting/Directory.Packages.Helix.props` file to add a new package version.

cc: @eerhardt @davidfowl @sebastienros @radical 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
