### PR TITLE
Add tracing to the CLI

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="StreamJsonRpc" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -31,6 +31,24 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         return responseTimestamp;
     }
 
+    public async Task RequestStopAsync(CancellationToken cancellationToken)
+    {
+        // This RPC call is required to allow the CLI to trigger a clean shutdown
+        // of the AppHost process. The AppHost process will then trigger the shutdown
+        // which will allow the CLI to await the pending run.
+
+        using var activity = _activitySource.StartActivity(nameof(RequestStopAsync), ActivityKind.Client);
+
+        var rpc = await _rpcTaskCompletionSource.Task;
+
+        logger.LogDebug("Requesting stop");
+
+        await rpc.InvokeWithCancellationAsync(
+            "RequestStopAsync",
+            Array.Empty<object>(),
+            cancellationToken);
+    }
+
     public async Task<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)> GetDashboardUrlsAsync(CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity(nameof(GetDashboardUrlsAsync), ActivityKind.Client);

--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -11,11 +11,14 @@ namespace Aspire.Cli.Backchannel;
 
 internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, CliRpcTarget target)
 {
+    private readonly ActivitySource _activitySource = new(nameof(Aspire.Cli.Backchannel.AppHostBackchannel), "1.0.0");
     private readonly TaskCompletionSource<JsonRpc> _rpcTaskCompletionSource = new();
     private Process? _process;
 
     public async Task<long> PingAsync(long timestamp, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(PingAsync), ActivityKind.Client);
+
         var rpc = await _rpcTaskCompletionSource.Task;
 
         logger.LogDebug("Sent ping with timestamp {Timestamp}", timestamp);
@@ -30,6 +33,8 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async Task<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)> GetDashboardUrlsAsync(CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(GetDashboardUrlsAsync), ActivityKind.Client);
+
         var rpc = await _rpcTaskCompletionSource.Task;
 
         logger.LogDebug("Requesting dashboard URL");
@@ -44,6 +49,8 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> GetResourceStatesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(GetResourceStatesAsync), ActivityKind.Client);
+
         var rpc = await _rpcTaskCompletionSource.Task;
 
         logger.LogDebug("Requesting resource states");
@@ -63,6 +70,8 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async Task ConnectAsync(Process process, string socketPath, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(ConnectAsync), ActivityKind.Client);
+
         _process = process;
 
         if (_rpcTaskCompletionSource.Task.IsCompleted)
@@ -84,6 +93,8 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async Task<string[]> GetPublishersAsync(CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(GetPublishersAsync), ActivityKind.Client);
+
         var rpc = await _rpcTaskCompletionSource.Task.ConfigureAwait(false);
 
         logger.LogDebug("Requesting publishers");
@@ -98,6 +109,8 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(GetPublishingActivitiesAsync), ActivityKind.Client);
+
         var rpc = await _rpcTaskCompletionSource.Task;
 
         logger.LogDebug("Requesting publishing activities.");

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -15,12 +15,22 @@ namespace Aspire.Cli;
 
 internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider serviceProvider)
 {
+    private readonly ActivitySource _activitySource = new ActivitySource(nameof(Aspire.Cli.DotNetCliRunner));
+
     internal Func<int> GetCurrentProcessId { get; set; } = () => Environment.ProcessId;
 
-    public async Task<int> RunAsync(FileInfo projectFile, bool watch, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
+    public async Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(RunAsync), ActivityKind.Client);
+
+        if (watch && noBuild)
+        {
+            throw new InvalidOperationException("Cannot use --watch and --no-build at the same time.");
+        }
+
         var watchOrRunCommand = watch ? "watch" : "run";
-        string[] cliArgs = [watchOrRunCommand, "--project", projectFile.FullName, "--", ..args];
+        var noBuildSwitch = noBuild ? "--no-build" : string.Empty;
+        string[] cliArgs = [watchOrRunCommand, noBuildSwitch, "--project", projectFile.FullName, "--", ..args];
         return await ExecuteAsync(
             args: cliArgs,
             env: env,
@@ -32,6 +42,8 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> CheckHttpCertificateAsync(CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(CheckHttpCertificateAsync), ActivityKind.Client);
+
         string[] cliArgs = ["dev-certs", "https", "--check", "--trust"];
         return await ExecuteAsync(
             args: cliArgs,
@@ -44,6 +56,8 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> TrustHttpCertificateAsync(CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(TrustHttpCertificateAsync), ActivityKind.Client);
+
         string[] cliArgs = ["dev-certs", "https", "--trust"];
         return await ExecuteAsync(
             args: cliArgs,
@@ -56,6 +70,8 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(InstallTemplateAsync), ActivityKind.Client);
+
         List<string> cliArgs = ["new", "install", $"{packageName}::{version}"];
 
         if (force)
@@ -156,6 +172,8 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> NewProjectAsync(string templateName, string name, string outputPath, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(NewProjectAsync), ActivityKind.Client);
+
         string[] cliArgs = ["new", templateName, "--name", name, "--output", outputPath];
         return await ExecuteAsync(
             args: cliArgs,
@@ -183,6 +201,8 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, Action<StreamWriter, StreamReader, StreamReader>? streamsCallback, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(ExecuteAsync), ActivityKind.Client);
+
         var startInfo = new ProcessStartInfo("dotnet")
         {
             WorkingDirectory = workingDirectory.FullName,
@@ -301,7 +321,9 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     private async Task StartBackchannelAsync(Process process, string socketPath, TaskCompletionSource<AppHostBackchannel> backchannelCompletionSource, CancellationToken cancellationToken)
     {
-        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(250));
+        using var activity = _activitySource.StartActivity(nameof(StartBackchannelAsync), ActivityKind.Client);
+
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
 
         var backchannel = serviceProvider.GetRequiredService<AppHostBackchannel>();
         var connectionAttempts = 0;
@@ -349,34 +371,49 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         } while (await timer.WaitForNextTickAsync(cancellationToken));
     }
 
-    public async Task<int> AddPackageAsync(FileInfo projectFilepath, string packageName, string packageVersion, CancellationToken cancellationToken)
+    public async Task<int> BuildAsync(FileInfo projectFilePath, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(BuildAsync), ActivityKind.Client);
+
+        string[] cliArgs = ["build", projectFilePath.FullName];
+        return await ExecuteAsync(
+            args: cliArgs,
+            env: null,
+            workingDirectory: projectFilePath.Directory!,
+            backchannelCompletionSource: null,
+            streamsCallback: null,
+            cancellationToken: cancellationToken);
+    }
+    public async Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, CancellationToken cancellationToken)
+    {
+        using var activity = _activitySource.StartActivity(nameof(AddPackageAsync), ActivityKind.Client);
+
         string[] cliArgs = [
             "add",
-            projectFilepath.FullName,
+            projectFilePath.FullName,
             "package",
             packageName,
             "--version",
             packageVersion
         ];
 
-        logger.LogInformation("Adding package {PackageName} with version {PackageVersion} to project {ProjectFilePath}", packageName, packageVersion, projectFilepath.FullName);
+        logger.LogInformation("Adding package {PackageName} with version {PackageVersion} to project {ProjectFilePath}", packageName, packageVersion, projectFilePath.FullName);
 
         var result = await ExecuteAsync(
             args: cliArgs,
             env: null,
-            workingDirectory: projectFilepath.Directory!,
+            workingDirectory: projectFilePath.Directory!,
             backchannelCompletionSource: null,
             streamsCallback: (_, _, _) => { },
             cancellationToken: cancellationToken);
 
         if (result != 0)
         {
-            logger.LogError("Failed to add package {PackageName} with version {PackageVersion} to project {ProjectFilePath}. See debug logs for more details.", packageName, packageVersion, projectFilepath.FullName);
+            logger.LogError("Failed to add package {PackageName} with version {PackageVersion} to project {ProjectFilePath}. See debug logs for more details.", packageName, packageVersion, projectFilePath.FullName);
         }
         else
         {
-            logger.LogInformation("Package {PackageName} with version {PackageVersion} added to project {ProjectFilePath}", packageName, packageVersion, projectFilepath.FullName);
+            logger.LogInformation("Package {PackageName} with version {PackageVersion} added to project {ProjectFilePath}", packageName, packageVersion, projectFilePath.FullName);
         }
 
         return result;
@@ -384,6 +421,8 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(FileInfo projectFilePath, string query, bool prerelease, int take, int skip, string? nugetSource, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(SearchPackagesAsync), ActivityKind.Client);
+
         List<string> cliArgs = [
             "package",
             "search",

--- a/src/Aspire.Cli/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGetPackageCache.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli;
@@ -12,10 +13,14 @@ internal interface INuGetPackageCache
 
 internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNetCliRunner cliRunner) : INuGetPackageCache
 {
+    private readonly ActivitySource _activitySource = new(nameof(Aspire.Cli.NuGetPackageCache), "1.0.0");
+
     private const int SearchPageSize = 100;
 
     public async Task<IEnumerable<NuGetPackage>> GetPackagesAsync(FileInfo projectFile, bool prerelease, string? source, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity(nameof(GetPackagesAsync), ActivityKind.Client);
+
         logger.LogDebug("Getting integrations from NuGet");
 
         var collectedPackages = new List<NuGetPackage>();

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -160,8 +160,6 @@ public class Program
         command.SetAction(async (parseResult, ct) => {
             using var activity = s_activitySource.StartActivity($"{nameof(ConfigureRunCommand)}-Action", ActivityKind.Internal);
 
-            _ = app.RunAsync(ct);
-
             var runner = app.Services.GetRequiredService<DotNetCliRunner>();
             var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
             var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
@@ -641,7 +639,7 @@ public class Program
         command.SetAction(async (parseResult, ct) => {
             using var activity = s_activitySource.StartActivity($"{nameof(ConfigureNewCommand)}-Action", ActivityKind.Internal);
 
-            var cliRunner = app.Services.GetRequiredService<DotNetCliRunner>();
+            var runner = app.Services.GetRequiredService<DotNetCliRunner>();
 
             var templateVersion = parseResult.GetValue<string>("--version");
             var prerelease = parseResult.GetValue<bool>("--prerelease");
@@ -668,7 +666,7 @@ public class Program
                 .StartAsync(
                     ":ice:  Getting latest templates...",
                     async context => {
-                        return await cliRunner.InstallTemplateAsync("Aspire.ProjectTemplates", templateVersion!, source, true, ct);
+                        return await runner.InstallTemplateAsync("Aspire.ProjectTemplates", templateVersion!, source, true, ct);
                     });
 
             if (templateInstallResult.ExitCode != 0)
@@ -702,7 +700,7 @@ public class Program
                 .StartAsync(
                     ":rocket:  Creating new Aspire project...",
                     async context => {
-                        return await cliRunner.NewProjectAsync(
+                        return await runner.NewProjectAsync(
                     templateName,
                     name,
                     outputPath,
@@ -717,7 +715,7 @@ public class Program
 
             try
             {
-                await EnsureCertificatesTrustedAsync(cliRunner, ct);
+                await EnsureCertificatesTrustedAsync(runner, ct);
             }
             catch (Exception ex)
             {

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -19,7 +20,9 @@ internal class AppHostRpcTarget(
     ResourceNotificationService resourceNotificationService,
     IServiceProvider serviceProvider,
     IDistributedApplicationEventing eventing,
-    PublishingActivityProgressReporter activityReporter) 
+    PublishingActivityProgressReporter activityReporter,
+    IHostApplicationLifetime lifetime
+    ) 
 {
     public async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
     {
@@ -72,6 +75,13 @@ internal class AppHostRpcTarget(
                 endpointUris
                 );
         }
+    }
+
+    public Task RequestStopAsync(CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        lifetime.StopApplication();
+        return Task.CompletedTask;
     }
 
     public Task<long> PingAsync(long timestamp, CancellationToken cancellationToken)


### PR DESCRIPTION
This is an initial pass at adding tracing to the CLI. To see the tracing data you can use the Aspire dashboard. Start the aspire dashboard in standalone mode using the following command:

```
docker run --rm -it `
  -p 18888:18888 `
  -p 4317:18889 `
  --name aspire-dashboard `
  mcr.microsoft.com/dotnet/aspire-dashboard:latest
```

Then before running the `aspire` CLI, run the following command to configure environment variables:

```powershell
$env:OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
$env:OTEL_SERVICE_NAME = "Aspire.Cli"
```

```bash
export OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
export OTEL_SERVICE_NAME = "Aspire.Cli"
```