### PR TITLE
mysql test timeouts

### DIFF
--- a/tests/Aspire.Hosting.MySql.Tests/Aspire.Hosting.MySql.Tests.csproj
+++ b/tests/Aspire.Hosting.MySql.Tests/Aspire.Hosting.MySql.Tests.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="..\..\src\Components\Aspire.Pomelo.EntityFrameworkCore.MySql\Aspire.Pomelo.EntityFrameworkCore.MySql.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -28,7 +28,8 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     [RequiresDocker]
     public async Task VerifyWaitForOnMySqlBlocksDependentResources()
     {
-        var ct = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan).Token;
+        using var cts = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
+        var ct = cts.Token;
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
 
         var healthCheckTcs = new TaskCompletionSource<HealthCheckResult>();
@@ -66,7 +67,8 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     [RequiresDocker]
     public async Task VerifyMySqlResource()
     {
-        var ct = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2).Token;
+        using var cts = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2);
+        var ct = cts.Token;
         var pipeline = new ResiliencePipelineBuilder()
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2), ShouldHandle = new PredicateBuilder().Handle<MySqlException>() })
             .Build();
@@ -120,7 +122,8 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
         string? volumeName = null;
         string? bindMountPath = null;
 
-        var ct = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2).Token;
+        using var cts = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2);
+        var ct = cts.Token;
         var pipeline = new ResiliencePipelineBuilder()
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2) })
             .Build();
@@ -297,7 +300,8 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     {
         // Creates a script that should be executed when the container is initialized.
 
-        var ct = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2).Token;
+        using var cts = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2);
+        var ct = cts.Token;
         var pipeline = new ResiliencePipelineBuilder()
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2), ShouldHandle = new PredicateBuilder().Handle<MySqlException>() })
             .Build();
@@ -381,7 +385,8 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/7340")]
     public async Task VerifyEfMySql()
     {
-        var ct = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2).Token;
+        using var cts = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2);
+        var ct = cts.Token;
         var pipeline = new ResiliencePipelineBuilder()
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(1), ShouldHandle = new PredicateBuilder().Handle<MySqlException>() })
             .Build();
@@ -454,7 +459,8 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
         // it generates and mounts a config.user.inc.php file instead of using environment variables.
         // For this reason we need to test with and without multiple instances to cover both scenarios.
 
-        var ct = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2).Token;
+        using var cts = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2);
+        var ct = cts.Token;
 
         // Use the same path for both runs
         var aspireStorePath = Directory.CreateTempSubdirectory().FullName;

--- a/tests/Aspire.Hosting.Tests/Utils/LoggerNotificationExtensions.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/LoggerNotificationExtensions.cs
@@ -28,7 +28,7 @@ public static class LoggerNotificationExtensions
         return WaitForTextAsync(app, (log) => log.Contains(logText), resourceName, cancellationToken);
     }
 
-    public static async Task WaitForHealthyAsync<T>(this DistributedApplication app, IResourceBuilder<T> resource, CancellationToken cancellationToken = default) where T: IResource
+    public static async Task WaitForHealthyAsync<T>(this DistributedApplication app, IResourceBuilder<T> resource, CancellationToken cancellationToken = default) where T : IResource
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentNullException.ThrowIfNull(resource);
@@ -51,6 +51,16 @@ public static class LoggerNotificationExtensions
 
         return app.WaitForTextAsync((log) => logTexts.Any(x => log.Contains(x)), resourceName, cancellationToken);
     }
+
+    /// <summary>
+    /// Waits for the specified text to be logged.
+    /// </summary>
+    /// <param name="app">The <see cref="DistributedApplication" /> instance to watch.</param>
+    /// <param name="predicate">A predicate checking the text to wait for.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    public static Task WaitForTextAsync(this DistributedApplication app, Predicate<string> predicate, CancellationToken cancellationToken = default)
+        => app.WaitForTextAsync(predicate, resourceName: null, cancellationToken);
 
     /// <summary>
     /// Waits for the specified text to be logged.

--- a/tests/Shared/AsyncTestHelpers.cs
+++ b/tests/Shared/AsyncTestHelpers.cs
@@ -20,11 +20,13 @@ internal static class TestConstants
     // Less time waiting for hang unit tests to fail in aspnetcore solution.
     public static readonly int DefaultTimeoutDuration = 5 * 1000 * (PlatformDetection.IsRunningOnCI ? 6 : 1); // 5 sec, 30 sec in CI
     public static readonly int LongTimeoutDuration = 60 * 1000 * (PlatformDetection.IsRunningOnCI ? 3 : 1); // 60 sec, 180 sec in CI
+    public static readonly int ExtraLongTimeoutDuration = 60 * 1000 * 3 * (PlatformDetection.IsRunningOnCI ? 2 : 1); // 180 sec, 360 sec in CI -- useful when a docker image might need pulling
     public static readonly int DefaultOrchestratorTestTimeout = 15 * 1000 * (PlatformDetection.IsRunningOnCI ? 2 : 1); // 15 sec, 30 sec in CI
     public static readonly int DefaultOrchestratorTestLongTimeout = 45 * 1000 * (PlatformDetection.IsRunningOnCI ? 4 : 1); // 45 sec, 180 sec in CI
 
     public static TimeSpan DefaultTimeoutTimeSpan { get; } = TimeSpan.FromMilliseconds(DefaultTimeoutDuration);
     public static TimeSpan LongTimeoutTimeSpan { get; } = TimeSpan.FromMilliseconds(LongTimeoutDuration);
+    public static TimeSpan ExtraLongTimeoutTimeSpan { get; } = TimeSpan.FromMilliseconds(ExtraLongTimeoutDuration);
 }
 
 internal static class AsyncTestHelpers


### PR DESCRIPTION
## Description

MySql test was timing out here and it seemed almost all the 2 mins was pulling the mysql docker image.
https://github.com/dotnet/aspire/blob/1007a6c69ab3e2e1a09e06bbf02d53a1208a8c2e/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs#L156

1. Change MySql tests to have a single timeout using a ct, so they're easier to reason about.
2. Change the ct timeout to something similar in terms of a new ExtraLongTimeout, so it can be changed centrally.
3. Make ExtraLongTimeout longer on CI.

It's super hard to reason about whether timeouts are too long or not. They're everywhere in the tests. But it probably makes sense to convert tests to have an overall timeout like this so they're easier to reason about, and to centralize the value to some extent.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
