### PR TITLE
Error handling for GetCapabilitiesAsync connection issues

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -88,38 +88,49 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 
     public async Task ConnectAsync(Process process, string socketPath, CancellationToken cancellationToken)
     {
-        using var activity = _activitySource.StartActivity();
-
-        _process = process;
-
-        if (_rpcTaskCompletionSource.Task.IsCompleted)
+        try
         {
-            throw new InvalidOperationException("Already connected to AppHost backchannel.");
+            using var activity = _activitySource.StartActivity();
+
+            _process = process;
+
+            if (_rpcTaskCompletionSource.Task.IsCompleted)
+            {
+                throw new InvalidOperationException("Already connected to AppHost backchannel.");
+            }
+
+            logger.LogDebug("Connecting to AppHost backchannel at {SocketPath}", socketPath);
+            var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            var endpoint = new UnixDomainSocketEndPoint(socketPath);
+            await socket.ConnectAsync(endpoint, cancellationToken);
+            logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
+
+            var stream = new NetworkStream(socket, true);
+            var rpc = JsonRpc.Attach(stream, target);
+
+            var capabilities = await rpc.InvokeWithCancellationAsync<string[]>(
+                "GetCapabilitiesAsync",
+                Array.Empty<object>(),
+                cancellationToken);
+
+            if (!capabilities.Any(s => s == "baseline.v0"))
+            {
+                throw new AppHostIncompatibleException(
+                    $"AppHost is incompatible with the CLI. The AppHost must be updated to a version that supports the baseline.v0 capability.",
+                    "baseline.v0"
+                    );
+            }
+
+            _rpcTaskCompletionSource.SetResult(rpc);
         }
-
-        logger.LogDebug("Connecting to AppHost backchannel at {SocketPath}", socketPath);
-        var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
-        var endpoint = new UnixDomainSocketEndPoint(socketPath);
-        await socket.ConnectAsync(endpoint, cancellationToken);
-        logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
-
-        var stream = new NetworkStream(socket, true);
-        var rpc = JsonRpc.Attach(stream, target);
-
-        var capabilities = await rpc.InvokeWithCancellationAsync<string[]>(
-            "GetCapabilitiesAsync",
-            Array.Empty<object>(),
-            cancellationToken);
-
-        if (!capabilities.Any(s => s == "baseline.v0"))
+        catch (RemoteMethodNotFoundException ex)
         {
+            logger.LogError(ex, "Failed to connect to AppHost backchannel. The AppHost must be updated to a version that supports the baseline.v0 capability.");
             throw new AppHostIncompatibleException(
                 $"AppHost is incompatible with the CLI. The AppHost must be updated to a version that supports the baseline.v0 capability.",
                 "baseline.v0"
                 );
         }
-
-        _rpcTaskCompletionSource.SetResult(rpc);
     }
 
     public async Task<string[]> GetPublishersAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -486,6 +486,12 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
                 throw;
             }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "An unexpected error occured while trying to connect to the backchannel.");
+                backchannelCompletionSource.SetException(ex);
+                throw;
+            }
 
         } while (await timer.WaitForNextTickAsync(cancellationToken));
     }

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -488,7 +488,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "An unexpected error occured while trying to connect to the backchannel.");
+                logger.LogError(ex, "An unexpected error occurred while trying to connect to the backchannel.");
                 backchannelCompletionSource.SetException(ex);
                 throw;
             }


### PR DESCRIPTION
Implement error handling for missing or unexpected exceptions during the connection to the AppHost backchannel, ensuring proper logging and exception propagation.

Previously if we got an unexpected exception we would keep retrying. We now treat an unexpected exception as a failure condition. We also specifically handle the scenario where the GetCapabiltiiesAsync method is missing on the remote app host which can occur with some preview builds of 9.2.0 (9.1.0 builds are already treated as explicitly incompatible by this stage).