### PR TITLE
Don't restore page state on first load

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -6,6 +6,7 @@ using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -73,7 +74,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        NavigationManager.LocationChanged += (_, _) => NavigationService.IsFirstPageLoad = false;
+        NavigationManager.LocationChanged += OnLocationChanged;
 
         // Theme change can be triggered from the settings dialog. This logic applies the new theme to the browser window.
         // Note that this event could be raised from a settings dialog opened in a different browser window.
@@ -279,8 +280,14 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         StateHasChanged();
     }
 
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+    {
+        NavigationService.IsFirstPageLoad = false;
+    }
+
     public async ValueTask DisposeAsync()
     {
+        NavigationManager.LocationChanged -= OnLocationChanged;
         _shortcutManagerReference?.Dispose();
         _layoutReference?.Dispose();
         _themeChangedSubscription?.Dispose();

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -65,11 +65,16 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     [Inject]
     public required ILocalStorage LocalStorage { get; init; }
 
+    [Inject]
+    public required NavigationService NavigationService { get; init; }
+
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
+        NavigationManager.LocationChanged += (_, _) => NavigationService.IsFirstPageLoad = false;
+
         // Theme change can be triggered from the settings dialog. This logic applies the new theme to the browser window.
         // Note that this event could be raised from a settings dialog opened in a different browser window.
         _themeChangedSubscription = ThemeManager.OnThemeChanged(async () =>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -58,6 +58,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
+    public required NavigationService NavigationService { get; init; }
+
+    [Inject]
     public required ILogger<ConsoleLogs> Logger { get; init; }
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Pages/IPageWithSessionAndUrlState.cs
+++ b/src/Aspire.Dashboard/Components/Pages/IPageWithSessionAndUrlState.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.Layout;
+using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components.Pages;
@@ -27,6 +28,7 @@ public interface IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>
 
     public NavigationManager NavigationManager { get; }
     public ISessionStorage SessionStorage { get; }
+    public NavigationService NavigationService { get; }
 
     /// <summary>
     /// The view model containing live state, to be instantiated in OnInitialized.
@@ -92,7 +94,7 @@ public static class PageExtensions
     /// </returns>
     public static async Task<bool> InitializeViewModelAsync<TViewModel, TSerializableViewModel>(this IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel> page) where TSerializableViewModel : class
     {
-        if (string.Equals(page.BasePath, page.NavigationManager.ToBaseRelativePath(page.NavigationManager.Uri)))
+        if (string.Equals(page.BasePath, page.NavigationManager.ToBaseRelativePath(page.NavigationManager.Uri)) && !page.NavigationService.IsFirstPageLoad)
         {
             var result = await page.SessionStorage.GetAsync<TSerializableViewModel>(page.SessionStorageKey).ConfigureAwait(false);
             if (result is { Success: true, Value: not null })

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -54,6 +54,9 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
+    public required NavigationService NavigationService { get; init; }
+
+    [Inject]
     public required ISessionStorage SessionStorage { get; init; }
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -43,6 +43,8 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
     [Inject]
     public required NavigationManager NavigationManager { get; init; }
     [Inject]
+    public required NavigationService NavigationService { get; init; }
+    [Inject]
     public required DashboardCommandExecutor DashboardCommandExecutor { get; init; }
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -68,6 +68,9 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
+    public required NavigationService NavigationService { get; init; }
+
+    [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -57,6 +57,9 @@ public partial class TraceDetail : ComponentBase, IDisposable
     [Inject]
     public required NavigationManager NavigationManager { get; init; }
 
+    [Inject]
+    public required NavigationService NavigationService { get; init; }
+
     protected override void OnInitialized()
     {
         _gridColumns = [

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -76,6 +76,9 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
     public required NavigationManager NavigationManager { get; set; }
 
     [Inject]
+    public required NavigationService NavigationService { get; init; }
+
+    [Inject]
     public required ISessionStorage SessionStorage { get; set; }
 
     [Inject]

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -255,6 +255,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddScoped<ShortcutManager>();
         builder.Services.AddScoped<ConsoleLogsManager>();
         builder.Services.AddSingleton<IInstrumentUnitResolver, DefaultInstrumentUnitResolver>();
+        builder.Services.AddScoped<NavigationService>();
 
         // Time zone is set by the browser.
         builder.Services.AddScoped<BrowserTimeProvider>();

--- a/src/Aspire.Dashboard/Model/BrowserStorage/BrowserStorageBase.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/BrowserStorageBase.cs
@@ -7,7 +7,7 @@ namespace Aspire.Dashboard.Model.BrowserStorage;
 
 public abstract class BrowserStorageBase : IBrowserStorage
 {
-    private readonly ProtectedBrowserStorage _protectedBrowserStorage;
+    protected readonly ProtectedBrowserStorage _protectedBrowserStorage;
 
     protected BrowserStorageBase(ProtectedBrowserStorage protectedBrowserStorage, ILogger logger)
     {
@@ -43,4 +43,6 @@ public abstract class BrowserStorageBase : IBrowserStorage
     {
         await _protectedBrowserStorage.SetAsync(key, value!).ConfigureAwait(false);
     }
+
+    public abstract Task DeleteAsync(string key);
 }

--- a/src/Aspire.Dashboard/Model/BrowserStorage/IBrowserStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/IBrowserStorage.cs
@@ -7,4 +7,5 @@ public interface IBrowserStorage
 {
     Task<StorageResult<TValue>> GetAsync<TValue>(string key);
     Task SetAsync<TValue>(string key, TValue value);
+    Task DeleteAsync(string key);
 }

--- a/src/Aspire.Dashboard/Model/BrowserStorage/LocalBrowserStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/LocalBrowserStorage.cs
@@ -55,4 +55,7 @@ public class LocalBrowserStorage : BrowserStorageBase, ILocalStorage
 
     private ValueTask<string?> GetJsonAsync(string key)
         => _jsRuntime.InvokeAsync<string?>("localStorage.getItem", key);
+
+    public override async Task DeleteAsync(string key)
+        => await _jsRuntime.InvokeVoidAsync("localStorage.removeItem", key).ConfigureAwait(false);
 }

--- a/src/Aspire.Dashboard/Model/BrowserStorage/SessionBrowserStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/SessionBrowserStorage.cs
@@ -10,4 +10,9 @@ public class SessionBrowserStorage : BrowserStorageBase, ISessionStorage
     public SessionBrowserStorage(ProtectedSessionStorage protectedSessionStorage, ILogger<SessionBrowserStorage> logger) : base(protectedSessionStorage, logger)
     {
     }
+
+    public override async Task DeleteAsync(string key)
+    {
+        await _protectedBrowserStorage.DeleteAsync(key).ConfigureAwait(false);
+    }
 }

--- a/src/Aspire.Dashboard/Model/NavigationService.cs
+++ b/src/Aspire.Dashboard/Model/NavigationService.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public sealed class NavigationService
+{
+    public bool IsFirstPageLoad { get; set; } = true;
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -139,6 +139,7 @@ public partial class MainLayoutTests : DashboardTestContext
         Services.AddSingleton<IToastService, ToastService>();
         Services.AddSingleton<GlobalState>();
         Services.Configure<DashboardOptions>(o => o.Otlp.AuthMode = OtlpAuthMode.Unsecured);
+        Services.AddSingleton<NavigationService>();
 
         var version = typeof(FluentMain).Assembly.GetName().Version!;
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -548,6 +548,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         Services.AddSingleton<DashboardCommandExecutor>();
         Services.AddSingleton<ConsoleLogsManager>();
         Services.AddSingleton<PauseManager>();
+        Services.AddSingleton<NavigationService>();
     }
 
     private static string GetFluentFile(string filePath, Version version)

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -191,6 +191,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         Services.AddSingleton<LibraryConfiguration>();
         Services.AddSingleton<IKeyCodeService, KeyCodeService>();
         Services.AddSingleton<GlobalState>();
+        Services.AddSingleton<NavigationService>();
     }
 
     private static string GetFluentFile(string filePath, Version version)

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -184,6 +184,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         Services.AddSingleton<ShortcutManager>();
         Services.AddSingleton<LibraryConfiguration>();
         Services.AddSingleton<IKeyCodeService, KeyCodeService>();
+        Services.AddSingleton<NavigationService>();
     }
 
     private static string GetFluentFile(string filePath, Version version)

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/MetricsSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/MetricsSetupHelpers.cs
@@ -93,6 +93,7 @@ internal static class MetricsSetupHelpers
         context.Services.AddSingleton<IKeyCodeService, KeyCodeService>();
         context.Services.AddSingleton<IThemeResolver, TestThemeResolver>();
         context.Services.AddSingleton<ThemeManager>();
+        context.Services.AddSingleton<NavigationService>();
     }
 
     private static string GetFluentFile(string filePath, Version version)

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -109,6 +109,7 @@ internal static class ResourceSetupHelpers
         context.Services.AddFluentUIComponents();
         context.Services.AddScoped<DashboardCommandExecutor, DashboardCommandExecutor>();
         context.Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient(isEnabled: true, initialResources: [], resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>));
+        context.Services.AddSingleton<NavigationService>();
 
         var dimensionManager = context.Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestLocalStorage.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestLocalStorage.cs
@@ -38,4 +38,9 @@ public sealed class TestLocalStorage : ILocalStorage
         }
         return Task.CompletedTask;
     }
+
+    public Task DeleteAsync(string key)
+    {
+        return Task.CompletedTask;
+    }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestSessionStorage.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestSessionStorage.cs
@@ -30,4 +30,9 @@ public sealed class TestSessionStorage : ISessionStorage
 
         return Task.CompletedTask;
     }
+
+    public Task DeleteAsync(string key)
+    {
+        return Task.CompletedTask;
+    }
 }


### PR DESCRIPTION
## Description

I noticed that there's a bug with the current "state restore" logic. If you navigate intentionally to a different url (ie by updating the url in the omnibar and navigating), the existing page state will still be restored.

This disables state restore just for the initial page load. The main purpose of this state restoration logic is to restore state when navigating _between_ pages, which isn't touched.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
