### PR TITLE
Fix --watch hangs.

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -80,12 +80,15 @@ internal sealed class RunCommand : BaseCommand
 
         var watch = parseResult.GetValue<bool>("--watch");
 
-        var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
-
-        if (buildExitCode != 0)
+        if (!watch)
         {
-            AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be built. For more information run with --debug switch.[/]");
-            return ExitCodeConstants.FailedToBuildArtifacts;
+            var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
+
+            if (buildExitCode != 0)
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be built. For more information run with --debug switch.[/]");
+                return ExitCodeConstants.FailedToBuildArtifacts;
+            }
         }
 
         var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -93,7 +93,7 @@ internal sealed class RunCommand : BaseCommand
         var pendingRun = _runner.RunAsync(
             effectiveAppHostProjectFile,
             watch,
-            true,
+            !watch, // If we aren't in watch mode we can no-build here, but watch doesn't support no-build.
             Array.Empty<string>(),
             env,
             backchannelCompletitionSource,

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -75,6 +75,7 @@ internal sealed class RunCommand : BaseCommand
             }
 
             var watch = parseResult.GetValue<bool>("--watch");
+
             if (!watch)
             {
                 var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
@@ -91,14 +92,6 @@ internal sealed class RunCommand : BaseCommand
             if (!appHostCompatabilityCheck?.IsCompatableAppHost ?? throw new InvalidOperationException("IsCompatableAppHost is null"))
             {
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
-            }
-
-            var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
-
-            if (buildExitCode != 0)
-            {
-                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be built. For more information run with --debug switch.[/]");
-                return ExitCodeConstants.FailedToBuildArtifacts;
             }
 
             var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -126,7 +126,9 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
         if (watch && noBuild)
         {
-            throw new InvalidOperationException("Cannot use --watch and --no-build at the same time.");
+            var ex = new InvalidOperationException("Cannot use --watch and --no-build at the same time.");
+            backchannelCompletionSource?.SetException(ex);
+            throw ex;
         }
 
         var watchOrRunCommand = watch ? "watch" : "run";


### PR DESCRIPTION
This PR fixes hangs when using `aspire run --watch`. There was a bug introduced when I split out the build leg from starting the app host. Basically I started attempting to launch the apphost in --no-build mode which is fine -except when you are in watch mode. `RunAsync` checks for this and throws an exception, unfortunately awaiting the result of `RunAsync` doesn't occur until after the backchannel has returned.

So the fix involves a few things:

1. Fix the logic so that when running with `--watch` we don't try launch the app host in `--no-build` mode.
2. Fix the logic in `RunAsync` where it checks and throws to also call `SetException` on the backchannel completion source.
3. Fix the logic so we don't bother prebuilding when in watch mode as it ultimately makes startup slower.
