### PR TITLE
Introduce version selector for Aspire templates

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -66,9 +66,9 @@ internal sealed class AddCommand : BaseCommand
 
             var source = parseResult.GetValue<string?>("--source");
 
-            var packages = await AnsiConsole.Status().StartAsync(
+            var packages = await InteractionUtils.ShowStatusAsync(
                 "Searching for Aspire packages...",
-                context => _nuGetPackageCache.GetPackagesAsync(effectiveAppHostProjectFile.Directory!, prerelease, source, cancellationToken)
+                () => _nuGetPackageCache.GetIntegrationPackagesAsync(effectiveAppHostProjectFile.Directory!, prerelease, source, cancellationToken)
                 );
 
             var version = parseResult.GetValue<string?>("--version");

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -124,8 +124,8 @@ internal sealed class NewCommand : BaseCommand
                 () => _nuGetPackageCache.GetTemplatePackagesAsync(workingDirectory, prerelease, source, cancellationToken)
                 );
 
-            var sekectedPackage = await InteractionUtils.PromptForTemplatesVersionAsync(candidatePackages, cancellationToken);
-            return sekectedPackage.Version;
+            var selectedPackage = await InteractionUtils.PromptForTemplatesVersionAsync(candidatePackages, cancellationToken);
+            return selectedPackage.Version;
         }
     }
 

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -44,7 +44,7 @@ internal sealed class NewCommand : BaseCommand
         Options.Add(templateVersionOption);
 
         var prereleaseOption = new Option<bool>("--prerelease");
-        prereleaseOption.Description = "Include prelease versions when searching for project templates.";
+        prereleaseOption.Description = "Include prerelease versions when searching for project templates.";
         Options.Add(prereleaseOption);
     }
 

--- a/src/Aspire.Cli/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGetPackageCache.cs
@@ -8,7 +8,8 @@ namespace Aspire.Cli;
 
 internal interface INuGetPackageCache
 {
-    Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, string? source, CancellationToken cancellationToken);
+    Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, string? source, CancellationToken cancellationToken);
+    Task<IEnumerable<NuGetPackage>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, string? source, CancellationToken cancellationToken);
 }
 
 internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNetCliRunner cliRunner) : INuGetPackageCache
@@ -17,7 +18,17 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNe
 
     private const int SearchPageSize = 100;
 
-    public async Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, string? source, CancellationToken cancellationToken)
+    public async Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, string? source, CancellationToken cancellationToken)
+    {
+        return await GetPackagesAsync(workingDirectory, "Aspire.ProjectTemplates", prerelease, source, cancellationToken);
+    }
+
+    public async Task<IEnumerable<NuGetPackage>> GetIntegrationPackagesAsync(DirectoryInfo workingDirectory, bool prerelease, string? source, CancellationToken cancellationToken)
+    {
+        return await GetPackagesAsync(workingDirectory, "Aspire.Hosting", prerelease, source, cancellationToken);
+    }
+
+    internal async Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, string query, bool prerelease, string? source, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -32,7 +43,7 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNe
             // This search should pick up Aspire.Hosting.* and CommunityToolkit.Aspire.Hosting.*
             var result = await cliRunner.SearchPackagesAsync(
                 workingDirectory,
-                "Aspire.Hosting",
+                query,
                 prerelease,
                 SearchPageSize,
                 skip,
@@ -69,8 +80,9 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, DotNe
 
         static bool IsOfficialOrCommunityToolkitPackage(string packageName)
         {
-            var isHostingOrCommunityToolkitNamespaced = packageName.StartsWith("Aspire.Hosting.", StringComparison.OrdinalIgnoreCase) ||
-                   packageName.StartsWith("CommunityToolkit.Aspire.Hosting.", StringComparison.OrdinalIgnoreCase);
+            var isHostingOrCommunityToolkitNamespaced = packageName.StartsWith("Aspire.Hosting.", StringComparison.Ordinal) ||
+                   packageName.StartsWith("CommunityToolkit.Aspire.Hosting.", StringComparison.Ordinal) ||
+                   packageName.Equals("Aspire.ProjectTemplates", StringComparison.Ordinal);
             
             var isExcluded = packageName.StartsWith("Aspire.Hosting.AppHost") ||
                              packageName.StartsWith("Aspire.Hosting.Sdk") ||

--- a/src/Aspire.Cli/Utils/InteractionUtils.cs
+++ b/src/Aspire.Cli/Utils/InteractionUtils.cs
@@ -8,6 +8,24 @@ namespace Aspire.Cli.Utils;
 
 internal static class InteractionUtils
 {
+    public static async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action)
+    {
+        return await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots3)
+            .SpinnerStyle(Style.Parse("purple"))
+            .StartAsync(statusText, (context) => action());
+    }
+
+    public static async Task<NuGetPackage> PromptForTemplatesVersionAsync(IEnumerable<NuGetPackage> candidatePackages, CancellationToken cancellationToken)
+    {
+        return await PromptForSelectionAsync(
+            "Select a template version:",
+            candidatePackages,
+            (p) => $"{p.Version} ({p.Source})",
+            cancellationToken
+            );
+    }
+
     public static async Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(promptText, nameof(promptText));


### PR DESCRIPTION
Implement a version selection feature for Aspire project templates, allowing users to choose from available versions, including pre-release options. Update related methods and interfaces to support this functionality.

Fixes #8627
Fixes #8597
Fixes #8626