### PR TITLE
Never render secrets into values.yaml

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesResourceContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResourceContext.cs
@@ -360,7 +360,7 @@ internal sealed class KubernetesResourceContext(
             formattedName.ToHelmSecretExpression(resource.Name) :
             formattedName.ToHelmConfigExpression(resource.Name);
 
-        var value = parameter.Default is null ? null : parameter.Value;
+        var value = parameter.Default is null || parameter.Secret ? null : parameter.Value;
         return new(expression, value);
     }
 

--- a/tests/Aspire.Hosting.Kubernetes.Tests/ExpectedValues.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/ExpectedValues.cs
@@ -29,6 +29,7 @@ public static class ExpectedValues
         secrets:
           myapp:
             param1: ""
+            param3: ""
         config:
           myapp:
             ASPNETCORE_ENVIRONMENT: "Development"
@@ -39,7 +40,7 @@ public static class ExpectedValues
             OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
             OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "in_memory"
             services__myapp__http__0: "http://myapp:8080"
-
+        
         """;
 
     public const string ProjectOneDeployment =
@@ -194,6 +195,7 @@ public static class ExpectedValues
             component: "myapp"
         stringData:
           param1: "{{ .Values.secrets.myapp.param1 }}"
+          param3: "{{ .Values.secrets.myapp.param3 }}"
           ConnectionStrings__cs: "Url={{ .Values.config.myapp.param0 }}, Secret={{ .Values.secrets.myapp.param1 }}"
         type: "Opaque"
 

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -48,6 +48,7 @@ public class KubernetesPublisherTests(KubernetesPublisherFixture fixture)
             var param0 = builder.AddParameter("param0");
             var param1 = builder.AddParameter("param1", secret: true);
             var param2 = builder.AddParameter("param2", "default", publishValueAsDefault: true);
+            var param3 = builder.AddResource(ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, "param3"));
             var cs = builder.AddConnectionString("cs", ReferenceExpression.Create($"Url={param0}, Secret={param1}"));
 
             // Add a container to the application
@@ -57,6 +58,7 @@ public class KubernetesPublisherTests(KubernetesPublisherFixture fixture)
                 .WithEnvironment("param0", param0)
                 .WithEnvironment("param1", param1)
                 .WithEnvironment("param2", param2)
+                .WithEnvironment("param3", param3)
                 .WithReference(cs)
                 .WithVolume("logs", "/logs")
                 .WithArgs("--cs", cs.Resource);


### PR DESCRIPTION
## Description

Don't render generated secrets in values.yaml

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [x] No
