### PR TITLE
Show neutral icon for container exiting with status code 0

### DIFF
--- a/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
@@ -22,6 +22,11 @@ internal static class ResourceViewModelExtensions
         return resource.KnownState is KnownResourceState.Finished;
     }
 
+    public static bool IsExitedState(this ResourceViewModel resource)
+    {
+        return resource.KnownState is KnownResourceState.Exited;
+    }
+
     public static bool IsStopped(this ResourceViewModel resource)
     {
         return resource.KnownState is KnownResourceState.Exited or KnownResourceState.Finished or KnownResourceState.FailedToStart;

--- a/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
@@ -42,7 +42,7 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
                 icon = new Icons.Filled.Size16.ErrorCircle();
                 color = Color.Error;
             }
-            else if (resource.IsFinishedState())
+            else if (resource.IsFinishedState() || resource.IsExitedState())
             {
                 // Process completed successfully.
                 icon = new Icons.Regular.Size16.RecordStop();

--- a/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
@@ -42,7 +42,7 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
                 icon = new Icons.Filled.Size16.ErrorCircle();
                 color = Color.Error;
             }
-            else if (resource.IsFinishedState() || resource.IsExitedState())
+            else if (resource.TryGetExitCode(out _) && (resource.IsFinishedState() || resource.IsExitedState()))
             {
                 // Process completed successfully.
                 icon = new Icons.Regular.Size16.RecordStop();

--- a/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
@@ -42,7 +42,7 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
                 icon = new Icons.Filled.Size16.ErrorCircle();
                 color = Color.Error;
             }
-            else if (resource.TryGetExitCode(out _) && (resource.IsFinishedState() || resource.IsExitedState()))
+            else if (resource.IsFinishedState() || resource.IsExitedState())
             {
                 // Process completed successfully.
                 icon = new Icons.Regular.Size16.RecordStop();

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
@@ -26,6 +26,9 @@ public class ResourceStateViewModelTests
         /* state */ KnownResourceState.Exited, 3, null, null,
         /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExitedUnexpectedly)}:{ResourceType}+3", "ErrorCircle", Color.Error, "Exited")]
     [InlineData(
+        /* state */ KnownResourceState.Exited, 0, null, null,
+        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:{ResourceType}", "RecordStop", Color.Info, "Exited")]
+    [InlineData(
         /* state */ KnownResourceState.Finished, 0, null, null,
         /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:{ResourceType}", "RecordStop", Color.Info, "Finished")]
     [InlineData(

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
@@ -19,7 +19,7 @@ public class ResourceStateViewModelTests
     // Resource is no longer running
     [InlineData(
         /* state */ "Container", KnownResourceState.Exited, null, null,null,
-        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:Container", "Warning", Color.Warning, "Exited")]
+        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:Container", "RecordStop", Color.Info, "Exited")]
     [InlineData(
         /* state */ "Container", KnownResourceState.Exited, 3, null, null,
         /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExitedUnexpectedly)}:Container+3", "ErrorCircle", Color.Error, "Exited")]
@@ -31,7 +31,7 @@ public class ResourceStateViewModelTests
         /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:Container", "RecordStop", Color.Info, "Finished")]
     [InlineData(
         /* state */ "CustomResource", KnownResourceState.Finished, null, null, null,
-        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:Container", "RecordStop", Color.Info, "Finished")]
+        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:CustomResource", "RecordStop", Color.Info, "Finished")]
     [InlineData(
         /* state */ "Container", KnownResourceState.Unknown, null, null, null,
         /* expected output */ "Unknown", "CircleHint", Color.Info, "Unknown")]

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
@@ -15,48 +15,50 @@ namespace Aspire.Dashboard.Tests.Model;
 
 public class ResourceStateViewModelTests
 {
-    private const string ResourceType = "Container";
-
     [Theory]
     // Resource is no longer running
     [InlineData(
-        /* state */ KnownResourceState.Exited, null, null,null,
-        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:{ResourceType}", "Warning", Color.Warning, "Exited")]
+        /* state */ "Container", KnownResourceState.Exited, null, null,null,
+        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:Container", "Warning", Color.Warning, "Exited")]
     [InlineData(
-        /* state */ KnownResourceState.Exited, 3, null, null,
-        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExitedUnexpectedly)}:{ResourceType}+3", "ErrorCircle", Color.Error, "Exited")]
+        /* state */ "Container", KnownResourceState.Exited, 3, null, null,
+        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExitedUnexpectedly)}:Container+3", "ErrorCircle", Color.Error, "Exited")]
     [InlineData(
-        /* state */ KnownResourceState.Exited, 0, null, null,
-        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:{ResourceType}", "RecordStop", Color.Info, "Exited")]
+        /* state */ "Container", KnownResourceState.Exited, 0, null, null,
+        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:Container", "RecordStop", Color.Info, "Exited")]
     [InlineData(
-        /* state */ KnownResourceState.Finished, 0, null, null,
-        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:{ResourceType}", "RecordStop", Color.Info, "Finished")]
+        /* state */ "Container", KnownResourceState.Finished, 0, null, null,
+        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:Container", "RecordStop", Color.Info, "Finished")]
     [InlineData(
-        /* state */ KnownResourceState.Unknown, null, null, null,
+        /* state */ "CustomResource", KnownResourceState.Finished, null, null, null,
+        /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceExited)}:Container", "RecordStop", Color.Info, "Finished")]
+    [InlineData(
+        /* state */ "Container", KnownResourceState.Unknown, null, null, null,
         /* expected output */ "Unknown", "CircleHint", Color.Info, "Unknown")]
     // Health checks
     [InlineData(
-        /* state */ KnownResourceState.Running, null, "Healthy", null,
+        /* state */ "Container", KnownResourceState.Running, null, "Healthy", null,
         /* expected output */ "Running", "CheckmarkCircle", Color.Success, "Running")]
     [InlineData(
-        /* state */ KnownResourceState.Running, null, "", null,
+        /* state */ "Container", KnownResourceState.Running, null, "", null,
         /* expected output */ $"Localized:{nameof(Columns.RunningAndUnhealthyResourceStateToolTip)}", "CheckmarkCircleWarning", Color.Warning, "Running (Unhealthy)")]
     [InlineData(
-        /* state */ KnownResourceState.Running, null, "Unhealthy", null,
+        /* state */ "Container", KnownResourceState.Running, null, "Unhealthy", null,
         /* expected output */ $"Localized:{nameof(Columns.RunningAndUnhealthyResourceStateToolTip)}", "CheckmarkCircleWarning", Color.Warning, "Running (Unhealthy)")]
     [InlineData(
-        /* state */ KnownResourceState.Running, null, "Healthy", "warning",
+        /* state */ "Container", KnownResourceState.Running, null, "Healthy", "warning",
         /* expected output */ "Running", "Warning", Color.Warning, "Running")]
     [InlineData(
-        /* state */ KnownResourceState.Running, null, "Healthy", "NOT_A_VALID_STATE_STYLE",
+        /* state */ "Container", KnownResourceState.Running, null, "Healthy", "NOT_A_VALID_STATE_STYLE",
         /* expected output */ "Running", "Circle", Color.Neutral, "Running")]
     [InlineData(
-        /* state */ KnownResourceState.Running, null, null, "info",
+        /* state */ "Container", KnownResourceState.Running, null, null, "info",
         /* expected output */ "Running", "Info", Color.Info, "Running")]
     [InlineData(
-        /* state */ KnownResourceState.RuntimeUnhealthy, null, null, null,
+        /* state */ "Container", KnownResourceState.RuntimeUnhealthy, null, null, null,
         /* expected output */ $"Localized:{nameof(Columns.StateColumnResourceContainerRuntimeUnhealthy)}", "Warning", Color.Warning, "Runtime unhealthy")]
     public void ResourceViewModel_ReturnsCorrectIconAndTooltip(
+        string resourceType,
         KnownResourceState state,
         int? exitCode,
         string? healthStatusString,
@@ -79,7 +81,7 @@ public class ResourceStateViewModelTests
             reportHealthStatus: healthStatus,
             createNullHealthReport: healthStatusString == "",
             stateStyle: stateStyle,
-            resourceType: ResourceType,
+            resourceType: resourceType,
             properties: propertiesDictionary);
 
         if (exitCode is not null)


### PR DESCRIPTION
## Description

Fixes #6785

![image](https://github.com/user-attachments/assets/066d50b9-5c7f-4150-aa15-55ad5cf5fecd)

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
