### PR TITLE
Update Docker Compose service conditions to use 'service_started' instead of healthy

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -236,9 +236,11 @@ internal sealed class DockerComposePublishingContext(
                         {
                             Condition = waitAnnotation.WaitType switch
                             {
-                                WaitType.WaitUntilHealthy => "service_healthy",
+                                // REVIEW: This only works if the target service has health checks,
+                                // revisit this when we have a way to add health checks to the compose service
+                                // WaitType.WaitUntilHealthy => "service_healthy",
                                 WaitType.WaitForCompletion => "service_completed_successfully",
-                                _ => "service_healthy",
+                                _ => "service_started",
                             },
                         };
                     }

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -113,7 +113,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
                   - "8001:8000"
                 depends_on:
                   cache:
-                    condition: "service_healthy"
+                    condition: "service_started"
                   something:
                     condition: "service_completed_successfully"
                 networks:


### PR DESCRIPTION
- Using service_healthy requires health checks