### PR TITLE
Adding descriptions to all args/options in CLI.

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -16,7 +16,7 @@ internal sealed class AddCommand : BaseCommand
     private readonly INuGetPackageCache _nuGetPackageCache;
 
     public AddCommand(DotNetCliRunner runner, INuGetPackageCache nuGetPackageCache)
-        : base("add", "Add an integration or other resource to the Aspire project.")
+        : base("add", "Add an integration to the Aspire project.")
     {
         ArgumentNullException.ThrowIfNull(runner, nameof(runner));
         ArgumentNullException.ThrowIfNull(nuGetPackageCache, nameof(nuGetPackageCache));

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -23,10 +23,10 @@ internal sealed class AddCommand : BaseCommand
         _runner = runner;
         _nuGetPackageCache = nuGetPackageCache;
 
-        var resourceArgument = new Argument<string>("resource");
-        resourceArgument.Description = "The name of the integration or resource to add (e.g. redis, postgres).";
-        resourceArgument.Arity = ArgumentArity.ZeroOrOne;
-        Arguments.Add(resourceArgument);
+        var integrationArgument = new Argument<string>("integration");
+        integrationArgument.Description = "The name of the integration to add (e.g. redis, postgres).";
+        integrationArgument.Arity = ArgumentArity.ZeroOrOne;
+        Arguments.Add(integrationArgument);
 
         var projectOption = new Option<FileInfo?>("--project");
         projectOption.Description = "The path to the project file to add the integration to.";
@@ -52,7 +52,7 @@ internal sealed class AddCommand : BaseCommand
 
         try
         {
-            var integrationName = parseResult.GetValue<string>("resource");
+            var integrationName = parseResult.GetValue<string>("integration");
 
             var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
             var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -15,7 +15,8 @@ internal sealed class AddCommand : BaseCommand
     private readonly DotNetCliRunner _runner;
     private readonly INuGetPackageCache _nuGetPackageCache;
 
-    public AddCommand(DotNetCliRunner runner, INuGetPackageCache nuGetPackageCache) : base("add", "Add an integration or other resource to the Aspire project.")
+    public AddCommand(DotNetCliRunner runner, INuGetPackageCache nuGetPackageCache)
+        : base("add", "Add an integration or other resource to the Aspire project.")
     {
         ArgumentNullException.ThrowIfNull(runner, nameof(runner));
         ArgumentNullException.ThrowIfNull(nuGetPackageCache, nameof(nuGetPackageCache));
@@ -23,20 +24,25 @@ internal sealed class AddCommand : BaseCommand
         _nuGetPackageCache = nuGetPackageCache;
 
         var resourceArgument = new Argument<string>("resource");
+        resourceArgument.Description = "The name of the integration or resource to add (e.g. redis, postgres).";
         resourceArgument.Arity = ArgumentArity.ZeroOrOne;
         Arguments.Add(resourceArgument);
 
         var projectOption = new Option<FileInfo?>("--project");
+        projectOption.Description = "The path to the project file to add the integration to.";
         projectOption.Validators.Add(ProjectFileHelper.ValidateProjectOption);
         Options.Add(projectOption);
 
         var versionOption = new Option<string>("--version", "-v");
+        versionOption.Description = "The version of the integration to add.";
         Options.Add(versionOption);
 
         var prereleaseOption = new Option<bool>("--prerelease");
+        prereleaseOption.Description = "Include pre-release versions of the integration when searching.";
         Options.Add(prereleaseOption);
 
         var sourceOption = new Option<string?>("--source", "-s");
+        sourceOption.Description = "The NuGet source to use for the integration.";
         Options.Add(sourceOption);
     }
 

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -15,7 +15,8 @@ internal sealed class NewCommand : BaseCommand
     private readonly DotNetCliRunner _runner;
     private readonly INuGetPackageCache _nuGetPackageCache;
 
-    public NewCommand(DotNetCliRunner runner, INuGetPackageCache nuGetPackageCache) : base("new", "Create a new Aspire sample project.")
+    public NewCommand(DotNetCliRunner runner, INuGetPackageCache nuGetPackageCache)
+        : base("new", "Create a new Aspire sample project.")
     {
         ArgumentNullException.ThrowIfNull(runner, nameof(runner));
         ArgumentNullException.ThrowIfNull(nuGetPackageCache, nameof(nuGetPackageCache));
@@ -23,19 +24,24 @@ internal sealed class NewCommand : BaseCommand
         _nuGetPackageCache = nuGetPackageCache;
 
         var templateArgument = new Argument<string>("template");
+        templateArgument.Description = "The name of the project template to use (e.g. aspire-starter, aspire).";
         templateArgument.Arity = ArgumentArity.ZeroOrOne;
         Arguments.Add(templateArgument);
 
         var nameOption = new Option<string>("--name", "-n");
+        nameOption.Description = "The name of the project to create.";
         Options.Add(nameOption);
 
         var outputOption = new Option<string?>("--output", "-o");
+        outputOption.Description = "The output path for the project.";
         Options.Add(outputOption);
         
         var sourceOption = new Option<string?>("--source", "-s");
+        sourceOption.Description = "The NuGet source to use for the project templates.";
         Options.Add(sourceOption);
 
         var templateVersionOption = new Option<string?>("--version", "-v");
+        templateVersionOption.Description = "The version of the project templates to use.";
         Options.Add(templateVersionOption);
     }
 

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -15,19 +15,23 @@ internal sealed class PublishCommand : BaseCommand
     private readonly ActivitySource _activitySource = new ActivitySource(nameof(PublishCommand));
     private readonly DotNetCliRunner _runner;
 
-    public PublishCommand(DotNetCliRunner runner) : base("publish", "Generates deployment artifacts for an Aspire app host project.")
+    public PublishCommand(DotNetCliRunner runner)
+        : base("publish", "Generates deployment artifacts for an Aspire app host project.")
     {
         ArgumentNullException.ThrowIfNull(runner, nameof(runner));
         _runner = runner;
 
         var projectOption = new Option<FileInfo?>("--project");
+        projectOption.Description = "The path to the Aspire app host project file.";
         projectOption.Validators.Add(ProjectFileHelper.ValidateProjectOption);
         Options.Add(projectOption);
 
         var publisherOption = new Option<string>("--publisher", "-p");
+        publisherOption.Description = "The name of the publisher to use.";
         Options.Add(publisherOption);
 
         var outputPath = new Option<string>("--output-path", "-o");
+        outputPath.Description = "The output path for the generated artifacts.";
         outputPath.DefaultValueFactory = (result) => Path.Combine(Environment.CurrentDirectory);
         Options.Add(outputPath);
     }

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -14,13 +14,16 @@ namespace Aspire.Cli.Commands;
 
 internal sealed class RootCommand : BaseRootCommand
 {
-    public RootCommand(NewCommand newCommand, RunCommand runCommand, AddCommand addCommand, PublishCommand publishCommand) : base("Aspire CLI")
+    public RootCommand(NewCommand newCommand, RunCommand runCommand, AddCommand addCommand, PublishCommand publishCommand)
+        : base("Use the Aspire command-line interface to create, run, and publish Aspire-based applications.")
     {
         var debugOption = new Option<bool>("--debug", "-d");
+        debugOption.Description = "Enable debug logging to the console.";
         debugOption.Recursive = true;
         Options.Add(debugOption);
         
         var waitForDebuggerOption = new Option<bool>("--wait-for-debugger", "-w");
+        waitForDebuggerOption.Description = "Wait for a debugger to attach before executing the command.";
         waitForDebuggerOption.Recursive = true;
         waitForDebuggerOption.DefaultValueFactory = (result) => false;
 

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -15,7 +15,7 @@ namespace Aspire.Cli.Commands;
 internal sealed class RootCommand : BaseRootCommand
 {
     public RootCommand(NewCommand newCommand, RunCommand runCommand, AddCommand addCommand, PublishCommand publishCommand)
-        : base("Use the Aspire command-line interface to create, run, and publish Aspire-based applications.")
+        : base("The Aspire CLI can be used to create, run, and publish Aspire-based applications.")
     {
         var debugOption = new Option<bool>("--debug", "-d");
         debugOption.Description = "Enable debug logging to the console.";

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -24,10 +24,10 @@ internal sealed class RunCommand : BaseCommand
 
         _runner = runner;
 
-        var projectArgument = new Argument<FileInfo?>("project");
-        projectArgument.Description = "The path to the Aspire app host project file.";
-        projectArgument.Validators.Add(ProjectFileHelper.ValidateProjectArgument);
-        Arguments.Add(projectArgument);
+        var projectOption = new Option<FileInfo?>("--project");
+        projectOption.Description = "The path to the Aspire app host project file.";
+        projectOption.Validators.Add(ProjectFileHelper.ValidateProjectOption);
+        Options.Add(projectOption);
 
         var watchOption = new Option<bool>("--watch", "-w");
         watchOption.Description = "Start .NET project resources in watch mode.";
@@ -38,7 +38,7 @@ internal sealed class RunCommand : BaseCommand
     {
         using var activity = _activitySource.StartActivity();
 
-        var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("project");
+        var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
         var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);
         
         if (effectiveAppHostProjectFile is null)

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -17,17 +17,20 @@ internal sealed class RunCommand : BaseCommand
     private readonly ActivitySource _activitySource = new ActivitySource(nameof(RunCommand));
     private readonly DotNetCliRunner _runner;
 
-    public RunCommand(DotNetCliRunner runner) : base("run", "Run an Aspire app host in development mode.")
+    public RunCommand(DotNetCliRunner runner)
+        : base("run", "Run an Aspire app host in development mode.")
     {
         ArgumentNullException.ThrowIfNull(runner, nameof(runner));
 
         _runner = runner;
 
         var projectArgument = new Argument<FileInfo?>("project");
+        projectArgument.Description = "The path to the Aspire app host project file.";
         projectArgument.Validators.Add(ProjectFileHelper.ValidateProjectArgument);
         Arguments.Add(projectArgument);
 
         var watchOption = new Option<bool>("--watch", "-w");
+        watchOption.Description = "Start .NET project resources in watch mode.";
         Options.Add(watchOption);
     }
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -30,7 +30,7 @@ internal sealed class RunCommand : BaseCommand
         Options.Add(projectOption);
 
         var watchOption = new Option<bool>("--watch", "-w");
-        watchOption.Description = "Start .NET project resources in watch mode.";
+        watchOption.Description = "Start project resources in watch mode.";
         Options.Add(watchOption);
     }
 


### PR DESCRIPTION
CLI help text pass.

# `aspire --help`

```
Description:
  The Aspire CLI can be used to create, run, and publish Aspire-based applications.

Usage:
  aspire [command] [options]

Options:
  -?, -h, --help           Show help and usage information
  --version                Show version information
  -d, --debug              Enable debug logging to the console.
  -w, --wait-for-debugger  Wait for a debugger to attach before executing the command. [default: False]

Commands:
  new <template>  Create a new Aspire sample project.
  run             Run an Aspire app host in development mode.
  add <resource>  Add an integration to the Aspire project.
  publish         Generates deployment artifacts for an Aspire app host project.
```

# `aspire new --help`

```
Description:
  Create a new Aspire sample project.

Usage:
  aspire new [<template>] [options]

Arguments:
  <template>  The name of the project template to use (e.g. aspire-starter, aspire).

Options:
  -n, --name               The name of the project to create.
  -o, --output             The output path for the project.
  -s, --source             The NuGet source to use for the project templates.
  -v, --version            The version of the project templates to use.
  -?, -h, --help           Show help and usage information
  -d, --debug              Enable debug logging to the console.
  -w, --wait-for-debugger  Wait for a debugger to attach before executing the command. [default: False]
```

# `aspire run --help`

```
Description:
  Run an Aspire app host in development mode.

Usage:
  aspire run [options]

Options:
  --project                The path to the Aspire app host project file.
  -w, --watch              Start .NET project resources in watch mode.
  -?, -h, --help           Show help and usage information
  -d, --debug              Enable debug logging to the console.
  -w, --wait-for-debugger  Wait for a debugger to attach before executing the command. [default: False]
```

# `aspire add --help`

```
Description:
  Add an integration to the Aspire project.

Usage:
  aspire add [<resource>] [options]

Arguments:
  <resource>  The name of the integration or resource to add (e.g. redis, postgres).

Options:
  --project                The path to the project file to add the integration to.
  -v, --version            The version of the integration to add.
  --prerelease             Include pre-release versions of the integration when searching.
  -s, --source             The NuGet source to use for the integration.
  -?, -h, --help           Show help and usage information
  -d, --debug              Enable debug logging to the console.
  -w, --wait-for-debugger  Wait for a debugger to attach before executing the command. [default: False]
```

# `aspire publish --help`

```
Description:
  Generates deployment artifacts for an Aspire app host project.

Usage:
  aspire publish [options]

Options:
  --project                The path to the Aspire app host project file.
  -p, --publisher          The name of the publisher to use.
  -o, --output-path        The output path for the generated artifacts. [default: /workspaces/aspire/src/Aspire.Cli]
  -?, -h, --help           Show help and usage information
  -d, --debug              Enable debug logging to the console.
  -w, --wait-for-debugger  Wait for a debugger to attach before executing the command. [default: False]
```
