### PR TITLE
Fixed issue with PublishAsDockerFile

### DIFF
--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -688,7 +688,11 @@ public static class ProjectResourceBuilderExtensions
         var cb = builder.ApplicationBuilder.AddResource(container);
         // WithImage makes this a container resource (adding the annotation)
         cb.WithImage(builder.Resource.Name);
-        cb.WithDockerfile(contextPath: builder.Resource.GetProjectMetadata().ProjectPath);
+
+        var projectFilePath = builder.Resource.GetProjectMetadata().ProjectPath;
+        var projectDirectoryPath = Path.GetDirectoryName(projectFilePath) ?? throw new InvalidOperationException($"Unable to get directory name for {projectFilePath}");
+
+        cb.WithDockerfile(contextPath: projectDirectoryPath);
         // Arguments to the executable often contain physical paths that are not valid in the container
         // Clear them out so that the container can be set up with the correct arguments
         cb.WithArgs(c => c.Args.Clear());

--- a/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
@@ -215,8 +215,9 @@ public class PublishAsDockerfileTests
         using var tempDir = CreateDirectoryWithDockerFile();
 
         var path = tempDir.Directory.FullName;
+        var projectPath = Path.Combine(path, "project.csproj");
 
-        var project = builder.AddProject("project", path, o => o.ExcludeLaunchProfile = true)
+        var project = builder.AddProject("project", projectPath, o => o.ExcludeLaunchProfile = true)
                             .WithArgs("/usr/foo")
                             .PublishAsDockerFile(c =>
                              {


### PR DESCRIPTION
## Description

Update Dockerfile context path to use project directory instead of project file path

Fixes #8435

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
