### PR TITLE
Add cancellationtoken to test templates

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/9.2/IntegrationTest1.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/9.2/IntegrationTest1.cs
@@ -20,6 +20,7 @@ public class IntegrationTest1
     // public async Task GetWebResourceRootReturnsOkStatusCode()
     // {
     //     // Arrange
+    //     var cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
     //     var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.MyAspireApp_AppHost>();
     //     appHost.Services.AddLogging(logging =>
     //     {
@@ -33,13 +34,13 @@ public class IntegrationTest1
     //         clientBuilder.AddStandardResilienceHandler();
     //     });
     //
-    //     await using var app = await appHost.BuildAsync().WaitAsync(DefaultTimeout);
-    //     await app.StartAsync().WaitAsync(DefaultTimeout);
+    //     await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    //     await app.StartAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
     //
     //     // Act
     //     var httpClient = app.CreateHttpClient("webfrontend");
-    //     await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend").WaitAsync(DefaultTimeout);
-    //     var response = await httpClient.GetAsync("/");
+    //     await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend", cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    //     var response = await httpClient.GetAsync("/", cancellationToken);
     //
     //     // Assert
     //     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/9.2/IntegrationTest1.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/9.2/IntegrationTest1.cs
@@ -19,6 +19,7 @@ public class IntegrationTest1
     // public async Task GetWebResourceRootReturnsOkStatusCode()
     // {
     //     // Arrange
+    //     var cancellationToken = TestContext.CurrentContext.CancellationToken;
     //     var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.MyAspireApp_AppHost>();
     //     appHost.Services.AddLogging(logging =>
     //     {
@@ -32,13 +33,13 @@ public class IntegrationTest1
     //         clientBuilder.AddStandardResilienceHandler();
     //     });
     //
-    //     await using var app = await appHost.BuildAsync().WaitAsync(DefaultTimeout);
-    //     await app.StartAsync().WaitAsync(DefaultTimeout);
+    //     await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    //     await app.StartAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
     //
     //     // Act
     //     var httpClient = app.CreateHttpClient("webfrontend");
-    //     await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend").WaitAsync(DefaultTimeout);
-    //     var response = await httpClient.GetAsync("/");
+    //     await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend", cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    //     var response = await httpClient.GetAsync("/", cancellationToken);
     //
     //     // Assert
     //     Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.Tests/WebTests.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.Tests/WebTests.cs
@@ -19,7 +19,17 @@ public class WebTests
     public async Task GetWebResourceRootReturnsOkStatusCode()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.GeneratedClassNamePrefix_AppHost>();
+#if (TestFx == "MSTest")
+        CancellationToken cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
+#elif (TestFx == "NUnit")
+        CancellationToken cancellationToken = TestContext.CurrentContext.CancellationToken;
+#elif (XUnitVersion == "v2")
+        CancellationToken cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
+#else // XunitVersion v3 or v3mtp
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+#endif
+
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.GeneratedClassNamePrefix_AppHost>(cancellationToken);
         appHost.Services.AddLogging(logging =>
         {
             logging.SetMinimumLevel(LogLevel.Debug);
@@ -35,13 +45,13 @@ public class WebTests
             clientBuilder.AddStandardResilienceHandler();
         });
 
-        await using var app = await appHost.BuildAsync().WaitAsync(DefaultTimeout);
-        await app.StartAsync().WaitAsync(DefaultTimeout);
+        await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+        await app.StartAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
 
         // Act
         var httpClient = app.CreateHttpClient("webfrontend");
-        await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend").WaitAsync(DefaultTimeout);
-        var response = await httpClient.GetAsync("/");
+        await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend", cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+        var response = await httpClient.GetAsync("/", cancellationToken);
 
         // Assert
 #if (TestFx == "MSTest")

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.Tests/WebTests.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.Tests/WebTests.cs
@@ -20,13 +20,13 @@ public class WebTests
     {
         // Arrange
 #if (TestFx == "MSTest")
-        CancellationToken cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
+        var cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
 #elif (TestFx == "NUnit")
-        CancellationToken cancellationToken = TestContext.CurrentContext.CancellationToken;
+        var cancellationToken = TestContext.CurrentContext.CancellationToken;
 #elif (XUnitVersion == "v2")
-        CancellationToken cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
+        var cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
 #else // XunitVersion v3 or v3mtp
-        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var cancellationToken = TestContext.Current.CancellationToken;
 #endif
 
         var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.GeneratedClassNamePrefix_AppHost>(cancellationToken);

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/9.2/IntegrationTest1.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/9.2/IntegrationTest1.cs
@@ -20,9 +20,9 @@ public class IntegrationTest1
     // {
     //      // Arrange
 #if (XUnitVersion == "v2")
-    //      CancellationToken cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
+    //      var cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
 #else // XunitVersion v3 or v3mtp
-    //      CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+    //      var cancellationToken = TestContext.Current.CancellationToken;
 #endif
     //      var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.MyAspireApp_AppHost>(cancellationToken);
     //      appHost.Services.AddLogging(logging =>

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/9.2/IntegrationTest1.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/9.2/IntegrationTest1.cs
@@ -18,30 +18,35 @@ public class IntegrationTest1
     // [Fact]
     // public async Task GetWebResourceRootReturnsOkStatusCode()
     // {
-    //     // Arrange
-    //     var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.MyAspireApp_AppHost>();
-    //     appHost.Services.AddLogging(logging =>
-    //     {
-    //         logging.SetMinimumLevel(LogLevel.Debug);
-    //         // Override the logging filters from the app's configuration
-    //         logging.AddFilter(appHost.Environment.ApplicationName, LogLevel.Debug);
-    //         logging.AddFilter("Aspire.", LogLevel.Debug);
-    //         // To output logs to the xUnit.net ITestOutputHelper, consider adding a package from https://www.nuget.org/packages?q=xunit+logging
-    //     });
-    //     appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
-    //     {
-    //         clientBuilder.AddStandardResilienceHandler();
-    //     });
+    //      // Arrange
+#if (XUnitVersion == "v2")
+    //      CancellationToken cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
+#else // XunitVersion v3 or v3mtp
+    //      CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+#endif
+    //      var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.MyAspireApp_AppHost>(cancellationToken);
+    //      appHost.Services.AddLogging(logging =>
+    //      {
+    //          logging.SetMinimumLevel(LogLevel.Debug);
+    //          // Override the logging filters from the app's configuration
+    //          logging.AddFilter(appHost.Environment.ApplicationName, LogLevel.Debug);
+    //          logging.AddFilter("Aspire.", LogLevel.Debug);
+    //          // To output logs to the xUnit.net ITestOutputHelper, consider adding a package from https://www.nuget.org/packages?q=xunit+logging
+    //      });
+    //      appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
+    //      {
+    //          clientBuilder.AddStandardResilienceHandler();
+    //      });
     //
-    //     await using var app = await appHost.BuildAsync().WaitAsync(DefaultTimeout);
-    //     await app.StartAsync().WaitAsync(DefaultTimeout);
+    //      await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    //      await app.StartAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
     //
-    //     // Act
-    //     var httpClient = app.CreateHttpClient("webfrontend");
-    //     await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend").WaitAsync(DefaultTimeout);
-    //     var response = await httpClient.GetAsync("/");
+    //      // Act
+    //      var httpClient = app.CreateHttpClient("webfrontend");
+    //      await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend", cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    //      var response = await httpClient.GetAsync("/", cancellationToken);
     //
-    //     // Assert
-    //     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    //      // Assert
+    //      Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     // }
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/9.2/IntegrationTest1.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/9.2/IntegrationTest1.cs
@@ -18,35 +18,35 @@ public class IntegrationTest1
     // [Fact]
     // public async Task GetWebResourceRootReturnsOkStatusCode()
     // {
-    //      // Arrange
+    //     // Arrange
 #if (XUnitVersion == "v2")
-    //      var cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
+    //     var cancellationToken = new CancellationTokenSource(DefaultTimeout).Token;
 #else // XunitVersion v3 or v3mtp
-    //      var cancellationToken = TestContext.Current.CancellationToken;
+    //     var cancellationToken = TestContext.Current.CancellationToken;
 #endif
-    //      var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.MyAspireApp_AppHost>(cancellationToken);
-    //      appHost.Services.AddLogging(logging =>
-    //      {
-    //          logging.SetMinimumLevel(LogLevel.Debug);
-    //          // Override the logging filters from the app's configuration
-    //          logging.AddFilter(appHost.Environment.ApplicationName, LogLevel.Debug);
-    //          logging.AddFilter("Aspire.", LogLevel.Debug);
-    //          // To output logs to the xUnit.net ITestOutputHelper, consider adding a package from https://www.nuget.org/packages?q=xunit+logging
-    //      });
-    //      appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
-    //      {
-    //          clientBuilder.AddStandardResilienceHandler();
-    //      });
+    //     var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.MyAspireApp_AppHost>(cancellationToken);
+    //     appHost.Services.AddLogging(logging =>
+    //     {
+    //         logging.SetMinimumLevel(LogLevel.Debug);
+    //         // Override the logging filters from the app's configuration
+    //         logging.AddFilter(appHost.Environment.ApplicationName, LogLevel.Debug);
+    //         logging.AddFilter("Aspire.", LogLevel.Debug);
+    //         // To output logs to the xUnit.net ITestOutputHelper, consider adding a package from https://www.nuget.org/packages?q=xunit+logging
+    //     });
+    //     appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
+    //     {
+    //         clientBuilder.AddStandardResilienceHandler();
+    //     });
     //
-    //      await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
-    //      await app.StartAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    //     await using var app = await appHost.BuildAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    //     await app.StartAsync(cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
     //
-    //      // Act
-    //      var httpClient = app.CreateHttpClient("webfrontend");
-    //      await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend", cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
-    //      var response = await httpClient.GetAsync("/", cancellationToken);
+    //     // Act
+    //     var httpClient = app.CreateHttpClient("webfrontend");
+    //     await app.ResourceNotifications.WaitForResourceHealthyAsync("webfrontend", cancellationToken).WaitAsync(DefaultTimeout, cancellationToken);
+    //     var response = await httpClient.GetAsync("/", cancellationToken);
     //
-    //      // Assert
-    //      Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    //     // Assert
+    //     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     // }
 }

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -14,10 +14,8 @@ public class NewUpAndBuildSupportProjectTemplates(ITestOutputHelper testOutput) 
     [MemberData(nameof(TestDataForNewAndBuildTemplateTests), parameters: ["aspire-nunit", ""])]
     [MemberData(nameof(TestDataForNewAndBuildTemplateTests), parameters: ["aspire-xunit", ""])]
     [MemberData(nameof(TestDataForNewAndBuildTemplateTests), parameters: ["aspire-xunit", "--xunit-version v2"])]
-
-    // ActiveIssue: https://github.com/dotnet/aspire/issues/8393
-    // [MemberData(nameof(TestDataForNewAndBuildTemplateTests), parameters: ["aspire-xunit", "--xunit-version v3"])]
-    // [MemberData(nameof(TestDataForNewAndBuildTemplateTests), parameters: ["aspire-xunit", "--xunit-version v3mtp"])]
+    [MemberData(nameof(TestDataForNewAndBuildTemplateTests), parameters: ["aspire-xunit", "--xunit-version v3"])]
+    [MemberData(nameof(TestDataForNewAndBuildTemplateTests), parameters: ["aspire-xunit", "--xunit-version v3mtp"])]
     public async Task CanNewAndBuild(string templateName, string extraTestCreationArgs, TestSdk sdk, TestTargetFramework tfm, string? error)
     {
         var id = GetNewProjectId(prefix: $"new_build_{FixupSymbolName(templateName)}");


### PR DESCRIPTION
## Description

It was least messy to just add a CT for all frameworks. Xunit v3 and Nunit supply a CT on a static that is canceled when tests are canceled. Xunit v2 and MSTest need a property/constructor added to get such a CT so I just used the regular timeout for them.

Fixes https://github.com/dotnet/aspire/issues/8393

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
