### PR TITLE
[tests] Simplify some dashboard parts of template tests

### DIFF
--- a/tests/Aspire.Templates.Tests/StarterTemplateRunTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateRunTestsBase.cs
@@ -47,8 +47,9 @@ public abstract class StarterTemplateRunTestsBase<T> : TemplateTestsBase, IClass
             timeoutSecs: DashboardResourcesWaitTimeoutSecs,
             logPath: _testFixture.Project.LogPath);
 
-        string url = resourceRows.First(r => r.Name == "webfrontend")
-                        .Endpoints.First(e => e.StartsWith(urlPrefix));
+        string url = _testFixture.Project.InfoTable["webfrontend"].Endpoints
+            .First(e => e.Uri.StartsWith(urlPrefix))
+            .Uri;
         await CheckWebFrontendWorksAsync(context, url, _testOutput, _testFixture.Project.LogPath, hasRedisCache: HasRedisCache);
     }
 
@@ -65,8 +66,9 @@ public abstract class StarterTemplateRunTestsBase<T> : TemplateTestsBase, IClass
             timeoutSecs: DashboardResourcesWaitTimeoutSecs,
             logPath: _testFixture.Project.LogPath);
 
-        string url = resourceRows.First(r => r.Name == "apiservice")
-                        .Endpoints.First(e => e.StartsWith(urlPrefix));
+        string url = _testFixture.Project.InfoTable["apiservice"].Endpoints
+            .First(e => e.Uri.StartsWith(urlPrefix))
+            .Uri;
         await CheckApiServiceWorksAsync(url, _testOutput, _testFixture.Project.LogPath);
     }
 
@@ -149,14 +151,12 @@ public abstract class StarterTemplateRunTestsBase<T> : TemplateTestsBase, IClass
             new(Type: "Project",
                 Name: "apiservice",
                 State: "Running",
-                SourceContains: $"{project.Id}.ApiService.csproj",
-                Endpoints: ["^http://localhost:\\d+$", "^https://localhost:\\d+$"]),
+                SourceContains: $"{project.Id}.ApiService.csproj"),
 
             new(Type: "Project",
                 Name: "webfrontend",
                 State: "Running",
-                SourceContains: $"{project.Id}.Web.csproj",
-                Endpoints: ["^http://localhost:\\d+$", "^https://localhost:\\d+$"])
+                SourceContains: $"{project.Id}.Web.csproj")
         };
 
         if (hasRedisCache)
@@ -165,15 +165,14 @@ public abstract class StarterTemplateRunTestsBase<T> : TemplateTestsBase, IClass
                 new ResourceRow(Type: "Container",
                                 Name: "cache",
                                 State: "Running",
-                                SourceContains: $"{RedisContainerImageTags.Registry}/{RedisContainerImageTags.Image}:{RedisContainerImageTags.Tag}",
-                                Endpoints: ["tcp://localhost:\\d+"]));
+                                SourceContains: $"{RedisContainerImageTags.Registry}/{RedisContainerImageTags.Image}:{RedisContainerImageTags.Tag}"));
         }
 
         return expectedResources;
     }
 }
 
-public sealed record ResourceRow(string Type, string Name, string State, string SourceContains, string[] Endpoints);
+public sealed record ResourceRow(string Type, string Name, string State, string SourceContains);
 
 public sealed record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {


### PR DESCRIPTION
Reading the `Endpoints` from the dashboard for various resources is very
fragile as it depends on html layout, which can change, and can have
overflows etc.

Instead, we drop checking for Endpoints from the dashboard, as it should
be getting validated in other ways. And we use `AspireProject.InfoTable`
to get the endpoints, and check them.

Fixes https://github.com/dotnet/aspire/issues/8473 .
