### PR TITLE
When publishing via `aspire publish` the AppHost lifetime should be controlled by CLI.

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -288,6 +288,11 @@ public class Program
                         }
                     }
 
+                    // When we are running in publish mode we don't want the app host to
+                    // stop itself while we might still be streaming data back across
+                    // the RPC backchannel. So we need to take responsibility for stopping
+                    // the app host. If the CLI exits/crashes without explicitly stopping
+                    // the app host the orphan detector in the app host will kick in.
                     await backchannel.RequestStopAsync(ct).ConfigureAwait(false);
                     return await pendingRun;
                 });

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -288,8 +288,8 @@ public class Program
                         }
                     }
 
+                    await backchannel.RequestStopAsync(ct).ConfigureAwait(false);
                     return await pendingRun;
-
                 });
 
             if (exitCode != 0)

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -29,6 +29,14 @@ internal class AppHostRpcTarget(
         while (cancellationToken.IsCancellationRequested == false)
         {
             var publishingActivity = await activityReporter.ActivitiyUpdated.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+            if (publishingActivity == null)
+            {
+                // If the publishing activity is null, it means that the activity has been removed.
+                // This can happen if the activity is complete or an error occurred.
+                yield break;
+            }
+
             yield return (
                 publishingActivity.Id,
                 publishingActivity.StatusMessage,
@@ -40,7 +48,7 @@ internal class AppHostRpcTarget(
             {
                 // If the activity is complete or an error and it is the primary activity,
                 // we can stop listening for updates.
-                break;
+                yield break;
             }
         }
     }

--- a/src/Aspire.Hosting/Backchannel/BackchannelService.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelService.cs
@@ -13,7 +13,13 @@ namespace Aspire.Hosting.Cli;
 
 internal sealed class BackchannelService(ILogger<BackchannelService> logger, IConfiguration configuration, AppHostRpcTarget appHostRpcTarget, IDistributedApplicationEventing eventing, IServiceProvider serviceProvider) : BackgroundService
 {
-    private readonly List<JsonRpc> _rpcs = new();
+    private JsonRpc? _rpc;
+    
+    public bool IsBackchannelExpected => configuration.GetValue<string>(KnownConfigNames.UnixSocketPath) is {};
+
+    private readonly TaskCompletionSource _backchannelConnectedTcs = new();
+
+    public Task BackchannelConnected => _backchannelConnectedTcs.Task;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -39,21 +45,24 @@ internal sealed class BackchannelService(ILogger<BackchannelService> logger, ICo
                 EventDispatchBehavior.NonBlockingConcurrent,
                 stoppingToken).ConfigureAwait(false);
 
-            do
-            {
-                var clientSocket = await serverSocket.AcceptAsync(stoppingToken).ConfigureAwait(false);
-                var stream = new NetworkStream(clientSocket, true);
-                var rpc = JsonRpc.Attach(stream, appHostRpcTarget);
-                _rpcs.Add(rpc);
+            var clientSocket = await serverSocket.AcceptAsync(stoppingToken).ConfigureAwait(false);
+            var stream = new NetworkStream(clientSocket, true);
+            var rpc = JsonRpc.Attach(stream, appHostRpcTarget);
+            _rpc = rpc;
 
-                var backchannelConnectedEvent = new BackchannelConnectedEvent(serviceProvider, unixSocketPath);
-                await eventing.PublishAsync(
-                    backchannelConnectedEvent,
-                    EventDispatchBehavior.NonBlockingConcurrent,
-                    stoppingToken).ConfigureAwait(false);
+            // NOTE: The DistributedApplicationRunner will await this TCS
+            //       when a backchannel is expected, and will not stop
+            //       the application itself - it will instead wait for
+            //       the CLI to stop the application explicitly.
+            _backchannelConnectedTcs.SetResult();
 
-                logger.LogDebug("Accepted backchannel connection from {RemoteEndPoint}", clientSocket.RemoteEndPoint);
-            } while (!stoppingToken.IsCancellationRequested);
+            var backchannelConnectedEvent = new BackchannelConnectedEvent(serviceProvider, unixSocketPath);
+            await eventing.PublishAsync(
+                backchannelConnectedEvent,
+                EventDispatchBehavior.NonBlockingConcurrent,
+                stoppingToken).ConfigureAwait(false);
+
+            logger.LogDebug("Accepted backchannel connection from {RemoteEndPoint}", clientSocket.RemoteEndPoint);
         }
         catch (TaskCanceledException ex)
         {

--- a/tests/Aspire.Hosting.Tests/OperationModesTests.cs
+++ b/tests/Aspire.Hosting.Tests/OperationModesTests.cs
@@ -131,7 +131,7 @@ public class OperationModesTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task VerifyExplicitPublishModeInvocation()
+    public void VerifyExplicitPublishModeInvocation()
     {
         // The purpose of this test is to verify that the apphost executable will continue
         // to enter publish mode if the --publisher argument is specified.
@@ -139,25 +139,7 @@ public class OperationModesTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder
             .Create(["--operation", "publish", "--publisher", "manifest", "--output-path", "test-output-path"])
             .WithTestAndResourceLogging(outputHelper);
-        builder.Configuration[KnownConfigNames.UnixSocketPath] = UnixSocketHelper.GetBackchannelSocketPath();
-
-        var tcs = new TaskCompletionSource<DistributedApplicationExecutionContext>();
-        builder.Eventing.Subscribe<BackchannelReadyEvent>((e, ct) => {
-            var context = e.Services.GetRequiredService<DistributedApplicationExecutionContext>();
-            tcs.SetResult(context);
-            return Task.CompletedTask;
-        });
-
-        using var app = builder.Build();
-        
-        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
-
-        var context = await tcs.Task.WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
-
-        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
-
-        Assert.Equal(DistributedApplicationOperation.Publish, context.Operation);
-        Assert.True(context.IsPublishMode);
+        Assert.Equal(DistributedApplicationOperation.Publish, builder.ExecutionContext.Operation);
     }
 
     [Fact]


### PR DESCRIPTION
This fixes a race condition which become obvious with very fast running publishers. Specifically we were not waiting for the backchannel to connect before the publishers started doing their thing, and the publishers could exit - terminating the apphost before all of the publishing activity data was streamed back to the CLI.

This change modifies the DistributedApplicationRunner and BackchannelService so that if a backchannel is required the DistributedApplicationRunner will wait until it connects then let the publishers work.

After the publishers have finished processing the AppHost will remain active until the CLI tells it to stop via the RPC channel. If the CLI process exits/crashes without telling the AppHost to terminate, orphan detection will kick in and the AppHost will self terminate.

https://github.com/user-attachments/assets/49093756-899e-43c0-bd3d-cd86a03e006d


