### PR TITLE
Change publisher extension namespaces

### DIFF
--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -3,10 +3,6 @@
 
 #pragma warning disable ASPIREPUBLISHERS001
 
-using Aspire.Hosting.Azure;
-using Aspire.Hosting.Docker;
-using Aspire.Hosting.Kubernetes;
-
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureContainerAppEnvironment("env");

--- a/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.Azure;
 
-namespace Aspire.Hosting.Azure;
+namespace Aspire.Hosting;
 
 /// <summary>
 /// Extensions for adding the Azure publisher to the application model.

--- a/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
@@ -3,7 +3,9 @@
 
 #pragma warning disable ASPIREPUBLISHERS001
 
-namespace Aspire.Hosting.Docker;
+using Aspire.Hosting.Docker;
+
+namespace Aspire.Hosting;
 
 /// <summary>
 /// Extensions for adding a Docker Compose publisher to the application model.

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
@@ -3,7 +3,9 @@
 
 #pragma warning disable ASPIREPUBLISHERS001
 
-namespace Aspire.Hosting.Kubernetes;
+using Aspire.Hosting.Kubernetes;
+
+namespace Aspire.Hosting;
 
 /// <summary>
 /// Extensions for adding a Kubernetes publisher to the application model.


### PR DESCRIPTION
Refactor publisher extension namespaces to unify them under a single namespace to make them more discoverable.

Fixes #8309