### PR TITLE
Link resources in more cases

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs
@@ -77,6 +77,8 @@ public static class AzureBicepResourceExtensions
     public static IResourceBuilder<T> WithEnvironment<T>(this IResourceBuilder<T> builder, string name, BicepOutputReference bicepOutputReference)
         where T : IResourceWithEnvironment
     {
+        builder.WithResourceRelationship(bicepOutputReference.Resource);
+
         return builder.WithEnvironment(ctx =>
         {
             ctx.EnvironmentVariables[name] = bicepOutputReference;
@@ -205,6 +207,9 @@ public static class AzureBicepResourceExtensions
         where T : AzureBicepResource
     {
         BicepIdentifierHelpers.ThrowIfInvalid(name);
+
+        builder.WithResourceRelationship(value);
+
         builder.Resource.Parameters[name] = value;
         return builder;
     }
@@ -221,6 +226,9 @@ public static class AzureBicepResourceExtensions
         where T : AzureBicepResource
     {
         BicepIdentifierHelpers.ThrowIfInvalid(name);
+
+        builder.WithResourceRelationship(value.Resource);
+
         builder.Resource.Parameters[name] = value.Resource;
         return builder;
     }
@@ -237,6 +245,9 @@ public static class AzureBicepResourceExtensions
         where T : AzureBicepResource
     {
         BicepIdentifierHelpers.ThrowIfInvalid(name);
+
+        builder.WithResourceRelationship(value.Resource);
+
         builder.Resource.Parameters[name] = value;
         return builder;
     }
@@ -253,6 +264,9 @@ public static class AzureBicepResourceExtensions
         where T : AzureBicepResource
     {
         BicepIdentifierHelpers.ThrowIfInvalid(name);
+
+        builder.WithResourceRelationship(value);
+
         builder.Resource.Parameters[name] = value;
         return builder;
     }
@@ -269,6 +283,9 @@ public static class AzureBicepResourceExtensions
         where T : AzureBicepResource
     {
         BicepIdentifierHelpers.ThrowIfInvalid(name);
+
+        builder.WithResourceRelationship(value.Resource);
+
         builder.Resource.Parameters[name] = value;
         return builder;
     }

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -39,6 +39,7 @@ public static class ConnectionStringBuilderExtensions
     {
         var cs = new ConnectionStringResource(name, connectionStringExpression);
         return builder.AddResource(cs)
+                      .WithResourceRelationship(connectionStringExpression)
                       .WithInitialState(new CustomResourceSnapshot
                       {
                           ResourceType = "ConnectionString",

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -52,6 +52,8 @@ public static class ResourceBuilderExtensions
 
         var expression = value.GetExpression();
 
+        builder.WithResourceRelationship(expression);
+
         return builder.WithEnvironment(context =>
         {
             context.EnvironmentVariables[name] = expression;
@@ -72,6 +74,8 @@ public static class ResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
         ArgumentNullException.ThrowIfNull(value);
+
+        builder.WithResourceRelationship(value);
 
         return builder.WithEnvironment(context =>
         {
@@ -140,6 +144,8 @@ public static class ResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(name);
         ArgumentNullException.ThrowIfNull(endpointReference);
 
+        builder.WithResourceRelationship(endpointReference.Resource);
+
         return builder.WithEnvironment(context =>
         {
             context.EnvironmentVariables[name] = endpointReference;
@@ -159,6 +165,8 @@ public static class ResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(name);
         ArgumentNullException.ThrowIfNull(parameter);
+
+        builder.WithResourceRelationship(parameter.Resource);
 
         return builder.WithEnvironment(context =>
         {
@@ -183,6 +191,8 @@ public static class ResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(envVarName);
         ArgumentNullException.ThrowIfNull(resource);
+
+        builder.WithResourceRelationship(resource.Resource);
 
         return builder.WithEnvironment(context =>
         {
@@ -216,6 +226,8 @@ public static class ResourceBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(args);
+
+        WalkAndLinkResourceReferences(builder, args);
 
         return builder.WithArgs(context => context.Args.AddRange(args));
     }
@@ -351,7 +363,7 @@ public static class ResourceBuilderExtensions
         var resource = source.Resource;
         connectionName ??= resource.Name;
 
-        builder.WithRelationship(resource, KnownRelationshipTypes.Reference);
+        builder.WithResourceRelationship(resource);
 
         return builder.WithEnvironment(context =>
         {
@@ -457,7 +469,7 @@ public static class ResourceBuilderExtensions
             endpointReferenceAnnotation.EndpointNames.Add(endpointName);
         }
 
-        builder.WithRelationship(resourceWithEndpoints, KnownRelationshipTypes.Reference);
+        builder.WithResourceRelationship(resourceWithEndpoints);
     }
 
     /// <summary>
@@ -1658,6 +1670,89 @@ public static class ResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(type);
 
         return builder.WithAnnotation(new ResourceRelationshipAnnotation(resource, type));
+    }
+
+    /// <summary>
+    /// Adds a <see cref="ResourceRelationshipAnnotation"/> to the resource annotations to add a reference to another resource.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="resource">The resource that the relationship is to.</param>
+    /// <returns>A resource builder.</returns>
+    public static IResourceBuilder<T> WithResourceRelationship<T>(
+        this IResourceBuilder<T> builder,
+        IResource resource) where T : IResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return builder.WithAnnotation(new ResourceRelationshipAnnotation(resource, KnownRelationshipTypes.Reference));
+    }
+
+    /// <summary>
+    /// Walks the reference expression and adds <see cref="ResourceRelationshipAnnotation"/>s for all resources found in the expression.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="expression">The reference expression.</param>
+    /// <returns>A resource builder.</returns>
+    public static IResourceBuilder<T> WithResourceRelationship<T>(
+        this IResourceBuilder<T> builder,
+        ReferenceExpression expression) where T : IResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(expression);
+
+        WalkAndLinkResourceReferences(builder, expression.ValueProviders);
+
+        return builder;
+    }
+
+    private static void WalkAndLinkResourceReferences<T>(IResourceBuilder<T> builder, IEnumerable<object> values)
+        where T : IResource
+    {
+        foreach (var value in values)
+        {
+            if (value is IResource resource)
+            {
+                builder.WithResourceRelationship(resource);
+            }
+            else if (value is IResourceBuilder<IResource> resourceBuilder)
+            {
+                builder.WithResourceRelationship(resourceBuilder);
+            }
+            else if (value is IValueWithReferences valueWithReferences)
+            {
+                foreach (var reference in valueWithReferences.References)
+                {
+                    if (reference is IResource resourceReference)
+                    {
+                        builder.WithResourceRelationship(resourceReference);
+                    }
+                    else if (reference is IResourceBuilder<IResource> resourceBuilderReference)
+                    {
+                        builder.WithResourceRelationship(resourceBuilderReference);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds a <see cref="ResourceRelationshipAnnotation"/> to the resource annotations to add a reference to another resource.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="resourceBuilder">The resource builder that the relationship is to.</param>
+    /// <returns>A resource builder.</returns>
+    public static IResourceBuilder<T> WithResourceRelationship<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<IResource> resourceBuilder) where T : IResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(resourceBuilder);
+
+        return builder.WithAnnotation(new ResourceRelationshipAnnotation(resourceBuilder.Resource, KnownRelationshipTypes.Reference));
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -70,6 +70,26 @@ public class AzureBicepProvisionerTests
         Assert.Equal("paramValue", parameters["param"]?["value"]?.ToString());
         Assert.Equal("paramValue/1", parameters["expr"]?["value"]?.ToString());
         Assert.Equal("http://localhost:1023", parameters["endpoint"]?["value"]?.ToString());
+
+        // We don't yet process relationships set via the callbacks
+        // so we don't see the testResource2 nor exe1
+        Assert.True(bicep0.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Collection(relationships.DistinctBy(r => (r.Resource, r.Type)),
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(connectionStringResource.Resource, r.Resource);
+            },
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(param.Resource, r.Resource);
+            },
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(container.Resource, r.Resource);
+            });
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Containers.Tests/ContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ContainerResourceTests.cs
@@ -120,6 +120,10 @@ public class ContainerResourceTests
             arg => Assert.Equal("http://c1:1234", arg), // this is the container hostname
             arg => Assert.Equal("connectionString", arg));
 
+        // We don't yet process relationships set via the callbacks
+        // so we don't see the testResource2 nor exe1
+        Assert.False(c2.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+
         var manifest = await ManifestUtils.GetManifest(c2.Resource);
 
         var expectedManifest =

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -48,6 +48,16 @@ public class ExecutableResourceTests
             arg => Assert.Equal("anotherConnectionString", arg)
             );
 
+        Assert.True(exe2.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        // We don't yet process relationships set via the callbacks
+        // so we don't see the testResource2 nor exe1
+        Assert.Collection(relationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(testResource, r.Resource);
+            });
+
         var manifest = await ManifestUtils.GetManifest(exe2.Resource).DefaultTimeout();
 
         var expectedManifest =

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -591,6 +591,9 @@ public class ProjectResourceTests
         Assert.Collection(args,
             arg => Assert.Equal("arg1", arg),
             arg => Assert.Equal("http://localhost:1234", arg));
+
+        // We don't yet process relationships set via the callbacks
+        Assert.False(project.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -55,6 +55,14 @@ public class WithEnvironmentTests
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.Equal("https://localhost:2000", config["myName"]);
+
+        Assert.True(projectB.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Collection(relationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(projectA.Resource, r.Resource);
+            });
     }
 
     [Fact]
@@ -117,6 +125,14 @@ public class WithEnvironmentTests
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectA.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.Equal("MY_PARAMETER_VALUE", config["MY_PARAMETER"]);
+
+        Assert.True(projectA.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Collection(relationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(parameter.Resource, r.Resource);
+            });
     }
 
     [Fact]
@@ -236,6 +252,19 @@ public class WithEnvironmentTests
         Assert.Equal("{container1.bindings.primary.port}", manifestConfig["PORT"]);
         Assert.Equal("{container1.bindings.primary.targetPort}", manifestConfig["TARGET_PORT"]);
         Assert.Equal("{test.connectionString};name=1", manifestConfig["HOST"]);
+
+        Assert.True(containerB.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Collection(relationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(container.Resource, r.Resource);
+            },
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(test.Resource, r.Resource);
+            });
     }
 
     [Fact]
@@ -289,6 +318,14 @@ public class WithEnvironmentTests
 
         // Assert
         Assert.Single(publishConfig, kvp => kvp.Key == envVarName && kvp.Value == "{sourceService.connectionString}");
+
+        Assert.True(targetBuilder.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Collection(relationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(sourceBuilder.Resource, r.Resource);
+            });
     }
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -338,8 +338,6 @@ public class WithReferenceTests
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
         Assert.Equal(1, servicesKeysCount);
         Assert.Equal("Endpoint=http://localhost:3452;Key=secretKey", config["ConnectionStrings__cs"]);
-
-        
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -29,6 +29,14 @@ public class WithReferenceTests
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.Equal("https://localhost:2000", config["services__projecta__mybinding__0"]);
+
+        Assert.True(projectB.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Collection(relationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(projectA.Resource, r.Resource);
+            });
     }
 
     [Fact]
@@ -101,6 +109,14 @@ public class WithReferenceTests
 
         Assert.Equal("https://localhost:2000", config["services__projecta__mybinding__0"]);
         Assert.Equal("https://localhost:3000", config["services__projecta__mybinding2__0"]);
+
+        Assert.True(projectB.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Collection(relationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(projectA.Resource, r.Resource);
+            });
     }
 
     [Fact]
@@ -122,6 +138,14 @@ public class WithReferenceTests
 
         Assert.Equal("https://localhost:2000", config["services__projecta__mybinding__0"]);
         Assert.Equal("http://localhost:3000", config["services__projecta__mybinding2__0"]);
+
+        Assert.True(projectB.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Collection(relationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(projectA.Resource, r.Resource);
+            });
     }
 
     [Fact]
@@ -268,6 +292,27 @@ public class WithReferenceTests
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
         Assert.Equal(1, servicesKeysCount);
         Assert.Equal("Endpoint=http://localhost:3452;Key=secretKey", config["ConnectionStrings__cs"]);
+
+        Assert.True(projectB.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
+        Assert.Collection(relationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(resource.Resource, r.Resource);
+            });
+
+        Assert.True(resource.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var csRelationships));
+        Assert.Collection(csRelationships,
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(endpoint.Resource, r.Resource);
+            },
+            r =>
+            {
+                Assert.Equal("Reference", r.Type);
+                Assert.Same(key.Resource, r.Resource);
+            });
     }
 
     [Fact]
@@ -293,6 +338,8 @@ public class WithReferenceTests
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
         Assert.Equal(1, servicesKeysCount);
         Assert.Equal("Endpoint=http://localhost:3452;Key=secretKey", config["ConnectionStrings__cs"]);
+
+        
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Added resource linking in more methods and handle more cases (like ReferenceExpression's). Exposed a new method `WithResourceRelationship` to avoid leaking the name "Resource" as a known relationship type. Added lots of tests to assert the current behavior.

Fixes #8345

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
