### PR TITLE
Interactive prompting for `aspire new`

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -11,13 +11,13 @@ namespace Aspire.Cli.Backchannel;
 
 internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, CliRpcTarget target)
 {
-    private readonly ActivitySource _activitySource = new(nameof(Aspire.Cli.Backchannel.AppHostBackchannel), "1.0.0");
+    private readonly ActivitySource _activitySource = new(nameof(AppHostBackchannel));
     private readonly TaskCompletionSource<JsonRpc> _rpcTaskCompletionSource = new();
     private Process? _process;
 
     public async Task<long> PingAsync(long timestamp, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(PingAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         var rpc = await _rpcTaskCompletionSource.Task;
 
@@ -37,7 +37,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         // of the AppHost process. The AppHost process will then trigger the shutdown
         // which will allow the CLI to await the pending run.
 
-        using var activity = _activitySource.StartActivity(nameof(RequestStopAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         var rpc = await _rpcTaskCompletionSource.Task;
 
@@ -51,7 +51,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async Task<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)> GetDashboardUrlsAsync(CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(GetDashboardUrlsAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         var rpc = await _rpcTaskCompletionSource.Task;
 
@@ -67,7 +67,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> GetResourceStatesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(GetResourceStatesAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         var rpc = await _rpcTaskCompletionSource.Task;
 
@@ -88,7 +88,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async Task ConnectAsync(Process process, string socketPath, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(ConnectAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         _process = process;
 
@@ -111,7 +111,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async Task<string[]> GetPublishersAsync(CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(GetPublishersAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         var rpc = await _rpcTaskCompletionSource.Task.ConfigureAwait(false);
 
@@ -127,7 +127,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(GetPublishingActivitiesAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         var rpc = await _rpcTaskCompletionSource.Task;
 

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -11,7 +11,7 @@ namespace Aspire.Cli.Commands;
 
 internal sealed class AddCommand : BaseCommand
 {
-    private readonly ActivitySource _activitySource = new ActivitySource("Aspire.Cli");
+    private readonly ActivitySource _activitySource = new ActivitySource(nameof(AddCommand));
     private readonly DotNetCliRunner _runner;
     private readonly INuGetPackageCache _nuGetPackageCache;
 
@@ -42,7 +42,7 @@ internal sealed class AddCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity($"{nameof(ExecuteAsync)}", ActivityKind.Internal);
+        using var activity = _activitySource.StartActivity();
 
         try
         {

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -62,7 +62,7 @@ internal sealed class AddCommand : BaseCommand
 
             var packages = await AnsiConsole.Status().StartAsync(
                 "Searching for Aspire packages...",
-                context => _nuGetPackageCache.GetPackagesAsync(effectiveAppHostProjectFile, prerelease, source, cancellationToken)
+                context => _nuGetPackageCache.GetPackagesAsync(effectiveAppHostProjectFile.Directory!, prerelease, source, cancellationToken)
                 );
 
             var version = parseResult.GetValue<string?>("--version");

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -11,7 +11,7 @@ namespace Aspire.Cli.Commands;
 
 internal sealed class NewCommand : BaseCommand
 {
-    private readonly ActivitySource _activitySource = new ActivitySource("Aspire.Cli");
+    private readonly ActivitySource _activitySource = new ActivitySource(nameof(NewCommand));
     private readonly DotNetCliRunner _runner;
 
     public NewCommand(DotNetCliRunner runner) : base("new", "Create a new Aspire sample project.")
@@ -79,7 +79,7 @@ internal sealed class NewCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity($"{nameof(ExecuteAsync)}", ActivityKind.Internal);
+        using var activity = _activitySource.StartActivity();
 
         var templateVersion = parseResult.GetValue<string>("--version");
         var prerelease = parseResult.GetValue<bool>("--prerelease");

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -12,7 +12,7 @@ namespace Aspire.Cli.Commands;
 
 internal sealed class PublishCommand : BaseCommand
 {
-    private readonly ActivitySource _activitySource = new ActivitySource("Aspire.Cli");
+    private readonly ActivitySource _activitySource = new ActivitySource(nameof(PublishCommand));
     private readonly DotNetCliRunner _runner;
 
     public PublishCommand(DotNetCliRunner runner) : base("publish", "Generates deployment artifacts for an Aspire app host project.")
@@ -34,7 +34,7 @@ internal sealed class PublishCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity($"{nameof(ExecuteAsync)}", ActivityKind.Internal);
+        using var activity = _activitySource.StartActivity();
 
         var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
         var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.Commands;
 
 internal sealed class RunCommand : BaseCommand
 {
-    private readonly ActivitySource _activitySource = new ActivitySource("Aspire.Cli");
+    private readonly ActivitySource _activitySource = new ActivitySource(nameof(RunCommand));
     private readonly DotNetCliRunner _runner;
 
     public RunCommand(DotNetCliRunner runner) : base("run", "Run an Aspire app host in development mode.")
@@ -33,7 +33,7 @@ internal sealed class RunCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity($"{nameof(ExecuteAsync)}", ActivityKind.Internal);
+        using var activity = _activitySource.StartActivity();
 
         var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
         var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -477,7 +477,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         return result;
     }
 
-    public async Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(FileInfo projectFilePath, string query, bool prerelease, int take, int skip, string? nugetSource, CancellationToken cancellationToken)
+    public async Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(DirectoryInfo workingDirectory, string query, bool prerelease, int take, int skip, string? nugetSource, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -510,7 +510,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         var result = await ExecuteAsync(
             args: cliArgs.ToArray(),
             env: null,
-            workingDirectory: projectFilePath.Directory!,
+            workingDirectory: workingDirectory!,
             backchannelCompletionSource: null,
             streamsCallback: (_, output, _) => {
                 // We need to read the output of the streams
@@ -550,6 +550,12 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
                 foreach (var packageResult in sourcePackagesArray.EnumerateArray())
                 {
                     var id = packageResult.GetProperty("id").GetString();
+
+                    // var version = prerelease switch {
+                    //     true => packageResult.GetProperty("version").GetString(),
+                    //     false => packageResult.GetProperty("latestVersion").GetString()
+                    // };
+
                     var version = packageResult.GetProperty("latestVersion").GetString();
 
                     foundPackages.Add(new NuGetPackage

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -15,13 +15,13 @@ namespace Aspire.Cli;
 
 internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider serviceProvider)
 {
-    private readonly ActivitySource _activitySource = new ActivitySource(nameof(Aspire.Cli.DotNetCliRunner));
+    private readonly ActivitySource _activitySource = new ActivitySource(nameof(DotNetCliRunner));
 
     internal Func<int> GetCurrentProcessId { get; set; } = () => Environment.ProcessId;
 
     public async Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(FileInfo projectFile, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(GetAppHostInformationAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         string[] cliArgs = ["msbuild", "-getproperty:IsAspireHost,AspireHostingSDKVersion"];
 
@@ -79,7 +79,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(RunAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         if (watch && noBuild)
         {
@@ -100,7 +100,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> CheckHttpCertificateAsync(CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(CheckHttpCertificateAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         string[] cliArgs = ["dev-certs", "https", "--check", "--trust"];
         return await ExecuteAsync(
@@ -114,7 +114,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> TrustHttpCertificateAsync(CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(TrustHttpCertificateAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         string[] cliArgs = ["dev-certs", "https", "--trust"];
         return await ExecuteAsync(
@@ -230,7 +230,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> NewProjectAsync(string templateName, string name, string outputPath, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(NewProjectAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         string[] cliArgs = ["new", templateName, "--name", name, "--output", outputPath];
         return await ExecuteAsync(
@@ -259,7 +259,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, Action<StreamWriter, StreamReader, StreamReader>? streamsCallback, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(ExecuteAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         var startInfo = new ProcessStartInfo("dotnet")
         {
@@ -379,7 +379,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     private async Task StartBackchannelAsync(Process process, string socketPath, TaskCompletionSource<AppHostBackchannel> backchannelCompletionSource, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(StartBackchannelAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
 
@@ -431,7 +431,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<int> BuildAsync(FileInfo projectFilePath, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(BuildAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         string[] cliArgs = ["build", projectFilePath.FullName];
         return await ExecuteAsync(
@@ -444,7 +444,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
     }
     public async Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(AddPackageAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         string[] cliArgs = [
             "add",
@@ -479,7 +479,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     public async Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(FileInfo projectFilePath, string query, bool prerelease, int take, int skip, string? nugetSource, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(SearchPackagesAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         List<string> cliArgs = [
             "package",

--- a/src/Aspire.Cli/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGetPackageCache.cs
@@ -13,13 +13,13 @@ internal interface INuGetPackageCache
 
 internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNetCliRunner cliRunner) : INuGetPackageCache
 {
-    private readonly ActivitySource _activitySource = new(nameof(Aspire.Cli.NuGetPackageCache), "1.0.0");
+    private readonly ActivitySource _activitySource = new(nameof(NuGetPackageCache));
 
     private const int SearchPageSize = 100;
 
     public async Task<IEnumerable<NuGetPackage>> GetPackagesAsync(FileInfo projectFile, bool prerelease, string? source, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity(nameof(GetPackagesAsync), ActivityKind.Client);
+        using var activity = _activitySource.StartActivity();
 
         logger.LogDebug("Getting integrations from NuGet");
 

--- a/src/Aspire.Cli/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGetPackageCache.cs
@@ -8,7 +8,7 @@ namespace Aspire.Cli;
 
 internal interface INuGetPackageCache
 {
-    Task<IEnumerable<NuGetPackage>> GetPackagesAsync(FileInfo projectFile, bool prerelease, string? source, CancellationToken cancellationToken);
+    Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, string? source, CancellationToken cancellationToken);
 }
 
 internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNetCliRunner cliRunner) : INuGetPackageCache
@@ -17,7 +17,7 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNe
 
     private const int SearchPageSize = 100;
 
-    public async Task<IEnumerable<NuGetPackage>> GetPackagesAsync(FileInfo projectFile, bool prerelease, string? source, CancellationToken cancellationToken)
+    public async Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, string? source, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -31,7 +31,7 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNe
         {
             // This search should pick up Aspire.Hosting.* and CommunityToolkit.Aspire.Hosting.*
             var result = await cliRunner.SearchPackagesAsync(
-                projectFile,
+                workingDirectory,
                 "Aspire.Hosting",
                 prerelease,
                 SearchPageSize,

--- a/src/Aspire.Cli/Utils/PromptUtils.cs
+++ b/src/Aspire.Cli/Utils/PromptUtils.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console;
+
+namespace Aspire.Cli.Utils;
+
+internal static class PromptUtils
+{
+    public static async Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(promptText, nameof(promptText));
+        var prompt = new TextPrompt<string>(promptText);
+
+        if (defaultValue is not null)
+        {
+            prompt.DefaultValue(defaultValue);
+            prompt.ShowDefaultValue();
+        }
+
+        if (validator is not null)
+        {
+            prompt.Validate(validator);
+        }
+
+        return await AnsiConsole.PromptAsync(prompt, cancellationToken);
+    }
+
+    public static async Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T: notnull
+    {
+        ArgumentNullException.ThrowIfNull(promptText, nameof(promptText));
+        ArgumentNullException.ThrowIfNull(choices, nameof(choices));
+        ArgumentNullException.ThrowIfNull(choiceFormatter, nameof(choiceFormatter));
+
+        var prompt = new SelectionPrompt<T>()
+            .Title(promptText)
+            .UseConverter(choiceFormatter)
+            .AddChoices(choices)
+            .PageSize(10)
+            .EnableSearch()
+            .HighlightStyle(Style.Parse("darkmagenta"));
+
+        return await AnsiConsole.PromptAsync(prompt, cancellationToken);
+    }
+}


### PR DESCRIPTION
Fixes #8515

This PR updates the `aspire new` command to support interactive prompting. Here is a video of the interactive prompt, but read below for some more technical details/decisions from this approach.

https://github.com/user-attachments/assets/7aca8b13-3413-4ede-ab95-497037bdc01a

A few notes on the technical implementation:

1. I do not use a pick-list for selecting the template version. When using multiple feeds (paritcularly our internal ones) where we have thousands of versions of the `Aspire.ProjectTemplates` package it becomes difficult to present a list that makes sense. Instead, we just prompt for the version of the templates and default to the CLI version number. The thinking here is that the CLI will become the primary driver of newer template adoption, and generally you want to use the latest CLI and templates.

2. The `--prerelease` switch has been removed from the CLI as it is redundant.

3. The `--source` switch is still supported to cope with the situation where the same package version might be available from two sources, but it is not prompted - this is more of an advanced scenario.

Here is the non-interactive flow still working for comparison:


https://github.com/user-attachments/assets/39ef0aa8-8527-41b1-b92b-55251c9da863

