### PR TITLE
Look for shipping artifacts according to the build configuration

### DIFF
--- a/tests/Shared/TemplatesTesting/BuildEnvironment.cs
+++ b/tests/Shared/TemplatesTesting/BuildEnvironment.cs
@@ -101,7 +101,11 @@ public class BuildEnvironment
                 sdkForTemplatePath = Path.GetDirectoryName(dotnetPath)!;
             }
 
-            BuiltNuGetsPath = Path.Combine(RepoRoot.FullName, "artifacts", "packages", EnvironmentVariables.BuildConfiguration, "Shipping");
+#if RELEASE
+            BuiltNuGetsPath = Path.Combine(RepoRoot.FullName, "artifacts", "packages", "Release", "Shipping");
+#else
+            BuiltNuGetsPath = Path.Combine(RepoRoot.FullName, "artifacts", "packages", "Debug", "Shipping");
+#endif
 
             PlaywrightProvider.DetectAndSetInstalledPlaywrightDependenciesPath(RepoRoot);
         }

--- a/tests/Shared/TemplatesTesting/EnvironmentVariables.cs
+++ b/tests/Shared/TemplatesTesting/EnvironmentVariables.cs
@@ -11,8 +11,7 @@ public static class EnvironmentVariables
     public static readonly string? BuiltNuGetsPath           = Environment.GetEnvironmentVariable("BUILT_NUGETS_PATH");
     public static readonly bool    ShowBuildOutput           = Environment.GetEnvironmentVariable("SHOW_BUILD_OUTPUT") is "true";
     public static readonly bool    IsRunningOnCI             = Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null;
-    public static readonly bool    TestsRunningOutsideOfRepo     = Environment.GetEnvironmentVariable("TestsRunningOutsideOfRepo") is "true";
-    public static readonly string  BuildConfiguration        = Environment.GetEnvironmentVariable("BUILD_CONFIGURATION") ?? "Debug";
+    public static readonly bool    TestsRunningOutsideOfRepo = Environment.GetEnvironmentVariable("TestsRunningOutsideOfRepo") is "true";
     public static readonly string? TestScenario              = Environment.GetEnvironmentVariable("TEST_SCENARIO");
     public static readonly string? DefaultTFMForTesting      = Environment.GetEnvironmentVariable("DEFAULT_TFM_FOR_TESTING");
 }


### PR DESCRIPTION
The E2E and the Template tests look for Shipping artifacts in incorrect location, unless it is explicitly configured. 

E.g., I'm build and running tests explicitly in RELEASE build, but the tests look under a Debug path...
![image](https://github.com/user-attachments/assets/5905b01d-11db-46f3-8351-ade90b4738ba)

We should expect a developer to set an additional env var, when the developer has already explicitly built in specific configuration.

Since we only have two build configs, I resorted to only #if..#else. When/if we decide to support more build configurations, we can revisit the code to extend the condition.