### PR TITLE
Translate WaitAnnotations to docker compose depends_on

### DIFF
--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Service.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/Service.cs
@@ -123,12 +123,13 @@ public sealed class Service : NamedComposeMember
 
     /// <summary>
     /// Specifies a list of services that this service depends on.
-    /// The dependencies are expressed as a list of service names.
+    /// The dependencies are expressed as service names with optional conditions.
+    /// Supported conditions are: "service_started", "service_healthy", "service_completed_successfully"
     /// This property defines the order in which services should be started,
     /// ensuring that the specified services are initialized before the current service.
     /// </summary>
     [YamlMember(Alias = "depends_on", DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
-    public List<string> DependsOn { get; set; } = [];
+    public Dictionary<string, ServiceDependency> DependsOn { get; set; } = [];
 
     /// <summary>
     /// Specifies the user that the container will run as.

--- a/src/Aspire.Hosting.Docker/Resources/ComposeNodes/ServiceDependency.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ComposeNodes/ServiceDependency.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using YamlDotNet.Serialization;
+
+namespace Aspire.Hosting.Docker.Resources.ComposeNodes;
+
+/// <summary>
+/// Represents a service dependency in a Docker Compose file.
+/// </summary>
+[YamlSerializable]
+public sealed class ServiceDependency
+{
+    /// <summary>
+    /// Gets or sets the condition under which the service should be started.
+    /// </summary>
+    [YamlMember(Alias = "condition")]
+    public string? Condition { get; set; }
+}


### PR DESCRIPTION
## Description

Set depends_on in the generated compose file based on WaitAnnotation.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [] Yes
    - Is this introducing a breaking change?
  - [x] No
