### PR TITLE
Add WithHttpsHealthCheck() to start template

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.AppHost/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.AppHost/Program.cs
@@ -4,10 +4,12 @@ var builder = DistributedApplication.CreateBuilder(args);
 var cache = builder.AddRedis("cache");
 
 #endif
-var apiService = builder.AddProject<Projects.GeneratedClassNamePrefix_ApiService>("apiservice");
+var apiService = builder.AddProject<Projects.GeneratedClassNamePrefix_ApiService>("apiservice")
+    .WithHttpsHealthCheck("/health");
 
 builder.AddProject<Projects.GeneratedClassNamePrefix_Web>("webfrontend")
     .WithExternalHttpEndpoints()
+    .WithHttpsHealthCheck("/health")
 #if UseRedisCache
     .WithReference(cache)
     .WaitFor(cache)

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.AppHost/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.AppHost/Program.cs
@@ -5,11 +5,19 @@ var cache = builder.AddRedis("cache");
 
 #endif
 var apiService = builder.AddProject<Projects.GeneratedClassNamePrefix_ApiService>("apiservice")
+#if HasHttpsProfile
     .WithHttpsHealthCheck("/health");
+#else
+    .WithHttpHealthCheck("/health");
+#endif
 
 builder.AddProject<Projects.GeneratedClassNamePrefix_Web>("webfrontend")
     .WithExternalHttpEndpoints()
+#if HasHttpsProfile
     .WithHttpsHealthCheck("/health")
+#else
+    .WithHttpHealthCheck("/health")
+#endif
 #if UseRedisCache
     .WithReference(cache)
     .WaitFor(cache)


### PR DESCRIPTION
## Description

Updates the starter template so that the app host health checks include checking the health checks endpoints of the two ASP.NET Core projects added via `WithHttpsHealthChecks("/health")`.

As suggested here: https://github.com/dotnet/aspire/discussions/8139#discussioncomment-12576305

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
