### PR TITLE
[release/9.2] Add RPC protocol compat check.

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -106,6 +106,19 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         var stream = new NetworkStream(socket, true);
         var rpc = JsonRpc.Attach(stream, target);
 
+        var capabilities = await rpc.InvokeWithCancellationAsync<string[]>(
+            "GetCapabilitiesAsync",
+            Array.Empty<object>(),
+            cancellationToken);
+
+        if (!capabilities.Any(s => s == "baseline.v0"))
+        {
+            throw new AppHostIncompatibleException(
+                $"AppHost is incompatible with the CLI. The AppHost must be updated to a version that supports the baseline.v0 capability.",
+                "baseline.v0"
+                );
+        }
+
         _rpcTaskCompletionSource.SetResult(rpc);
     }
 
@@ -144,5 +157,21 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         {
             yield return state;
         }
+    }
+
+    public async Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken)
+    {
+        using var activity = _activitySource.StartActivity();
+
+        var rpc = await _rpcTaskCompletionSource.Task.ConfigureAwait(false);
+
+        logger.LogDebug("Requesting capabilities");
+
+        var capabilities = await rpc.InvokeWithCancellationAsync<string[]>(
+            "GetCapabilitiesAsync",
+            Array.Empty<object>(),
+            cancellationToken).ConfigureAwait(false);
+
+        return capabilities;
     }
 }

--- a/src/Aspire.Cli/Backchannel/AppHostIncompatibleException.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostIncompatibleException.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Backchannel;
+
+internal sealed class AppHostIncompatibleException(string message, string requiredCapability) : Exception(message)
+{
+    public string RequiredCapability { get; } = requiredCapability;
+}

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -70,7 +70,7 @@ internal sealed class NewCommand : BaseCommand
         }
         else
         {
-            return await PromptUtils.PromptForSelectionAsync(
+            return await InteractionUtils.PromptForSelectionAsync(
                 "Select a project template:",
                 validTemplates,
                 t => $"{t.TemplateName} ({t.TemplateDescription})",
@@ -84,7 +84,7 @@ internal sealed class NewCommand : BaseCommand
         if (parseResult.GetValue<string>("--name") is not { } name)
         {
             var defaultName = new DirectoryInfo(Environment.CurrentDirectory).Name;
-            name = await PromptUtils.PromptForStringAsync("Enter the project name:",
+            name = await InteractionUtils.PromptForStringAsync("Enter the project name:",
                 defaultValue: defaultName,
                 cancellationToken: cancellationToken);
         }
@@ -96,7 +96,7 @@ internal sealed class NewCommand : BaseCommand
     {
         if (parseResult.GetValue<string>("--output") is not { } outputPath)
         {
-            outputPath = await PromptUtils.PromptForStringAsync(
+            outputPath = await InteractionUtils.PromptForStringAsync(
                 "Enter the output path:",
                 defaultValue: pathAppendage ?? ".",
                 cancellationToken: cancellationToken
@@ -114,7 +114,7 @@ internal sealed class NewCommand : BaseCommand
         }
         else
         {
-            version = await PromptUtils.PromptForStringAsync(
+            version = await InteractionUtils.PromptForStringAsync(
                 "Project templates version:",
                 defaultValue: VersionHelper.GetDefaultTemplateVersion(),
                 validator: (string value) => {

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -61,7 +61,7 @@ internal sealed class PublishCommand : BaseCommand
 
             appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
 
-            if (!appHostCompatibilityCheck?.IsCompatableAppHost ?? throw new InvalidOperationException("IsCompatableAppHost is null"))
+            if (!appHostCompatibilityCheck?.IsCompatableAppHost ?? throw new InvalidOperationException("IsCompatibleAppHost is null"))
             {
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -38,7 +38,7 @@ internal sealed class PublishCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        (bool IsCompatableAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatabilityCheck = null;
+        (bool IsCompatableAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
 
         try
         {
@@ -59,9 +59,9 @@ internal sealed class PublishCommand : BaseCommand
                 env[KnownConfigNames.WaitForDebugger] = "true";
             }
 
-            appHostCompatabilityCheck = await AppHostHelper.CheckAppHostCompatabilityAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
+            appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
 
-            if (!appHostCompatabilityCheck?.IsCompatableAppHost ?? throw new InvalidOperationException("IsCompatableAppHost is null"))
+            if (!appHostCompatibilityCheck?.IsCompatableAppHost ?? throw new InvalidOperationException("IsCompatableAppHost is null"))
             {
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
@@ -255,7 +255,7 @@ internal sealed class PublishCommand : BaseCommand
         {
             return InteractionUtils.DisplayIncompatibleVersionError(
                 ex,
-                appHostCompatabilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
+                appHostCompatibilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
                 );
         }
     }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -36,7 +36,7 @@ internal sealed class RunCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        (bool IsCompatableAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatabilityCheck = null;
+        (bool IsCompatableAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
         try
         {
             using var activity = _activitySource.StartActivity();
@@ -74,9 +74,9 @@ internal sealed class RunCommand : BaseCommand
                 return ExitCodeConstants.FailedToTrustCertificates;
             }
 
-            appHostCompatabilityCheck = await AppHostHelper.CheckAppHostCompatabilityAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
+            appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
 
-            if (!appHostCompatabilityCheck?.IsCompatableAppHost ?? throw new InvalidOperationException("IsCompatibleAppHost is null"))
+            if (!appHostCompatibilityCheck?.IsCompatableAppHost ?? throw new InvalidOperationException("IsCompatibleAppHost is null"))
             {
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
@@ -217,7 +217,7 @@ internal sealed class RunCommand : BaseCommand
         {
             return InteractionUtils.DisplayIncompatibleVersionError(
                 ex,
-                appHostCompatabilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
+                appHostCompatibilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
                 );
         }
     }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -36,175 +36,186 @@ internal sealed class RunCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity();
-
-        var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
-        var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);
-        
-        if (effectiveAppHostProjectFile is null)
-        {
-            return ExitCodeConstants.FailedToFindProject;
-        }
-
-        var env = new Dictionary<string, string>();
-
-        var debug = parseResult.GetValue<bool>("--debug");
-
-        var waitForDebugger = parseResult.GetValue<bool>("--wait-for-debugger");
-
-        var forceUseRichConsole = Environment.GetEnvironmentVariable(KnownConfigNames.ForceRichConsole) == "true";
-        
-        var useRichConsole = forceUseRichConsole || !debug && !waitForDebugger;
-
-        if (waitForDebugger)
-        {
-            env[KnownConfigNames.WaitForDebugger] = "true";
-        }
-
+        (bool IsCompatableAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatabilityCheck = null;
         try
         {
-            await CertificatesHelper.EnsureCertificatesTrustedAsync(_runner, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            AnsiConsole.MarkupLine($"[red bold]:thumbs_down:  An error occurred while trusting the certificates: {ex.Message}[/]");
-            return ExitCodeConstants.FailedToTrustCertificates;
-        }
+            using var activity = _activitySource.StartActivity();
 
-        var appHostCompatabilityCheck = await AppHostHelper.CheckAppHostCompatabilityAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
-
-        if (!appHostCompatabilityCheck.IsCompatableAppHost)
-        {
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
-        }
-
-        var watch = parseResult.GetValue<bool>("--watch");
-
-        var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
-
-        if (buildExitCode != 0)
-        {
-            AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be built. For more information run with --debug switch.[/]");
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-
-        var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();
-
-        var pendingRun = _runner.RunAsync(
-            effectiveAppHostProjectFile,
-            watch,
-            true,
-            Array.Empty<string>(),
-            env,
-            backchannelCompletitionSource,
-            cancellationToken);
-
-        if (useRichConsole)
-        {
-            // We wait for the back channel to be created to signal that
-            // the AppHost is ready to accept requests.
-            var backchannel = await AnsiConsole.Status()
-                                                .Spinner(Spinner.Known.Dots3)
-                                                .SpinnerStyle(Style.Parse("purple"))
-                                                .StartAsync(":linked_paperclips:  Starting Aspire app host...", async context => {
-                                                    return await backchannelCompletitionSource.Task;
-                                                });
-
-            // We wait for the first update of the console model via RPC from the AppHost.
-            var dashboardUrls = await AnsiConsole.Status()
-                                                .Spinner(Spinner.Known.Dots3)
-                                                .SpinnerStyle(Style.Parse("purple"))
-                                                .StartAsync(":chart_increasing:  Starting Aspire dashboard...", async context => {
-                                                    return await backchannel.GetDashboardUrlsAsync(cancellationToken);
-                                                });
-
-            AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine($"[green bold]Dashboard[/]:");
-            if (dashboardUrls.CodespacesUrlWithLoginToken is not  null)
+            var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
+            var effectiveAppHostProjectFile = ProjectFileHelper.UseOrFindAppHostProjectFile(passedAppHostProjectFile);
+            
+            if (effectiveAppHostProjectFile is null)
             {
-                AnsiConsole.MarkupLine($":chart_increasing:  Direct: [link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
-                AnsiConsole.MarkupLine($":chart_increasing:  Codespaces: [link={dashboardUrls.CodespacesUrlWithLoginToken}]{dashboardUrls.CodespacesUrlWithLoginToken}[/]");
+                return ExitCodeConstants.FailedToFindProject;
+            }
+
+            var env = new Dictionary<string, string>();
+
+            var debug = parseResult.GetValue<bool>("--debug");
+
+            var waitForDebugger = parseResult.GetValue<bool>("--wait-for-debugger");
+
+            var forceUseRichConsole = Environment.GetEnvironmentVariable(KnownConfigNames.ForceRichConsole) == "true";
+            
+            var useRichConsole = forceUseRichConsole || !debug && !waitForDebugger;
+
+            if (waitForDebugger)
+            {
+                env[KnownConfigNames.WaitForDebugger] = "true";
+            }
+
+            try
+            {
+                await CertificatesHelper.EnsureCertificatesTrustedAsync(_runner, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down:  An error occurred while trusting the certificates: {ex.Message}[/]");
+                return ExitCodeConstants.FailedToTrustCertificates;
+            }
+
+            appHostCompatabilityCheck = await AppHostHelper.CheckAppHostCompatabilityAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
+
+            if (!appHostCompatabilityCheck?.IsCompatableAppHost ?? throw new InvalidOperationException("IsCompatableAppHost is null"))
+            {
+                return ExitCodeConstants.FailedToDotnetRunAppHost;
+            }
+
+            var watch = parseResult.GetValue<bool>("--watch");
+
+            var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, effectiveAppHostProjectFile, cancellationToken);
+
+            if (buildExitCode != 0)
+            {
+                AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be built. For more information run with --debug switch.[/]");
+                return ExitCodeConstants.FailedToBuildArtifacts;
+            }
+
+            var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();
+
+            var pendingRun = _runner.RunAsync(
+                effectiveAppHostProjectFile,
+                watch,
+                true,
+                Array.Empty<string>(),
+                env,
+                backchannelCompletitionSource,
+                cancellationToken);
+
+            if (useRichConsole)
+            {
+                // We wait for the back channel to be created to signal that
+                // the AppHost is ready to accept requests.
+                var backchannel = await AnsiConsole.Status()
+                        .Spinner(Spinner.Known.Dots3)
+                        .SpinnerStyle(Style.Parse("purple"))
+                        .StartAsync(":linked_paperclips:  Starting Aspire app host...", async context => {
+                            return await backchannelCompletitionSource.Task;
+                        });
+
+                // We wait for the first update of the console model via RPC from the AppHost.
+                var dashboardUrls = await AnsiConsole.Status()
+                                                    .Spinner(Spinner.Known.Dots3)
+                                                    .SpinnerStyle(Style.Parse("purple"))
+                                                    .StartAsync(":chart_increasing:  Starting Aspire dashboard...", async context => {
+                                                        return await backchannel.GetDashboardUrlsAsync(cancellationToken);
+                                                    });
+
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"[green bold]Dashboard[/]:");
+                if (dashboardUrls.CodespacesUrlWithLoginToken is not  null)
+                {
+                    AnsiConsole.MarkupLine($":chart_increasing:  Direct: [link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
+                    AnsiConsole.MarkupLine($":chart_increasing:  Codespaces: [link={dashboardUrls.CodespacesUrlWithLoginToken}]{dashboardUrls.CodespacesUrlWithLoginToken}[/]");
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($":chart_increasing:  [link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
+                }
+                AnsiConsole.WriteLine();
+
+                var table = new Table().Border(TableBorder.Rounded);
+
+                await AnsiConsole.Live(table).StartAsync(async context => {
+
+                    var knownResources = new SortedDictionary<string, (string Resource, string Type, string State, string[] Endpoints)>();
+
+                    table.AddColumn("Resource");
+                    table.AddColumn("Type");
+                    table.AddColumn("State");
+                    table.AddColumn("Endpoint(s)");
+
+                    var resourceStates = backchannel.GetResourceStatesAsync(cancellationToken);
+
+                    try
+                    {
+                        await foreach(var resourceState in resourceStates)
+                        {
+                            knownResources[resourceState.Resource] = resourceState;
+
+                            table.Rows.Clear();
+
+                            foreach (var knownResource in knownResources)
+                            {
+                                var nameRenderable = new Text(knownResource.Key, new Style().Foreground(Color.White));
+
+                                var typeRenderable = new Text(knownResource.Value.Type, new Style().Foreground(Color.White));
+
+                                var stateRenderable = knownResource.Value.State switch {
+                                    "Running" => new Text(knownResource.Value.State, new Style().Foreground(Color.Green)),
+                                    "Starting" => new Text(knownResource.Value.State, new Style().Foreground(Color.LightGreen)),
+                                    "FailedToStart" => new Text(knownResource.Value.State, new Style().Foreground(Color.Red)),
+                                    "Waiting" => new Text(knownResource.Value.State, new Style().Foreground(Color.White)),
+                                    "Unhealthy" => new Text(knownResource.Value.State, new Style().Foreground(Color.Yellow)),
+                                    "Exited" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
+                                    "Finished" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
+                                    "NotStarted" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
+                                    _ => new Text(knownResource.Value.State ?? "Unknown", new Style().Foreground(Color.Grey))
+                                };
+
+                                IRenderable endpointsRenderable = new Text("None");
+                                if (knownResource.Value.Endpoints?.Length > 0)
+                                {
+                                    endpointsRenderable = new Rows(
+                                        knownResource.Value.Endpoints.Select(e => new Text(e, new Style().Link(e)))
+                                    );
+                                }
+
+                                table.AddRow(nameRenderable, typeRenderable, stateRenderable, endpointsRenderable);
+                            }
+
+                            context.Refresh();
+                        }
+                    }
+                    catch (ConnectionLostException ex) when (ex.InnerException is OperationCanceledException)
+                    {
+                        // This exception will be thrown if the cancellation request reaches the WaitForExitAsync
+                        // call on the process and shuts down the apphost before the JsonRpc connection gets it meaning
+                        // that the apphost side of the RPC connection will be closed. Therefore if we get a 
+                        // ConnectionLostException AND the inner exception is an OperationCancelledException we can
+                        // asume that the apphost was shutdown and we can ignore it.
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // This exception will be thrown if the cancellation request reaches the our side
+                        // of the backchannel side first and the connection is torn down on our-side
+                        // gracefully. We can ignore this exception as well.
+                    }
+                });
+
+                return await pendingRun;
             }
             else
             {
-                AnsiConsole.MarkupLine($":chart_increasing:  [link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
+                return await pendingRun;
             }
-            AnsiConsole.WriteLine();
-
-            var table = new Table().Border(TableBorder.Rounded);
-
-            await AnsiConsole.Live(table).StartAsync(async context => {
-
-                var knownResources = new SortedDictionary<string, (string Resource, string Type, string State, string[] Endpoints)>();
-
-                table.AddColumn("Resource");
-                table.AddColumn("Type");
-                table.AddColumn("State");
-                table.AddColumn("Endpoint(s)");
-
-                var resourceStates = backchannel.GetResourceStatesAsync(cancellationToken);
-
-                try
-                {
-                    await foreach(var resourceState in resourceStates)
-                    {
-                        knownResources[resourceState.Resource] = resourceState;
-
-                        table.Rows.Clear();
-
-                        foreach (var knownResource in knownResources)
-                        {
-                            var nameRenderable = new Text(knownResource.Key, new Style().Foreground(Color.White));
-
-                            var typeRenderable = new Text(knownResource.Value.Type, new Style().Foreground(Color.White));
-
-                            var stateRenderable = knownResource.Value.State switch {
-                                "Running" => new Text(knownResource.Value.State, new Style().Foreground(Color.Green)),
-                                "Starting" => new Text(knownResource.Value.State, new Style().Foreground(Color.LightGreen)),
-                                "FailedToStart" => new Text(knownResource.Value.State, new Style().Foreground(Color.Red)),
-                                "Waiting" => new Text(knownResource.Value.State, new Style().Foreground(Color.White)),
-                                "Unhealthy" => new Text(knownResource.Value.State, new Style().Foreground(Color.Yellow)),
-                                "Exited" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
-                                "Finished" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
-                                "NotStarted" => new Text(knownResource.Value.State, new Style().Foreground(Color.Grey)),
-                                _ => new Text(knownResource.Value.State ?? "Unknown", new Style().Foreground(Color.Grey))
-                            };
-
-                            IRenderable endpointsRenderable = new Text("None");
-                            if (knownResource.Value.Endpoints?.Length > 0)
-                            {
-                                endpointsRenderable = new Rows(
-                                    knownResource.Value.Endpoints.Select(e => new Text(e, new Style().Link(e)))
-                                );
-                            }
-
-                            table.AddRow(nameRenderable, typeRenderable, stateRenderable, endpointsRenderable);
-                        }
-
-                        context.Refresh();
-                    }
-                }
-                catch (ConnectionLostException ex) when (ex.InnerException is OperationCanceledException)
-                {
-                    // This exception will be thrown if the cancellation request reaches the WaitForExitAsync
-                    // call on the process and shuts down the apphost before the JsonRpc connection gets it meaning
-                    // that the apphost side of the RPC connection will be closed. Therefore if we get a 
-                    // ConnectionLostException AND the inner exception is an OperationCancelledException we can
-                    // asume that the apphost was shutdown and we can ignore it.
-                }
-                catch (OperationCanceledException)
-                {
-                    // This exception will be thrown if the cancellation request reaches the our side
-                    // of the backchannel side first and the connection is torn down on our-side
-                    // gracefully. We can ignore this exception as well.
-                }
-            });
-
-            return await pendingRun;
         }
-        else
+        catch (AppHostIncompatibleException ex)
         {
-            return await pendingRun;
+            return InteractionUtils.DisplayIncompatibleVersionError(
+                ex,
+                appHostCompatabilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
+                );
         }
     }
 }

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -126,7 +126,9 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
         if (watch && noBuild)
         {
-            throw new InvalidOperationException("Cannot use --watch and --no-build at the same time.");
+            var ex = new InvalidOperationException("Cannot use --watch and --no-build at the same time.");
+            backchannelCompletionSource?.SetException(ex);
+            throw ex;
         }
 
         var watchOrRunCommand = watch ? "watch" : "run";

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -468,6 +468,22 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
                     // We don't want to spam the logs with our early connection attempts.
                 }
             }
+            catch (AppHostIncompatibleException ex)
+            {
+                logger.LogError(
+                    ex,
+                    "The app host is incompatible with the CLI and must be updated to a version that supports the {RequiredCapability} capability.",
+                    ex.RequiredCapability
+                    );
+
+                // If the app host is incompatable then there is no point
+                // trying to reconnect, we should propogate the exception
+                // up to the code that needs to back channel so it can display
+                // and error message to the user.
+                backchannelCompletionSource.SetException(ex);
+
+                throw;
+            }
 
         } while (await timer.WaitForNextTickAsync(cancellationToken));
     }

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -14,4 +14,5 @@ internal static class ExitCodeConstants
     public const int FailedToBuildArtifacts = 6;
     public const int FailedToFindProject = 7;
     public const int FailedToTrustCertificates = 8;
+    public const int AppHostIncompatible = 9;
 }

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -11,39 +11,39 @@ internal static class AppHostHelper
 {
     private static readonly ActivitySource s_activitySource = new ActivitySource(nameof(AppHostHelper));
 
-    internal static async Task<(bool IsCompatableAppHost, bool SupportsBackchannel)> CheckAppHostCompatabilityAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
+    internal static async Task<(bool IsCompatableAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)> CheckAppHostCompatabilityAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
     {
             var appHostInformation = await GetAppHostInformationAsync(runner, projectFile, cancellationToken);
 
             if (appHostInformation.ExitCode != 0)
             {
                 AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project could not be analyzed due to a build error. For more information run with --debug switch.[/]");
-                return (false, false);
+                return (false, false, null);
             }
 
             if (!appHostInformation.IsAspireHost)
             {
                 AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The project is not an Aspire app host project.[/]");
-                return (false, false);
+                return (false, false, null);
             }
 
             if (!SemVersion.TryParse(appHostInformation.AspireHostingSdkVersion, out var aspireSdkVersion))
             {
                 AnsiConsole.MarkupLine($"[red bold]:thumbs_down: Could not parse Aspire SDK version.[/]");
-                return (false, false);
+                return (false, false, null);
             }
 
             var compatibleRanges = SemVersionRange.Parse("^9.2.0-dev", SemVersionRangeOptions.IncludeAllPrerelease);
             if (!aspireSdkVersion.Satisfies(compatibleRanges))
             {
                 AnsiConsole.MarkupLine($"[red bold]:thumbs_down: The Aspire SDK version '{appHostInformation.AspireHostingSdkVersion}' is not supported. Please update to the latest version.[/]");
-                return (false, false);
+                return (false, false, appHostInformation.AspireHostingSdkVersion);
             }
             else
             {
                 // NOTE: When we go to support < 9.2.0 app hosts this is where we'll make
                 //       a determination as to whether the apphsot supports backchannel or not.
-                return (true, true);
+                return (true, true, appHostInformation.AspireHostingSdkVersion);
             }
     }
 

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -11,7 +11,7 @@ internal static class AppHostHelper
 {
     private static readonly ActivitySource s_activitySource = new ActivitySource(nameof(AppHostHelper));
 
-    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)> CheckAppHostCompatabilityAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
+    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)> CheckAppHostCompatibilityAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
     {
             var appHostInformation = await GetAppHostInformationAsync(runner, projectFile, cancellationToken);
 

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -11,7 +11,7 @@ internal static class AppHostHelper
 {
     private static readonly ActivitySource s_activitySource = new ActivitySource(nameof(AppHostHelper));
 
-    internal static async Task<(bool IsCompatableAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)> CheckAppHostCompatabilityAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
+    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)> CheckAppHostCompatabilityAsync(DotNetCliRunner runner, FileInfo projectFile, CancellationToken cancellationToken)
     {
             var appHostInformation = await GetAppHostInformationAsync(runner, projectFile, cancellationToken);
 

--- a/src/Aspire.Cli/Utils/InteractionUtils.cs
+++ b/src/Aspire.Cli/Utils/InteractionUtils.cs
@@ -1,11 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Backchannel;
 using Spectre.Console;
 
 namespace Aspire.Cli.Utils;
 
-internal static class PromptUtils
+internal static class InteractionUtils
 {
     public static async Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
     {
@@ -41,5 +42,18 @@ internal static class PromptUtils
             .HighlightStyle(Style.Parse("darkmagenta"));
 
         return await AnsiConsole.PromptAsync(prompt, cancellationToken);
+    }
+
+    public static int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingSdkVersion)
+    {
+        var cliInformationalVersion = VersionHelper.GetDefaultTemplateVersion();
+        
+        AnsiConsole.MarkupLine($"[red bold]:thumbs_down:  The app host is not compatible. Consider upgrading the app host or Aspire CLI.[/]");
+        Console.WriteLine();
+        AnsiConsole.MarkupLine($"\t[bold]Aspire Hosting SDK Version[/]: {appHostHostingSdkVersion}");
+        AnsiConsole.MarkupLine($"\t[bold]Aspire CLI Version[/]: {cliInformationalVersion}");
+        AnsiConsole.MarkupLine($"\t[bold]Required Capability[/]: {ex.RequiredCapability}");
+        Console.WriteLine();
+        return ExitCodeConstants.AppHostIncompatible;
     }
 }

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -138,4 +138,31 @@ internal class AppHostRpcTarget(
         var publishers = e.Advertisements.Select(x => x.Name);
         return [..publishers];
     }
+
+#pragma warning disable CA1822
+    public Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken)
+    {
+        // The purpose of this API is to allow the CLI to determine what API surfaces
+        // the AppHost supports. In 9.2 we'll be saying that you need a 9.2 apphost,
+        // but the 9.3 CLI might actually support working with 9.2 apphosts. The idea
+        // is that when the backchannel is established the CLI will call this API
+        // and store the results. The "baseline.v0" capability is the bare minimum
+        // that we need as of CLI version 9.2-preview*.
+        //
+        // Some capabilties will be opt in. For example in 9.3 we might refine the
+        // publishing activities API to return more information, or add log streaming
+        // features. So that would add a new capability that the apphsot can report
+        // on initial backchannel negotiation and the CLI can adapt its behavior around
+        // that. There may be scenarios where we need to break compataiblity at which
+        // point we might increase the baseline version that the apphost reports.
+        //
+        // The ability to support a back channel at all is determined by the CLI by
+        // making sure that the apphost version is at least > 9.2.
+
+        _ = cancellationToken;
+        return Task.FromResult(new string[] {
+            "baseline.v0"
+            });
+    }
+#pragma warning restore CA1822
 }


### PR DESCRIPTION
Manual backport of #8577 to release/9.2

## Customer Impact

This PR introduces an API to the AppHost RPC target which allows the CLI to query for a set of capabilities. If the required capabilities are not available then the CLI can terminate with an error message indicating the missing required capability. At the moment there is only one capability `baseline.v0`. This will also allow us to implement graceful fallback of behaviors in the future.

## Testing

Manual

## Risk

Moderate

## Regression?

No