### PR TITLE
Rename IKeyVaultResource and IKeyVaultSecretReference

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -714,7 +714,7 @@ internal sealed class AzureContainerAppsInfrastructure(
                     return (AllocateParameter(secretOutputReference, secretType: SecretType.KeyVault), SecretType.KeyVault);
                 }
 
-                if (value is IKeyVaultSecretReference vaultSecretReference)
+                if (value is IAzureKeyVaultSecretReference vaultSecretReference)
                 {
                     if (parent is null)
                     {
@@ -797,7 +797,7 @@ internal sealed class AzureContainerAppsInfrastructure(
                 return secret.Properties.SecretUri;
             }
 
-            private BicepValue<string> AllocateKeyVaultSecretUriReference(IKeyVaultSecretReference secretOutputReference)
+            private BicepValue<string> AllocateKeyVaultSecretUriReference(IAzureKeyVaultSecretReference secretOutputReference)
             {
                 if (!KeyVaultRefs.TryGetValue(secretOutputReference.Resource.Name, out var kv))
                 {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -365,7 +365,7 @@ public static class AzureCosmosExtensions
     /// <param name="builder">The Azure Cosmos DB resource builder.</param>
     /// <param name="keyVaultBuilder">The Azure Key Vault resource builder where the connection string used to connect to this AzureCosmosDBResource will be stored.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> builder.</returns>
-    public static IResourceBuilder<AzureCosmosDBResource> WithAccessKeyAuthentication(this IResourceBuilder<AzureCosmosDBResource> builder, IResourceBuilder<IKeyVaultResource> keyVaultBuilder)
+    public static IResourceBuilder<AzureCosmosDBResource> WithAccessKeyAuthentication(this IResourceBuilder<AzureCosmosDBResource> builder, IResourceBuilder<IAzureKeyVaultResource> keyVaultBuilder)
     {
         ArgumentNullException.ThrowIfNull(builder);
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -41,7 +41,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     ///
     /// This is set when access key authentication is used. The connection string is stored in a secret in the Azure Key Vault.
     /// </summary>
-    internal IKeyVaultSecretReference? ConnectionStringSecretOutput { get; set; }
+    internal IAzureKeyVaultSecretReference? ConnectionStringSecretOutput { get; set; }
 
     private BicepOutputReference NameOutputReference => new("name", this);
 

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="configureInfrastructure">Callback to configure the Azure resources.</param>
 public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure)
-    : AzureProvisioningResource(name, configureInfrastructure), IResourceWithConnectionString, IKeyVaultResource
+    : AzureProvisioningResource(name, configureInfrastructure), IResourceWithConnectionString, IAzureKeyVaultResource
 {
     /// <summary>
     /// Gets the "vaultUri" output reference for the Azure Key Vault resource.
@@ -31,12 +31,12 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create($"{VaultUri}");
 
-    BicepOutputReference IKeyVaultResource.VaultUriOutputReference => VaultUri;
+    BicepOutputReference IAzureKeyVaultResource.VaultUriOutputReference => VaultUri;
 
     // In run mode, this is set to the secret client used to access the Azure Key Vault.
-    internal Func<IKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
+    internal Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
 
-    Func<IKeyVaultSecretReference, CancellationToken, Task<string?>>? IKeyVaultResource.SecretResolver
+    Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? IAzureKeyVaultResource.SecretResolver
     {
         get => SecretResolver;
         set => SecretResolver = value;
@@ -48,7 +48,7 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     /// <param name="secretName"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
-    public IKeyVaultSecretReference GetSecretReference(string secretName)
+    public IAzureKeyVaultSecretReference GetSecretReference(string secretName)
     {
         ArgumentException.ThrowIfNullOrEmpty(secretName, nameof(secretName));
 

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="secretName">The name of the secret.</param>
 /// <param name="azureKeyVaultResource">The Azure Key Vault resource.</param>
-internal sealed class AzureKeyVaultSecretReference(string secretName, AzureKeyVaultResource azureKeyVaultResource) : IKeyVaultSecretReference, IValueProvider, IManifestExpressionProvider
+internal sealed class AzureKeyVaultSecretReference(string secretName, AzureKeyVaultResource azureKeyVaultResource) : IAzureKeyVaultSecretReference, IValueProvider, IManifestExpressionProvider
 {
     /// <summary>
     /// Gets the name of the secret.
@@ -20,7 +20,7 @@ internal sealed class AzureKeyVaultSecretReference(string secretName, AzureKeyVa
     /// <summary>
     /// Gets the Azure Key Vault resource.
     /// </summary>
-    public IKeyVaultResource Resource => azureKeyVaultResource;
+    public IAzureKeyVaultResource Resource => azureKeyVaultResource;
 
     string IManifestExpressionProvider.ValueExpression => $"{{{azureKeyVaultResource.Name}.secrets.{SecretName}}}";
 

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -118,7 +118,7 @@ public static class AzurePostgresExtensions
     /// This requires changes to the application code to use an azure credential to authenticate with the resource. See
     /// https://learn.microsoft.com/azure/postgresql/flexible-server/how-to-connect-with-managed-identity#connect-using-managed-identity-in-c for more information.
     ///
-    /// You can use the <see cref="WithPasswordAuthentication(IResourceBuilder{AzurePostgresFlexibleServerResource}, IResourceBuilder{IKeyVaultResource}, IResourceBuilder{ParameterResource}?, IResourceBuilder{ParameterResource}?)"/> method to configure the resource to use password authentication.
+    /// You can use the <see cref="WithPasswordAuthentication(IResourceBuilder{AzurePostgresFlexibleServerResource}, IResourceBuilder{IAzureKeyVaultResource}, IResourceBuilder{ParameterResource}?, IResourceBuilder{ParameterResource}?)"/> method to configure the resource to use password authentication.
     /// </remarks>
     /// <example>
     /// The following example creates an Azure PostgreSQL Flexible Server resource and referencing that resource in a .NET project.
@@ -317,7 +317,7 @@ public static class AzurePostgresExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> builder.</returns>
     public static IResourceBuilder<AzurePostgresFlexibleServerResource> WithPasswordAuthentication(
         this IResourceBuilder<AzurePostgresFlexibleServerResource> builder,
-        IResourceBuilder<IKeyVaultResource> keyVaultBuilder,
+        IResourceBuilder<IAzureKeyVaultResource> keyVaultBuilder,
         IResourceBuilder<ParameterResource>? userName = null,
         IResourceBuilder<ParameterResource>? password = null)
     {

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -33,7 +33,7 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
     ///
     /// This is set when password authentication is used. The connection string is stored in a secret in the Azure Key Vault.
     /// </summary>
-    internal IKeyVaultSecretReference? ConnectionStringSecretOutput { get; set; }
+    internal IAzureKeyVaultSecretReference? ConnectionStringSecretOutput { get; set; }
 
     private BicepOutputReference NameOutputReference => new("name", this);
 

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
@@ -29,7 +29,7 @@ public class AzureRedisCacheResource(string name, Action<AzureResourceInfrastruc
     ///
     /// This is set when access key authentication is used. The connection string is stored in a secret in the Azure Key Vault.
     /// </summary>
-    internal IKeyVaultSecretReference? ConnectionStringSecretOutput { get; set; }
+    internal IAzureKeyVaultSecretReference? ConnectionStringSecretOutput { get; set; }
 
     private BicepOutputReference NameOutputReference => new("name", this);
 

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -96,7 +96,7 @@ public static class AzureRedisExtensions
     /// This requires changes to the application code to use an azure credential to authenticate with the resource. See
     /// https://github.com/Azure/Microsoft.Azure.StackExchangeRedis for more information.
     ///
-    /// You can use the <see cref="WithAccessKeyAuthentication(IResourceBuilder{AzureRedisCacheResource}, IResourceBuilder{IKeyVaultResource})"/> method to configure the resource to use access key authentication.
+    /// You can use the <see cref="WithAccessKeyAuthentication(IResourceBuilder{AzureRedisCacheResource}, IResourceBuilder{IAzureKeyVaultResource})"/> method to configure the resource to use access key authentication.
     /// </remarks>
     /// <example>
     /// The following example creates an Azure Cache for Redis resource and referencing that resource in a .NET project.
@@ -218,7 +218,7 @@ public static class AzureRedisExtensions
     /// <param name="builder">The Azure Cache for Redis resource builder.</param>
     /// <param name="keyVaultBuilder">The Azure Key Vault resource builder where the connection string used to connect to this AzureRedisCacheResource will be stored.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> builder.</returns>
-    public static IResourceBuilder<AzureRedisCacheResource> WithAccessKeyAuthentication(this IResourceBuilder<AzureRedisCacheResource> builder, IResourceBuilder<IKeyVaultResource> keyVaultBuilder)
+    public static IResourceBuilder<AzureRedisCacheResource> WithAccessKeyAuthentication(this IResourceBuilder<AzureRedisCacheResource> builder, IResourceBuilder<IAzureKeyVaultResource> keyVaultBuilder)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(keyVaultBuilder);

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -362,7 +362,7 @@ internal sealed class AzureResourcePreparer(
             return;
         }
 
-        if (value is IKeyVaultSecretReference keyVaultSecretReference)
+        if (value is IAzureKeyVaultSecretReference keyVaultSecretReference)
         {
             azureReferences.Add(keyVaultSecretReference.Resource);
             return;

--- a/src/Aspire.Hosting.Azure/IAzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/IAzureKeyVaultResource.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Represents a resource that represents an Azure Key Vault.
 /// </summary>
-public interface IKeyVaultResource : IResource, IAzureResource
+public interface IAzureKeyVaultResource : IResource, IAzureResource
 {
     /// <summary>
     /// Gets the output reference that represents the vault uri for the Azure Key Vault resource.
@@ -23,12 +23,12 @@ public interface IKeyVaultResource : IResource, IAzureResource
     /// <summary>
     /// Gets or sets the secret resolver function used to resolve secrets at runtime.
     /// </summary>
-    Func<IKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
+    Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
 
     /// <summary>
     /// Gets a secret reference for the specified secret name.
     /// </summary>
     /// <param name="secretName">The name of the secret.</param>
     /// <returns>A reference to the secret.</returns>
-    IKeyVaultSecretReference GetSecretReference(string secretName);
+    IAzureKeyVaultSecretReference GetSecretReference(string secretName);
 }

--- a/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Represents a reference to a secret in an Azure Key Vault resource.
 /// </summary>
-public interface IKeyVaultSecretReference : IValueProvider, IManifestExpressionProvider
+public interface IAzureKeyVaultSecretReference : IValueProvider, IManifestExpressionProvider
 {
     /// <summary>
     /// Gets the name of the secret.
@@ -18,5 +18,5 @@ public interface IKeyVaultSecretReference : IValueProvider, IManifestExpressionP
     /// <summary>
     /// Gets the Azure Key Vault resource.
     /// </summary>
-    IKeyVaultResource Resource { get; }
+    IAzureKeyVaultResource Resource { get; }
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -278,7 +278,7 @@ internal sealed class BicepProvisioner(
         }
 
         // Populate secret outputs from key vault (if any)
-        if (resource is IKeyVaultResource kvr)
+        if (resource is IAzureKeyVaultResource kvr)
         {
             var vaultUri = resource.Outputs[kvr.VaultUriOutputReference.Name] as string ?? throw new InvalidOperationException($"{kvr.VaultUriOutputReference.Name} not found in outputs.");
 


### PR DESCRIPTION
Using the Azure prefix, as we do this everywhere else.

Contributes to #7811

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
