### PR TITLE
AddAzureContainerAppEnvironment should use the environment name as a prefix

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
+++ b/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Azure.Provisioning.OperationalInsights" />
     <PackageReference Include="Azure.Provisioning.KeyVault" />
     <PackageReference Include="Azure.Provisioning.Storage" />
-    <PackageReference Include="Aspire.Hosting.Azure" VersionOverride="9.3.0-*" />
+    <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
+++ b/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Azure.Provisioning.OperationalInsights" />
     <PackageReference Include="Azure.Provisioning.KeyVault" />
     <PackageReference Include="Azure.Provisioning.Storage" />
-    <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
+    <PackageReference Include="Aspire.Hosting.Azure" VersionOverride="9.3.0-*" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting.Azure.AppContainers/AzdAzureContainerAppEnvironment.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzdAzureContainerAppEnvironment.cs
@@ -33,9 +33,9 @@ internal sealed class AzdAzureContainerAppEnvironment : IAzureContainerAppEnviro
         return SecretOutputExpression.GetSecretOutputKeyVault(resource);
     }
 
-    public IManifestExpressionProvider GetVolumeStorage(IResource resource, ContainerMountType type, string volumeIndex)
+    public IManifestExpressionProvider GetVolumeStorage(IResource resource, ContainerMountAnnotation volume, int volumeIndex)
     {
-        return VolumeStorageExpression.GetVolumeStorage(resource, type, volumeIndex);
+        return VolumeStorageExpression.GetVolumeStorage(resource, volume.Type, volumeIndex);
     }
 
     /// <summary>
@@ -73,7 +73,7 @@ internal sealed class AzdAzureContainerAppEnvironment : IAzureContainerAppEnviro
     /// <summary>
     /// Generates expressions for the volume storage account. That azd creates.
     /// </summary>
-    private sealed class VolumeStorageExpression(IResource resource, ContainerMountType type, string index) : IManifestExpressionProvider
+    private sealed class VolumeStorageExpression(IResource resource, ContainerMountType type, int index) : IManifestExpressionProvider
     {
         public string ValueExpression => type switch
         {
@@ -82,7 +82,7 @@ internal sealed class AzdAzureContainerAppEnvironment : IAzureContainerAppEnviro
             _ => throw new NotSupportedException()
         };
 
-        public static IManifestExpressionProvider GetVolumeStorage(IResource resource, ContainerMountType type, string index) =>
+        public static IManifestExpressionProvider GetVolumeStorage(IResource resource, ContainerMountType type, int index) =>
             new VolumeStorageExpression(resource, type, index);
     }
 }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -13,6 +13,8 @@ namespace Aspire.Hosting.Azure.AppContainers;
 public class AzureContainerAppEnvironmentResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure) :
     AzureProvisioningResource(name, configureInfrastructure), IAzureContainerAppEnvironment
 {
+    internal bool UseAzdNamingConvention { get; set; }
+
     /// <summary>
     /// Gets the unique identifier of the Container App Environment.
     /// </summary>

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -76,10 +76,21 @@ public static class AzureContainerAppExtensions
 
             infra.Add(tags);
 
+            ProvisioningVariable? resourceToken = null;
+            if (appEnvResource.UseAzdNamingConvention)
+            {
+                resourceToken = new ProvisioningVariable("resourceToken", typeof(string))
+                {
+                    Value = BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)
+                };
+                infra.Add(resourceToken);
+            }
+
             var identity = new UserAssignedIdentity(Infrastructure.NormalizeBicepIdentifier($"{appEnvResource.Name}_mi"))
             {
                 Tags = tags
             };
+
             infra.Add(identity);
 
             var containerRegistry = new ContainerRegistryService(Infrastructure.NormalizeBicepIdentifier($"{appEnvResource.Name}_acr"))
@@ -215,11 +226,7 @@ public static class AzureContainerAppExtensions
 
             if (appEnvResource.UseAzdNamingConvention)
             {
-                var resourceToken = new ProvisioningVariable("resourceToken", typeof(string))
-                {
-                    Value = BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)
-                };
-                infra.Add(resourceToken);
+                Debug.Assert(resourceToken is not null);
 
                 identity.Name = BicepFunction.Interpolate($"mi-{resourceToken}");
                 containerRegistry.Name = new FunctionCallExpression(

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -64,6 +64,7 @@ public static class AzureContainerAppExtensions
 
         var containerAppEnvResource = new AzureContainerAppEnvironmentResource(name, static infra =>
         {
+            var appEnvResource = (AzureContainerAppEnvironmentResource)infra.AspireResource;
             var userPrincipalId = new ProvisioningParameter("userPrincipalId", typeof(string));
 
             infra.Add(userPrincipalId);
@@ -75,14 +76,13 @@ public static class AzureContainerAppExtensions
 
             infra.Add(tags);
 
-            var identity = new UserAssignedIdentity("mi")
+            var identity = new UserAssignedIdentity(Infrastructure.NormalizeBicepIdentifier($"{appEnvResource.Name}_mi"))
             {
                 Tags = tags
             };
-
             infra.Add(identity);
 
-            var containerRegistry = new ContainerRegistryService("acr")
+            var containerRegistry = new ContainerRegistryService(Infrastructure.NormalizeBicepIdentifier($"{appEnvResource.Name}_acr"))
             {
                 Sku = new() { Name = ContainerRegistrySkuName.Basic },
                 Tags = tags
@@ -96,7 +96,7 @@ public static class AzureContainerAppExtensions
             pullRa.Name = BicepFunction.CreateGuid(containerRegistry.Id, identity.Id, pullRa.RoleDefinitionId);
             infra.Add(pullRa);
 
-            var laWorkspace = new OperationalInsightsWorkspace("law")
+            var laWorkspace = new OperationalInsightsWorkspace(Infrastructure.NormalizeBicepIdentifier($"{appEnvResource.Name}_law"))
             {
                 Sku = new() { Name = OperationalInsightsWorkspaceSkuName.PerGB2018 },
                 Tags = tags
@@ -104,7 +104,7 @@ public static class AzureContainerAppExtensions
 
             infra.Add(laWorkspace);
 
-            var containerAppEnvironment = new ContainerAppManagedEnvironment("cae")
+            var containerAppEnvironment = new ContainerAppManagedEnvironment(appEnvResource.GetBicepIdentifier())
             {
                 WorkloadProfiles = [
                     new ContainerAppWorkloadProfile()
@@ -149,9 +149,10 @@ public static class AzureContainerAppExtensions
 
             var resource = (AzureContainerAppEnvironmentResource)infra.AspireResource;
 
+            StorageAccount? storageVolume = null;
             if (resource.VolumeNames.Count > 0)
             {
-                var storageVolume = new StorageAccount("storageVolume")
+                storageVolume = new StorageAccount(Infrastructure.NormalizeBicepIdentifier($"{appEnvResource.Name}_storageVolume"))
                 {
                     Tags = tags,
                     Sku = new StorageSku() { Name = StorageSkuName.StandardLrs },
@@ -210,6 +211,33 @@ public static class AzureContainerAppExtensions
                 {
                     Value = value.Name
                 });
+            }
+
+            if (appEnvResource.UseAzdNamingConvention)
+            {
+                var resourceToken = new ProvisioningVariable("resourceToken", typeof(string))
+                {
+                    Value = BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)
+                };
+                infra.Add(resourceToken);
+
+                identity.Name = BicepFunction.Interpolate($"mi-{resourceToken}");
+                containerRegistry.Name = new FunctionCallExpression(
+                    new IdentifierExpression("replace"),
+                    new InterpolatedStringExpression(
+                        [
+                            new StringLiteralExpression("acr-"),
+                        new IdentifierExpression(resourceToken.BicepIdentifier)
+                        ]),
+                    new StringLiteralExpression("-"),
+                    new StringLiteralExpression(""));
+                laWorkspace.Name = BicepFunction.Interpolate($"law-{resourceToken}");
+                containerAppEnvironment.Name = BicepFunction.Interpolate($"cae-{resourceToken}");
+
+                if (storageVolume is not null)
+                {
+                    storageVolume.Name = BicepFunction.Interpolate($"vol{resourceToken}");
+                }
             }
 
             infra.Add(new ProvisioningOutput("MANAGED_IDENTITY_NAME", typeof(string))
@@ -271,5 +299,22 @@ public static class AzureContainerAppExtensions
         }
 
         return builder.AddResource(containerAppEnvResource);
+    }
+
+    /// <summary>
+    /// Configures the container app environment resources to use the same naming conventions as azd.
+    /// </summary>
+    /// <param name="builder">The AzureContainerAppEnvironmentResource to configure.</param>
+    /// <returns><see cref="IResourceBuilder{T}"/></returns>
+    /// <remarks>
+    /// By default, the container app environment resources use a different naming convention than azd.
+    /// 
+    /// This method allows for reusing the previously deployed resources if the application was deployed using
+    /// azd without calling <see cref="AddAzureContainerAppEnvironment"/>
+    /// </remarks>
+    public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithAzdResourceNaming(this IResourceBuilder<AzureContainerAppEnvironmentResource> builder)
+    {
+        builder.Resource.UseAzdNamingConvention = true;
+        return builder;
     }
 }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -600,8 +600,8 @@ internal sealed class AzureContainerAppsInfrastructure(
                     {
                         var (index, volumeName) = volume.Type switch
                         {
-                            ContainerMountType.BindMount => ($"{bindMountIndex}", $"bm{bindMountIndex}"),
-                            ContainerMountType.Volume => ($"{volumeIndex}", $"v{volumeIndex}"),
+                            ContainerMountType.BindMount => (bindMountIndex, $"bm{bindMountIndex}"),
+                            ContainerMountType.Volume => (volumeIndex, $"v{volumeIndex}"),
                             _ => throw new NotSupportedException()
                         };
 
@@ -614,7 +614,7 @@ internal sealed class AzureContainerAppsInfrastructure(
                             volumeIndex++;
                         }
 
-                        var volumeStorageParameter = AllocateVolumeStorageAccount(volume.Type, index);
+                        var volumeStorageParameter = AllocateVolumeStorageAccount(volume, index);
 
                         var containerAppVolume = new ContainerAppVolume
                         {
@@ -768,8 +768,8 @@ internal sealed class AzureContainerAppsInfrastructure(
                 throw new NotSupportedException("Unsupported value type " + value.GetType());
             }
 
-            private ProvisioningParameter AllocateVolumeStorageAccount(ContainerMountType type, string volumeIndex) =>
-                AllocateParameter(_containerAppEnvironmentContext.Environment.GetVolumeStorage(resource, type, volumeIndex));
+            private ProvisioningParameter AllocateVolumeStorageAccount(ContainerMountAnnotation volume, int volumeIndex) =>
+                AllocateParameter(_containerAppEnvironmentContext.Environment.GetVolumeStorage(resource, volume, volumeIndex));
 
             private BicepValue<string> AllocateKeyVaultSecretUriReference(BicepSecretOutputReference secretOutputReference)
             {

--- a/src/Aspire.Hosting.Azure.AppContainers/IAzureContainerAppEnvironment.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/IAzureContainerAppEnvironment.cs
@@ -17,5 +17,5 @@ internal interface IAzureContainerAppEnvironment
     IManifestExpressionProvider ContainerAppEnvironmentName { get; }
 
     IManifestExpressionProvider GetSecretOutputKeyVault(AzureBicepResource resource);
-    IManifestExpressionProvider GetVolumeStorage(IResource resource, ContainerMountType type, string volumeIndex);
+    IManifestExpressionProvider GetVolumeStorage(IResource resource, ContainerMountAnnotation volume, int volumeIndex);
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -3366,7 +3366,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
 
             resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
-              name: take('sharesvolumescache0-${uniqueString(resourceGroup().id)}', 63)
+              name: take('${toLower('cache')}-${toLower('data')}', 60)
               properties: {
                 enabledProtocols: 'SMB'
                 shareQuota: 1024
@@ -3375,7 +3375,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
 
             resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2024-03-01' = {
-              name: take('managedstoragevolumescache${uniqueString(resourceGroup().id)}', 24)
+              name: take('${toLower('cache')}-${toLower('data')}', 32)
               properties: {
                 azureFile: {
                   accountName: env_storageVolume.name

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -3212,12 +3212,19 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         }
     }
 
-    [Fact]
-    public async Task AddContainerAppEnvironmentAddsEnvironmentResource()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AddContainerAppEnvironmentAddsEnvironmentResource(bool useAzdNaming)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppEnvironment("env");
+        var env = builder.AddAzureContainerAppEnvironment("env");
+
+        if (useAzdNaming)
+        {
+            env.WithAzdResourceNaming();
+        }
 
         var pg = builder.AddAzurePostgresFlexibleServer("pg")
                         .WithPasswordAuthentication()
@@ -3252,151 +3259,305 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
 
         Assert.Equal(expectedManifest, m);
 
-        var expectedBicep =
-        """
-        @description('The location for the resource(s) to be deployed.')
-        param location string = resourceGroup().location
-        
-        param userPrincipalId string
-        
-        param tags object = { }
-        
-        resource mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-          name: take('mi-${uniqueString(resourceGroup().id)}', 128)
-          location: location
-          tags: tags
-        }
-        
-        resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
-          name: take('acr${uniqueString(resourceGroup().id)}', 50)
-          location: location
-          sku: {
-            name: 'Basic'
-          }
-          tags: tags
-        }
-        
-        resource acr_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-          name: guid(acr.id, mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
-          properties: {
-            principalId: mi.properties.principalId
-            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
-            principalType: 'ServicePrincipal'
-          }
-          scope: acr
-        }
-        
-        resource law 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
-          name: take('law-${uniqueString(resourceGroup().id)}', 63)
-          location: location
-          properties: {
-            sku: {
-              name: 'PerGB2018'
+        string expectedBicep;
+        if (useAzdNaming)
+        {
+            expectedBicep =
+            """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param userPrincipalId string
+
+            param tags object = { }
+
+            resource env_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+              name: 'mi-${resourceToken}'
+              location: location
+              tags: tags
             }
-          }
-          tags: tags
-        }
-        
-        resource cae 'Microsoft.App/managedEnvironments@2024-03-01' = {
-          name: take('cae${uniqueString(resourceGroup().id)}', 24)
-          location: location
-          properties: {
-            appLogsConfiguration: {
-              destination: 'log-analytics'
-              logAnalyticsConfiguration: {
-                customerId: law.properties.customerId
-                sharedKey: law.listKeys().primarySharedKey
+
+            resource env_acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+              name: replace('acr-${resourceToken}', '-', '')
+              location: location
+              sku: {
+                name: 'Basic'
               }
+              tags: tags
             }
-            workloadProfiles: [
-              {
-                name: 'consumption'
-                workloadProfileType: 'Consumption'
+
+            resource env_acr_env_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(env_acr.id, env_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+              properties: {
+                principalId: env_mi.properties.principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+                principalType: 'ServicePrincipal'
               }
-            ]
-          }
-          tags: tags
-        }
-        
-        resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
-          name: 'aspire-dashboard'
-          properties: {
-            componentType: 'AspireDashboard'
-          }
-          parent: cae
-        }
-        
-        resource cae_Contributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-          name: guid(cae.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c'))
-          properties: {
-            principalId: userPrincipalId
-            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-          }
-          scope: cae
-        }
-        
-        resource storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
-          name: take('storagevolume${uniqueString(resourceGroup().id)}', 24)
-          kind: 'StorageV2'
-          location: location
-          sku: {
-            name: 'Standard_LRS'
-          }
-          properties: {
-            largeFileSharesState: 'Enabled'
-          }
-          tags: tags
-        }
-        
-        resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2024-01-01' = {
-          name: 'default'
-          parent: storageVolume
-        }
-        
-        resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
-          name: take('sharesvolumescache0-${uniqueString(resourceGroup().id)}', 63)
-          properties: {
-            enabledProtocols: 'SMB'
-            shareQuota: 1024
-          }
-          parent: storageVolumeFileService
-        }
-        
-        resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2024-03-01' = {
-          name: take('managedstoragevolumescache${uniqueString(resourceGroup().id)}', 24)
-          properties: {
-            azureFile: {
-              accountName: storageVolume.name
-              accountKey: storageVolume.listKeys().keys[0].value
-              accessMode: 'ReadWrite'
-              shareName: shares_volumes_cache_0.name
+              scope: env_acr
             }
-          }
-          parent: cae
+
+            resource env_law 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+              name: 'law-${resourceToken}'
+              location: location
+              properties: {
+                sku: {
+                  name: 'PerGB2018'
+                }
+              }
+              tags: tags
+            }
+
+            resource env 'Microsoft.App/managedEnvironments@2024-03-01' = {
+              name: 'cae-${resourceToken}'
+              location: location
+              properties: {
+                appLogsConfiguration: {
+                  destination: 'log-analytics'
+                  logAnalyticsConfiguration: {
+                    customerId: env_law.properties.customerId
+                    sharedKey: env_law.listKeys().primarySharedKey
+                  }
+                }
+                workloadProfiles: [
+                  {
+                    name: 'consumption'
+                    workloadProfileType: 'Consumption'
+                  }
+                ]
+              }
+              tags: tags
+            }
+
+            resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+              name: 'aspire-dashboard'
+              properties: {
+                componentType: 'AspireDashboard'
+              }
+              parent: env
+            }
+
+            resource env_Contributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(env.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c'))
+              properties: {
+                principalId: userPrincipalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+              }
+              scope: env
+            }
+
+            resource env_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+              name: 'vol${resourceToken}'
+              kind: 'StorageV2'
+              location: location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              properties: {
+                largeFileSharesState: 'Enabled'
+              }
+              tags: tags
+            }
+
+            resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2024-01-01' = {
+              name: 'default'
+              parent: env_storageVolume
+            }
+
+            resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+              name: take('sharesvolumescache0-${uniqueString(resourceGroup().id)}', 63)
+              properties: {
+                enabledProtocols: 'SMB'
+                shareQuota: 1024
+              }
+              parent: storageVolumeFileService
+            }
+
+            resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2024-03-01' = {
+              name: take('managedstoragevolumescache${uniqueString(resourceGroup().id)}', 24)
+              properties: {
+                azureFile: {
+                  accountName: env_storageVolume.name
+                  accountKey: env_storageVolume.listKeys().keys[0].value
+                  accessMode: 'ReadWrite'
+                  shareName: shares_volumes_cache_0.name
+                }
+              }
+              parent: env
+            }
+
+            var resourceToken = uniqueString(resourceGroup().id)
+
+            output volumes_cache_0 string = managedStorage_volumes_cache_0.name
+
+            output MANAGED_IDENTITY_NAME string = 'mi-${resourceToken}'
+
+            output MANAGED_IDENTITY_PRINCIPAL_ID string = env_mi.properties.principalId
+
+            output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = 'law-${resourceToken}'
+
+            output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
+
+            output AZURE_CONTAINER_REGISTRY_NAME string = replace('acr-${resourceToken}', '-', '')
+
+            output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
+
+            output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = env_mi.id
+
+            output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = 'cae-${resourceToken}'
+
+            output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = env.id
+
+            output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = env.properties.defaultDomain
+            """;
         }
-        
-        output volumes_cache_0 string = managedStorage_volumes_cache_0.name
-        
-        output MANAGED_IDENTITY_NAME string = mi.name
-        
-        output MANAGED_IDENTITY_PRINCIPAL_ID string = mi.properties.principalId
-        
-        output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = law.name
-        
-        output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = law.id
-        
-        output AZURE_CONTAINER_REGISTRY_NAME string = acr.name
-        
-        output AZURE_CONTAINER_REGISTRY_ENDPOINT string = acr.properties.loginServer
-        
-        output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = mi.id
-        
-        output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = cae.name
-        
-        output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = cae.id
-        
-        output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = cae.properties.defaultDomain
-        """;
+        else
+        {
+            expectedBicep =
+            """
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param userPrincipalId string
+
+            param tags object = { }
+
+            resource env_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+              name: take('env_mi-${uniqueString(resourceGroup().id)}', 128)
+              location: location
+              tags: tags
+            }
+
+            resource env_acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+              name: take('envacr${uniqueString(resourceGroup().id)}', 50)
+              location: location
+              sku: {
+                name: 'Basic'
+              }
+              tags: tags
+            }
+
+            resource env_acr_env_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(env_acr.id, env_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+              properties: {
+                principalId: env_mi.properties.principalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+                principalType: 'ServicePrincipal'
+              }
+              scope: env_acr
+            }
+
+            resource env_law 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+              name: take('envlaw-${uniqueString(resourceGroup().id)}', 63)
+              location: location
+              properties: {
+                sku: {
+                  name: 'PerGB2018'
+                }
+              }
+              tags: tags
+            }
+
+            resource env 'Microsoft.App/managedEnvironments@2024-03-01' = {
+              name: take('env${uniqueString(resourceGroup().id)}', 24)
+              location: location
+              properties: {
+                appLogsConfiguration: {
+                  destination: 'log-analytics'
+                  logAnalyticsConfiguration: {
+                    customerId: env_law.properties.customerId
+                    sharedKey: env_law.listKeys().primarySharedKey
+                  }
+                }
+                workloadProfiles: [
+                  {
+                    name: 'consumption'
+                    workloadProfileType: 'Consumption'
+                  }
+                ]
+              }
+              tags: tags
+            }
+
+            resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+              name: 'aspire-dashboard'
+              properties: {
+                componentType: 'AspireDashboard'
+              }
+              parent: env
+            }
+
+            resource env_Contributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(env.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c'))
+              properties: {
+                principalId: userPrincipalId
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+              }
+              scope: env
+            }
+
+            resource env_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+              name: take('envstoragevolume${uniqueString(resourceGroup().id)}', 24)
+              kind: 'StorageV2'
+              location: location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              properties: {
+                largeFileSharesState: 'Enabled'
+              }
+              tags: tags
+            }
+
+            resource storageVolumeFileService 'Microsoft.Storage/storageAccounts/fileServices@2024-01-01' = {
+              name: 'default'
+              parent: env_storageVolume
+            }
+
+            resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
+              name: take('sharesvolumescache0-${uniqueString(resourceGroup().id)}', 63)
+              properties: {
+                enabledProtocols: 'SMB'
+                shareQuota: 1024
+              }
+              parent: storageVolumeFileService
+            }
+
+            resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2024-03-01' = {
+              name: take('managedstoragevolumescache${uniqueString(resourceGroup().id)}', 24)
+              properties: {
+                azureFile: {
+                  accountName: env_storageVolume.name
+                  accountKey: env_storageVolume.listKeys().keys[0].value
+                  accessMode: 'ReadWrite'
+                  shareName: shares_volumes_cache_0.name
+                }
+              }
+              parent: env
+            }
+
+            output volumes_cache_0 string = managedStorage_volumes_cache_0.name
+
+            output MANAGED_IDENTITY_NAME string = env_mi.name
+
+            output MANAGED_IDENTITY_PRINCIPAL_ID string = env_mi.properties.principalId
+
+            output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = env_law.name
+
+            output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
+
+            output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
+
+            output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
+
+            output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = env_mi.id
+
+            output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = env.name
+
+            output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = env.id
+
+            output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = env.properties.defaultDomain
+            """;
+        }
         output.WriteLine(bicep);
         Assert.Equal(expectedBicep, bicep);
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -3271,6 +3271,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
 
             param tags object = { }
 
+            var resourceToken = uniqueString(resourceGroup().id)
+
             resource env_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
               name: 'mi-${resourceToken}'
               location: location
@@ -3384,8 +3386,6 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               }
               parent: env
             }
-
-            var resourceToken = uniqueString(resourceGroup().id)
 
             output volumes_cache_0 string = managedStorage_volumes_cache_0.name
 


### PR DESCRIPTION
We should be prefixing the resources created via AddAzureContainerAppEnvironment with the environment name. This will allow for multiple environments to be in a single distributed application in the future.

With this change, it means deploying to existing environments will duplicate resources. To solve that, add a new method WithAzdResourceNaming, which will revert the resource names back to the previous naming scheme.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
