### PR TITLE
Fix aspire new --help throwing error.

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -583,17 +583,6 @@ public class Program
         command.Options.Add(sourceOption);
 
         var templateVersionOption = new Option<string?>("--version", "-v");
-        templateVersionOption.DefaultValueFactory = (result) => 
-        {
-            if (result.GetValue<bool>("--prerelease"))
-            {
-                return "*-*";
-            }
-            else
-            {
-                return VersionHelper.GetDefaultTemplateVersion();
-            }
-        };
         command.Options.Add(templateVersionOption);
 
         command.SetAction(async (parseResult, ct) => {
@@ -602,6 +591,22 @@ public class Program
             _ = app.RunAsync(ct);
 
             var templateVersion = parseResult.GetValue<string>("--version");
+            var prerelease = parseResult.GetValue<bool>("--prerelease");
+
+            if (templateVersion is not null && prerelease)
+            {
+                AnsiConsole.MarkupLine("[red bold]:thumbs_down:  The --version and --prerelease options are mutually exclusive.[/]");
+                return ExitCodeConstants.FailedToCreateNewProject;
+            }
+            else if (prerelease)
+            {
+                templateVersion = "*-*";
+            }
+            else if (templateVersion is null)
+            {
+                templateVersion = VersionHelper.GetDefaultTemplateVersion();
+            }
+
             var source = parseResult.GetValue<string?>("--source");
 
             var templateInstallResult = await AnsiConsole.Status()


### PR DESCRIPTION
Fixes #8394

The problem was that the default value factory cannot access other parsed values.

I also cleaned up the logic a little bit so its easier to guess what is going to happen.

Now you cannot use -v and --prerelease at the same time. With neither specified the template version will be the same as the CLI version (whether it is prerelease or not).

If you specify --prerelease then we'll use *-* and you'll get the highest package version from the feeds.

If you specify -v you'll get exactly what you specified.

`aspire new` will fail if all the dependencies aren't available in the source feeds.