### PR TITLE
azd up doesn't show the Aspire dashboard URL with AddAzureContainerAppEnvironment

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
@@ -19,6 +19,8 @@ param secretparam_value string
 
 param api_identity_outputs_principalname string
 
+param infra_outputs_azure_container_apps_environment_default_domain string
+
 param infra_outputs_azure_container_apps_environment_id string
 
 param infra_outputs_azure_container_registry_endpoint string

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
@@ -46,6 +46,7 @@
         "params": {
           "infra_outputs_volumes_cache_0": "{infra.outputs.volumes_cache_0}",
           "cache_password_value": "{cache-password.value}",
+          "infra_outputs_azure_container_apps_environment_default_domain": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
           "infra_outputs_azure_container_apps_environment_id": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
         }
       },
@@ -108,6 +109,7 @@
         "type": "azure.bicep.v0",
         "path": "pythonapp.module.bicep",
         "params": {
+          "infra_outputs_azure_container_apps_environment_default_domain": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
           "infra_outputs_azure_container_apps_environment_id": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
           "infra_outputs_azure_container_registry_endpoint": "{infra.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
           "infra_outputs_azure_container_registry_managed_identity_id": "{infra.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -130,6 +132,7 @@
           "account_kv_outputs_name": "{account-kv.outputs.name}",
           "secretparam_value": "{secretparam.value}",
           "api_identity_outputs_principalname": "{api-identity.outputs.principalName}",
+          "infra_outputs_azure_container_apps_environment_default_domain": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
           "infra_outputs_azure_container_apps_environment_id": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
           "infra_outputs_azure_container_registry_endpoint": "{infra.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
           "infra_outputs_azure_container_registry_managed_identity_id": "{infra.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/cache.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/cache.module.bicep
@@ -6,6 +6,8 @@ param infra_outputs_volumes_cache_0 string
 @secure()
 param cache_password_value string
 
+param infra_outputs_azure_container_apps_environment_default_domain string
+
 param infra_outputs_azure_container_apps_environment_id string
 
 resource cache 'Microsoft.App/containerApps@2024-03-01' = {

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/pythonapp.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/pythonapp.module.bicep
@@ -1,6 +1,8 @@
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
+param infra_outputs_azure_container_apps_environment_default_domain string
+
 param infra_outputs_azure_container_apps_environment_id string
 
 param infra_outputs_azure_container_registry_endpoint string

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -297,6 +297,11 @@ internal sealed class AzureContainerAppsInfrastructure(
 
                 await ProcessEnvironmentAsync(executionContext, cancellationToken).ConfigureAwait(false);
                 await ProcessArgumentsAsync(executionContext, cancellationToken).ConfigureAwait(false);
+
+                // Write a fake parameter for the container app environment
+                // so azd knows the Dashboard URL - see https://github.com/dotnet/aspire/issues/8449.
+                // This is temporary until a real fix can be made in azd.
+                AllocateParameter(_containerAppEnvironmentContext.Environment.ContainerAppDomain);
             }
 
             private void ProcessEndpoints()

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -169,6 +169,11 @@ internal sealed class AzureContainerAppsInfrastructure(
 
             public void BuildContainerApp(AzureResourceInfrastructure c)
             {
+                // Write a fake parameter for the container app environment
+                // so azd knows the Dashboard URL - see https://github.com/dotnet/aspire/issues/8449.
+                // This is temporary until a real fix can be made in azd.
+                AllocateParameter(_containerAppEnvironmentContext.Environment.ContainerAppDomain);
+
                 var containerAppIdParam = AllocateParameter(_containerAppEnvironmentContext.Environment.ContainerAppEnvironmentId);
 
                 ProvisioningParameter? containerImageParam = null;
@@ -297,11 +302,6 @@ internal sealed class AzureContainerAppsInfrastructure(
 
                 await ProcessEnvironmentAsync(executionContext, cancellationToken).ConfigureAwait(false);
                 await ProcessArgumentsAsync(executionContext, cancellationToken).ConfigureAwait(false);
-
-                // Write a fake parameter for the container app environment
-                // so azd knows the Dashboard URL - see https://github.com/dotnet/aspire/issues/8449.
-                // This is temporary until a real fix can be made in azd.
-                AllocateParameter(_containerAppEnvironmentContext.Environment.ContainerAppDomain);
             }
 
             private void ProcessEndpoints()

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -53,6 +53,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -65,6 +66,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
@@ -131,6 +134,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
             "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -146,6 +150,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         param outputs_azure_container_registry_endpoint string
@@ -227,6 +233,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "path": "api.module.bicep",
           "params": {
             "api_containerport": "{api.containerPort}",
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
             "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -243,6 +250,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         param location string = resourceGroup().location
         
         param api_containerport string
+
+        param outputs_azure_container_apps_environment_default_domain string
         
         param outputs_azure_container_apps_environment_id string
         
@@ -361,6 +370,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
             "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -377,6 +387,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         param outputs_azure_container_registry_endpoint string
@@ -465,6 +477,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
             "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -480,6 +493,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         param outputs_azure_container_registry_endpoint string
@@ -572,6 +587,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "value": "{value.value}",
             "minReplicas": "{minReplicas.value}"
@@ -586,6 +602,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         param value string
@@ -656,6 +674,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
@@ -1205,6 +1225,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -1217,6 +1238,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
@@ -1285,6 +1308,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "certificateName": "{certificateName.value}",
             "customDomain": "{customDomain.value}"
@@ -1299,6 +1323,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         param certificateName string
@@ -1385,6 +1411,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "initialCertificateName": "{initialCertificateName.value}",
             "customDomain": "{customDomain.value}",
@@ -1400,6 +1427,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         param initialCertificateName string
@@ -1490,6 +1519,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "certificateName1": "{certificateName1.value}",
             "customDomain1": "{customDomain1.value}",
@@ -1506,6 +1536,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         param certificateName1 string
@@ -1598,6 +1630,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             "api_volumes_0_storage": "{api.volumes.0.storage}",
             "api_volumes_1_storage": "{api.volumes.1.storage}",
             "api_bindmounts_0_storage": "{api.bindMounts.0.storage}",
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -1616,6 +1649,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         
         param api_bindmounts_0_storage string
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
@@ -1735,6 +1770,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             "mydb_secretoutputs": "{mydb.secretOutputs}",
             "mydb_secretoutputs_connectionstring": "{mydb.secretOutputs.connectionString}",
             "mydb_secretoutputs_connectionstring1": "{mydb.secretOutputs.connectionString1}",
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -1761,6 +1797,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @secure()
         param mydb_secretoutputs_connectionstring1 string
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         resource mydb_kv_outputs_name_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
@@ -1938,6 +1976,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         resource api1 'Microsoft.App/containerApps@2024-03-01' = {
@@ -2014,6 +2054,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -2026,6 +2067,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
@@ -2094,6 +2137,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -2106,6 +2150,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
@@ -2181,6 +2227,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
@@ -2193,6 +2240,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
@@ -2262,6 +2311,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "path": "api.module.bicep",
           "params": {
             "api_containerport": "{api.containerPort}",
+            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
             "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
             "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -2279,6 +2329,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         
         param api_containerport string
         
+        param outputs_azure_container_apps_environment_default_domain string
+
         param outputs_azure_container_apps_environment_id string
         
         param outputs_azure_container_registry_endpoint string
@@ -2401,6 +2453,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               "params": {
                 "api_identity_outputs_id": "{api-identity.outputs.id}",
                 "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
+                "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
                 "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
                 "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
                 "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -2446,6 +2499,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             
             param api_identity_outputs_clientid string
             
+            param outputs_azure_container_apps_environment_default_domain string
+
             param outputs_azure_container_apps_environment_id string
             
             param outputs_azure_container_registry_endpoint string
@@ -2603,6 +2658,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 "api_identity_outputs_id": "{api-identity.outputs.id}",
                 "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
                 "cosmos_outputs_connectionstring": "{cosmos.outputs.connectionString}",
+                "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
                 "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
                 "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
                 "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -2650,6 +2706,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             
             param cosmos_outputs_connectionstring string
             
+            param outputs_azure_container_apps_environment_default_domain string
+
             param outputs_azure_container_apps_environment_id string
             
             param outputs_azure_container_registry_endpoint string
@@ -2813,6 +2871,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 "api_identity_outputs_id": "{api-identity.outputs.id}",
                 "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
                 "redis_outputs_connectionstring": "{redis.outputs.connectionString}",
+                "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
                 "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
                 "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
                 "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
@@ -2861,6 +2920,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             
             param redis_outputs_connectionstring string
             
+            param outputs_azure_container_apps_environment_default_domain string
+
             param outputs_azure_container_apps_environment_id string
             
             param outputs_azure_container_registry_endpoint string

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
@@ -192,6 +192,8 @@ public class AzurePublisherTests(ITestOutputHelper output)
             
             output account_connectionString string = account.outputs.connectionString
             
+            output acaEnv_AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = acaEnv.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+
             output acaEnv_AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = acaEnv.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
             
             output fe_identity_id string = fe_identity.outputs.id


### PR DESCRIPTION
## Description

In order for azd to know where the dashboard URL is, we need to reference the AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN in the aspire-manifest.json somewhere. To do this, we generate a parameter in all container apps that references this output.

Fix #8449

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
