### PR TITLE
Disable otel when env not present.

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -45,7 +45,7 @@ public class Program
                                                 nameof(Aspire.Cli.Program));
                                             });
 
-        if (builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"] is { } otlpEndpoint)
+        if (builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"] is {})
         {
             // NOTE: If we always enable the OTEL exporter it dramatically
             //       impacts the CLI in terms of exiting quickly because it

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -36,15 +36,22 @@ public class Program
             logging.IncludeScopes = true;
             });
 
-        builder.Services.AddOpenTelemetry()
-                        .UseOtlpExporter()
-                        .WithTracing(tracing => {
-                            tracing.AddSource(
-                                nameof(Aspire.Cli.NuGetPackageCache),
-                                nameof(Aspire.Cli.Backchannel.AppHostBackchannel),
-                                nameof(Aspire.Cli.DotNetCliRunner),
-                                nameof(Aspire.Cli.Program));
-                        });
+        var otelBuilder = builder.Services.AddOpenTelemetry()
+                                          .WithTracing(tracing => {
+                                            tracing.AddSource(
+                                                nameof(Aspire.Cli.NuGetPackageCache),
+                                                nameof(Aspire.Cli.Backchannel.AppHostBackchannel),
+                                                nameof(Aspire.Cli.DotNetCliRunner),
+                                                nameof(Aspire.Cli.Program));
+                                            });
+
+        if (builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"] is { } otlpEndpoint)
+        {
+            // NOTE: If we always enable the OTEL exporter it dramatically
+            //       impacts the CLI in terms of exiting quickly because it
+            //       has to finish sending telemetry.
+            otelBuilder.UseOtlpExporter();
+        }
 
         var debugMode = args?.Any(a => a == "--debug" || a == "-d") ?? false;
 

--- a/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
@@ -87,6 +87,7 @@ public class AddPythonAppTests(ITestOutputHelper outputHelper)
 
     [Fact]
     [RequiresTools(["python"])]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/8466")]
     public async Task PythonResourceFinishesSuccessfully()
     {
         var (projectDirectory, _, scriptName) = CreateTempPythonProject(outputHelper);

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -13,6 +13,7 @@ public class MSBuildTests
     /// Tests that when an AppHost has a ProjectReference to a library project, a warning is emitted.
     /// </summary>
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/8467")]
     public void EnsureWarningsAreEmittedWhenProjectReferencingLibraries()
     {
         var repoRoot = MSBuildUtils.GetRepoRoot();

--- a/tests/Aspire.Hosting.Tests/OperationModesTests.cs
+++ b/tests/Aspire.Hosting.Tests/OperationModesTests.cs
@@ -63,7 +63,7 @@ public class OperationModesTests(ITestOutputHelper outputHelper)
 
         var context = await tcs.Task.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
 
-        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StopAsync().WaitAsync(TestConstants.LongTimeoutTimeSpan);
 
         Assert.Equal(DistributedApplicationOperation.Run, context.Operation);
         Assert.True(context.IsRunMode);


### PR DESCRIPTION
Fixes a perf issue due to the OTEL exporter always being active.