### PR TITLE
[tests] Correctly mark Aspire.Dashboard.Tests.Integration.Playwright.AppBarTests with RequiresPlaywright

### DIFF
--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Aspire.Dashboard.Tests.Integration.Playwright;
 
+[RequiresPlaywright]
 public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
 {
     public AppBarTests(DashboardServerFixture dashboardServerFixture)


### PR DESCRIPTION
…AppBarTests with `RequiresPlaywright`.

These tests were un-quarantined in #8615, but they lacked the `RequiresPlaywright` attribute, which caused them to run on Azdo/Linux where Playwright is not available.