### PR TITLE
Improve path prompt for aspire new command.

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -49,13 +49,13 @@ internal sealed class NewCommand : BaseCommand
         //       interrogate the various options and add them. For now we will 
         //       keep it simple.
         (string TemplateName, string TemplateDescription, string? PathAppendage)[] validTemplates = [
-            ("aspire-starter", "Aspire Starter App", "src") ,
-            ("aspire", "Aspire Empty App", "src"),
-            ("aspire-apphost", "Aspire App Host", null),
-            ("aspire-servicedefaults", "Aspire Service Defaults", null),
-            ("aspire-mstest", "Aspire Test Project (MSTest)", null),
-            ("aspire-nunit", "Aspire Test Project (NUnit)", null),
-            ("aspire-xunit", "Aspire Test Project (xUnit)", null)
+            ("aspire-starter", "Aspire Starter App", "./src") ,
+            ("aspire", "Aspire Empty App", "./src"),
+            ("aspire-apphost", "Aspire App Host", "./"),
+            ("aspire-servicedefaults", "Aspire Service Defaults", "./"),
+            ("aspire-mstest", "Aspire Test Project (MSTest)", "./"),
+            ("aspire-nunit", "Aspire Test Project (NUnit)", "./"),
+            ("aspire-xunit", "Aspire Test Project (xUnit)", "./")
             ];
 
         if (parseResult.GetValue<string?>("template") is { } templateName && validTemplates.SingleOrDefault(t => t.TemplateName == templateName) is { } template)
@@ -92,7 +92,7 @@ internal sealed class NewCommand : BaseCommand
         {
             outputPath = await PromptUtils.PromptForStringAsync(
                 "Enter the output path:",
-                defaultValue: Path.Combine(Environment.CurrentDirectory, pathAppendage ?? string.Empty),
+                defaultValue: pathAppendage ?? ".",
                 cancellationToken: cancellationToken
                 );
         }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -23,9 +23,9 @@ internal sealed class RunCommand : BaseCommand
 
         _runner = runner;
 
-        var projectOption = new Option<FileInfo?>("--project");
-        projectOption.Validators.Add(ProjectFileHelper.ValidateProjectOption);
-        Options.Add(projectOption);
+        var projectArgument = new Argument<FileInfo?>("project");
+        projectArgument.Validators.Add(ProjectFileHelper.ValidateProjectArgument);
+        Arguments.Add(projectArgument);
 
         var watchOption = new Option<bool>("--watch", "-w");
         Options.Add(watchOption);
@@ -35,7 +35,7 @@ internal sealed class RunCommand : BaseCommand
     {
         using var activity = _activitySource.StartActivity();
 
-        var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
+        var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("project");
         var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);
         
         if (effectiveAppHostProjectFile is null)

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -23,7 +23,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
     {
         using var activity = _activitySource.StartActivity();
 
-        string[] cliArgs = ["msbuild", "-getproperty:IsAspireHost,AspireHostingSDKVersion"];
+        string[] cliArgs = ["msbuild", "-getproperty:IsAspireHost,AspireHostingSDKVersion", projectFile.FullName];
 
         string? stdout = null;
         string? stderr = null;

--- a/src/Aspire.Cli/Utils/ProjectFileHelper.cs
+++ b/src/Aspire.Cli/Utils/ProjectFileHelper.cs
@@ -47,6 +47,38 @@ internal static class ProjectFileHelper
         };
     }
 
+    internal static void ValidateProjectArgument(ArgumentResult result)
+    {
+        var value = result.GetValueOrDefault<FileInfo?>();
+
+        if (value is null)
+        {
+            // Having no value here is fine, but there has to
+            // be a single csproj file in the current
+            // working directory.
+            var csprojFiles = Directory.GetFiles(Environment.CurrentDirectory, "*.csproj");
+
+            if (csprojFiles.Length > 1)
+            {
+                result.AddError("The --project option was not specified and multiple *.csproj files were detected.");
+                return;
+            }
+            else if (csprojFiles.Length == 0)
+            {
+                result.AddError("The --project option was not specified and no *.csproj files were detected.");
+                return;
+            }
+
+            return;
+        }
+
+        if (!File.Exists(value.FullName))
+        {
+            result.AddError("The specified project file does not exist.");
+            return;
+        }
+    }
+
     internal static void ValidateProjectOption(OptionResult result)
     {
         var value = result.GetValueOrDefault<FileInfo?>();

--- a/src/Aspire.Cli/Utils/ProjectFileHelper.cs
+++ b/src/Aspire.Cli/Utils/ProjectFileHelper.cs
@@ -60,12 +60,12 @@ internal static class ProjectFileHelper
 
             if (csprojFiles.Length > 1)
             {
-                result.AddError("The --project option was not specified and multiple *.csproj files were detected.");
+                result.AddError("The project argument was not specified and multiple *.csproj files were detected.");
                 return;
             }
             else if (csprojFiles.Length == 0)
             {
-                result.AddError("The --project option was not specified and no *.csproj files were detected.");
+                result.AddError("The project argument was not specified and no *.csproj files were detected.");
                 return;
             }
 


### PR DESCRIPTION
This PR improves the way that we prompt for the output path in the `aspire new` command. Previously we howed the absolution path as a default. Now we show a relative path which the user can accept or override with a new relative path or a new absolute path:


https://github.com/user-attachments/assets/7602a305-1ade-4055-bb4b-b5d891dbc346

