### PR TITLE
Update Keycloak Hosting Integration to work with Azure Container Apps

### DIFF
--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -14,8 +14,17 @@ public static class KeycloakResourceBuilderExtensions
     private const string AdminEnvVarName = "KC_BOOTSTRAP_ADMIN_USERNAME";
     private const string AdminPasswordEnvVarName = "KC_BOOTSTRAP_ADMIN_PASSWORD";
     private const string HealthCheckEnvVarName = "KC_HEALTH_ENABLED"; // As per https://www.keycloak.org/observability/health
+    private const string ProxyEdgeEnvVarName = "KC_PROXY";
+    private const string HttpPortEnvVarName = "KC_HTTP_PORT";
+    private const string HttpEnabledEnvVarName = "KC_HTTP_ENABLED";
+    private const string HostNamePortEnvVarName = "KC_HOSTNAME_PORT";
+    private const string HostNameStrictBackchannelEnvVarName = "KC_HOSTNAME_STRICT_BACKCHANNEL";
+    private const string ProxyHeadersEnvVarName = "KC_PROXY_HEADERS";
+    private const string HostNameStrictEnvVarName = "KC_HOSTNAME_STRICT";
+    private const string HostNameStrictHttpsEnvVarName = "KC_HOSTNAME_STRICT_HTTPS";
 
     private const int DefaultContainerPort = 8080;
+    private const int HttpsContainerPort = 8443;
     private const int ManagementInterfaceContainerPort = 9000; // As per https://www.keycloak.org/server/management-interface
     private const string ManagementEndpointName = "management";
     private const string RealmImportDirectory = "/opt/keycloak/data/import";
@@ -61,7 +70,7 @@ public static class KeycloakResourceBuilderExtensions
             .WithImage(KeycloakContainerImageTags.Image)
             .WithImageRegistry(KeycloakContainerImageTags.Registry)
             .WithImageTag(KeycloakContainerImageTags.Tag)
-            .WithHttpEndpoint(port: port, targetPort: DefaultContainerPort)
+            .WithHttpEndpoint(port: port, targetPort: HttpsContainerPort)
             .WithHttpEndpoint(targetPort: ManagementInterfaceContainerPort, name: ManagementEndpointName)
             .WithHttpHealthCheck(endpointName: ManagementEndpointName, path: "/health/ready")
             .WithEnvironment(context =>
@@ -69,6 +78,14 @@ public static class KeycloakResourceBuilderExtensions
                 context.EnvironmentVariables[AdminEnvVarName] = resource.AdminReference;
                 context.EnvironmentVariables[AdminPasswordEnvVarName] = resource.AdminPasswordParameter;
                 context.EnvironmentVariables[HealthCheckEnvVarName] = "true";
+                context.EnvironmentVariables[ProxyEdgeEnvVarName] = "edge";
+                context.EnvironmentVariables[HttpPortEnvVarName] = HttpsContainerPort.ToString();
+                context.EnvironmentVariables[HttpEnabledEnvVarName] = "true";
+                context.EnvironmentVariables[HostNamePortEnvVarName] = HttpsContainerPort.ToString();
+                context.EnvironmentVariables[HostNameStrictBackchannelEnvVarName] = "false";
+                context.EnvironmentVariables[ProxyHeadersEnvVarName] = "xforwarded";
+                context.EnvironmentVariables[HostNameStrictEnvVarName] = "false";
+                context.EnvironmentVariables[HostNameStrictHttpsEnvVarName] = "false";
             });
 
         if (builder.ExecutionContext.IsRunMode)

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Keycloak;
+using System.Globalization;
 
 namespace Aspire.Hosting;
 
@@ -23,8 +24,7 @@ public static class KeycloakResourceBuilderExtensions
     private const string HostNameStrictEnvVarName = "KC_HOSTNAME_STRICT";
     private const string HostNameStrictHttpsEnvVarName = "KC_HOSTNAME_STRICT_HTTPS";
 
-    private const int DefaultContainerPort = 8080;
-    private const int HttpsContainerPort = 8443;
+    private const int DefaultContainerPort = 8443;
     private const int ManagementInterfaceContainerPort = 9000; // As per https://www.keycloak.org/server/management-interface
     private const string ManagementEndpointName = "management";
     private const string RealmImportDirectory = "/opt/keycloak/data/import";
@@ -70,7 +70,7 @@ public static class KeycloakResourceBuilderExtensions
             .WithImage(KeycloakContainerImageTags.Image)
             .WithImageRegistry(KeycloakContainerImageTags.Registry)
             .WithImageTag(KeycloakContainerImageTags.Tag)
-            .WithHttpEndpoint(port: port, targetPort: HttpsContainerPort)
+            .WithHttpEndpoint(port: port, targetPort: DefaultContainerPort)
             .WithHttpEndpoint(targetPort: ManagementInterfaceContainerPort, name: ManagementEndpointName)
             .WithHttpHealthCheck(endpointName: ManagementEndpointName, path: "/health/ready")
             .WithEnvironment(context =>
@@ -79,9 +79,9 @@ public static class KeycloakResourceBuilderExtensions
                 context.EnvironmentVariables[AdminPasswordEnvVarName] = resource.AdminPasswordParameter;
                 context.EnvironmentVariables[HealthCheckEnvVarName] = "true";
                 context.EnvironmentVariables[ProxyEdgeEnvVarName] = "edge";
-                context.EnvironmentVariables[HttpPortEnvVarName] = HttpsContainerPort.ToString();
+                context.EnvironmentVariables[HttpPortEnvVarName] = DefaultContainerPort.ToString(CultureInfo.InvariantCulture);
                 context.EnvironmentVariables[HttpEnabledEnvVarName] = "true";
-                context.EnvironmentVariables[HostNamePortEnvVarName] = HttpsContainerPort.ToString();
+                context.EnvironmentVariables[HostNamePortEnvVarName] = DefaultContainerPort.ToString(CultureInfo.InvariantCulture);
                 context.EnvironmentVariables[HostNameStrictBackchannelEnvVarName] = "false";
                 context.EnvironmentVariables[ProxyHeadersEnvVarName] = "xforwarded";
                 context.EnvironmentVariables[HostNameStrictEnvVarName] = "false";

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
@@ -29,7 +29,7 @@ public class KeycloakResourceBuilderTests
         const string defaultEndpointName = "http";
 
         var endpoint = Assert.Single(containerResource.Annotations.OfType<EndpointAnnotation>().Where(e => e.Name == defaultEndpointName));
-        Assert.Equal(8080, endpoint.TargetPort);
+        Assert.Equal(8443, endpoint.TargetPort);
         Assert.False(endpoint.IsExternal);
         Assert.Equal(defaultEndpointName, endpoint.Name);
         Assert.Null(endpoint.Port);
@@ -125,14 +125,22 @@ public class KeycloakResourceBuilderTests
               "env": {
                 "KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
                 "KC_BOOTSTRAP_ADMIN_PASSWORD": "{keycloak-password.value}",
-                "KC_HEALTH_ENABLED": "true"
+                "KC_HEALTH_ENABLED": "true",
+                "KC_PROXY": "edge",
+                "KC_HTTP_PORT": "8443",
+                "KC_HTTP_ENABLED": "true",
+                "KC_HOSTNAME_PORT": "8443",
+                "KC_HOSTNAME_STRICT_BACKCHANNEL": "false",
+                "KC_PROXY_HEADERS": "xforwarded",
+                "KC_HOSTNAME_STRICT": "false",
+                "KC_HOSTNAME_STRICT_HTTPS": "false"
               },
               "bindings": {
                 "http": {
                   "scheme": "http",
                   "protocol": "tcp",
                   "transport": "http",
-                  "targetPort": 8080
+                  "targetPort": 8443
                 },
                 "management": {
                   "scheme": "http",


### PR DESCRIPTION
## Description

Per #6004, deploying a container provisioned via the Keycloak integration won't start in Azure Container Apps (ACA).

ACA will try to activate it, but it continuously fails.

The container reports this in the logs:

`Key material not provided to setup HTTPS. Please configure your keys/certificates or start the server in development mode.`

This PR includes a basic starting point for changes required to get Keycloak working in Azure Container Apps (see #6004).

This may need to be altered to add local dev case to continue to use default local dev port of 8080 via http and only include these additional env vars when deploying to azure container apps or if passed port is 8443. Open to making additional changes based on review and suggestions, but wanted to show bare minimum to get it working and be able to support ACA SSL.

Fixes # 6004

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [x] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
