### PR TITLE
Return correct exit code from build.ps1

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -5,5 +5,5 @@ set _args=%*
 if "%~1"=="-?" set _args=-help
 if "%~1"=="/?" set _args=-help
 
-powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0eng\build.ps1'" %_args%
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0eng\build.ps1' %_args%; exit $LASTEXITCODE"
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
This baffled me for some time - I kick off a GHA build, and the log shows multiple build errors, yet the step is reported as success. Which implies the exit code is lost somewhere in transit.

E.g., eng/build.ps1 exists with `1`, yet build.cmd exits with `0`:
![image](https://github.com/user-attachments/assets/73347601-d1c5-4f2d-bc23-abd8a91449e8)


This fixes the issue. The proof is [here](https://github.com/RussKie/aspire/actions/runs/14302308829/job/40078752922#step:3:52).