### PR TITLE
Big refactor of run command into separate class.

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+
+namespace Aspire.Cli.Commmands;
+
+internal abstract class BaseCommand : Command
+{
+    protected BaseCommand(string name, string description) : base(name, description)
+    {
+        SetAction(ExecuteAsync);
+    }
+
+    protected abstract Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken);
+}

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -3,7 +3,7 @@
 
 using System.CommandLine;
 
-namespace Aspire.Cli.Commmands;
+namespace Aspire.Cli.Commands;
 
 internal abstract class BaseCommand : Command
 {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -17,7 +17,7 @@ internal sealed class RunCommand : BaseCommand
     private readonly ActivitySource _activitySource = new ActivitySource("Aspire.Cli");
     private readonly DotNetCliRunner _runner;
 
-    public RunCommand(DotNetCliRunner runner) : base("run", "Run a .NET Aspire AppHost project in development mode.")
+    public RunCommand(DotNetCliRunner runner) : base("run", "Run an Aspire app host in development mode.")
     {
         ArgumentNullException.ThrowIfNull(runner, nameof(runner));
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Diagnostics;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commmands;
+using Aspire.Cli.Utils;
+using Aspire.Hosting;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using StreamJsonRpc;
+
+namespace Aspire.Cli.Commands;
+
+internal sealed class RunCommand : BaseCommand
+{
+    private readonly ActivitySource _activitySource = new ActivitySource("Aspire.Cli");
+    private readonly DotNetCliRunner _runner;
+
+    public RunCommand(DotNetCliRunner runner) : base("run", "Run a .NET Aspire AppHost project in development mode.")
+    {
+        ArgumentNullException.ThrowIfNull(runner, nameof(runner));
+
+        _runner = runner;
+
+        var projectOption = new Option<FileInfo?>("--project");
+        projectOption.Validators.Add(ProjectFileHelper.ValidateProjectOption);
+        Options.Add(projectOption);
+
+        var watchOption = new Option<bool>("--watch", "-w");
+        Options.Add(watchOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+            using var activity = _activitySource.StartActivity($"{nameof(ExecuteAsync)}", ActivityKind.Internal);
+
+            var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
+            var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);
+            
+            if (effectiveAppHostProjectFile is null)
+            {
+                return ExitCodeConstants.FailedToFindProject;
+            }
+
+            var env = new Dictionary<string, string>();
+
+            var debug = parseResult.GetValue<bool>("--debug");
+
+            var waitForDebugger = parseResult.GetValue<bool>("--wait-for-debugger");
+
+            var forceUseRichConsole = Environment.GetEnvironmentVariable(KnownConfigNames.ForceRichConsole) == "true";
+            
+            var useRichConsole = forceUseRichConsole || !debug && !waitForDebugger;
+
+            if (waitForDebugger)
+            {
+                env[KnownConfigNames.WaitForDebugger] = "true";
+            }
+
+            try
+            {
+                await CertificatesHelper.EnsureCertificatesTrustedAsync(_runner, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down:  An error occurred while trusting the certificates: {ex.Message}[/]");
+                return ExitCodeConstants.FailedToTrustCertificates;
+            }
+
+            var appHostCompatabilityCheck = await AppHostHelper.CheckAppHostCompatabilityAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
+
+            if (!appHostCompatabilityCheck.IsCompatableAppHost)
+            {
+                return ExitCodeConstants.FailedToDotnetRunAppHost;
+            }
+
+            var watch = parseResult.GetValue<bool>("--watch");
+
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots3)
+                .SpinnerStyle(Style.Parse("purple"))
+                .StartAsync(":hammer_and_wrench:  Building apphost...", async context => {
+                    await _runner.BuildAsync(effectiveAppHostProjectFile, cancellationToken).ConfigureAwait(false);
+                });
+
+            var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();
+
+            var pendingRun = _runner.RunAsync(
+                effectiveAppHostProjectFile,
+                watch,
+                true,
+                Array.Empty<string>(),
+                env,
+                backchannelCompletitionSource,
+                cancellationToken);
+
+            if (useRichConsole)
+            {
+                // We wait for the back channel to be created to signal that
+                // the AppHost is ready to accept requests.
+                var backchannel = await AnsiConsole.Status()
+                                                   .Spinner(Spinner.Known.Dots3)
+                                                   .SpinnerStyle(Style.Parse("purple"))
+                                                   .StartAsync(":linked_paperclips:  Starting Aspire app host...", async context => {
+                                                        return await backchannelCompletitionSource.Task;
+                                                   });
+
+                // We wait for the first update of the console model via RPC from the AppHost.
+                var dashboardUrls = await AnsiConsole.Status()
+                                                    .Spinner(Spinner.Known.Dots3)
+                                                    .SpinnerStyle(Style.Parse("purple"))
+                                                    .StartAsync(":chart_increasing:  Starting Aspire dashboard...", async context => {
+                                                        return await backchannel.GetDashboardUrlsAsync(cancellationToken);
+                                                    });
+
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"[green bold]Dashboard[/]:");
+                if (dashboardUrls.CodespacesUrlWithLoginToken is not  null)
+                {
+                    AnsiConsole.MarkupLine($":chart_increasing:  Direct: [link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
+                    AnsiConsole.MarkupLine($":chart_increasing:  Codespaces: [link={dashboardUrls.CodespacesUrlWithLoginToken}]{dashboardUrls.CodespacesUrlWithLoginToken}[/]");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($":chart_increasing:  [link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
+                }
+                AnsiConsole.WriteLine();
+
+                var table = new Table().Border(TableBorder.Rounded);
+
+                await AnsiConsole.Live(table).StartAsync(async context => {
+
+                    var knownResources = new SortedDictionary<string, (string Resource, string Type, string State, string[] Endpoints)>();
+
+                    table.AddColumn("Resource");
+                    table.AddColumn("Type");
+                    table.AddColumn("State");
+                    table.AddColumn("Endpoint(s)");
+
+                    var resourceStates = backchannel.GetResourceStatesAsync(cancellationToken);
+
+                    try
+                    {
+                        await foreach(var resourceState in resourceStates)
+                        {
+                            knownResources[resourceState.Resource] = resourceState;
+
+                            table.Rows.Clear();
+
+                            foreach (var knownResource in knownResources)
+                            {
+                                var nameRenderable = new Text(knownResource.Key, new Style().Foreground(Color.White));
+
+                                var typeRenderable = new Text(knownResource.Value.Type, new Style().Foreground(Color.White));
+
+                                var stateRenderable = knownResource.Value.State switch {
+                                    "Running" => new Text(knownResource.Value.State, new Style().Foreground(Color.Green)),
+                                    "Starting" => new Text(knownResource.Value.State, new Style().Foreground(Color.LightGreen)),
+                                    "FailedToStart" => new Text(knownResource.Value.State, new Style().Foreground(Color.Red)),
+                                    "Waiting" => new Text(knownResource.Value.State, new Style().Foreground(Color.White)),
+                                    "Unhealthy" => new Text(knownResource.Value.State, new Style().Foreground(Color.Yellow)),
+                                    "Exited" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
+                                    "Finished" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
+                                    "NotStarted" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
+                                    _ => new Text(knownResource.Value.State ?? "Unknown", new Style().Foreground(Color.Grey))
+                                };
+
+                                IRenderable endpointsRenderable = new Text("None");
+                                if (knownResource.Value.Endpoints?.Length > 0)
+                                {
+                                    endpointsRenderable = new Rows(
+                                        knownResource.Value.Endpoints.Select(e => new Text(e, new Style().Link(e)))
+                                    );
+                                }
+
+                                table.AddRow(nameRenderable, typeRenderable, stateRenderable, endpointsRenderable);
+                            }
+
+                            context.Refresh();
+                        }
+                    }
+                    catch (ConnectionLostException ex) when (ex.InnerException is OperationCanceledException)
+                    {
+                        // This exception will be thrown if the cancellation request reaches the WaitForExitAsync
+                        // call on the process and shuts down the apphost before the JsonRpc connection gets it meaning
+                        // that the apphost side of the RPC connection will be closed. Therefore if we get a 
+                        // ConnectionLostException AND the inner exception is an OperationCancelledException we can
+                        // asume that the apphost was shutdown and we can ignore it.
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // This exception will be thrown if the cancellation request reaches the our side
+                        // of the backchannel side first and the connection is torn down on our-side
+                        // gracefully. We can ignore this exception as well.
+                    }
+                });
+
+                return await pendingRun;
+            }
+            else
+            {
+                return await pendingRun;
+            }
+    }
+}

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -4,7 +4,6 @@
 using System.CommandLine;
 using System.Diagnostics;
 using Aspire.Cli.Backchannel;
-using Aspire.Cli.Commmands;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Spectre.Console;

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -7,16 +7,14 @@ using System.Data;
 using System.Diagnostics;
 using System.Text;
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commands;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
-using Semver;
 using Spectre.Console;
-using Spectre.Console.Rendering;
-using StreamJsonRpc;
 
 namespace Aspire.Cli;
 
@@ -54,10 +52,15 @@ public class Program
             builder.Logging.AddConsole();
         }
 
+        // Shared services.
         builder.Services.AddTransient<DotNetCliRunner>();
         builder.Services.AddTransient<AppHostBackchannel>();
         builder.Services.AddSingleton<CliRpcTarget>();
         builder.Services.AddTransient<INuGetPackageCache, NuGetPackageCache>();
+
+        // Commands.
+        builder.Services.AddTransient<RunCommand>();
+
         var app = builder.Build();
         return app;
     }
@@ -103,350 +106,10 @@ public class Program
         return rootCommand;
     }
 
-    private static void ValidateProjectOption(OptionResult result)
-    {
-        var value = result.GetValueOrDefault<FileInfo?>();
-
-        if (result.Implicit)
-        {
-            // Having no value here is fine, but there has to
-            // be a single csproj file in the current
-            // working directory.
-            var csprojFiles = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj");
-
-            if (csprojFiles.Length > 1)
-            {
-                result.AddError("The --project option was not specified and multiple *.csproj files were detected.");
-                return;
-            }
-            else if (csprojFiles.Length == 0)
-            {
-                result.AddError("The --project option was not specified and no *.csproj files were detected.");
-                return;
-            }
-
-            return;
-        }
-
-        if (value is null)
-        {
-            result.AddError("The --project option was specified but no path was provided.");
-            return;
-        }
-
-        if (!File.Exists(value.FullName))
-        {
-            result.AddError("The specified project file does not exist.");
-            return;
-        }
-    }
-
     private static void ConfigureRunCommand(Command parentCommand, IHost app)
     {
-        var command = new Command("run", "Run a .NET Aspire AppHost project in development mode.");
-
-        var projectOption = new Option<FileInfo?>("--project");
-        projectOption.Validators.Add(ValidateProjectOption);
-        command.Options.Add(projectOption);
-
-        var watchOption = new Option<bool>("--watch", "-w");
-        command.Options.Add(watchOption);
-
-        command.SetAction(async (parseResult, ct) => {
-            using var activity = s_activitySource.StartActivity($"{nameof(ConfigureRunCommand)}-Action", ActivityKind.Internal);
-
-            var runner = app.Services.GetRequiredService<DotNetCliRunner>();
-            var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
-            var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
-            
-            if (effectiveAppHostProjectFile is null)
-            {
-                return ExitCodeConstants.FailedToFindProject;
-            }
-
-            var env = new Dictionary<string, string>();
-
-            var debug = parseResult.GetValue<bool>("--debug");
-
-            var waitForDebugger = parseResult.GetValue<bool>("--wait-for-debugger");
-
-            var forceUseRichConsole = Environment.GetEnvironmentVariable(KnownConfigNames.ForceRichConsole) == "true";
-            
-            var useRichConsole = forceUseRichConsole || !debug && !waitForDebugger;
-
-            if (waitForDebugger)
-            {
-                env[KnownConfigNames.WaitForDebugger] = "true";
-            }
-
-            try
-            {
-                await EnsureCertificatesTrustedAsync(runner, ct);
-            }
-            catch (Exception ex)
-            {
-                AnsiConsole.MarkupLine($"[red bold]:thumbs_down:  An error occurred while trusting the certificates: {ex.Message}[/]");
-                return ExitCodeConstants.FailedToTrustCertificates;
-            }
-
-            var appHostCompatabilityCheck = await CheckAppHostCompatabilityAsync(runner, effectiveAppHostProjectFile, ct);
-
-            if (!appHostCompatabilityCheck.IsCompatableAppHost)
-            {
-                return ExitCodeConstants.FailedToDotnetRunAppHost;
-            }
-
-            var watch = parseResult.GetValue<bool>("--watch");
-
-            await AnsiConsole.Status()
-                .Spinner(Spinner.Known.Dots3)
-                .SpinnerStyle(Style.Parse("purple"))
-                .StartAsync(":hammer_and_wrench:  Building apphost...", async context => {
-                    await runner.BuildAsync(effectiveAppHostProjectFile, ct).ConfigureAwait(false);
-                });
-
-            var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();
-
-            var pendingRun = runner.RunAsync(
-                effectiveAppHostProjectFile,
-                watch,
-                true,
-                Array.Empty<string>(),
-                env,
-                backchannelCompletitionSource,
-                ct);
-
-            if (useRichConsole)
-            {
-                // We wait for the back channel to be created to signal that
-                // the AppHost is ready to accept requests.
-                var backchannel = await AnsiConsole.Status()
-                                                   .Spinner(Spinner.Known.Dots3)
-                                                   .SpinnerStyle(Style.Parse("purple"))
-                                                   .StartAsync(":linked_paperclips:  Starting Aspire app host...", async context => {
-                                                        return await backchannelCompletitionSource.Task;
-                                                   });
-
-                // We wait for the first update of the console model via RPC from the AppHost.
-                var dashboardUrls = await AnsiConsole.Status()
-                                                    .Spinner(Spinner.Known.Dots3)
-                                                    .SpinnerStyle(Style.Parse("purple"))
-                                                    .StartAsync(":chart_increasing:  Starting Aspire dashboard...", async context => {
-                                                        return await backchannel.GetDashboardUrlsAsync(ct);
-                                                    });
-
-                AnsiConsole.WriteLine();
-                AnsiConsole.MarkupLine($"[green bold]Dashboard[/]:");
-                if (dashboardUrls.CodespacesUrlWithLoginToken is not  null)
-                {
-                    AnsiConsole.MarkupLine($":chart_increasing:  Direct: [link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
-                    AnsiConsole.MarkupLine($":chart_increasing:  Codespaces: [link={dashboardUrls.CodespacesUrlWithLoginToken}]{dashboardUrls.CodespacesUrlWithLoginToken}[/]");
-                }
-                else
-                {
-                    AnsiConsole.MarkupLine($":chart_increasing:  [link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
-                }
-                AnsiConsole.WriteLine();
-
-                var table = new Table().Border(TableBorder.Rounded);
-
-                await AnsiConsole.Live(table).StartAsync(async context => {
-
-                    var knownResources = new SortedDictionary<string, (string Resource, string Type, string State, string[] Endpoints)>();
-
-                    table.AddColumn("Resource");
-                    table.AddColumn("Type");
-                    table.AddColumn("State");
-                    table.AddColumn("Endpoint(s)");
-
-                    var resourceStates = backchannel.GetResourceStatesAsync(ct);
-
-                    try
-                    {
-                        await foreach(var resourceState in resourceStates)
-                        {
-                            knownResources[resourceState.Resource] = resourceState;
-
-                            table.Rows.Clear();
-
-                            foreach (var knownResource in knownResources)
-                            {
-                                var nameRenderable = new Text(knownResource.Key, new Style().Foreground(Color.White));
-
-                                var typeRenderable = new Text(knownResource.Value.Type, new Style().Foreground(Color.White));
-
-                                var stateRenderable = knownResource.Value.State switch {
-                                    "Running" => new Text(knownResource.Value.State, new Style().Foreground(Color.Green)),
-                                    "Starting" => new Text(knownResource.Value.State, new Style().Foreground(Color.LightGreen)),
-                                    "FailedToStart" => new Text(knownResource.Value.State, new Style().Foreground(Color.Red)),
-                                    "Waiting" => new Text(knownResource.Value.State, new Style().Foreground(Color.White)),
-                                    "Unhealthy" => new Text(knownResource.Value.State, new Style().Foreground(Color.Yellow)),
-                                    "Exited" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
-                                    "Finished" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
-                                    "NotStarted" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
-                                    _ => new Text(knownResource.Value.State ?? "Unknown", new Style().Foreground(Color.Grey))
-                                };
-
-                                IRenderable endpointsRenderable = new Text("None");
-                                if (knownResource.Value.Endpoints?.Length > 0)
-                                {
-                                    endpointsRenderable = new Rows(
-                                        knownResource.Value.Endpoints.Select(e => new Text(e, new Style().Link(e)))
-                                    );
-                                }
-
-                                table.AddRow(nameRenderable, typeRenderable, stateRenderable, endpointsRenderable);
-                            }
-
-                            context.Refresh();
-                        }
-                    }
-                    catch (ConnectionLostException ex) when (ex.InnerException is OperationCanceledException)
-                    {
-                        // This exception will be thrown if the cancellation request reaches the WaitForExitAsync
-                        // call on the process and shuts down the apphost before the JsonRpc connection gets it meaning
-                        // that the apphost side of the RPC connection will be closed. Therefore if we get a 
-                        // ConnectionLostException AND the inner exception is an OperationCancelledException we can
-                        // asume that the apphost was shutdown and we can ignore it.
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // This exception will be thrown if the cancellation request reaches the our side
-                        // of the backchannel side first and the connection is torn down on our-side
-                        // gracefully. We can ignore this exception as well.
-                    }
-                });
-
-                return await pendingRun;
-            }
-            else
-            {
-                return await pendingRun;
-            }
-        });
-
-        parentCommand.Subcommands.Add(command);
-    }
-
-    private static async Task<(bool IsCompatableAppHost, bool SupportsBackchannel)> CheckAppHostCompatabilityAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
-    {
-            var appHostInformation = await GetAppHostInformationAsync(runner, projectFile, cancellationToken);
-
-            if (appHostInformation.ExitCode != 0)
-            {
-                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be analyzed due to a build error. For more information run with --debug switch.[/]");
-                return (false, false);
-            }
-
-            if (!appHostInformation.IsAspireHost)
-            {
-                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project is not an Aspire AppHost project.[/]");
-                return (false, false);
-            }
-
-            if (!SemVersion.TryParse(appHostInformation.AspireHostingSdkVersion, out var aspireSdkVersion))
-            {
-                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: Could not parse Aspire SDK version.[/]");
-                return (false, false);
-            }
-
-            var compatableRanges = SemVersionRange.Parse("^9.2.0-dev", SemVersionRangeOptions.IncludeAllPrerelease);
-            if (!aspireSdkVersion.Satisfies(compatableRanges))
-            {
-                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The Aspire SDK version '{appHostInformation.AspireHostingSdkVersion}' is not supported. Please update to the latest version.[/]");
-                return (false, false);
-            }
-            else
-            {
-                // NOTE: When we go to support < 9.2.0 app hosts this is where we'll make
-                //       a determination as to whether the apphsot supports backchannel or not.
-                return (true, true);
-            }
-    }
-
-    private static async Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
-    {
-        using var activity = s_activitySource.StartActivity(nameof(GetAppHostInformationAsync), ActivityKind.Client);
-
-        var appHostInformationResult = await AnsiConsole.Status()
-            .Spinner(Spinner.Known.Dots3)
-            .SpinnerStyle(Style.Parse("purple"))
-            .StartAsync(
-                ":microscope: Checking project type...",
-                async (context) => {
-                    return await runner.GetAppHostInformationAsync(projectFile, cancellationToken);
-                });
-
-        return appHostInformationResult;
-    }
-
-    private static async Task EnsureCertificatesTrustedAsync(DotNetCliRunner runner, CancellationToken cancellationToken)
-    {
-        using var activity = s_activitySource.StartActivity(nameof(EnsureCertificatesTrustedAsync), ActivityKind.Client);
-
-        var checkExitCode = await AnsiConsole.Status()
-            .Spinner(Spinner.Known.Dots3)
-            .SpinnerStyle(Style.Parse("purple"))
-            .StartAsync(
-                ":locked_with_key: Checking certificates...",
-                async (context) => {
-                    return await runner.CheckHttpCertificateAsync(cancellationToken);
-                });
-
-        if (checkExitCode != 0)
-        {
-            var trustExitCode = await AnsiConsole.Status()
-                .Spinner(Spinner.Known.Dots3)
-                .SpinnerStyle(Style.Parse("purple"))
-                .StartAsync(
-                    ":locked_with_key: Trusting certificates...",
-                    async (context) => {
-                        return await runner.TrustHttpCertificateAsync(cancellationToken);
-                    });
-
-            if (trustExitCode != 0)
-            {
-                throw new InvalidOperationException($"Failed to trust certificates, trust command failed with exit code: {trustExitCode}");
-            }
-        }
-    }
-
-    private static FileInfo? UseOrFindAppHostProjectFile(FileInfo? projectFile)
-    {
-        if (projectFile is not null)
-        {
-            // If the project file is passed, just use it.
-            return projectFile;
-        }
-
-        var projectFilePaths = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj");
-        try 
-        {
-            var projectFilePath = projectFilePaths?.SingleOrDefault();
-            if (projectFilePath is null)
-            {
-                throw new InvalidOperationException("No project file found.");
-            }
-            else
-            {
-                return new FileInfo(projectFilePath);
-            }
-            
-        }
-        catch (Exception ex)
-        {
-            Debug.WriteLine(ex.Message);
-            if (projectFilePaths.Length > 1)
-            {
-                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and multiple *.csproj files were detected.[/]");
-                
-            }
-            else
-            {
-                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and no *.csproj files were detected.[/]");
-            }
-            return null;
-        };
+        var command = app.Services.GetRequiredService<RunCommand>();
+        parentCommand.Add(command);
     }
 
     private static void ConfigurePublishCommand(Command parentCommand, IHost app)
@@ -454,7 +117,7 @@ public class Program
         var command = new Command("publish", "Generates deployment artifacts for a .NET Aspire AppHost project.");
 
         var projectOption = new Option<FileInfo?>("--project");
-        projectOption.Validators.Add(ValidateProjectOption);
+        projectOption.Validators.Add(ProjectFileHelper.ValidateProjectOption);
         command.Options.Add(projectOption);
 
         var publisherOption = new Option<string>("--publisher", "-p");
@@ -469,7 +132,7 @@ public class Program
 
             var runner = app.Services.GetRequiredService<DotNetCliRunner>();
             var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
-            var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
+            var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);
             
             if (effectiveAppHostProjectFile is null)
             {
@@ -483,7 +146,7 @@ public class Program
                 env[KnownConfigNames.WaitForDebugger] = "true";
             }
 
-            var appHostCompatabilityCheck = await CheckAppHostCompatabilityAsync(runner, effectiveAppHostProjectFile, ct);
+            var appHostCompatabilityCheck = await AppHostHelper.CheckAppHostCompatabilityAsync(runner, effectiveAppHostProjectFile, ct);
 
             if (!appHostCompatabilityCheck.IsCompatableAppHost)
             {
@@ -776,7 +439,7 @@ public class Program
 
             try
             {
-                await EnsureCertificatesTrustedAsync(runner, ct);
+                await CertificatesHelper.EnsureCertificatesTrustedAsync(runner, ct);
             }
             catch (Exception ex)
             {
@@ -860,7 +523,7 @@ public class Program
         command.Arguments.Add(resourceArgument);
 
         var projectOption = new Option<FileInfo?>("--project");
-        projectOption.Validators.Add(ValidateProjectOption);
+        projectOption.Validators.Add(ProjectFileHelper.ValidateProjectOption);
         command.Options.Add(projectOption);
 
         var versionOption = new Option<string>("--version", "-v");
@@ -882,7 +545,7 @@ public class Program
                 var integrationName = parseResult.GetValue<string>("resource");
 
                 var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
-                var effectiveAppHostProjectFile = UseOrFindAppHostProjectFile(passedAppHostProjectFile);
+                var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);
                 
                 if (effectiveAppHostProjectFile is null)
                 {

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -23,7 +23,7 @@ internal static class AppHostHelper
 
             if (!appHostInformation.IsAspireHost)
             {
-                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project is not an Aspire AppHost project.[/]");
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project is not an Aspire app host project.[/]");
                 return (false, false);
             }
 

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Semver;
+using Spectre.Console;
+using System.Diagnostics;
+
+namespace Aspire.Cli.Utils;
+
+internal static class AppHostHelper
+{
+    private static readonly ActivitySource s_activitySource = new ActivitySource(nameof(AppHostHelper));
+
+    internal static async Task<(bool IsCompatableAppHost, bool SupportsBackchannel)> CheckAppHostCompatabilityAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
+    {
+            var appHostInformation = await GetAppHostInformationAsync(runner, projectFile, cancellationToken);
+
+            if (appHostInformation.ExitCode != 0)
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be analyzed due to a build error. For more information run with --debug switch.[/]");
+                return (false, false);
+            }
+
+            if (!appHostInformation.IsAspireHost)
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project is not an Aspire AppHost project.[/]");
+                return (false, false);
+            }
+
+            if (!SemVersion.TryParse(appHostInformation.AspireHostingSdkVersion, out var aspireSdkVersion))
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: Could not parse Aspire SDK version.[/]");
+                return (false, false);
+            }
+
+            var compatableRanges = SemVersionRange.Parse("^9.2.0-dev", SemVersionRangeOptions.IncludeAllPrerelease);
+            if (!aspireSdkVersion.Satisfies(compatableRanges))
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The Aspire SDK version '{appHostInformation.AspireHostingSdkVersion}' is not supported. Please update to the latest version.[/]");
+                return (false, false);
+            }
+            else
+            {
+                // NOTE: When we go to support < 9.2.0 app hosts this is where we'll make
+                //       a determination as to whether the apphsot supports backchannel or not.
+                return (true, true);
+            }
+    }
+
+    internal static async Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
+    {
+        using var activity = s_activitySource.StartActivity(nameof(GetAppHostInformationAsync), ActivityKind.Client);
+
+        var appHostInformationResult = await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots3)
+            .SpinnerStyle(Style.Parse("purple"))
+            .StartAsync(
+                ":microscope: Checking project type...",
+                async (context) => {
+                    return await runner.GetAppHostInformationAsync(projectFile, cancellationToken);
+                });
+
+        return appHostInformationResult;
+    }
+}

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -33,8 +33,8 @@ internal static class AppHostHelper
                 return (false, false);
             }
 
-            var compatableRanges = SemVersionRange.Parse("^9.2.0-dev", SemVersionRangeOptions.IncludeAllPrerelease);
-            if (!aspireSdkVersion.Satisfies(compatableRanges))
+            var compatibleRanges = SemVersionRange.Parse("^9.2.0-dev", SemVersionRangeOptions.IncludeAllPrerelease);
+            if (!aspireSdkVersion.Satisfies(compatibleRanges))
             {
                 AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The Aspire SDK version '{appHostInformation.AspireHostingSdkVersion}' is not supported. Please update to the latest version.[/]");
                 return (false, false);

--- a/src/Aspire.Cli/Utils/CertificatesHelper.cs
+++ b/src/Aspire.Cli/Utils/CertificatesHelper.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console;
+using System.Diagnostics;
+
+namespace Aspire.Cli.Utils;
+
+internal static class CertificatesHelper
+{
+    private static readonly ActivitySource s_activitySource = new ActivitySource(nameof(CertificatesHelper));
+
+    internal static async Task EnsureCertificatesTrustedAsync(DotNetCliRunner runner, CancellationToken cancellationToken)
+    {
+        using var activity = s_activitySource.StartActivity(nameof(EnsureCertificatesTrustedAsync), ActivityKind.Client);
+
+        var checkExitCode = await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots3)
+            .SpinnerStyle(Style.Parse("purple"))
+            .StartAsync(
+                ":locked_with_key: Checking certificates...",
+                async (context) => {
+                    return await runner.CheckHttpCertificateAsync(cancellationToken);
+                });
+
+        if (checkExitCode != 0)
+        {
+            var trustExitCode = await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots3)
+                .SpinnerStyle(Style.Parse("purple"))
+                .StartAsync(
+                    ":locked_with_key: Trusting certificates...",
+                    async (context) => {
+                        return await runner.TrustHttpCertificateAsync(cancellationToken);
+                    });
+
+            if (trustExitCode != 0)
+            {
+                throw new InvalidOperationException($"Failed to trust certificates, trust command failed with exit code: {trustExitCode}");
+            }
+        }
+    }
+}

--- a/src/Aspire.Cli/Utils/ProjectFileHelper.cs
+++ b/src/Aspire.Cli/Utils/ProjectFileHelper.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console;
+using System.CommandLine.Parsing;
+using System.Diagnostics;
+
+namespace Aspire.Cli.Utils;
+
+internal static class ProjectFileHelper
+{
+    internal static FileInfo? UseOrFindAppHostProjectFile(FileInfo? projectFile)
+    {
+        if (projectFile is not null)
+        {
+            // If the project file is passed, just use it.
+            return projectFile;
+        }
+
+        var projectFilePaths = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj");
+        try 
+        {
+            var projectFilePath = projectFilePaths?.SingleOrDefault();
+            if (projectFilePath is null)
+            {
+                throw new InvalidOperationException("No project file found.");
+            }
+            else
+            {
+                return new FileInfo(projectFilePath);
+            }
+            
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex.Message);
+            if (projectFilePaths.Length > 1)
+            {
+                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and multiple *.csproj files were detected.[/]");
+                
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[red bold]:police_car_light: The --project option was not specified and no *.csproj files were detected.[/]");
+            }
+            return null;
+        };
+    }
+
+    internal static void ValidateProjectOption(OptionResult result)
+    {
+        var value = result.GetValueOrDefault<FileInfo?>();
+
+        if (result.Implicit)
+        {
+            // Having no value here is fine, but there has to
+            // be a single csproj file in the current
+            // working directory.
+            var csprojFiles = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj");
+
+            if (csprojFiles.Length > 1)
+            {
+                result.AddError("The --project option was not specified and multiple *.csproj files were detected.");
+                return;
+            }
+            else if (csprojFiles.Length == 0)
+            {
+                result.AddError("The --project option was not specified and no *.csproj files were detected.");
+                return;
+            }
+
+            return;
+        }
+
+        if (value is null)
+        {
+            result.AddError("The --project option was specified but no path was provided.");
+            return;
+        }
+
+        if (!File.Exists(value.FullName))
+        {
+            result.AddError("The specified project file does not exist.");
+            return;
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the `aspire run` command functionality into a separate class. I am doing each command as a separate PR with this one probably being the largest in terms of moving things around.

A bunch of commonly used helpers are moved into separate static helper classes. Once all commands are migrated these might be reorganized into discreet services to aid in testability but this was the best for now since not all commands are being done at once.

This PR should bring no functional difference at all.