### PR TITLE
Follow up from azd naming change

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -223,6 +223,9 @@ public static class AzureContainerAppExtensions
                             _ => throw new NotSupportedException()
                         };
 
+                        // Remove '.' and '-' characters from volumeName
+                        volumeName = volumeName.Replace(".", "").Replace("-", "");
+
                         share.Name = BicepFunction.Take(
                             BicepFunction.Interpolate(
                                 $"{BicepFunction.ToLower(output.resource.Name)}-{BicepFunction.ToLower(volumeName)}"),
@@ -253,11 +256,10 @@ public static class AzureContainerAppExtensions
                 identity.Name = BicepFunction.Interpolate($"mi-{resourceToken}");
                 containerRegistry.Name = new FunctionCallExpression(
                     new IdentifierExpression("replace"),
-                    new InterpolatedStringExpression(
-                        [
-                            new StringLiteralExpression("acr-"),
+                    new InterpolatedStringExpression([
+                        new StringLiteralExpression("acr-"),
                         new IdentifierExpression(resourceToken.BicepIdentifier)
-                        ]),
+                    ]),
                     new StringLiteralExpression("-"),
                     new StringLiteralExpression(""));
                 laWorkspace.Name = BicepFunction.Interpolate($"law-{resourceToken}");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -3231,7 +3231,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                         .AddDatabase("db");
 
         builder.AddContainer("cache", "redis")
-               .WithVolume("data", "/data")
+               .WithVolume("App.da-ta", "/data")
                .WithReference(pg);
 
         using var app = builder.Build();
@@ -3366,7 +3366,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
 
             resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/shares@2024-01-01' = {
-              name: take('${toLower('cache')}-${toLower('data')}', 60)
+              name: take('${toLower('cache')}-${toLower('Appdata')}', 60)
               properties: {
                 enabledProtocols: 'SMB'
                 shareQuota: 1024
@@ -3375,7 +3375,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             }
 
             resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2024-03-01' = {
-              name: take('${toLower('cache')}-${toLower('data')}', 32)
+              name: take('${toLower('cache')}-${toLower('Appdata')}', 32)
               properties: {
                 azureFile: {
                   accountName: env_storageVolume.name


### PR DESCRIPTION
## Description

Remove dots and dashes from the volume name to align with azd naming

This change was included in [[release/9.2] AddAzureContainerAppEnvironment should use the environment name as a prefix (dotnet/aspire#8607)](https://github.com/dotnet/aspire/pull/8607). Forward porting it back to main and adding a test.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
