### PR TITLE
Disable resource command buttons while they are running

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -12,7 +12,7 @@
         {
             var highlightedCommand = _highlightedCommands[i];
 
-            <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
+            <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
                 @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && IconResolver.ResolveIconName(highlightedCommand.IconName, IconSize.Size16, highlightedCommand.IconVariant) is { } icon)
                 {
                     <FluentIcon Value="@icon" Width="16px" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -40,6 +40,9 @@ public partial class ResourceActions : ComponentBase
     public required EventCallback<CommandViewModel> CommandSelected { get; set; }
 
     [Parameter]
+    public required Func<ResourceViewModel, CommandViewModel, bool> IsCommandExecuting { get; set; }
+
+    [Parameter]
     public required EventCallback<string> OnViewDetails { get; set; }
 
     [Parameter]
@@ -142,7 +145,7 @@ public partial class ResourceActions : ComponentBase
                     Tooltip = command.DisplayDescription,
                     Icon = icon,
                     OnClick = () => CommandSelected.InvokeAsync(command),
-                    IsDisabled = command.State == CommandViewModelState.Disabled
+                    IsDisabled = command.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, command)
                 });
             }
         }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -38,7 +38,7 @@
                 {
                     <FluentButton Appearance="Appearance.Lightweight"
                                   Title="@(!string.IsNullOrEmpty(command.DisplayDescription) ? command.DisplayDescription : command.DisplayName)"
-                                  Disabled="@(command.State == CommandViewModelState.Disabled)"
+                                  Disabled="@(command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(PageViewModel.SelectedResource!.Name, command.Name))"
                                   OnClick="@(() => ExecuteResourceCommandAsync(command))"
                                   Class="highlighted-command">
                         @if (!string.IsNullOrEmpty(command.IconName) && IconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) is { } icon)

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -344,7 +344,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                         Tooltip = command.DisplayDescription,
                         Icon = icon,
                         OnClick = () => ExecuteResourceCommandAsync(command),
-                        IsDisabled = command.State == CommandViewModelState.Disabled
+                        IsDisabled = command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(PageViewModel.SelectedResource!.Name, command.Name)
                     });
                 }
             }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -179,6 +179,7 @@
                                                 <div class="grid-action-container" @onclick:stopPropagation="true">
                                                     <ResourceActions Commands="@context.Resource.Commands"
                                                                      CommandSelected="async (command) => await ExecuteResourceCommandAsync(context.Resource, command)"
+                                                                     IsCommandExecuting="@((resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name))"
                                                                      OnViewDetails="@((buttonId) => ShowResourceDetailsAsync(context.Resource, buttonId))"
                                                                      Resource="context.Resource"
                                                                      GetResourceName="GetResourceName"

--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -46,7 +46,7 @@ public sealed class DashboardCommandExecutor(
             // For example:
             // 1. Click the stop command on a resource. The command is disabled while running.
             // 2. The stop command finishes, and it is re-enabled.
-            // 3. A new resource state arrives in the dashboard, replacing the stop command with the run command.  
+            // 3. A new resource state arrives in the dashboard, replacing the stop command with the run command.
             //
             // To prevent the stop command from being temporarily enabled, introduce a delay between a command finishing and re-enabling it in the dashboard.
             // This delay is chosen to balance avoiding an incorrect temporary state (since the new resource state should arrive within a second) and maintaining responsiveness.

--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -42,13 +42,13 @@ public sealed class DashboardCommandExecutor(
         }
         finally
         {
-            // There may be a delay between a command finishing and the arrival of a new resource state with updated commands sent to the client.  
-            // For example:  
-            // 1. Click the stop command on a resource. The command is disabled while running.  
-            // 2. The stop command finishes, and it is re-enabled.  
+            // There may be a delay between a command finishing and the arrival of a new resource state with updated commands sent to the client.
+            // For example:
+            // 1. Click the stop command on a resource. The command is disabled while running.
+            // 2. The stop command finishes, and it is re-enabled.
             // 3. A new resource state arrives in the dashboard, replacing the stop command with the run command.  
-            //  
-            // To prevent the stop command from being temporarily enabled, introduce a delay between a command finishing and re-enabling it in the dashboard.  
+            //
+            // To prevent the stop command from being temporarily enabled, introduce a delay between a command finishing and re-enabling it in the dashboard.
             // This delay is chosen to balance avoiding an incorrect temporary state (since the new resource state should arrive within a second) and maintaining responsiveness.
             await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
 

--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -42,14 +42,14 @@ public sealed class DashboardCommandExecutor(
         }
         finally
         {
-            // There can be an interval inbetween a command finishing and new resource state with commands being sent to the client.
-            // For example:
-            // 1. Click stop command on a resource. The command is disabled while running.
-            // 2. Stop command finishes. The command is enabled.
-            // 3. New resource state arrives in dashboard with stop command replaced by run command.
-            //
-            // To avoid the stop command temporarily being enabled, add a delay between a command finishing, and it being re-enabled in the dashboard.
-            // This delay was chosen to balance avoiding an incorrect temporary state (new resource state should arrive within a second) and responsiveness.
+            // There may be a delay between a command finishing and the arrival of a new resource state with updated commands sent to the client.  
+            // For example:  
+            // 1. Click the stop command on a resource. The command is disabled while running.  
+            // 2. The stop command finishes, and it is re-enabled.  
+            // 3. A new resource state arrives in the dashboard, replacing the stop command with the run command.  
+            //  
+            // To prevent the stop command from being temporarily enabled, introduce a delay between a command finishing and re-enabling it in the dashboard.  
+            // This delay is chosen to balance avoiding an incorrect temporary state (since the new resource state should arrive within a second) and maintaining responsiveness.
             await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
 
             lock (_lock)

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -375,7 +375,6 @@ public partial class ConsoleLogsTests : DashboardTestContext
 
         var dashboardCommandExecutor = Services.GetRequiredService<DashboardCommandExecutor>();
 
-        // Act 1
         var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
         {
             builder.Add(p => p.ResourceName, "test-resource");
@@ -386,7 +385,6 @@ public partial class ConsoleLogsTests : DashboardTestContext
         var logger = Services.GetRequiredService<ILogger<ConsoleLogsTests>>();
         var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
 
-        // Assert 1
         AngleSharp.Dom.IElement highlightedCommand = default!;
         cut.WaitForState(() => instance.PageViewModel.SelectedResource == testResource);
         cut.WaitForAssertion(() =>
@@ -395,8 +393,10 @@ public partial class ConsoleLogsTests : DashboardTestContext
             highlightedCommand = Assert.Single(highlightedCommands);
         });
 
+        // Act
         highlightedCommand.Click();
 
+        // Assert
         await AsyncTestHelpers.AssertIsTrueRetryAsync(() => dashboardCommandExecutor.IsExecuting("test-resource", "test-name"), "Command start executing");
 
         resourceCommandChannel.Writer.TryWrite(new ResourceCommandResponseViewModel

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashboardClient.cs
@@ -12,6 +12,7 @@ public class TestDashboardClient : IDashboardClient
 {
     private readonly Func<string, Channel<IReadOnlyList<ResourceLogLine>>>? _consoleLogsChannelProvider;
     private readonly Func<Channel<IReadOnlyList<ResourceViewModelChange>>>? _resourceChannelProvider;
+    private readonly Channel<ResourceCommandResponseViewModel>? _resourceCommandsChannel;
     private readonly IList<ResourceViewModel>? _initialResources;
 
     public bool IsEnabled { get; }
@@ -22,11 +23,13 @@ public class TestDashboardClient : IDashboardClient
         bool? isEnabled = false,
         Func<string, Channel<IReadOnlyList<ResourceLogLine>>>? consoleLogsChannelProvider = null,
         Func<Channel<IReadOnlyList<ResourceViewModelChange>>>? resourceChannelProvider = null,
+        Channel<ResourceCommandResponseViewModel>? resourceCommandsChannel = null,
         IList<ResourceViewModel>? initialResources = null)
     {
         IsEnabled = isEnabled ?? false;
         _consoleLogsChannelProvider = consoleLogsChannelProvider;
         _resourceChannelProvider = resourceChannelProvider;
+        _resourceCommandsChannel = resourceCommandsChannel;
         _initialResources = initialResources;
     }
 
@@ -37,7 +40,12 @@ public class TestDashboardClient : IDashboardClient
 
     public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        if (_resourceCommandsChannel == null)
+        {
+            throw new InvalidOperationException("No resource command channel set.");
+        }
+
+        return _resourceCommandsChannel.Reader.ReadAsync(cancellationToken).AsTask();
     }
 
     public async IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, [EnumeratorCancellation] CancellationToken cancellationToken)


### PR DESCRIPTION
## Description

Disable command buttons while the command is running. Avoid issues around double clicking a command.

Fixes https://github.com/dotnet/aspire/issues/7993

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
