### PR TITLE
Remove null/nullable parameter from DistributedApplicationExecutionContext

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -130,7 +130,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         {
             DistributedApplicationOperation.Run => new DistributedApplicationExecutionContextOptions(operation),
             DistributedApplicationOperation.Inspect => new DistributedApplicationExecutionContextOptions(operation),
-            _ => new DistributedApplicationExecutionContextOptions(operation, _innerBuilder.Configuration["Publishing:Publisher"])
+            DistributedApplicationOperation.Publish => new DistributedApplicationExecutionContextOptions(operation, _innerBuilder.Configuration["Publishing:Publisher"] ?? "manifest"),
+            _ => throw new DistributedApplicationException("Invalid operation specified. Valid operations are 'publish', 'inspect', or 'run'.")
         };
     }
 

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -36,7 +36,7 @@ public class DistributedApplicationExecutionContext
     /// <summary>
     /// The name of the publisher that is being used if <see cref="Operation"/> is set to <see cref="DistributedApplicationOperation.Publish"/>. 
     /// </summary>
-    public string? PublisherName { get; set; }
+    public string PublisherName { get; set; }
 
     private readonly DistributedApplicationExecutionContextOptions? _options;
 

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContextOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContextOptions.cs
@@ -21,7 +21,7 @@ public class DistributedApplicationExecutionContextOptions
     /// </summary>
     /// <param name="operation">Indicates whether the AppHost is running in Publish mode or Run mode.</param>
     /// <param name="publisherName">The publisher name if in Publish mode.</param>
-    public DistributedApplicationExecutionContextOptions(DistributedApplicationOperation operation, string? publisherName = null)
+    public DistributedApplicationExecutionContextOptions(DistributedApplicationOperation operation, string? publisherName)
     {
         this.Operation = operation;
         this.PublisherName = publisherName;
@@ -38,7 +38,7 @@ public class DistributedApplicationExecutionContextOptions
     public DistributedApplicationOperation Operation { get; }
 
     /// <summary>
-    /// The name of the publisher if running in pbublish mode.
+    /// The name of the publisher if running in publish mode.
     /// </summary>
     public string? PublisherName { get; }
 }

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContextOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContextOptions.cs
@@ -12,8 +12,9 @@ public class DistributedApplicationExecutionContextOptions
     /// Constructs a <see cref="DistributedApplicationExecutionContextOptions" />.
     /// </summary>
     /// <param name="operation">Indicates whether the AppHost is running in Publish mode or Run mode.</param>
-    public DistributedApplicationExecutionContextOptions(DistributedApplicationOperation operation) : this(operation, null)
+    public DistributedApplicationExecutionContextOptions(DistributedApplicationOperation operation)
     {
+        this.Operation = operation;
     }
 
     /// <summary>
@@ -21,7 +22,7 @@ public class DistributedApplicationExecutionContextOptions
     /// </summary>
     /// <param name="operation">Indicates whether the AppHost is running in Publish mode or Run mode.</param>
     /// <param name="publisherName">The publisher name if in Publish mode.</param>
-    public DistributedApplicationExecutionContextOptions(DistributedApplicationOperation operation, string? publisherName)
+    public DistributedApplicationExecutionContextOptions(DistributedApplicationOperation operation, string publisherName)
     {
         this.Operation = operation;
         this.PublisherName = publisherName;


### PR DESCRIPTION
## Description

1- There is an overload that doesn't take the parameter.
2- Property can't be created with a `null` PublisherName.

Contributes to https://github.com/dotnet/aspire/pull/7811

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
