### PR TITLE
Omnibus fixes for `aspire add`

### DIFF
--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -462,7 +462,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             env: null,
             workingDirectory: projectFilePath.Directory!,
             backchannelCompletionSource: null,
-            streamsCallback: (_, _, _) => { },
+            streamsCallback: null,
             cancellationToken: cancellationToken);
 
         if (result != 0)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -920,6 +920,12 @@ public class Program
 
                 var packagesWithShortName = packages.Select(p => GenerateFriendlyName(p));
 
+                if (!packagesWithShortName.Any())
+                {
+                    AnsiConsole.MarkupLine("[red bold]:thumbs_down: No packages found.[/]");
+                    return ExitCodeConstants.FailedToAddPackage;
+                }
+
                 var filteredPackagesWithShortName = packagesWithShortName.Where(p => p.FriendlyName == integrationName || p.Package.Id == integrationName);
 
                 if (!filteredPackagesWithShortName.Any() && integrationName is not null)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -792,29 +792,47 @@ public class Program
         parentCommand.Subcommands.Add(command);
     }
 
-    private static (string FriendlyName, NuGetPackage Package) GetPackageByInteractiveFlow(IEnumerable<(string FriendlyName, NuGetPackage Package)> knownPackages)
+    private static async Task<(string FriendlyName, NuGetPackage Package)> GetPackageByInteractiveFlow(IEnumerable<(string FriendlyName, NuGetPackage Package)> possiblePackages, string? preferredVersion, CancellationToken cancellationToken)
     {
+        var distinctPackages = possiblePackages.DistinctBy(p => p.Package.Id);
+
         var packagePrompt = new SelectionPrompt<(string FriendlyName, NuGetPackage Package)>()
             .Title("Select an integration to add:")
             .UseConverter(PackageNameWithFriendlyNameIfAvailable)
             .PageSize(10)
             .EnableSearch()
             .HighlightStyle(Style.Parse("darkmagenta"))
-            .AddChoices(knownPackages);
+            .AddChoices(distinctPackages);
 
-        var selectedIntegration = AnsiConsole.Prompt(packagePrompt);
+        // If there is only one package, we can skip the prompt and just use it.
+        var selectedPackage = distinctPackages.Count() switch
+        {
+            1 => distinctPackages.First(),
+            > 1 => await AnsiConsole.PromptAsync(packagePrompt, cancellationToken),
+            _ => throw new InvalidOperationException("Unexpected number of packages found.")
+        };
 
-        var versionPrompt = new TextPrompt<string>($"Specify a version of {selectedIntegration.Package.Id}")
-            .DefaultValue(selectedIntegration.Package.Version)
-            .Validate(ValidatePackageVersion)
-            .ShowDefaultValue(true)
-            .DefaultValueStyle(Style.Parse("darkmagenta"));
+        var packageVersions = possiblePackages.Where(p => p.Package.Id == selectedPackage.Package.Id);
 
-        var version = AnsiConsole.Prompt(versionPrompt);
+        // If any of the package versions are an exact match for the preferred version
+        // then we can skip the version prompt and just use that version.
+        if (packageVersions.Any(p => p.Package.Version == preferredVersion))
+        {
+            var preferredVersionPackage = packageVersions.First(p => p.Package.Version == preferredVersion);
+            return preferredVersionPackage;
+        }
 
-        selectedIntegration.Package.Version = version;
+            // ... otherwise we had better prompt.
+        var versionPrompt = new SelectionPrompt<(string FriendlyName, NuGetPackage Package)>()
+            .Title($"Select a version of {selectedPackage.Package.Id}:")
+            .UseConverter(p => p.Package.Version)
+            .EnableSearch()
+            .HighlightStyle(Style.Parse("darkmagenta"))
+            .AddChoices(packageVersions);
 
-        return selectedIntegration;
+        var version = await AnsiConsole.PromptAsync(versionPrompt, cancellationToken);
+
+        return version;
 
         static string PackageNameWithFriendlyNameIfAvailable((string FriendlyName, NuGetPackage Package) packageWithFriendlyName)
         {
@@ -826,18 +844,6 @@ public class Program
             {
                 return packageWithFriendlyName.Package.Id;
             }
-        }
-    }
-
-    private static ValidationResult ValidatePackageVersion(string version)
-    {
-        if (SemVersion.TryParse(version, out var _))
-        {
-            return ValidationResult.Success();
-        }
-        else
-        {
-            return ValidationResult.Error("Invalid version format.");
         }
     }
 
@@ -910,24 +916,33 @@ public class Program
                     context => integrationLookup.GetPackagesAsync(effectiveAppHostProjectFile, prerelease, source, ct)
                     );
 
+                var version = parseResult.GetValue<string?>("--version");
+
                 var packagesWithShortName = packages.Select(p => GenerateFriendlyName(p));
 
-                var selectedNuGetPackage = packagesWithShortName.FirstOrDefault(p => p.FriendlyName == integrationName || p.Package.Id == integrationName);
+                var filteredPackagesWithShortName = packagesWithShortName.Where(p => p.FriendlyName == integrationName || p.Package.Id == integrationName);
 
-                if (selectedNuGetPackage == default)
+                if (!filteredPackagesWithShortName.Any() && integrationName is not null)
                 {
-                    selectedNuGetPackage = GetPackageByInteractiveFlow(packagesWithShortName);
+                    // If we didn't get an exact match on the friendly name or the package ID
+                    // then try a contains search to created a broader filtered list.
+                    filteredPackagesWithShortName = packagesWithShortName.Where(
+                        p => p.FriendlyName.Contains(integrationName, StringComparison.OrdinalIgnoreCase)
+                        || p.Package.Id.Contains(integrationName, StringComparison.OrdinalIgnoreCase)
+                        );
                 }
-                else
-                {
-                    // If we find an exact match we will use it, but override the version
-                    // if the version option is specified.
-                    var version = parseResult.GetValue<string?>("--version");
-                    if (version is not null)
-                    {
-                        selectedNuGetPackage.Package.Version = version;
-                    }
-                }
+
+                // If we didn't match any, show a complete list. If we matched one, and its
+                // an exact match, then we still prompt, but it will only prompt for
+                // the version. If there is more than one match then we prompt.
+                var selectedNuGetPackage = filteredPackagesWithShortName.Count() switch {
+                    0 => await GetPackageByInteractiveFlow(packagesWithShortName, null, ct),
+                    1 => filteredPackagesWithShortName.First().Package.Version == version
+                        ? filteredPackagesWithShortName.First()
+                        : await GetPackageByInteractiveFlow(filteredPackagesWithShortName, null, ct),
+                    > 1 => await GetPackageByInteractiveFlow(filteredPackagesWithShortName, version, ct),
+                    _ => throw new InvalidOperationException("Unexpected number of packages found.")
+                };
 
                 var addPackageResult = await AnsiConsole.Status().StartAsync(
                     "Adding Aspire integration...",
@@ -954,6 +969,11 @@ public class Program
                     AnsiConsole.MarkupLine($":thumbs_up: The package {selectedNuGetPackage.Package.Id}::{selectedNuGetPackage.Package.Version} was added successfully.");
                     return ExitCodeConstants.Success;
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                AnsiConsole.MarkupLine("[yellow bold]:stop_sign: Operation cancelled by user action.[/]");
+                return ExitCodeConstants.FailedToAddPackage;
             }
             catch (Exception ex)
             {

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -806,7 +806,7 @@ public class Program
 
         var versionPrompt = new TextPrompt<string>($"Specify a version of {selectedIntegration.Package.Id}")
             .DefaultValue(selectedIntegration.Package.Version)
-            .Validate(value => string.IsNullOrEmpty(value) ? ValidationResult.Error("Version cannot be empty.") : ValidationResult.Success())
+            .Validate(ValidatePackageVersion)
             .ShowDefaultValue(true)
             .DefaultValueStyle(Style.Parse("darkmagenta"));
 
@@ -826,6 +826,18 @@ public class Program
             {
                 return packageWithFriendlyName.Package.Id;
             }
+        }
+    }
+
+    private static ValidationResult ValidatePackageVersion(string version)
+    {
+        if (SemVersion.TryParse(version, out var _))
+        {
+            return ValidationResult.Success();
+        }
+        else
+        {
+            return ValidationResult.Error("Invalid version format.");
         }
     }
 


### PR DESCRIPTION
This PR dramatically improves the package installation and version selection logic for `aspire add` to make it more intuitive.

Now when using `aspire add postgres` (for example) you will get a list of all packages that contain the name "postgres". Once you disambiguate that you will be able to select the version unless you specified a version using the `--version` switch and there is an exact match, in that case it'll pick that one.

If it is not an exact match it will prompt (even if there is one option) so you don't accidentally install the incorrect version.

If you use a search term and it doesn't find any package then you'll get a complete list to search through (partial matches get a pre-filtered list to improve usability).

The `--prerelease` switch now just includes prerelease packages in the scope of the package search. If you do not specify `--prerelease` when installing a package that only exists in pre-release form then that package version will not be shown. The `--prerelease` switch must be used in order to install a pre-release package.

This PR also improves cancellation time (usually it would take a few seconds for the prompt to detect a CTRL-C. We now react immediately.

Also fixed a bug where we were discarding a lot of logs so that they couldn't even be seen with the `--debug` switch which would make it impossible to debug the following issue:

https://github.com/dotnet/aspire/issues/8371

Fixes #8349 and #8190

Some videos:

1) Video showing adding a specific package: `aspire add Aspire.Hosting.Redis --version 9.2.0-dev --prerelease`

https://github.com/user-attachments/assets/c30aa14f-35ff-4b8c-ae1d-e843eca194bb

2) Video showing searching for a redis prerelease package: `aspire add redis --prerelease`

https://github.com/user-attachments/assets/e01ba004-37e7-4ff9-bda2-5c1c4a2f5fda

3) Video showing package disambiguation: `aspire add postgres --prerelease`

https://github.com/user-attachments/assets/f4f3780b-bd58-4a6f-a030-6fc8e6969816

4) Video showing fast cancellation

https://github.com/user-attachments/assets/558a7403-2dc8-47ec-99bc-e8bb6552b8dc

5) Video showing debug showing underlying errors

https://github.com/user-attachments/assets/c8b429dc-d306-4858-bbfb-e89f47161824

(NOTE: I'm going to look at a general way to tidy up this output, but this PR fixes an issue where the output was missing entirely from the sub-process we launched.


