### PR TITLE
Ensure AzureProvisioningResource Outputs are populated correctly

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
@@ -78,7 +78,7 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
 
         ConfigureInfrastructure(infrastructure);
 
-        EnsureParametersAlign(infrastructure);
+        EnsureParametersAndOutputsAlign(infrastructure);
 
         var generationPath = Directory.CreateTempSubdirectory("aspire").FullName;
         var moduleSourcePath = Path.Combine(generationPath, "main.bicep");
@@ -145,7 +145,11 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
         return provisionedResource;
     }
 
-    private void EnsureParametersAlign(AzureResourceInfrastructure infrastructure)
+    /// <summary>
+    /// Ensures that the parameters and outputs in the bicep infrastructure align with the Parameters and Outputs
+    /// properties on the current <see cref="AzureProvisioningResource"/> Aspire resource.
+    /// </summary>
+    private void EnsureParametersAndOutputsAlign(AzureResourceInfrastructure infrastructure)
     {
         // WARNING: GetParameters currently returns more than one instance of the same
         //          parameter. Its the only API that gives us what we need (a list of
@@ -176,6 +180,13 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
             {
                 Parameters.TryAdd(infrastructureParameter.BicepIdentifier, null);
             }
+        }
+
+        // populate the Outputs dictionary with any outputs that are in the infrastructure,
+        // but don't overwrite any existing outputs that are already in the dictionary.
+        foreach (var output in infrastructure.GetProvisionableResources().OfType<ProvisioningOutput>())
+        {
+            Outputs.TryAdd(output.BicepIdentifier, null);
         }
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceTests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Azure.Provisioning;
+using Azure.Provisioning.KeyVault;
+using Xunit;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureProvisioningResourceTests
+{
+    [Fact]
+    public async Task VerifyOutputsAlign()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var resource1 = builder.AddAzureInfrastructure("resource1", infra =>
+        {
+            var kv = new KeyVaultService("kv");
+            infra.Add(kv);
+
+            infra.Add(new ProvisioningOutput("vaultUri", typeof(string))
+            {
+                Value = kv.Properties.VaultUri
+            });
+
+            infra.Add(new ProvisioningOutput("name", typeof(string)) { Value = kv.Name });
+        });
+
+        await AzureManifestUtils.GetManifestWithBicep(resource1.Resource);
+
+        Assert.Collection(resource1.Resource.Outputs,
+            output =>
+            {
+                Assert.Equal("vaultUri", output.Key);
+                Assert.Null(output.Value);
+            },
+            output =>
+            {
+                Assert.Equal("name", output.Key);
+                Assert.Null(output.Value);
+            });
+    }
+}


### PR DESCRIPTION
## Description

This allows other code to inspect which Outputs a resource has.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
