### PR TITLE
Switch to null as default for owner and group in WithContainerFiles

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
@@ -82,12 +82,12 @@ public sealed class ContainerFileSystemCallbackAnnotation : IResourceAnnotation
     public required string DestinationPath { get; init; }
 
     /// <summary>
-    /// The UID of the default owner for files/directories to be created or updated in the container. Defaults to 0 for root.
+    /// The UID of the default owner for files/directories to be created or updated in the container. The UID defaults to 0 if null.
     /// </summary>
     public int? DefaultOwner { get; init; }
 
     /// <summary>
-    /// The GID of the default group for files/directories to be created or updated in the container. Defaults to 0 for root.
+    /// The GID of the default group for files/directories to be created or updated in the container. The GID defaults to 0 if null.
     /// </summary>
     public int? DefaultGroup { get; init; }
 

--- a/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
@@ -84,12 +84,12 @@ public sealed class ContainerFileSystemCallbackAnnotation : IResourceAnnotation
     /// <summary>
     /// The UID of the default owner for files/directories to be created or updated in the container. Defaults to 0 for root.
     /// </summary>
-    public int DefaultOwner { get; init; }
+    public int? DefaultOwner { get; init; }
 
     /// <summary>
     /// The GID of the default group for files/directories to be created or updated in the container. Defaults to 0 for root.
     /// </summary>
-    public int DefaultGroup { get; init; }
+    public int? DefaultGroup { get; init; }
 
     /// <summary>
     /// The umask to apply to files or folders without an explicit mode permission. If set to null, a default umask value of 0022 (octal) will be used.

--- a/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
@@ -82,12 +82,12 @@ public sealed class ContainerFileSystemCallbackAnnotation : IResourceAnnotation
     public required string DestinationPath { get; init; }
 
     /// <summary>
-    /// The UID of the default owner for files/directories to be created or updated in the container. The UID defaults to 0 if null.
+    /// The UID of the default owner for files/directories to be created or updated in the container. The UID defaults to 0 for root if null.
     /// </summary>
     public int? DefaultOwner { get; init; }
 
     /// <summary>
-    /// The GID of the default group for files/directories to be created or updated in the container. The GID defaults to 0 if null.
+    /// The GID of the default group for files/directories to be created or updated in the container. The GID defaults to 0 for root if null.
     /// </summary>
     public int? DefaultGroup { get; init; }
 

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -706,8 +706,8 @@ public static class ContainerResourceBuilderExtensions
     /// <param name="builder">The resource builder for the container resource.</param>
     /// <param name="destinationPath">The destination (absolute) path in the container.</param>
     /// <param name="entries">The file system entries to create.</param>
-    /// <param name="defaultOwner">The default owner UID for the created or updated file system. Defaults to 0 for root.</param>
-    /// <param name="defaultGroup">The default group ID for the created or updated file system. Defaults to 0 for root.</param>
+    /// <param name="defaultOwner">The default owner UID for the created or updated file system. Defaults to 0 for root if not set.</param>
+    /// <param name="defaultGroup">The default group ID for the created or updated file system. Defaults to 0 for root if not set.</param>
     /// <param name="umask">The umask <see cref="UnixFileMode"/> permissions to exclude from the default file and folder permissions. This takes away (rather than granting) default permissions to files and folders without an explicit mode permission set.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
@@ -741,7 +741,7 @@ public static class ContainerResourceBuilderExtensions
     ///     defaultOwner: 1000);
     /// </code>
     /// </example>
-    public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, IEnumerable<ContainerFileSystemItem> entries, int defaultOwner = 0, int defaultGroup = 0, UnixFileMode? umask = null) where T : ContainerResource
+    public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, IEnumerable<ContainerFileSystemItem> entries, int? defaultOwner = null, int? defaultGroup = null, UnixFileMode? umask = null) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(destinationPath);
@@ -769,8 +769,8 @@ public static class ContainerResourceBuilderExtensions
     /// <param name="builder">The resource builder for the container resource.</param>
     /// <param name="destinationPath">The destination (absolute) path in the container.</param>
     /// <param name="callback">The callback that will be invoked when the resource is being created.</param>
-    /// <param name="defaultOwner">The default owner UID for the created or updated file system. Defaults to 0 for root.</param>
-    /// <param name="defaultGroup">The default group ID for the created or updated file system. Defaults to 0 for root.</param>
+    /// <param name="defaultOwner">The default owner UID for the created or updated file system. Defaults to 0 for root if not set.</param>
+    /// <param name="defaultGroup">The default group ID for the created or updated file system. Defaults to 0 for root if not set.</param>
     /// <param name="umask">The umask <see cref="UnixFileMode"/> permissions to exclude from the default file and folder permissions. This takes away (rather than granting) default permissions to files and folders without an explicit mode permission set.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
@@ -814,7 +814,7 @@ public static class ContainerResourceBuilderExtensions
     /// });
     /// </code>
     /// </example>
-    public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, Func<ContainerFileSystemCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> callback, int defaultOwner = 0, int defaultGroup = 0, UnixFileMode? umask = null) where T : ContainerResource
+    public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, Func<ContainerFileSystemCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> callback, int? defaultOwner = null, int? defaultGroup = null, UnixFileMode? umask = null) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(destinationPath);

--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -295,11 +295,13 @@ internal sealed class ContainerCreateFileSystem : IEquatable<ContainerCreateFile
 
     // The default owner UID to use for created (or updated) file system entries. Defaults to 0 for root.
     [JsonPropertyName("defaultOwner")]
-    public int DefaultOwner { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DefaultOwner { get; set; }
 
     // The default group GID to use for created (or updated) file system entries. Defaults to 0 for root.
     [JsonPropertyName("defaultGroup")]
-    public int DefaultGroup { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DefaultGroup { get; set; }
 
     // The umask for created files and folders without explicit permissions set (defaults to 022 if null)
     [JsonPropertyName("umask")]

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -476,8 +476,8 @@ public class AddPostgresTests
 
         Assert.Equal("/pgadmin4", createServers.DestinationPath);
         Assert.Null(createServers.Umask);
-        Assert.Equal(0, createServers.DefaultOwner);
-        Assert.Equal(0, createServers.DefaultGroup);
+        Assert.Null(createServers.DefaultOwner);
+        Assert.Null(createServers.DefaultGroup);
 
         var entries = await createServers.Callback(new() { Model = pgadmin, ServiceProvider = app.Services }, CancellationToken.None);
 
@@ -547,8 +547,8 @@ public class AddPostgresTests
 
         Assert.Equal("/", createBookmarks.DestinationPath);
         Assert.Null(createBookmarks.Umask);
-        Assert.Equal(0, createBookmarks.DefaultOwner);
-        Assert.Equal(0, createBookmarks.DefaultGroup);
+        Assert.Null(createBookmarks.DefaultOwner);
+        Assert.Null(createBookmarks.DefaultGroup);
 
         var entries = await createBookmarks.Callback(new() { Model = pgweb, ServiceProvider = app.Services }, CancellationToken.None);
 


### PR DESCRIPTION
## Description

To keep things future proof in case we ever want to change the default behavior, this switches the defaults for defaultOwner and defaultGroup to null instead of 0.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
