### PR TITLE
Property grid visualizer uses name value as title

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -25,7 +25,7 @@
                        HighlightText="@HighlightText" />
         </AspireTemplateColumn>
         <AspireTemplateColumn Title="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])" Class="valueColumn" SortBy="@ValueSort" Sortable="@IsValueSortable">
-            <GridValue ValueDescription="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])"
+            <GridValue ValueDescription="@context.Name"
                        Value="@context.Value"
                        ContentAfterValue="@GetContentAfterValue(context)"
                        EnableHighlighting="@(!string.IsNullOrEmpty(HighlightText))"

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -25,7 +25,7 @@
                        HighlightText="@HighlightText" />
         </AspireTemplateColumn>
         <AspireTemplateColumn Title="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])" Class="valueColumn" SortBy="@ValueSort" Sortable="@IsValueSortable">
-            <GridValue ValueDescription="@context.Name"
+            <GridValue ValueDescription="@(context.Name ?? ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])"
                        Value="@context.Value"
                        ContentAfterValue="@GetContentAfterValue(context)"
                        EnableHighlighting="@(!string.IsNullOrEmpty(HighlightText))"


### PR DESCRIPTION
An improvement I noticed we could make.

When viewing the value for the `REDIS_PASSWORD` env var:

Before:
![image](https://github.com/user-attachments/assets/bace1f10-556e-4de2-a2f9-3ae9de291213)

After:
![image](https://github.com/user-attachments/assets/d67685b3-2333-4149-bd02-2489349b4242)


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
