### PR TITLE
Add support for Keycloak deployment to ACA

### DIFF
--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -20,7 +20,6 @@ public static class KeycloakResourceBuilderExtensions
     private const string HostNameStrictEnvVarName = "KC_HOSTNAME_STRICT";
 
     private const int DefaultContainerPort = 8080;
-    private const int HttpsContainerPort = 8443;
     private const int ManagementInterfaceContainerPort = 9000; // As per https://www.keycloak.org/server/management-interface
     private const string ManagementEndpointName = "management";
     private const string RealmImportDirectory = "/opt/keycloak/data/import";
@@ -61,14 +60,12 @@ public static class KeycloakResourceBuilderExtensions
 
         var resource = new KeycloakResource(name, adminUsername?.Resource, passwordParameter);
 
-        var targetPort = port == HttpsContainerPort ? HttpsContainerPort : DefaultContainerPort;
-
         var keycloak = builder
             .AddResource(resource)
             .WithImage(KeycloakContainerImageTags.Image)
             .WithImageRegistry(KeycloakContainerImageTags.Registry)
             .WithImageTag(KeycloakContainerImageTags.Tag)
-            .WithHttpEndpoint(port: port, targetPort: targetPort)
+            .WithHttpEndpoint(port: port, targetPort: DefaultContainerPort)
             .WithHttpEndpoint(targetPort: ManagementInterfaceContainerPort, name: ManagementEndpointName)
             .WithHttpHealthCheck(endpointName: ManagementEndpointName, path: "/health/ready")
             .WithEnvironment(context =>

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Keycloak;
+using System.Globalization;
 
 namespace Aspire.Hosting;
 
@@ -14,8 +15,17 @@ public static class KeycloakResourceBuilderExtensions
     private const string AdminEnvVarName = "KC_BOOTSTRAP_ADMIN_USERNAME";
     private const string AdminPasswordEnvVarName = "KC_BOOTSTRAP_ADMIN_PASSWORD";
     private const string HealthCheckEnvVarName = "KC_HEALTH_ENABLED"; // As per https://www.keycloak.org/observability/health
+    private const string ProxyEdgeEnvVarName = "KC_PROXY";
+    private const string HttpPortEnvVarName = "KC_HTTP_PORT";
+    private const string HttpEnabledEnvVarName = "KC_HTTP_ENABLED";
+    private const string HostNamePortEnvVarName = "KC_HOSTNAME_PORT";
+    private const string HostNameStrictBackchannelEnvVarName = "KC_HOSTNAME_STRICT_BACKCHANNEL";
+    private const string ProxyHeadersEnvVarName = "KC_PROXY_HEADERS";
+    private const string HostNameStrictEnvVarName = "KC_HOSTNAME_STRICT";
+    private const string HostNameStrictHttpsEnvVarName = "KC_HOSTNAME_STRICT_HTTPS";
 
     private const int DefaultContainerPort = 8080;
+    private const int HttpsContainerPort = 8443;
     private const int ManagementInterfaceContainerPort = 9000; // As per https://www.keycloak.org/server/management-interface
     private const string ManagementEndpointName = "management";
     private const string RealmImportDirectory = "/opt/keycloak/data/import";
@@ -56,12 +66,14 @@ public static class KeycloakResourceBuilderExtensions
 
         var resource = new KeycloakResource(name, adminUsername?.Resource, passwordParameter);
 
+        var targetPort = port == HttpsContainerPort ? HttpsContainerPort : DefaultContainerPort;
+
         var keycloak = builder
             .AddResource(resource)
             .WithImage(KeycloakContainerImageTags.Image)
             .WithImageRegistry(KeycloakContainerImageTags.Registry)
             .WithImageTag(KeycloakContainerImageTags.Tag)
-            .WithHttpEndpoint(port: port, targetPort: DefaultContainerPort)
+            .WithHttpEndpoint(port: port, targetPort: targetPort)
             .WithHttpEndpoint(targetPort: ManagementInterfaceContainerPort, name: ManagementEndpointName)
             .WithHttpHealthCheck(endpointName: ManagementEndpointName, path: "/health/ready")
             .WithEnvironment(context =>

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Keycloak;
+using System.Globalization;
 
 namespace Aspire.Hosting;
 
@@ -19,6 +20,7 @@ public static class KeycloakResourceBuilderExtensions
     private const string HostNameStrictEnvVarName = "KC_HOSTNAME_STRICT";
 
     private const int DefaultContainerPort = 8080;
+    private const int HttpsContainerPort = 8443;
     private const int ManagementInterfaceContainerPort = 9000; // As per https://www.keycloak.org/server/management-interface
     private const string ManagementEndpointName = "management";
     private const string RealmImportDirectory = "/opt/keycloak/data/import";
@@ -59,12 +61,14 @@ public static class KeycloakResourceBuilderExtensions
 
         var resource = new KeycloakResource(name, adminUsername?.Resource, passwordParameter);
 
+        var targetPort = port == HttpsContainerPort ? HttpsContainerPort : DefaultContainerPort;
+
         var keycloak = builder
             .AddResource(resource)
             .WithImage(KeycloakContainerImageTags.Image)
             .WithImageRegistry(KeycloakContainerImageTags.Registry)
             .WithImageTag(KeycloakContainerImageTags.Tag)
-            .WithHttpEndpoint(port: port, targetPort: DefaultContainerPort)
+            .WithHttpEndpoint(port: port, targetPort: targetPort)
             .WithHttpEndpoint(targetPort: ManagementInterfaceContainerPort, name: ManagementEndpointName)
             .WithHttpHealthCheck(endpointName: ManagementEndpointName, path: "/health/ready")
             .WithEnvironment(context =>

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -15,17 +15,11 @@ public static class KeycloakResourceBuilderExtensions
     private const string AdminEnvVarName = "KC_BOOTSTRAP_ADMIN_USERNAME";
     private const string AdminPasswordEnvVarName = "KC_BOOTSTRAP_ADMIN_PASSWORD";
     private const string HealthCheckEnvVarName = "KC_HEALTH_ENABLED"; // As per https://www.keycloak.org/observability/health
-    private const string ProxyEdgeEnvVarName = "KC_PROXY";
-    private const string HttpPortEnvVarName = "KC_HTTP_PORT";
     private const string HttpEnabledEnvVarName = "KC_HTTP_ENABLED";
-    private const string HostNamePortEnvVarName = "KC_HOSTNAME_PORT";
-    private const string HostNameStrictBackchannelEnvVarName = "KC_HOSTNAME_STRICT_BACKCHANNEL";
     private const string ProxyHeadersEnvVarName = "KC_PROXY_HEADERS";
     private const string HostNameStrictEnvVarName = "KC_HOSTNAME_STRICT";
-    private const string HostNameStrictHttpsEnvVarName = "KC_HOSTNAME_STRICT_HTTPS";
 
     private const int DefaultContainerPort = 8080;
-    private const int HttpsContainerPort = 8443;
     private const int ManagementInterfaceContainerPort = 9000; // As per https://www.keycloak.org/server/management-interface
     private const string ManagementEndpointName = "management";
     private const string RealmImportDirectory = "/opt/keycloak/data/import";
@@ -66,14 +60,12 @@ public static class KeycloakResourceBuilderExtensions
 
         var resource = new KeycloakResource(name, adminUsername?.Resource, passwordParameter);
 
-        var targetPort = port == HttpsContainerPort ? HttpsContainerPort : DefaultContainerPort;
-
         var keycloak = builder
             .AddResource(resource)
             .WithImage(KeycloakContainerImageTags.Image)
             .WithImageRegistry(KeycloakContainerImageTags.Registry)
             .WithImageTag(KeycloakContainerImageTags.Tag)
-            .WithHttpEndpoint(port: port, targetPort: targetPort)
+            .WithHttpEndpoint(port: port, targetPort: DefaultContainerPort)
             .WithHttpEndpoint(targetPort: ManagementInterfaceContainerPort, name: ManagementEndpointName)
             .WithHttpHealthCheck(endpointName: ManagementEndpointName, path: "/health/ready")
             .WithEnvironment(context =>
@@ -81,6 +73,9 @@ public static class KeycloakResourceBuilderExtensions
                 context.EnvironmentVariables[AdminEnvVarName] = resource.AdminReference;
                 context.EnvironmentVariables[AdminPasswordEnvVarName] = resource.AdminPasswordParameter;
                 context.EnvironmentVariables[HealthCheckEnvVarName] = "true";
+                context.EnvironmentVariables[HttpEnabledEnvVarName] = "true";
+                context.EnvironmentVariables[ProxyHeadersEnvVarName] = "xforwarded";
+                context.EnvironmentVariables[HostNameStrictEnvVarName] = "false";
             })
             .WithUrlForEndpoint(ManagementEndpointName, u => u.DisplayLocation = UrlDisplayLocation.DetailsOnly);
 

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Keycloak;
-using System.Globalization;
 
 namespace Aspire.Hosting;
 

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
@@ -107,7 +107,7 @@ public class KeycloakResourceBuilderTests
     }
 
     [Fact]
-    public async Task VerifyManifestForHttp()
+    public async Task VerifyManifest()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var keycloak = builder.AddKeycloak("keycloak");
@@ -136,54 +136,6 @@ public class KeycloakResourceBuilderTests
                   "protocol": "tcp",
                   "transport": "http",
                   "targetPort": 8080
-                },
-                "management": {
-                  "scheme": "http",
-                  "protocol": "tcp",
-                  "transport": "http",
-                  "targetPort": 9000
-                }
-              }
-            }
-            """;
-        Assert.Equal(expectedManifest, manifest.ToString());
-    }
-
-    [Fact]
-    public async Task VerifyManifestForHttps()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create();
-        var keycloak = builder.AddKeycloak("keycloak", 8443);
-
-        var manifest = await ManifestUtils.GetManifest(keycloak.Resource);
-
-        var expectedManifest = $$"""
-            {
-              "type": "container.v0",
-              "image": "{{KeycloakContainerImageTags.Registry}}/{{KeycloakContainerImageTags.Image}}:{{KeycloakContainerImageTags.Tag}}",
-              "args": [
-                "start-dev",
-                "--import-realm"
-              ],
-              "env": {
-                "KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
-                "KC_BOOTSTRAP_ADMIN_PASSWORD": "{keycloak-password.value}",
-                "KC_HEALTH_ENABLED": "true",
-                "KC_PROXY": "edge",
-                "KC_HTTP_PORT": "8443",
-                "KC_HTTP_ENABLED": "true",
-                "KC_HOSTNAME_PORT": "8443",
-                "KC_HOSTNAME_STRICT_BACKCHANNEL": "false",
-                "KC_PROXY_HEADERS": "xforwarded",
-                "KC_HOSTNAME_STRICT": "false",
-                "KC_HOSTNAME_STRICT_HTTPS": "false"
-              },
-              "bindings": {
-                "http": {
-                  "scheme": "http",
-                  "protocol": "tcp",
-                  "transport": "http",
-                  "targetPort": 8443
                 },
                 "management": {
                   "scheme": "http",

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
@@ -107,7 +107,7 @@ public class KeycloakResourceBuilderTests
     }
 
     [Fact]
-    public async Task VerifyManifest()
+    public async Task VerifyManifestForHttp()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var keycloak = builder.AddKeycloak("keycloak");
@@ -136,6 +136,54 @@ public class KeycloakResourceBuilderTests
                   "protocol": "tcp",
                   "transport": "http",
                   "targetPort": 8080
+                },
+                "management": {
+                  "scheme": "http",
+                  "protocol": "tcp",
+                  "transport": "http",
+                  "targetPort": 9000
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
+    }
+
+    [Fact]
+    public async Task VerifyManifestForHttps()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var keycloak = builder.AddKeycloak("keycloak", 8443);
+
+        var manifest = await ManifestUtils.GetManifest(keycloak.Resource);
+
+        var expectedManifest = $$"""
+            {
+              "type": "container.v0",
+              "image": "{{KeycloakContainerImageTags.Registry}}/{{KeycloakContainerImageTags.Image}}:{{KeycloakContainerImageTags.Tag}}",
+              "args": [
+                "start-dev",
+                "--import-realm"
+              ],
+              "env": {
+                "KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
+                "KC_BOOTSTRAP_ADMIN_PASSWORD": "{keycloak-password.value}",
+                "KC_HEALTH_ENABLED": "true",
+                "KC_PROXY": "edge",
+                "KC_HTTP_PORT": "8443",
+                "KC_HTTP_ENABLED": "true",
+                "KC_HOSTNAME_PORT": "8443",
+                "KC_HOSTNAME_STRICT_BACKCHANNEL": "false",
+                "KC_PROXY_HEADERS": "xforwarded",
+                "KC_HOSTNAME_STRICT": "false",
+                "KC_HOSTNAME_STRICT_HTTPS": "false"
+              },
+              "bindings": {
+                "http": {
+                  "scheme": "http",
+                  "protocol": "tcp",
+                  "transport": "http",
+                  "targetPort": 8443
                 },
                 "management": {
                   "scheme": "http",

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
@@ -107,7 +107,7 @@ public class KeycloakResourceBuilderTests
     }
 
     [Fact]
-    public async Task VerifyManifest()
+    public async Task VerifyManifestForHttp()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var keycloak = builder.AddKeycloak("keycloak");
@@ -133,6 +133,54 @@ public class KeycloakResourceBuilderTests
                   "protocol": "tcp",
                   "transport": "http",
                   "targetPort": 8080
+                },
+                "management": {
+                  "scheme": "http",
+                  "protocol": "tcp",
+                  "transport": "http",
+                  "targetPort": 9000
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
+    }
+
+    [Fact]
+    public async Task VerifyManifestForHttps()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var keycloak = builder.AddKeycloak("keycloak", 8443);
+
+        var manifest = await ManifestUtils.GetManifest(keycloak.Resource);
+
+        var expectedManifest = $$"""
+            {
+              "type": "container.v0",
+              "image": "{{KeycloakContainerImageTags.Registry}}/{{KeycloakContainerImageTags.Image}}:{{KeycloakContainerImageTags.Tag}}",
+              "args": [
+                "start-dev",
+                "--import-realm"
+              ],
+              "env": {
+                "KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
+                "KC_BOOTSTRAP_ADMIN_PASSWORD": "{keycloak-password.value}",
+                "KC_HEALTH_ENABLED": "true",
+                "KC_PROXY": "edge",
+                "KC_HTTP_PORT": "8443",
+                "KC_HTTP_ENABLED": "true",
+                "KC_HOSTNAME_PORT": "8443",
+                "KC_HOSTNAME_STRICT_BACKCHANNEL": "false",
+                "KC_PROXY_HEADERS": "xforwarded",
+                "KC_HOSTNAME_STRICT": "false",
+                "KC_HOSTNAME_STRICT_HTTPS": "false"
+              },
+              "bindings": {
+                "http": {
+                  "scheme": "http",
+                  "protocol": "tcp",
+                  "transport": "http",
+                  "targetPort": 8443
                 },
                 "management": {
                   "scheme": "http",

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakResourceBuilderTests.cs
@@ -107,7 +107,7 @@ public class KeycloakResourceBuilderTests
     }
 
     [Fact]
-    public async Task VerifyManifestForHttp()
+    public async Task VerifyManifest()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var keycloak = builder.AddKeycloak("keycloak");
@@ -125,7 +125,10 @@ public class KeycloakResourceBuilderTests
               "env": {
                 "KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
                 "KC_BOOTSTRAP_ADMIN_PASSWORD": "{keycloak-password.value}",
-                "KC_HEALTH_ENABLED": "true"
+                "KC_HEALTH_ENABLED": "true",
+                "KC_HTTP_ENABLED": "true",
+                "KC_PROXY_HEADERS": "xforwarded",
+                "KC_HOSTNAME_STRICT": "false"
               },
               "bindings": {
                 "http": {
@@ -133,54 +136,6 @@ public class KeycloakResourceBuilderTests
                   "protocol": "tcp",
                   "transport": "http",
                   "targetPort": 8080
-                },
-                "management": {
-                  "scheme": "http",
-                  "protocol": "tcp",
-                  "transport": "http",
-                  "targetPort": 9000
-                }
-              }
-            }
-            """;
-        Assert.Equal(expectedManifest, manifest.ToString());
-    }
-
-    [Fact]
-    public async Task VerifyManifestForHttps()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create();
-        var keycloak = builder.AddKeycloak("keycloak", 8443);
-
-        var manifest = await ManifestUtils.GetManifest(keycloak.Resource);
-
-        var expectedManifest = $$"""
-            {
-              "type": "container.v0",
-              "image": "{{KeycloakContainerImageTags.Registry}}/{{KeycloakContainerImageTags.Image}}:{{KeycloakContainerImageTags.Tag}}",
-              "args": [
-                "start-dev",
-                "--import-realm"
-              ],
-              "env": {
-                "KC_BOOTSTRAP_ADMIN_USERNAME": "admin",
-                "KC_BOOTSTRAP_ADMIN_PASSWORD": "{keycloak-password.value}",
-                "KC_HEALTH_ENABLED": "true",
-                "KC_PROXY": "edge",
-                "KC_HTTP_PORT": "8443",
-                "KC_HTTP_ENABLED": "true",
-                "KC_HOSTNAME_PORT": "8443",
-                "KC_HOSTNAME_STRICT_BACKCHANNEL": "false",
-                "KC_PROXY_HEADERS": "xforwarded",
-                "KC_HOSTNAME_STRICT": "false",
-                "KC_HOSTNAME_STRICT_HTTPS": "false"
-              },
-              "bindings": {
-                "http": {
-                  "scheme": "http",
-                  "protocol": "tcp",
-                  "transport": "http",
-                  "targetPort": 8443
                 },
                 "management": {
                   "scheme": "http",


### PR DESCRIPTION
## Description

Per #6004, deploying a container provisioned via the Keycloak integration won't start in Azure Container Apps (ACA).

ACA will try to activate it, but it continuously fails.

The container reports this in the logs:

`Key material not provided to setup HTTPS. Please configure your keys/certificates or start the server in development mode.`

This PR includes a basic starting point for changes required to get Keycloak working in Azure Container Apps.

See [my comment](https://github.com/dotnet/aspire/issues/6004#issuecomment-2770390008) on #6004 showing what is necessary to get Keycloak working on ACA.

~~Currently, this only outputs the additional env vars if the passed port is 8443. Otherwise, it behaves as before for local dev scenarios. Open to making additional changes based on review and suggestions, but wanted to show bare minimum to get it working and be able to support ACA and SSL.~~

~~To opt-in to this configuration for deployment to ACA, users would simply specify port 8443 in the call to AddKeycloak like so:~~

~~var keycloak = builder.AddKeycloak("keycloak", 8443);~~

~~OR~~

~~var port = builder.Environment.IsDevelopment() ? 8080 : 8443;~~
~~var keycloak = builder.AddKeycloak("keycloak", port);~~

~~Another option would be an explicit Publish extension method similar to `PublishAsAzurePostgresFlexibleServer` on `IResourceBuilder<KeycloakResource>` builder for more fine-grained control over these settings.~~

The changes in this PR output 3 additional env vars:

```
    KC_HTTP_ENABLED=true
    KC_PROXY-HEADERS=xforwarded
    KC_HOSTNAME-STRICT=false
```

Since ACA includes TLS termination at the Envoy proxy, we're setting `KC_HTTP_ENABLED=true` per https://www.keycloak.org/server/hostname#_using_edge_tls_termination and `KC_PROXY-HEADERS=xforwarded` per https://www.keycloak.org/server/reverseproxy#_configure_the_reverse_proxy_headers.

Technically, `KC_HOSTNAME-STRICT` doesn't have to be false and shouldn't be for prod configurations, but if it's not, `KC_HOSTNAME` env var also has to be provided (see [here](https://www.keycloak.org/server/hostname)) and needs to match the ACA container url or a configured custom domain. We could make the inclusion of `KC_HOSTNAME` conditional with an additional param on the `AddKeycloak` extension method to, optionally, provide a custom domain which would be used to set the `KC_HOSTNAME` variable. Or, we'd need to always set `KC_HOSTNAME` to match the generated container url (`https://container-app-name.randomwords-digits.centralus.azurecontainerapps.io`) or use a custom domain as `KC_HOSTNAME` if specified.

Fixes #6004

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [x] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
