### PR TITLE
Change PublisherOptions - Allow skipping image building?

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposePublisherOptions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherOptions.cs
@@ -19,4 +19,9 @@ public sealed class DockerComposePublisherOptions : PublishingOptions
     /// The name of an existing network to be used.
     /// </summary>
     public string? ExistingNetworkName { get; set; }
+
+    /// <summary>
+    /// Indicates whether to build container images during the publishing process.
+    /// </summary>
+    public bool BuildImages { get; set; } = true;
 }


### PR DESCRIPTION
Update property access to use `PublisherOptions` directly for  consistency. Introduce a new option to control image building during  the publishing process. Ensure that image building only occurs when  enabled. Adjust tests to accommodate these changes.

Just thinking a user probably wouldn't want to rebuild and re-version all project container images if they were simply changing and publishing a new compose for container resource changes (new env vars, new tags etc).

Fixes #8782

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
