### PR TITLE
CLI publishing failure fixes.

### DIFF
--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -47,6 +47,8 @@ builder.AddProject<Projects.Publishers_Frontend>("frontend")
        .WithEnvironment("P3", param3)
        .WithReference(backend).WaitFor(backend);
 
+builder.AddDockerfile("mycontainer", "qots");
+
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code

--- a/playground/publishers/Publishers.AppHost/qots/Dockerfile
+++ b/playground/publishers/Publishers.AppHost/qots/Dockerfile
@@ -1,0 +1,12 @@
+# Stage 1: Build the Go program
+ARG GO_VERSION=1.23
+FROM mcr.microsoft.com/oss/go/microsoft/golang:${GO_VERSION} AS builder
+WORKDIR /app
+COPY . .
+RUN go build qots.go
+
+# Stage 2: Run the Go program
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+WORKDIR /app
+COPY --from=builder /app/qots .
+CMD ["./qots"]

--- a/playground/publishers/Publishers.AppHost/qots/qots.go
+++ b/playground/publishers/Publishers.AppHost/qots/qots.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"time"
+)
+
+func main() {
+	fmt.Println("Go runtime version:", runtime.Version())
+
+	quotes := []string{
+		"With great power comes great responsibility. - Spider-Man",
+		"I'm Batman. - Batman",
+		"I am Iron Man. - Iron Man",
+		"Why so serious? - The Joker",
+		"I'm always angry. - The Hulk",
+	}
+
+	rand.Seed(time.Now().UnixNano())
+
+	for {
+		quote := quotes[rand.Intn(len(quotes))]
+		fmt.Println(quote)
+		time.Sleep(time.Second)
+	}
+}

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -125,7 +125,7 @@ internal sealed class PublishCommand : BaseCommand
                 .HighlightStyle(Style.Parse("darkmagenta"))
                 .AddChoices(publishers!);
 
-            publisher = AnsiConsole.Prompt(publisherPrompt);
+            publisher = await AnsiConsole.PromptAsync(publisherPrompt, cancellationToken);
         }
 
         AnsiConsole.MarkupLine($":hammer_and_wrench:  Generating artifacts for '{publisher}' publisher...");

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -226,7 +226,7 @@ internal sealed class PublishCommand : BaseCommand
                     // stop the app host.
                     await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
                     var exitCode = await pendingRun;
-                    return exitCode; // shoudl be zero for orderly shutdown but we pass it along anyway.
+                    return exitCode; // should be zero for orderly shutdown but we pass it along anyway.
                 }
             });
 

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -144,7 +144,7 @@ internal sealed class PublishCommand : BaseCommand
                 
                 var backchannelCompletionSource = new TaskCompletionSource<AppHostBackchannel>();
 
-                var launchingAppHostTask = context.AddTask("Launching apphost");
+                var launchingAppHostTask = context.AddTask(":play_button: Launching apphost");
                 launchingAppHostTask.IsIndeterminate();
                 launchingAppHostTask.StartTask();
 
@@ -159,6 +159,7 @@ internal sealed class PublishCommand : BaseCommand
 
                 var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
 
+                launchingAppHostTask.Description = $":check_mark: Launching apphost";
                 launchingAppHostTask.Value = 100;
                 launchingAppHostTask.StopTask();
 
@@ -176,37 +177,67 @@ internal sealed class PublishCommand : BaseCommand
                         progressTasks.Add(publishingActivity.Id, progressTask);
                     }
 
-                    progressTask.Description = $"{publishingActivity.StatusText}";
+                    progressTask.Description = $":play_button: {publishingActivity.StatusText}";
 
-                    if (publishingActivity.IsComplete)
+                    if (publishingActivity.IsComplete && !publishingActivity.IsError)
                     {
+                        progressTask.Description = $":check_mark: {publishingActivity.StatusText}";
                         progressTask.Value = 100;
                         progressTask.StopTask();
                     }
                     else if (publishingActivity.IsError)
                     {
-                        progressTask.Value = 100;
-                        progressTask.StopTask();
+                        progressTask.Description = $"[red bold]:cross_mark: {publishingActivity.StatusText}[/]";
+                        progressTask.Value = 0;
+                        break;
+                    }
+                    else
+                    {
+                        // Keep going man!
                     }
                 }
+
+                await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
 
                 // When we are running in publish mode we don't want the app host to
                 // stop itself while we might still be streaming data back across
                 // the RPC backchannel. So we need to take responsibility for stopping
                 // the app host. If the CLI exits/crashes without explicitly stopping
                 // the app host the orphan detector in the app host will kick in.
-                await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
-                return await pendingRun;
+                if (progressTasks.Any(kvp => !kvp.Value.IsFinished))
+                {
+                    // Depending on the failure the publisher may return a zero
+                    // exit code.
+                    await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
+                    var exitCode = await pendingRun;
+
+                    // If we are in the state where we've detected an error because there
+                    // is an incomplete task then we stop the app host, but depending on
+                    // where/how the failure occured, we might still get a zero exit
+                    // code. If we get a non-zero exit code we want to return that
+                    // as it might be useful for diagnostic purposes, however if we don't
+                    // get a non-zero exit code we want to return our built-in exit code
+                    // for failed artifact build.
+                    return exitCode == 0 ? ExitCodeConstants.FailedToBuildArtifacts : exitCode;
+                }
+                else
+                {
+                    // If we are here then all the tasks are finished and we can
+                    // stop the app host.
+                    await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
+                    var exitCode = await pendingRun;
+                    return exitCode; // shoudl be zero for orderly shutdown but we pass it along anyway.
+                }
             });
 
         if (exitCode != 0)
         {
-            AnsiConsole.MarkupLine($"[red bold]:thumbs_down:  The build failed with exit code {exitCode}. For more information run with --debug switch.[/]");
+            AnsiConsole.MarkupLine($"[red bold]:thumbs_down: Publishing artifacts failed with exit code {exitCode}. For more information run with --debug switch.[/]");
             return ExitCodeConstants.FailedToBuildArtifacts;
         }
         else
         {
-            AnsiConsole.MarkupLine($"[green bold]:thumbs_up:  The build completed successfully to: {fullyQualifiedOutputPath}[/]");
+            AnsiConsole.MarkupLine($"[green bold]:thumbs_up: Successfully published artifacts to: {fullyQualifiedOutputPath}[/]");
             return ExitCodeConstants.Success;
         }
     }

--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -261,7 +261,7 @@ internal sealed class DockerComposePublishingContext(
                                                 $"{resourceInstance.Name}:latest");
 
                 containerImageName = $"${{{imageEnvName}}}";
-                return false;
+                return true;
             }
 
             return resourceInstance.TryGetContainerImageName(out containerImageName);

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -67,6 +67,11 @@ internal sealed class DistributedApplicationRunner(ILogger<DistributedApplicatio
                 logger.LogError(ex, "Failed to publish the distributed application.");
                 publishingActivity.IsError = true;
                 await activityReporter.UpdateActivityAsync(publishingActivity, stoppingToken).ConfigureAwait(false);
+
+                if (!backchannelService.IsBackchannelExpected)
+                {
+                     lifetime.StopApplication();
+                }
             }
         }
     }

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -140,7 +140,7 @@ internal sealed class ResourceContainerImageBuilder(
             publishingActivity.IsComplete = true;
             await activityReporter.UpdateActivityAsync(publishingActivity, cancellationToken).ConfigureAwait(false);
 
-            logger.LogError(
+            logger.LogDebug(
                 ".NET CLI completed with exit code: {ExitCode}",
                 process.ExitCode);
 


### PR DESCRIPTION
This PR improves the publishing failure UX. There are a couple of improvments.

1. Publisher selection is now using an async call from Spectre console so cancellation is faster.
2. Changed the app host so that if there is a failure during publishing that the app host stops (fixes: #8549)
3. Removed an erroneous LogError when it should have been a debug message.
4. Fixed TryGetContainerImageName which was also resulting in an erroneous warning/failure message when it actually worked.
5. Reworked the publisher UX so that when publishing fails, the stage in the publishing can be more obvious. This does require some publisher cooperation to catch and log publishing activities but at a minimum we'll get an error at the top level. Fixes: 

See video: #8547

https://github.com/user-attachments/assets/57ac0c65-c176-4b26-9637-5ffcc941cd2a