### PR TITLE
[release/9.2] Obsolete AddAzureContainerAppsInfrastructure (#8639)

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppContainerExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppContainerExtensions.cs
@@ -42,7 +42,7 @@ public static class AzureContainerAppContainerExtensions
             return container;
         }
 
-        container.ApplicationBuilder.AddAzureContainerAppsInfrastructure();
+        container.ApplicationBuilder.AddAzureContainerAppsInfrastructureCore();
 
         container.WithAnnotation(new AzureContainerAppCustomizationAnnotation(configure));
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -80,8 +80,15 @@ public class AzureContainerAppEnvironmentResource(string name, Action<AzureResou
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.GetVolumeStorage(IResource resource, ContainerMountAnnotation volume, int volumeIndex)
     {
+        var prefix = volume.Type switch
+        {
+            ContainerMountType.BindMount => "bindmounts",
+            ContainerMountType.Volume => "volumes",
+            _ => throw new NotSupportedException()
+        };
+
         // REVIEW: Should we use the same naming algorithm as azd?
-        var outputName = $"volumes_{resource.Name}_{volumeIndex}";
+        var outputName = $"{prefix}_{resource.Name}_{volumeIndex}";
 
         if (!VolumeNames.TryGetValue(outputName, out var volumeName))
         {

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExecutableExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExecutableExtensions.cs
@@ -42,7 +42,7 @@ public static class AzureContainerAppExecutableExtensions
             return executable;
         }
 
-        executable.ApplicationBuilder.AddAzureContainerAppsInfrastructure();
+        executable.ApplicationBuilder.AddAzureContainerAppsInfrastructureCore();
 
         return executable.WithAnnotation(new AzureContainerAppCustomizationAnnotation(configure));
     }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -28,7 +28,11 @@ public static class AzureContainerAppExtensions
     /// Adds the necessary infrastructure for Azure Container Apps to the distributed application builder.
     /// </summary>
     /// <param name="builder">The distributed application builder.</param>
-    public static IDistributedApplicationBuilder AddAzureContainerAppsInfrastructure(this IDistributedApplicationBuilder builder)
+    [Obsolete($"Use {nameof(AddAzureContainerAppEnvironment)} instead. This method will be removed in a future version.")]
+    public static IDistributedApplicationBuilder AddAzureContainerAppsInfrastructure(this IDistributedApplicationBuilder builder) =>
+        AddAzureContainerAppsInfrastructureCore(builder);
+
+    internal static IDistributedApplicationBuilder AddAzureContainerAppsInfrastructureCore(this IDistributedApplicationBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -52,7 +56,7 @@ public static class AzureContainerAppExtensions
     /// <returns><see cref="IResourceBuilder{T}"/></returns>
     public static IResourceBuilder<AzureContainerAppEnvironmentResource> AddAzureContainerAppEnvironment(this IDistributedApplicationBuilder builder, string name)
     {
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppsInfrastructureCore();
 
         // Only support one temporarily until we can support multiple environments
         // and allowing each container app to be explicit about which environment it uses

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppProjectExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppProjectExtensions.cs
@@ -42,7 +42,7 @@ public static class AzureContainerAppProjectExtensions
             return project;
         }
 
-        project.ApplicationBuilder.AddAzureContainerAppsInfrastructure();
+        project.ApplicationBuilder.AddAzureContainerAppsInfrastructureCore();
 
         project.WithAnnotation(new AzureContainerAppCustomizationAnnotation(configure));
 

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -85,7 +85,7 @@ internal sealed class AzureResourcePreparer(
         {
             if (resource.HasAnnotationOfType<RoleAssignmentAnnotation>())
             {
-                throw new InvalidOperationException("The application model does not support role assignments. Ensure you are using a publisher that supports role assignments, for example AddAzureContainerAppsInfrastructure.");
+                throw new InvalidOperationException("The application model does not support role assignments. Ensure you are using an environment that supports role assignments, for example AddAzureContainerAppEnvironment.");
             }
         }
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -25,7 +25,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         builder.AddAzureContainerAppsInfrastructure();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         builder.AddContainer("api", "myimage");
 
@@ -101,7 +103,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         var directory = Directory.CreateTempSubdirectory(".aspire-test");
 
@@ -134,10 +136,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
-            "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -150,13 +152,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
-        param outputs_azure_container_registry_endpoint string
+        param env_outputs_azure_container_registry_endpoint string
         
-        param outputs_azure_container_registry_managed_identity_id string
+        param env_outputs_azure_container_registry_managed_identity_id string
         
         param api_containerimage string
         
@@ -168,12 +170,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               activeRevisionsMode: 'Single'
               registries: [
                 {
-                  server: outputs_azure_container_registry_endpoint
-                  identity: outputs_azure_container_registry_managed_identity_id
+                  server: env_outputs_azure_container_registry_endpoint
+                  identity: env_outputs_azure_container_registry_managed_identity_id
                 }
               ]
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -189,7 +191,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           identity: {
             type: 'UserAssigned'
             userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
+              '${env_outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -203,7 +205,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddProject<Project>("api", launchProfileName: null)
             .WithHttpEndpoint();
@@ -233,10 +235,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "path": "api.module.bicep",
           "params": {
             "api_containerport": "{api.containerPort}",
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
-            "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -248,19 +250,19 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-        
+
         param api_containerport string
 
-        param outputs_azure_container_apps_environment_default_domain string
-        
-        param outputs_azure_container_apps_environment_id string
-        
-        param outputs_azure_container_registry_endpoint string
-        
-        param outputs_azure_container_registry_managed_identity_id string
-        
+        param env_outputs_azure_container_apps_environment_default_domain string
+
+        param env_outputs_azure_container_apps_environment_id string
+
+        param env_outputs_azure_container_registry_endpoint string
+
+        param env_outputs_azure_container_registry_managed_identity_id string
+
         param api_containerimage string
-        
+
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -274,12 +276,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               }
               registries: [
                 {
-                  server: outputs_azure_container_registry_endpoint
-                  identity: outputs_azure_container_registry_managed_identity_id
+                  server: env_outputs_azure_container_registry_endpoint
+                  identity: env_outputs_azure_container_registry_managed_identity_id
                 }
               ]
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -317,7 +319,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           identity: {
             type: 'UserAssigned'
             userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
+              '${env_outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -331,7 +333,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("infra");
 
         var env = builder.AddParameter("env");
 
@@ -370,10 +372,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
-            "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+            "infra_outputs_azure_container_apps_environment_default_domain": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "infra_outputs_azure_container_apps_environment_id": "{infra.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "infra_outputs_azure_container_registry_endpoint": "{infra.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "infra_outputs_azure_container_registry_managed_identity_id": "{infra.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}",
             "env": "{env.value}"
           }
@@ -387,13 +389,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param infra_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param infra_outputs_azure_container_apps_environment_id string
         
-        param outputs_azure_container_registry_endpoint string
+        param infra_outputs_azure_container_registry_endpoint string
         
-        param outputs_azure_container_registry_managed_identity_id string
+        param infra_outputs_azure_container_registry_managed_identity_id string
         
         param api_containerimage string
         
@@ -407,12 +409,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               activeRevisionsMode: 'Single'
               registries: [
                 {
-                  server: outputs_azure_container_registry_endpoint
-                  identity: outputs_azure_container_registry_managed_identity_id
+                  server: infra_outputs_azure_container_registry_endpoint
+                  identity: infra_outputs_azure_container_registry_managed_identity_id
                 }
               ]
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: infra_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -434,7 +436,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           identity: {
             type: 'UserAssigned'
             userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
+              '${infra_outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -448,7 +450,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddExecutable("api", "node.exe", Environment.CurrentDirectory)
                .PublishAsDockerFile();
@@ -477,10 +479,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
-            "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -493,13 +495,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
-        param outputs_azure_container_registry_endpoint string
+        param env_outputs_azure_container_registry_endpoint string
         
-        param outputs_azure_container_registry_managed_identity_id string
+        param env_outputs_azure_container_registry_managed_identity_id string
         
         param api_containerimage string
         
@@ -511,12 +513,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               activeRevisionsMode: 'Single'
               registries: [
                 {
-                  server: outputs_azure_container_registry_endpoint
-                  identity: outputs_azure_container_registry_managed_identity_id
+                  server: env_outputs_azure_container_registry_endpoint
+                  identity: env_outputs_azure_container_registry_managed_identity_id
                 }
               ]
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -532,7 +534,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           identity: {
             type: 'UserAssigned'
             userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
+              '${env_outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -546,7 +548,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         var value = builder.AddParameter("value");
         var minReplicas = builder.AddParameter("minReplicas");
@@ -587,8 +589,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "value": "{value.value}",
             "minReplicas": "{minReplicas.value}"
           }
@@ -602,9 +604,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         param value string
         
@@ -617,7 +619,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             configuration: {
               activeRevisionsMode: 'Single'
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -648,7 +650,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
                .WithEntrypoint("/bin/sh")
@@ -674,9 +676,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
@@ -685,7 +687,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             configuration: {
               activeRevisionsMode: 'Single'
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -717,7 +719,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         var db = builder.AddAzureCosmosDB("mydb");
         db.AddCosmosDatabase("cosmosdb", databaseName: "db");
@@ -800,10 +802,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             "value0_value": "{value0.value}",
             "value1_value": "{value1.value}",
             "cs_connectionstring": "{cs.connectionString}",
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
-            "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -846,13 +848,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @secure()
         param cs_connectionstring string
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
         
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
-        param outputs_azure_container_registry_endpoint string
+        param env_outputs_azure_container_registry_endpoint string
         
-        param outputs_azure_container_registry_managed_identity_id string
+        param env_outputs_azure_container_registry_managed_identity_id string
         
         param api_containerimage string
         
@@ -903,12 +905,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               }
               registries: [
                 {
-                  server: outputs_azure_container_registry_endpoint
-                  identity: outputs_azure_container_registry_managed_identity_id
+                  server: env_outputs_azure_container_registry_endpoint
+                  identity: env_outputs_azure_container_registry_managed_identity_id
                 }
               ]
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -969,11 +971,11 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                     }
                     {
                       name: 'HTTP_EP'
-                      value: 'http://api.internal.${outputs_azure_container_apps_environment_default_domain}'
+                      value: 'http://api.internal.${env_outputs_azure_container_apps_environment_default_domain}'
                     }
                     {
                       name: 'HTTPS_EP'
-                      value: 'https://api.internal.${outputs_azure_container_apps_environment_default_domain}'
+                      value: 'https://api.internal.${env_outputs_azure_container_apps_environment_default_domain}'
                     }
                     {
                       name: 'INTERNAL_EP'
@@ -989,11 +991,11 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                     }
                     {
                       name: 'HOST'
-                      value: 'api.internal.${outputs_azure_container_apps_environment_default_domain}'
+                      value: 'api.internal.${env_outputs_azure_container_apps_environment_default_domain}'
                     }
                     {
                       name: 'HOSTANDPORT'
-                      value: 'api.internal.${outputs_azure_container_apps_environment_default_domain}:80'
+                      value: 'api.internal.${env_outputs_azure_container_apps_environment_default_domain}:80'
                     }
                     {
                       name: 'SCHEME'
@@ -1019,7 +1021,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             type: 'UserAssigned'
             userAssignedIdentities: {
               '${api_identity_outputs_id}': { }
-              '${outputs_azure_container_registry_managed_identity_id}': { }
+              '${env_outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -1192,7 +1194,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
         builder.AddContainer("api", "myimage")
             .PublishAsAzureContainerApp((module, c) =>
             {
@@ -1225,8 +1227,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
         """;
@@ -1238,9 +1240,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
@@ -1249,7 +1251,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             configuration: {
               activeRevisionsMode: 'Single'
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -1276,7 +1278,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         var customDomain = builder.AddParameter("customDomain");
         var certificateName = builder.AddParameter("certificateName");
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
         builder.AddContainer("api", "myimage")
             .WithHttpEndpoint(targetPort: 1111)
             .PublishAsAzureContainerApp((module, c) =>
@@ -1308,8 +1310,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "certificateName": "{certificateName.value}",
             "customDomain": "{customDomain.value}"
           }
@@ -1323,9 +1325,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         param certificateName string
         
@@ -1345,12 +1347,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                   {
                     name: customDomain
                     bindingType: (certificateName != '') ? 'SniEnabled' : 'Disabled'
-                    certificateId: (certificateName != '') ? '${outputs_azure_container_apps_environment_id}/managedCertificates/${certificateName}' : null
+                    certificateId: (certificateName != '') ? '${env_outputs_azure_container_apps_environment_id}/managedCertificates/${certificateName}' : null
                   }
                 ]
               }
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -1378,7 +1380,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         var initialCertificateName = builder.AddParameter("initialCertificateName");
         var expectedCertificateName = builder.AddParameter("expectedCertificateName");
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
         builder.AddContainer("api", "myimage")
             .WithHttpEndpoint(targetPort: 1111)
             .PublishAsAzureContainerApp((module, c) =>
@@ -1411,8 +1413,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "initialCertificateName": "{initialCertificateName.value}",
             "customDomain": "{customDomain.value}",
             "expectedCertificateName": "{expectedCertificateName.value}"
@@ -1427,9 +1429,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         param initialCertificateName string
         
@@ -1451,12 +1453,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                   {
                     name: customDomain
                     bindingType: (expectedCertificateName != '') ? 'SniEnabled' : 'Disabled'
-                    certificateId: (expectedCertificateName != '') ? '${outputs_azure_container_apps_environment_id}/managedCertificates/${expectedCertificateName}' : null
+                    certificateId: (expectedCertificateName != '') ? '${env_outputs_azure_container_apps_environment_id}/managedCertificates/${expectedCertificateName}' : null
                   }
                 ]
               }
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -1486,7 +1488,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         var customDomain2 = builder.AddParameter("customDomain2");
         var certificateName2 = builder.AddParameter("certificateName2");
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
         builder.AddContainer("api", "myimage")
             .WithHttpEndpoint(targetPort: 1111)
             .PublishAsAzureContainerApp((module, c) =>
@@ -1519,8 +1521,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
             "certificateName1": "{certificateName1.value}",
             "customDomain1": "{customDomain1.value}",
             "certificateName2": "{certificateName2.value}",
@@ -1536,9 +1538,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         param certificateName1 string
         
@@ -1562,17 +1564,17 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                   {
                     name: customDomain1
                     bindingType: (certificateName1 != '') ? 'SniEnabled' : 'Disabled'
-                    certificateId: (certificateName1 != '') ? '${outputs_azure_container_apps_environment_id}/managedCertificates/${certificateName1}' : null
+                    certificateId: (certificateName1 != '') ? '${env_outputs_azure_container_apps_environment_id}/managedCertificates/${certificateName1}' : null
                   }
                   {
                     name: customDomain2
                     bindingType: (certificateName2 != '') ? 'SniEnabled' : 'Disabled'
-                    certificateId: (certificateName2 != '') ? '${outputs_azure_container_apps_environment_id}/managedCertificates/${certificateName2}' : null
+                    certificateId: (certificateName2 != '') ? '${env_outputs_azure_container_apps_environment_id}/managedCertificates/${certificateName2}' : null
                   }
                 ]
               }
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -1596,7 +1598,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithVolume("vol1", "/path1")
@@ -1627,11 +1629,11 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "api_volumes_0_storage": "{api.volumes.0.storage}",
-            "api_volumes_1_storage": "{api.volumes.1.storage}",
-            "api_bindmounts_0_storage": "{api.bindMounts.0.storage}",
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+            "env_outputs_volumes_api_0": "{env.outputs.volumes_api_0}",
+            "env_outputs_volumes_api_1": "{env.outputs.volumes_api_1}",
+            "env_outputs_bindmounts_api_0": "{env.outputs.bindmounts_api_0}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
         """;
@@ -1642,17 +1644,17 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
-        
-        param api_volumes_0_storage string
-        
-        param api_volumes_1_storage string
-        
-        param api_bindmounts_0_storage string
-        
-        param outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
-        
+        param env_outputs_volumes_api_0 string
+
+        param env_outputs_volumes_api_1 string
+
+        param env_outputs_bindmounts_api_0 string
+
+        param env_outputs_azure_container_apps_environment_default_domain string
+
+        param env_outputs_azure_container_apps_environment_id string
+
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
           location: location
@@ -1660,7 +1662,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             configuration: {
               activeRevisionsMode: 'Single'
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -1689,24 +1691,24 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 {
                   name: 'v0'
                   storageType: 'AzureFile'
-                  storageName: api_volumes_0_storage
+                  storageName: env_outputs_volumes_api_0
                 }
                 {
                   name: 'v1'
                   storageType: 'AzureFile'
-                  storageName: api_volumes_1_storage
+                  storageName: env_outputs_volumes_api_1
                 }
                 {
                   name: 'bm0'
                   storageType: 'AzureFile'
-                  storageName: api_bindmounts_0_storage
+                  storageName: env_outputs_bindmounts_api_0
                 }
               ]
             }
           }
         }
         """;
-
+        output.WriteLine(bicep);
         Assert.Equal(expectedBicep, bicep);
     }
 
@@ -1715,7 +1717,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         builder.AddAzureContainerAppsInfrastructure();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var db = builder.AddAzureCosmosDB("mydb").WithAccessKeyAuthentication();
         db.AddCosmosDatabase("db");
@@ -1951,7 +1955,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         builder.Services.Configure<AzureProvisioningOptions>(options => options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new MyResourceNamePropertyResolver()));
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api1", "myimage");
 
@@ -1976,9 +1980,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         resource api1 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api1-my'
@@ -1987,7 +1991,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             configuration: {
               activeRevisionsMode: 'Single'
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -2024,7 +2028,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithHttpEndpoint()
@@ -2054,8 +2058,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
         """;
@@ -2067,9 +2071,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
@@ -2083,7 +2087,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 transport: 'http'
               }
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -2107,7 +2111,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithHttpEndpoint(name: "one", targetPort: 8080)
@@ -2137,8 +2141,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
         """;
@@ -2150,9 +2154,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
@@ -2172,7 +2176,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 ]
               }
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -2196,7 +2200,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithHttpEndpoint()
@@ -2227,8 +2231,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "type": "azure.bicep.v0",
           "path": "api.module.bicep",
           "params": {
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
           }
         }
         """;
@@ -2240,9 +2244,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         @description('The location for the resource(s) to be deployed.')
         param location string = resourceGroup().location
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
         resource api 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'api'
@@ -2256,7 +2260,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 transport: 'http2'
               }
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -2280,7 +2284,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddProject<Project>("api", launchProfileName: null)
                .WithHttpEndpoint()
@@ -2311,10 +2315,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           "path": "api.module.bicep",
           "params": {
             "api_containerport": "{api.containerPort}",
-            "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
-            "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+            "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+            "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
             "api_containerimage": "{api.containerImage}"
           }
         }
@@ -2329,13 +2333,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         
         param api_containerport string
         
-        param outputs_azure_container_apps_environment_default_domain string
+        param env_outputs_azure_container_apps_environment_default_domain string
 
-        param outputs_azure_container_apps_environment_id string
+        param env_outputs_azure_container_apps_environment_id string
         
-        param outputs_azure_container_registry_endpoint string
+        param env_outputs_azure_container_registry_endpoint string
         
-        param outputs_azure_container_registry_managed_identity_id string
+        param env_outputs_azure_container_registry_managed_identity_id string
         
         param api_containerimage string
         
@@ -2352,12 +2356,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               }
               registries: [
                 {
-                  server: outputs_azure_container_registry_endpoint
-                  identity: outputs_azure_container_registry_managed_identity_id
+                  server: env_outputs_azure_container_registry_endpoint
+                  identity: env_outputs_azure_container_registry_managed_identity_id
                 }
               ]
             }
-            environmentId: outputs_azure_container_apps_environment_id
+            environmentId: env_outputs_azure_container_apps_environment_id
             template: {
               containers: [
                 {
@@ -2399,7 +2403,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
           identity: {
             type: 'UserAssigned'
             userAssignedIdentities: {
-              '${outputs_azure_container_registry_managed_identity_id}': { }
+              '${env_outputs_azure_container_registry_managed_identity_id}': { }
             }
           }
         }
@@ -2413,7 +2417,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         var storageName = builder.AddParameter("storageName");
         var storageRG = builder.AddParameter("storageRG");
@@ -2453,10 +2457,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
               "params": {
                 "api_identity_outputs_id": "{api-identity.outputs.id}",
                 "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
-                "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-                "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
-                "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-                "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+                "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+                "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+                "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+                "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
                 "api_containerimage": "{api.containerImage}"
               }
             }
@@ -2499,13 +2503,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             
             param api_identity_outputs_clientid string
             
-            param outputs_azure_container_apps_environment_default_domain string
+            param env_outputs_azure_container_apps_environment_default_domain string
 
-            param outputs_azure_container_apps_environment_id string
+            param env_outputs_azure_container_apps_environment_id string
             
-            param outputs_azure_container_registry_endpoint string
+            param env_outputs_azure_container_registry_endpoint string
             
-            param outputs_azure_container_registry_managed_identity_id string
+            param env_outputs_azure_container_registry_managed_identity_id string
             
             param api_containerimage string
             
@@ -2517,12 +2521,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                   activeRevisionsMode: 'Single'
                   registries: [
                     {
-                      server: outputs_azure_container_registry_endpoint
-                      identity: outputs_azure_container_registry_managed_identity_id
+                      server: env_outputs_azure_container_registry_endpoint
+                      identity: env_outputs_azure_container_registry_managed_identity_id
                     }
                   ]
                 }
-                environmentId: outputs_azure_container_apps_environment_id
+                environmentId: env_outputs_azure_container_apps_environment_id
                 template: {
                   containers: [
                     {
@@ -2557,7 +2561,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 type: 'UserAssigned'
                 userAssignedIdentities: {
                   '${api_identity_outputs_id}': { }
-                  '${outputs_azure_container_registry_managed_identity_id}': { }
+                  '${env_outputs_azure_container_registry_managed_identity_id}': { }
                 }
               }
             }
@@ -2618,7 +2622,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         var cosmosName = builder.AddParameter("cosmosName");
         var cosmosRG = builder.AddParameter("cosmosRG");
@@ -2658,10 +2662,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 "api_identity_outputs_id": "{api-identity.outputs.id}",
                 "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
                 "cosmos_outputs_connectionstring": "{cosmos.outputs.connectionString}",
-                "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-                "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
-                "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-                "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+                "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+                "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+                "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+                "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
                 "api_containerimage": "{api.containerImage}"
               }
             }
@@ -2706,13 +2710,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             
             param cosmos_outputs_connectionstring string
             
-            param outputs_azure_container_apps_environment_default_domain string
+            param env_outputs_azure_container_apps_environment_default_domain string
 
-            param outputs_azure_container_apps_environment_id string
+            param env_outputs_azure_container_apps_environment_id string
             
-            param outputs_azure_container_registry_endpoint string
+            param env_outputs_azure_container_registry_endpoint string
             
-            param outputs_azure_container_registry_managed_identity_id string
+            param env_outputs_azure_container_registry_managed_identity_id string
             
             param api_containerimage string
             
@@ -2724,12 +2728,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                   activeRevisionsMode: 'Single'
                   registries: [
                     {
-                      server: outputs_azure_container_registry_endpoint
-                      identity: outputs_azure_container_registry_managed_identity_id
+                      server: env_outputs_azure_container_registry_endpoint
+                      identity: env_outputs_azure_container_registry_managed_identity_id
                     }
                   ]
                 }
-                environmentId: outputs_azure_container_apps_environment_id
+                environmentId: env_outputs_azure_container_apps_environment_id
                 template: {
                   containers: [
                     {
@@ -2768,7 +2772,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 type: 'UserAssigned'
                 userAssignedIdentities: {
                   '${api_identity_outputs_id}': { }
-                  '${outputs_azure_container_registry_managed_identity_id}': { }
+                  '${env_outputs_azure_container_registry_managed_identity_id}': { }
                 }
               }
             }
@@ -2834,7 +2838,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         var redis = builder.AddAzureRedis("redis")
             .PublishAsExisting("myredis", "myRG");
@@ -2871,10 +2875,10 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 "api_identity_outputs_id": "{api-identity.outputs.id}",
                 "api_identity_outputs_clientid": "{api-identity.outputs.clientId}",
                 "redis_outputs_connectionstring": "{redis.outputs.connectionString}",
-                "outputs_azure_container_apps_environment_default_domain": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
-                "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
-                "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-                "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+                "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+                "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+                "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+                "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
                 "api_containerimage": "{api.containerImage}"
               }
             }
@@ -2920,13 +2924,13 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             
             param redis_outputs_connectionstring string
             
-            param outputs_azure_container_apps_environment_default_domain string
+            param env_outputs_azure_container_apps_environment_default_domain string
 
-            param outputs_azure_container_apps_environment_id string
+            param env_outputs_azure_container_apps_environment_id string
             
-            param outputs_azure_container_registry_endpoint string
+            param env_outputs_azure_container_registry_endpoint string
             
-            param outputs_azure_container_registry_managed_identity_id string
+            param env_outputs_azure_container_registry_managed_identity_id string
             
             param api_containerimage string
             
@@ -2938,12 +2942,12 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                   activeRevisionsMode: 'Single'
                   registries: [
                     {
-                      server: outputs_azure_container_registry_endpoint
-                      identity: outputs_azure_container_registry_managed_identity_id
+                      server: env_outputs_azure_container_registry_endpoint
+                      identity: env_outputs_azure_container_registry_managed_identity_id
                     }
                   ]
                 }
-                environmentId: outputs_azure_container_apps_environment_id
+                environmentId: env_outputs_azure_container_apps_environment_id
                 template: {
                   containers: [
                     {
@@ -2982,7 +2986,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 type: 'UserAssigned'
                 userAssignedIdentities: {
                   '${api_identity_outputs_id}': { }
-                  '${outputs_azure_container_registry_managed_identity_id}': { }
+                  '${env_outputs_azure_container_registry_managed_identity_id}': { }
                 }
               }
             }
@@ -3045,7 +3049,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithEndpoint(scheme: "foo");
@@ -3064,7 +3068,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithHttpEndpoint(name: "ep1")
@@ -3085,7 +3089,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithEndpoint("ep1", e => e.IsExternal = true);
@@ -3104,7 +3108,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithHttpEndpoint(targetPort: 80)
@@ -3124,7 +3128,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithHttpEndpoint(port: 8081);
@@ -3143,7 +3147,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
             .WithHttpsEndpoint(port: 8081);
@@ -3178,7 +3182,9 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         builder.AddAzureContainerAppsInfrastructure();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var pg = builder.AddAzurePostgresFlexibleServer("pg")
                         .WithPasswordAuthentication()

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -189,7 +189,7 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         if (useAcaInfrastructure)
         {
-            builder.AddAzureContainerAppsInfrastructure();
+            builder.AddAzureContainerAppEnvironment("env");
         }
 
         var cosmos = builder.AddAzureCosmosDB("cosmos");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -288,7 +288,7 @@ public class AzureFunctionsTests(ITestOutputHelper output)
     public async Task AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         // hardcoded sha256 to make the storage name deterministic
         builder.Configuration["AppHost:Sha256"] = "634f8";
@@ -378,7 +378,7 @@ public class AzureFunctionsTests(ITestOutputHelper output)
     public async Task AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         // hardcoded sha256 to make the storage name deterministic
         var storage = builder.AddAzureStorage("my-own-storage").RunAsEmulator();
@@ -460,7 +460,7 @@ public class AzureFunctionsTests(ITestOutputHelper output)
     public async Task AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage_WithRoleAssignments()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         // hardcoded sha256 to make the storage name deterministic
         var storage = builder.AddAzureStorage("my-own-storage").RunAsEmulator();
@@ -523,7 +523,7 @@ public class AzureFunctionsTests(ITestOutputHelper output)
     public async Task MultipleAddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure_WithHostStorage_WithRoleAssignments()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         // hardcoded sha256 to make the storage name deterministic
         var storage = builder.AddAzureStorage("my-own-storage").RunAsEmulator();

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
@@ -24,7 +24,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
 
         if (useAcaInfrastructure)
         {
-            builder.AddAzureContainerAppsInfrastructure();
+            builder.AddAzureContainerAppEnvironment("env");
 
             // on ACA infrastructure, if there are no references to the postgres resource,
             // then there won't be any roles created. So add a reference here.

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -25,7 +25,7 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
 
         if (useAcaInfrastructure)
         {
-            builder.AddAzureContainerAppsInfrastructure();
+            builder.AddAzureContainerAppEnvironment("env");
         }
 
         var redis = builder.AddAzureRedis("redis-cache");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -39,7 +39,7 @@ public class AzureResourcePreparerTests(ITestOutputHelper output)
         using var builder = TestDistributedApplicationBuilder.Create(operation);
         if (addContainerAppsInfra)
         {
-            builder.AddAzureContainerAppsInfrastructure();
+            builder.AddAzureContainerAppEnvironment("env");
         }
 
         var storage = builder.AddAzureStorage("storage");
@@ -125,7 +125,7 @@ public class AzureResourcePreparerTests(ITestOutputHelper output)
     public async Task AppliesRoleAssignmentsInRunMode(DistributedApplicationOperation operation)
     {
         using var builder = TestDistributedApplicationBuilder.Create(operation);
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         var storage = builder.AddAzureStorage("storage");
         var blobs = storage.AddBlobs("blobs");
@@ -216,7 +216,7 @@ public class AzureResourcePreparerTests(ITestOutputHelper output)
     public async Task FindsAzureReferencesFromArguments()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         var storage = builder.AddAzureStorage("storage");
         var blobs = storage.AddBlobs("blobs");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
@@ -26,7 +26,7 @@ public class AzureSqlExtensionsTests(ITestOutputHelper output)
 
         if (useAcaInfrastructure)
         {
-            builder.AddAzureContainerAppsInfrastructure();
+            builder.AddAzureContainerAppEnvironment("env");
 
             // on ACA infrastructure, if there are no references to the resource,
             // then there won't be any roles created. So add a reference here.

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
@@ -79,7 +79,9 @@ public class AppContainersPublicApiTests
 
         var action = () =>
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             builder.AddAzureContainerAppsInfrastructure();
+#pragma warning restore CS0618 // Type or member is obsolete
         };
 
         var exception = Assert.Throws<ArgumentNullException>(action);

--- a/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
@@ -469,7 +469,7 @@ public class RoleAssignmentTests(ITestOutputHelper output)
         bool includePrincipalName = false)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-        builder.AddAzureContainerAppsInfrastructure();
+        builder.AddAzureContainerAppEnvironment("env");
 
         configureBuilder(builder);
 


### PR DESCRIPTION
Backport of #8639 to release/9.2

/cc @eerhardt

## Customer Impact

We don't want users calling AddAzureContainerAppsInfrastructure anymore. They should be using AddAzureContainerAppEnvironment instead. The reason we want to push them to AddAzureContainerAppEnvironment is so we aren't "half in" `azd` infrastructure and half Aspire infrastructure.

There was also a bug exposed with tests in how we were naming volumes. Found by switching our tests from AddAzureContainerAppsInfrastructure to AddAzureContainerAppEnvironment.

## Testing

Existing tests

## Risk

Low

## Regression?

No