### PR TITLE
Detect apphost and check version.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -107,6 +107,7 @@
     <PackageVersion Include="System.IO.Hashing" Version="9.0.3" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.21.69" />
+    <PackageVersion Include="Semver" Version="3.0.0" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="9.0.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryLTSVersion)" />

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="StreamJsonRpc" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="Semver" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -209,8 +209,8 @@ public class Program
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
 
-            var compatableRanges = SemVersionRange.Parse("^9.2.0");
-            if (!aspireSdkVersion.Satisfies(compatableRanges))
+            var compatibleRanges = SemVersionRange.Parse("^9.2.0");
+            if (!aspireSdkVersion.Satisfies(compatibleRanges))
             {
                 AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The Aspire SDK version '{appHostInformation.AspireHostingSdkVersion}' is not supported. Please update to the latest version.[/]");
                 return ExitCodeConstants.FailedToDotnetRunAppHost;

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -209,7 +209,7 @@ public class Program
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
 
-            var compatableRanges = SemVersionRange.Parse("^9.2.0");
+            var compatableRanges = SemVersionRange.Parse("^9.2.0-dev", SemVersionRangeOptions.IncludeAllPrerelease);
             if (!aspireSdkVersion.Satisfies(compatableRanges))
             {
                 AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The Aspire SDK version '{appHostInformation.AspireHostingSdkVersion}' is not supported. Please update to the latest version.[/]");


### PR DESCRIPTION
This PR fixes: #8367 and #8391

Specifically if you do `aspire run` on a project that is not an app host you will get this output:

```bash
$ aspire run
👎 The project is not an Aspire AppHost project.
```

If you run `aspire run` on an AppHost that is not supported by the CLI, you will get this:

```bash
$ aspire run
👎 The Aspire SDK version '9.1.0' is not supported. Please update to the latest version.
```

(NOTE: We will be improving support for older versions of Aspire with a fallback experience but this check would still exist in order to kick us into the right mode.
