### PR TITLE
Disable OTEL telemetry in CLI if not a debug build.

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -9,9 +9,13 @@ using Aspire.Cli.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+
+#if DEBUG
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+#endif
+
 using RootCommand = Aspire.Cli.Commands.RootCommand;
 
 namespace Aspire.Cli;
@@ -32,6 +36,7 @@ public class Program
             logging.IncludeScopes = true;
             });
 
+#if DEBUG
         var otelBuilder = builder.Services
             .AddOpenTelemetry()
             .WithTracing(tracing => {
@@ -56,6 +61,7 @@ public class Program
             //       has to finish sending telemetry.
             otelBuilder.UseOtlpExporter();
         }
+#endif
 
         var debugMode = args?.Any(a => a == "--debug" || a == "-d") ?? false;
 


### PR DESCRIPTION
Alternative to #8611 