### PR TITLE
Update nightly references to daily

### DIFF
--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -8,7 +8,7 @@ See [machine-requirements.md](machine-requirements.md).
 
 ## (Optional) Create a local nuget.config file
 
-Since dogfooding will require using nightly build feeds, you may not want to add feeds globally which could alter how other code on your machine builds. To avoid this happening, you can create a local nuget.config file by running the following command in the root of your repository:
+Since dogfooding will require using daily build feeds, you may not want to add feeds globally which could alter how other code on your machine builds. To avoid this happening, you can create a local nuget.config file by running the following command in the root of your repository:
 
 ```bash
 dotnet new nugetconfig
@@ -33,7 +33,7 @@ If you use [Package Source Mapping](https://learn.microsoft.com/en-us/nuget/cons
 </packageSourceMapping>
 ```
 
-## Install the nightly .NET Aspire templates
+## Install the daily .NET Aspire templates
 
 To be able to create aspire projects, you will need to install the latest Aspire templates. You can do this by running the following command:
 


### PR DESCRIPTION
## Description

It slightly bugged me that the file is called `using-latest-daily.md`, yet the document refers to `nightly` in the contents.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
