### PR TITLE
Fix console logs error when unselecting resource

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -30,35 +30,38 @@
             <PauseIncomingDataSwitch IsPaused="@PauseManager.ConsoleLogsPaused" IsPausedChanged="@OnPausedChanged" />
             <ClearSignalsButton SelectedResource="PageViewModel.SelectedOption" HandleClearSignal="ClearConsoleLogs" />
 
-            @if (_highlightedCommands.Count > 0)
+            @if (PageViewModel.SelectedResource is { } selectedResource)
             {
-                <span style="margin-left: 10px;">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsResourceCommands)]</span>
-
-                @foreach (var command in _highlightedCommands)
+                if (_highlightedCommands.Count > 0)
                 {
-                    <FluentButton Appearance="Appearance.Lightweight"
-                                  Title="@(!string.IsNullOrEmpty(command.DisplayDescription) ? command.DisplayDescription : command.DisplayName)"
-                                  Disabled="@(command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(PageViewModel.SelectedResource!.Name, command.Name))"
-                                  OnClick="@(() => ExecuteResourceCommandAsync(command))"
-                                  Class="highlighted-command">
-                        @if (!string.IsNullOrEmpty(command.IconName) && IconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) is { } icon)
-                        {
-                            <FluentIcon Value="@icon" Width="16px" />
-                        }
-                        else
-                        {
-                            @command.DisplayName
-                        }
-                    </FluentButton>
-                }
-            }
+                    <span style="margin-left: 10px;">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsResourceCommands)]</span>
 
-            @if (_resourceMenuItems.Count > 0)
-            {
-                <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
-                                  Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
-                                  Items="@_resourceMenuItems"
-                                  Title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsResourceCommands)]" />
+                    @foreach (var command in _highlightedCommands)
+                    {
+                        <FluentButton Appearance="Appearance.Lightweight"
+                                      Title="@(!string.IsNullOrEmpty(command.DisplayDescription) ? command.DisplayDescription : command.DisplayName)"
+                                      Disabled="@(command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(selectedResource.Name, command.Name))"
+                                      OnClick="@(() => ExecuteResourceCommandAsync(command))"
+                                      Class="highlighted-command">
+                            @if (!string.IsNullOrEmpty(command.IconName) && IconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) is { } icon)
+                            {
+                                <FluentIcon Value="@icon" Width="16px" />
+                            }
+                            else
+                            {
+                                @command.DisplayName
+                            }
+                        </FluentButton>
+                    }
+                }
+
+                if (_resourceMenuItems.Count > 0)
+                {
+                    <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
+                                      Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
+                                      Items="@_resourceMenuItems"
+                                      Title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsResourceCommands)]" />
+                }
             }
 
             @if (ViewportInformation.IsDesktop)


### PR DESCRIPTION
## Description

I noticed an error when unselecting a resource. The resource is removed before highlighted commands are cleared.

Best reviewed with ignore whitespace on.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
