### PR TITLE
Fix a regression in endpoint resolution in environment variables

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -158,7 +158,9 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
         // However, ConnectionStringReference#GetValueAsync will throw if the connection string is not optional but is not present.
         // so we need to do the same here.
         var value = await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false);
-        if (string.IsNullOrEmpty(value.Value) && !cs.Optional)
+
+        // While pre-processing the endpoints, we never throw
+        if (!Preprocess && string.IsNullOrEmpty(value.Value) && !cs.Optional)
         {
             cs.ThrowConnectionStringUnavailableException();
         }


### PR DESCRIPTION
## Description

- Endpoints wrapped in connection strings were throwing during the preprocess pass of the evalution. Avoid throwing during that pass
- Added tests for this scenario

Fixes #8596

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
