### PR TITLE
Throw exception in `WaitForResourceAsync` and `WaitForResourceHealthyAsync` when resource does not exist

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -415,6 +415,14 @@ public class ResourceNotificationService : IDisposable
 
     private async Task<ResourceEvent> WaitForResourceCoreAsync(string resourceName, Func<ResourceEvent, bool> predicate, CancellationToken cancellationToken = default)
     {
+        var appModel = _serviceProvider.GetRequiredService<DistributedApplicationModel>();
+        var resourceExist = appModel.Resources.Any(resource => resource.Name.Equals(resourceName));
+
+        if (!resourceExist)
+        {
+            throw new InvalidOperationException($"Resource with name {resourceName} not found.");
+        }
+
         using var watchCts = CancellationTokenSource.CreateLinkedTokenSource(_disposing.Token, cancellationToken);
         var watchToken = watchCts.Token;
         await foreach (var resourceEvent in WatchAsync(watchToken).ConfigureAwait(false))


### PR DESCRIPTION
## Description

This pull request includes changes to the `ResourceNotificationService` class to add validation for resource existence and corresponding unit tests to ensure this validation works correctly. The most important changes are listed below:

### Validation for resource existence:

* [`src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs`](diffhunk://#diff-277b90393b291fcd3931cae92e7467ad513f793a3e5033bb85b1028b70c30a90R121-R132): Added checks to verify if a resource exists before proceeding with the `WaitForResourceAsync` and `WaitForResourceCoreAsync` methods. If the resource does not exist, an `InvalidOperationException` is thrown. [[1]](diffhunk://#diff-277b90393b291fcd3931cae92e7467ad513f793a3e5033bb85b1028b70c30a90R121-R132) [[2]](diffhunk://#diff-277b90393b291fcd3931cae92e7467ad513f793a3e5033bb85b1028b70c30a90R430-R441)

### Unit tests for resource existence validation:

* [`tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs`](diffhunk://#diff-9ae1c25ccac6806c894fdefd483c299fb5d26007a289ef181f8cf751970f39b3R405-R456): Added new unit tests to ensure that `WaitForResourceAsync` and `WaitForResourceHealthyAsync` methods throw an `InvalidOperationException` when the resource name does not exist.

### Additional imports for testing:

* [`tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs`](diffhunk://#diff-9ae1c25ccac6806c894fdefd483c299fb5d26007a289ef181f8cf751970f39b3R5-R8): Added necessary imports for dependency injection and health checks in the test file.

Fixes #8147 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
