### PR TITLE
Update visualizer secret warning and fixed regression

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -19,7 +19,7 @@ else
             {
                 <div class="block-warning">
                     <div class="block-warning-icon">
-                        <FluentIcon Value="new Icons.Filled.Size16.ErrorCircle()" Color="Color.Error" />
+                        <FluentIcon Value="new Icons.Filled.Size16.Warning()" Color="Color.Warning" />
                     </div>
 
                     <div class="block-warning-message">

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -19,7 +19,7 @@ else
             {
                 <div class="block-warning">
                     <div class="block-warning-icon">
-                        <FluentIcon Value="new Icons.Filled.Size16.Warning()" Color="Color.Warning" />
+                        <FluentIcon Value="new Icons.Filled.Size16.ErrorCircle()" Color="Color.Error" />
                     </div>
 
                     <div class="block-warning-message">

--- a/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
@@ -11,7 +11,7 @@
     {
         <div class="block-warning">
             <div class="block-warning-icon">
-                <FluentIcon Value="new Icons.Filled.Size16.ErrorCircle()" Color="Color.Error" />
+                <FluentIcon Value="new Icons.Filled.Size16.Warning()" Color="Color.Warning" />
             </div>
 
             <div class="block-warning-message">

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -30,28 +30,8 @@
 </FluentDialogHeader>
 
 <FluentDialogBody>
-    @if (Content.ContainsSecret && ShowContainsSecretsWarning is null)
-    {
-        return;
-    }
-
     <div class="text-visualizer-container">
-        @if (Content.ContainsSecret && ShowContainsSecretsWarning is true)
-        {
-            <div class="block-warning">
-                <div class="block-warning-icon">
-                    <FluentIcon Value="new Icons.Filled.Size16.Warning()" Color="Color.Warning" />
-                </div>
-
-                <div class="block-warning-message">
-                    <span class="title">@Loc[nameof(Dialogs.TextVisualizerSecretWarningTitle)]</span>
-                    @Loc[nameof(Dialogs.TextVisualizerSecretWarningDescription)]
-                </div>
-            </div>
-
-            <FluentButton Class="text-visualizer-unmask-content" OnClick="@UnmaskContentAsync">@Loc[nameof(Dialogs.TextVisualizerSecretWarningAcknowledge)]</FluentButton>
-        }
-        else
+        @if (IsTextContentDisplayed)
         {
             <div class="log-overflow">
                 <div class="log-container" id="@_logContainerId">
@@ -85,11 +65,27 @@
                           Class="text-visualizer-copy"
                           AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(FormattedText, ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
                 <span slot="start">
-                    <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start"/>
-                    <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start"/>
+                    <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
+                    <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
                 </span>
                 @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
             </FluentButton>
+        }
+        else if (ShowSecretsWarning is true)
+        {
+            @* Don't display until ShowSecretsWarning is loaded and is known to be true *@
+            <div class="block-warning">
+                <div class="block-warning-icon">
+                    <FluentIcon Value="new Icons.Filled.Size16.Warning()" Color="Color.Warning" />
+                </div>
+
+                <div class="block-warning-message">
+                    <span class="title">@Loc[nameof(Dialogs.TextVisualizerSecretWarningTitle)]</span>
+                    @Loc[nameof(Dialogs.TextVisualizerSecretWarningDescription)]
+                </div>
+            </div>
+
+            <FluentButton Class="text-visualizer-unmask-content" OnClick="@UnmaskContentAsync">@Loc[nameof(Dialogs.TextVisualizerSecretWarningAcknowledge)]</FluentButton>
         }
     </div>
 </FluentDialogBody>

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -38,9 +38,16 @@
     <div class="text-visualizer-container">
         @if (Content.ContainsSecret && ShowContainsSecretsWarning is true)
         {
-            <FluentMessageBar Title="@Loc[nameof(Dialogs.TextVisualizerSecretWarningTitle)]" Intent="@MessageIntent.Warning" AllowDismiss="false">
-                @Loc[nameof(Dialogs.TextVisualizerSecretWarningDescription)]
-            </FluentMessageBar>
+            <div class="block-warning">
+                <div class="block-warning-icon">
+                    <FluentIcon Value="new Icons.Filled.Size16.Warning()" Color="Color.Warning" />
+                </div>
+
+                <div class="block-warning-message">
+                    <span class="title">@Loc[nameof(Dialogs.TextVisualizerSecretWarningTitle)]</span>
+                    @Loc[nameof(Dialogs.TextVisualizerSecretWarningDescription)]
+                </div>
+            </div>
 
             <FluentButton Class="text-visualizer-unmask-content" OnClick="@UnmaskContentAsync">@Loc[nameof(Dialogs.TextVisualizerSecretWarningAcknowledge)]</FluentButton>
         }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -167,13 +167,13 @@ public class TextVisualizerDialogTests : DashboardTestContext
         await dialogService.ShowDialogAsync<TextVisualizerDialog>(new TextVisualizerDialogViewModel(rawText, string.Empty, ContainsSecret: true), []);
         cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
 
-        Assert.True(cut.HasComponent<FluentMessageBar>());
+        Assert.Single(cut.FindAll(".block-warning"));
         Assert.False(cut.HasComponent<Virtualize<TextVisualizerDialog.StringLogLine>>());
 
         cut.Find(".text-visualizer-unmask-content").Click();
 
         cut.WaitForAssertion(() => Assert.False(cut.FindComponent<TextVisualizerDialog>().Instance.ShowContainsSecretsWarning));
-        Assert.False(cut.HasComponent<FluentMessageBar>());
+        Assert.Empty(cut.FindAll(".block-warning"));
         Assert.True(cut.HasComponent<Virtualize<TextVisualizerDialog.StringLogLine>>());
         Assert.True(setShownDialog);
     }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -153,12 +153,12 @@ public class TextVisualizerDialogTests : DashboardTestContext
     {
         const string rawText = """my text with a secret""";
 
-        bool? setShownDialog = null;
+        bool? secretsWarningAcknowledged = null;
         var localStorage = new TestLocalStorage { OnSetUnprotectedAsync = (_, o) =>
             {
                 if (o is TextVisualizerDialog.TextVisualizerDialogSettings s)
                 {
-                    setShownDialog = s.ContainsSecretsWarningShown;
+                    secretsWarningAcknowledged = s.SecretsWarningAcknowledged;
                 }
             }
         };
@@ -172,10 +172,10 @@ public class TextVisualizerDialogTests : DashboardTestContext
 
         cut.Find(".text-visualizer-unmask-content").Click();
 
-        cut.WaitForAssertion(() => Assert.False(cut.FindComponent<TextVisualizerDialog>().Instance.ShowContainsSecretsWarning));
+        cut.WaitForAssertion(() => Assert.False(cut.FindComponent<TextVisualizerDialog>().Instance.ShowSecretsWarning));
         Assert.Empty(cut.FindAll(".block-warning"));
         Assert.True(cut.HasComponent<Virtualize<TextVisualizerDialog.StringLogLine>>());
-        Assert.True(setShownDialog);
+        Assert.True(secretsWarningAcknowledged);
     }
 
     [Fact]
@@ -184,12 +184,12 @@ public class TextVisualizerDialogTests : DashboardTestContext
         const string rawText = """my text with a secret""";
 
         var localStorage = new TestLocalStorage();
-        localStorage.OnGetUnprotectedAsync = _ => new ValueTuple<bool, object>(true, new TextVisualizerDialog.TextVisualizerDialogSettings(ContainsSecretsWarningShown: true));
+        localStorage.OnGetUnprotectedAsync = _ => new ValueTuple<bool, object>(true, new TextVisualizerDialog.TextVisualizerDialogSettings(SecretsWarningAcknowledged: true));
         var cut = SetUpDialog(out var dialogService, localStorage: localStorage);
         await dialogService.ShowDialogAsync<TextVisualizerDialog>(new TextVisualizerDialogViewModel(rawText, string.Empty, ContainsSecret: true), []);
-        cut.WaitForAssertion(() => Assert.False(cut.FindComponent<TextVisualizerDialog>().Instance.ShowContainsSecretsWarning));
+        cut.WaitForAssertion(() => Assert.False(cut.FindComponent<TextVisualizerDialog>().Instance.ShowSecretsWarning));
 
-        cut.WaitForAssertion(() => Assert.False(cut.FindComponent<TextVisualizerDialog>().Instance.ShowContainsSecretsWarning));
+        cut.WaitForAssertion(() => Assert.False(cut.FindComponent<TextVisualizerDialog>().Instance.ShowSecretsWarning));
         Assert.False(cut.HasComponent<FluentMessageBar>());
         Assert.True(cut.HasComponent<Virtualize<TextVisualizerDialog.StringLogLine>>());
     }


### PR DESCRIPTION
## Description

The text visualizer shows a warning when a secret is displayed for the first time. It was using a message bar control but this was a shortcut to create the right look.

PR replaces the message bar with HTML/CSS that looks functionality the same without needing to use the control.

Also, one of the places where we're already using (capture paused message) this should display a warning icon instead of an error icon.

**Update:** While testing this I found a regression introduced when the secret warning was added. Until you acknowledge the warning, highlighting is broken when viewing non-secrets. I fixed that, removed duplication around how things are shown, and improved some names.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
