### PR TITLE
Split out build step in publisher.

### DIFF
--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -62,6 +62,14 @@ internal sealed class PublishCommand : BaseCommand
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
 
+        var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
+
+        if (buildExitCode != 0)
+        {
+            AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be built. For more information run with --debug switch.[/]");
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+
         var publisher = parseResult.GetValue<string>("--publisher");
         var outputPath = parseResult.GetValue<string>("--output-path");
         var fullyQualifiedOutputPath = Path.GetFullPath(outputPath ?? ".");
@@ -81,7 +89,7 @@ internal sealed class PublishCommand : BaseCommand
                     var pendingInspectRun = _runner.RunAsync(
                         effectiveAppHostProjectFile,
                         false,
-                        false,
+                        true,
                         ["--operation", "inspect"],
                         null,
                         backchannelCompletionSource,

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -80,12 +80,13 @@ internal sealed class RunCommand : BaseCommand
 
         var watch = parseResult.GetValue<bool>("--watch");
 
-        await AnsiConsole.Status()
-            .Spinner(Spinner.Known.Dots3)
-            .SpinnerStyle(Style.Parse("purple"))
-            .StartAsync(":hammer_and_wrench:  Building app host...", async context => {
-                await _runner.BuildAsync(effectiveAppHostProjectFile, cancellationToken).ConfigureAwait(false);
-            });
+        var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
+
+        if (buildExitCode != 0)
+        {
+            AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be built. For more information run with --debug switch.[/]");
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
 
         var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();
 

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -62,4 +62,14 @@ internal static class AppHostHelper
 
         return appHostInformationResult;
     }
+    
+    internal static async Task<int> BuildAppHostAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
+    {
+        return await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots3)
+            .SpinnerStyle(Style.Parse("purple"))
+            .StartAsync(":hammer_and_wrench:  Building app host...", async context => {
+                return await runner.BuildAsync(projectFile, cancellationToken).ConfigureAwait(false);
+            });
+    }
 }


### PR DESCRIPTION
This PR splits out the build in the publisher to make it more obvious that publish involves doing a build. This is the make sure people don't think getting the list of publishers takes qutie so long and know its a function of build time.


https://github.com/user-attachments/assets/a0cbec8d-e880-42c7-820b-c613a18dade0

