### PR TITLE
[release/9.2] Fix up "project" to "--project" as a result of a bad merge.

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -38,7 +38,7 @@ internal sealed class RunCommand : BaseCommand
     {
         using var activity = _activitySource.StartActivity();
 
-        var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("project");
+        var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
         var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);
         
         if (effectiveAppHostProjectFile is null)


### PR DESCRIPTION
This PR fixes up a change that was dropped as the result of a merge conflict. This is blocking `aspire run` from working in the latest 9.2 builds.