### PR TITLE
Updating versions of .NET Servicing and Extensions and stabilize packages for 9.2

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,17 +29,17 @@
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
       <Sha>b9b5f5f43244f9b0f8d13de2cd699b90c69b75c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="9.3.0">
+    <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="9.4.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>f1f17e642a685df7e87b805be1efe4729ff725e4</Sha>
+      <Sha>7e7b3eeb834955d0c0676cb788d0b9b3c949b776</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="9.3.0">
+    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="9.4.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>f1f17e642a685df7e87b805be1efe4729ff725e4</Sha>
+      <Sha>7e7b3eeb834955d0c0676cb788d0b9b3c949b776</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.Testing" Version="9.4.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>f1f17e642a685df7e87b805be1efe4729ff725e4</Sha>
+      <Sha>7e7b3eeb834955d0c0676cb788d0b9b3c949b776</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
@@ -67,7 +67,7 @@
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>eba546b0f0d448e0176a2222548fd7a2fbf464c0</Sha>
+      <Sha>50c4cb9fc31c47f03eac865d7bc518af173b74b7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Options" Version="8.0.2">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
@@ -77,61 +77,61 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>9cb3b725e3ad2b57ddc9fb2dd48d2d170563a8f5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.OpenApi" Version="8.0.14">
+    <Dependency Name="Microsoft.AspNetCore.OpenApi" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="8.0.14">
+    <Dependency Name="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.14">
+    <Dependency Name="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.14">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.14">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Features" Version="8.0.14">
+    <Dependency Name="Microsoft.Extensions.Features" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.Certificate" Version="8.0.14">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.Certificate" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.14">
+    <Dependency Name="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="8.0.14">
+    <Dependency Name="Microsoft.AspNetCore.TestHost" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.14">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-efcore</Uri>
-      <Sha>d00955545e8afc997726aead9b0e6103b1ceade6</Sha>
+      <Sha>0118cb6810a48869bf7494aabd86ef44da5940a3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.14">
+    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-efcore</Uri>
-      <Sha>d00955545e8afc997726aead9b0e6103b1ceade6</Sha>
+      <Sha>0118cb6810a48869bf7494aabd86ef44da5940a3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-efcore</Uri>
-      <Sha>d00955545e8afc997726aead9b0e6103b1ceade6</Sha>
+      <Sha>0118cb6810a48869bf7494aabd86ef44da5940a3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="8.0.14">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-efcore</Uri>
-      <Sha>d00955545e8afc997726aead9b0e6103b1ceade6</Sha>
+      <Sha>0118cb6810a48869bf7494aabd86ef44da5940a3</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24453.2">
@@ -139,9 +139,9 @@
       <Sha>eb436a482c2a0c6aa45578ea0a48fd3782c275b2</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.SignalR.Client" Version="8.0.14">
+    <Dependency Name="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>25ef4aa38b77974263cb10f6e9cbd10135f17b59</Sha>
+      <Sha>8899cb30120d41413065f1b1465cdabefe0a1f9c</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <XUnitAnalyzersVersion>1.20.0</XUnitAnalyzersVersion>
     <XunitRunnerVisualStudioVersion>3.0.2</XunitRunnerVisualStudioVersion>
     <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>
@@ -37,44 +37,44 @@
     <MicrosoftDotNetBuildTasksInstallersVersion>9.0.0-beta.25164.2</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetBuildTasksWorkloadsVersion>9.0.0-beta.25164.2</MicrosoftDotNetBuildTasksWorkloadsVersion>
     <!-- dotnet/extensions -->
-    <MicrosoftExtensionsAIVersion>9.4.0-preview.1.25202.3</MicrosoftExtensionsAIVersion>
+    <MicrosoftExtensionsAIVersion>9.4.0-preview.1.25207.5</MicrosoftExtensionsAIVersion>
     <!-- when updating this, also update cgmanifest.json as it is consumed in templates -->
-    <MicrosoftExtensionsHttpResilienceVersion>9.3.0</MicrosoftExtensionsHttpResilienceVersion>
-    <MicrosoftExtensionsDiagnosticsTestingVersion>9.3.0</MicrosoftExtensionsDiagnosticsTestingVersion>
-    <MicrosoftExtensionsTimeProviderTestingVersion>9.3.0</MicrosoftExtensionsTimeProviderTestingVersion>
+    <MicrosoftExtensionsHttpResilienceVersion>9.4.0</MicrosoftExtensionsHttpResilienceVersion>
+    <MicrosoftExtensionsDiagnosticsTestingVersion>9.4.0</MicrosoftExtensionsDiagnosticsTestingVersion>
+    <MicrosoftExtensionsTimeProviderTestingVersion>9.4.0</MicrosoftExtensionsTimeProviderTestingVersion>
     <!-- for templates -->
     <MicrosoftAspNetCorePackageVersionForNet9>9.0.2</MicrosoftAspNetCorePackageVersionForNet9>
   </PropertyGroup>
   <!-- .NET 9.0 Package Versions -->
   <PropertyGroup Label="Current">
     <!-- EF -->
-    <MicrosoftEntityFrameworkCoreCosmosVersion>9.0.3</MicrosoftEntityFrameworkCoreCosmosVersion>
-    <MicrosoftEntityFrameworkCoreDesignVersion>9.0.3</MicrosoftEntityFrameworkCoreDesignVersion>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion>9.0.3</MicrosoftEntityFrameworkCoreSqlServerVersion>
-    <MicrosoftEntityFrameworkCoreToolsVersion>9.0.3</MicrosoftEntityFrameworkCoreToolsVersion>
+    <MicrosoftEntityFrameworkCoreCosmosVersion>9.0.4</MicrosoftEntityFrameworkCoreCosmosVersion>
+    <MicrosoftEntityFrameworkCoreDesignVersion>9.0.4</MicrosoftEntityFrameworkCoreDesignVersion>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion>9.0.4</MicrosoftEntityFrameworkCoreSqlServerVersion>
+    <MicrosoftEntityFrameworkCoreToolsVersion>9.0.4</MicrosoftEntityFrameworkCoreToolsVersion>
     <!-- ASP.NET Core -->
-    <MicrosoftAspNetCoreAuthenticationCertificateVersion>9.0.3</MicrosoftAspNetCoreAuthenticationCertificateVersion>
-    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>9.0.3</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
-    <MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>9.0.3</MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>
-    <MicrosoftAspNetCoreOutputCachingStackExchangeRedisVersion>9.0.3</MicrosoftAspNetCoreOutputCachingStackExchangeRedisVersion>
-    <MicrosoftAspNetCoreTestHostVersion>9.0.3</MicrosoftAspNetCoreTestHostVersion>
-    <MicrosoftExtensionsCachingStackExchangeRedisVersion>9.0.3</MicrosoftExtensionsCachingStackExchangeRedisVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreVersion>9.0.3</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksVersion>9.0.3</MicrosoftExtensionsDiagnosticsHealthChecksVersion>
-    <MicrosoftExtensionsFeaturesVersion>9.0.3</MicrosoftExtensionsFeaturesVersion>
-    <MicrosoftAspNetCoreSignalRClientVersion>9.0.3</MicrosoftAspNetCoreSignalRClientVersion>
+    <MicrosoftAspNetCoreAuthenticationCertificateVersion>9.0.4</MicrosoftAspNetCoreAuthenticationCertificateVersion>
+    <MicrosoftAspNetCoreAuthenticationJwtBearerVersion>9.0.4</MicrosoftAspNetCoreAuthenticationJwtBearerVersion>
+    <MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>9.0.4</MicrosoftAspNetCoreAuthenticationOpenIdConnectVersion>
+    <MicrosoftAspNetCoreOutputCachingStackExchangeRedisVersion>9.0.4</MicrosoftAspNetCoreOutputCachingStackExchangeRedisVersion>
+    <MicrosoftAspNetCoreTestHostVersion>9.0.4</MicrosoftAspNetCoreTestHostVersion>
+    <MicrosoftExtensionsCachingStackExchangeRedisVersion>9.0.4</MicrosoftExtensionsCachingStackExchangeRedisVersion>
+    <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreVersion>9.0.4</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreVersion>
+    <MicrosoftExtensionsDiagnosticsHealthChecksVersion>9.0.4</MicrosoftExtensionsDiagnosticsHealthChecksVersion>
+    <MicrosoftExtensionsFeaturesVersion>9.0.4</MicrosoftExtensionsFeaturesVersion>
+    <MicrosoftAspNetCoreSignalRClientVersion>9.0.4</MicrosoftAspNetCoreSignalRClientVersion>
     <!-- Runtime -->
-    <MicrosoftExtensionsHostingAbstractionsVersion>9.0.3</MicrosoftExtensionsHostingAbstractionsVersion>
-    <MicrosoftExtensionsHostingVersion>9.0.3</MicrosoftExtensionsHostingVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsVersion>9.0.3</MicrosoftExtensionsConfigurationAbstractionsVersion>
-    <MicrosoftExtensionsConfigurationBinderVersion>9.0.3</MicrosoftExtensionsConfigurationBinderVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>9.0.3</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>9.0.3</MicrosoftExtensionsLoggingAbstractionsVersion>
-    <MicrosoftExtensionsOptionsVersion>9.0.3</MicrosoftExtensionsOptionsVersion>
-    <MicrosoftExtensionsPrimitivesVersion>9.0.3</MicrosoftExtensionsPrimitivesVersion>
-    <MicrosoftExtensionsHttpVersion>9.0.3</MicrosoftExtensionsHttpVersion>
-    <SystemFormatsAsn1Version>9.0.3</SystemFormatsAsn1Version>
-    <SystemTextJsonVersion>9.0.3</SystemTextJsonVersion>
+    <MicrosoftExtensionsHostingAbstractionsVersion>9.0.4</MicrosoftExtensionsHostingAbstractionsVersion>
+    <MicrosoftExtensionsHostingVersion>9.0.4</MicrosoftExtensionsHostingVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsVersion>9.0.4</MicrosoftExtensionsConfigurationAbstractionsVersion>
+    <MicrosoftExtensionsConfigurationBinderVersion>9.0.4</MicrosoftExtensionsConfigurationBinderVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>9.0.4</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>9.0.4</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsOptionsVersion>9.0.4</MicrosoftExtensionsOptionsVersion>
+    <MicrosoftExtensionsPrimitivesVersion>9.0.4</MicrosoftExtensionsPrimitivesVersion>
+    <MicrosoftExtensionsHttpVersion>9.0.4</MicrosoftExtensionsHttpVersion>
+    <SystemFormatsAsn1Version>9.0.4</SystemFormatsAsn1Version>
+    <SystemTextJsonVersion>9.0.4</SystemTextJsonVersion>
     <!-- OpenTelemetry (OTel) -->
     <OpenTelemetryVersion>1.11.2</OpenTelemetryVersion>
     <OpenTelemetryInstrumentationAspNetCoreVersion>1.11.1</OpenTelemetryInstrumentationAspNetCoreVersion>
@@ -86,21 +86,21 @@
   <!-- .NET 8.0 Package Versions -->
   <PropertyGroup Label="LTS">
     <!-- EF -->
-    <MicrosoftEntityFrameworkCoreCosmosLTSVersion>8.0.14</MicrosoftEntityFrameworkCoreCosmosLTSVersion>
-    <MicrosoftEntityFrameworkCoreDesignLTSVersion>8.0.14</MicrosoftEntityFrameworkCoreDesignLTSVersion>
-    <MicrosoftEntityFrameworkCoreSqlServerLTSVersion>8.0.14</MicrosoftEntityFrameworkCoreSqlServerLTSVersion>
-    <MicrosoftEntityFrameworkCoreToolsLTSVersion>8.0.14</MicrosoftEntityFrameworkCoreToolsLTSVersion>
+    <MicrosoftEntityFrameworkCoreCosmosLTSVersion>8.0.15</MicrosoftEntityFrameworkCoreCosmosLTSVersion>
+    <MicrosoftEntityFrameworkCoreDesignLTSVersion>8.0.15</MicrosoftEntityFrameworkCoreDesignLTSVersion>
+    <MicrosoftEntityFrameworkCoreSqlServerLTSVersion>8.0.15</MicrosoftEntityFrameworkCoreSqlServerLTSVersion>
+    <MicrosoftEntityFrameworkCoreToolsLTSVersion>8.0.15</MicrosoftEntityFrameworkCoreToolsLTSVersion>
     <!-- ASP.NET Core -->
-    <MicrosoftAspNetCoreAuthenticationCertificateLTSVersion>8.0.14</MicrosoftAspNetCoreAuthenticationCertificateLTSVersion>
-    <MicrosoftAspNetCoreAuthenticationJwtBearerLTSVersion>8.0.14</MicrosoftAspNetCoreAuthenticationJwtBearerLTSVersion>
-    <MicrosoftAspNetCoreAuthenticationOpenIdConnectLTSVersion>8.0.14</MicrosoftAspNetCoreAuthenticationOpenIdConnectLTSVersion>
-    <MicrosoftAspNetCoreOutputCachingStackExchangeRedisLTSVersion>8.0.14</MicrosoftAspNetCoreOutputCachingStackExchangeRedisLTSVersion>
-    <MicrosoftAspNetCoreTestHostLTSVersion>8.0.14</MicrosoftAspNetCoreTestHostLTSVersion>
-    <MicrosoftExtensionsCachingStackExchangeRedisLTSVersion>8.0.14</MicrosoftExtensionsCachingStackExchangeRedisLTSVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreLTSVersion>8.0.14</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreLTSVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksLTSVersion>8.0.14</MicrosoftExtensionsDiagnosticsHealthChecksLTSVersion>
-    <MicrosoftExtensionsFeaturesLTSVersion>8.0.14</MicrosoftExtensionsFeaturesLTSVersion>
-    <MicrosoftAspNetCoreSignalRClientLTSVersion>8.0.14</MicrosoftAspNetCoreSignalRClientLTSVersion>
+    <MicrosoftAspNetCoreAuthenticationCertificateLTSVersion>8.0.15</MicrosoftAspNetCoreAuthenticationCertificateLTSVersion>
+    <MicrosoftAspNetCoreAuthenticationJwtBearerLTSVersion>8.0.15</MicrosoftAspNetCoreAuthenticationJwtBearerLTSVersion>
+    <MicrosoftAspNetCoreAuthenticationOpenIdConnectLTSVersion>8.0.15</MicrosoftAspNetCoreAuthenticationOpenIdConnectLTSVersion>
+    <MicrosoftAspNetCoreOutputCachingStackExchangeRedisLTSVersion>8.0.15</MicrosoftAspNetCoreOutputCachingStackExchangeRedisLTSVersion>
+    <MicrosoftAspNetCoreTestHostLTSVersion>8.0.15</MicrosoftAspNetCoreTestHostLTSVersion>
+    <MicrosoftExtensionsCachingStackExchangeRedisLTSVersion>8.0.15</MicrosoftExtensionsCachingStackExchangeRedisLTSVersion>
+    <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreLTSVersion>8.0.15</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreLTSVersion>
+    <MicrosoftExtensionsDiagnosticsHealthChecksLTSVersion>8.0.15</MicrosoftExtensionsDiagnosticsHealthChecksLTSVersion>
+    <MicrosoftExtensionsFeaturesLTSVersion>8.0.15</MicrosoftExtensionsFeaturesLTSVersion>
+    <MicrosoftAspNetCoreSignalRClientLTSVersion>8.0.15</MicrosoftAspNetCoreSignalRClientLTSVersion>
     <!-- Runtime -->
     <MicrosoftExtensionsHostingAbstractionsLTSVersion>8.0.1</MicrosoftExtensionsHostingAbstractionsLTSVersion>
     <MicrosoftExtensionsHostingLTSVersion>8.0.1</MicrosoftExtensionsHostingLTSVersion>

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -33,7 +33,7 @@
     `AspireProjectOrPackageReference` - maps to projects in `src/` or `src/Components/`
   -->
 
-  <Import Project="Sdk.props" Sdk="Aspire.AppHost.Sdk" Version="$(PackageVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
+  <Import Project="Sdk.props" Sdk="Aspire.AppHost.Sdk" Version="9.2.0" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
 
   <PropertyGroup>
     <!-- copy by default only when archiving tests, and for test projects that support running out of repo -->
@@ -151,6 +151,6 @@
     <AspireHostingSDKVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</AspireHostingSDKVersion>
   </PropertyGroup>
 
-  <Import Project="Sdk.targets" Sdk="Aspire.AppHost.Sdk" Version="$(PackageVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
+  <Import Project="Sdk.targets" Sdk="Aspire.AppHost.Sdk" Version="9.2.0" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
 
 </Project>

--- a/tests/Shared/RepoTesting/Directory.Packages.Helix.props
+++ b/tests/Shared/RepoTesting/Directory.Packages.Helix.props
@@ -3,85 +3,85 @@
 
   <ItemGroup Label="Aspire packages">
     <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Data.Tables" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Messaging.EventHubs" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Messaging.ServiceBus" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Messaging.WebPubSub" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Search.Documents" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Security.KeyVault" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Confluent.Kafka" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Azure.Data.Tables" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Azure.Messaging.EventHubs" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Azure.Messaging.ServiceBus" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Azure.Messaging.WebPubSub" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Azure.Search.Documents" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Azure.Security.KeyVault" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Confluent.Kafka" Version="9.2.0" />
     <PackageVersion Include="Aspire.Elastic.Clients.Elasticsearch" Version="$(PackageVersion)" />
 
-    <PackageVersion Include="Aspire.Hosting" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppConfiguration" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.EventHubs" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppConfiguration" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.EventHubs" Version="9.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.Functions" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.OperationalInsights" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Search" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.SignalR" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Azure.WebPubSub" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.OperationalInsights" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Search" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.SignalR" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.WebPubSub" Version="9.2.0" />
     <PackageVersion Include="Aspire.Hosting.Elasticsearch" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Garnet" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Kafka" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Garnet" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Kafka" Version="9.2.0" />
     <PackageVersion Include="Aspire.Hosting.Keycloak" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Milvus" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.MySql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Nats" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Oracle" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Orleans" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Python" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Qdrant" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.AppHost.Sdk" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Seq" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Valkey" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Milvus" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.MySql" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Nats" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Oracle" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Orleans" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Python" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Qdrant" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="9.2.0" />
+    <PackageVersion Include="Aspire.AppHost.Sdk" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Seq" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Valkey" Version="9.2.0" />
 
     <PackageVersion Include="Aspire.Keycloak.Authentication" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.Data.SqlClient" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Microsoft.Data.SqlClient" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.2.0" />
     <PackageVersion Include="Aspire.Milvus.Client" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.MongoDB.Driver" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.MongoDB.Driver.v3" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.MySqlConnector" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.NATS.Net" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Npgsql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Oracle.EntityFrameworkCore" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Pomelo.EntityFrameworkCore.MySql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Qdrant.Client" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.RabbitMQ.Client" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.RabbitMQ.Client.v7" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Seq" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.MongoDB.Driver" Version="9.2.0" />
+    <PackageVersion Include="Aspire.MongoDB.Driver.v3" Version="9.2.0" />
+    <PackageVersion Include="Aspire.MySqlConnector" Version="9.2.0" />
+    <PackageVersion Include="Aspire.NATS.Net" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Npgsql" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Oracle.EntityFrameworkCore" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Pomelo.EntityFrameworkCore.MySql" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Qdrant.Client" Version="9.2.0" />
+    <PackageVersion Include="Aspire.RabbitMQ.Client" Version="9.2.0" />
+    <PackageVersion Include="Aspire.RabbitMQ.Client.v7" Version="9.2.0" />
+    <PackageVersion Include="Aspire.Seq" Version="9.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="9.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="9.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="9.2.0" />
 
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(PackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" Version="$(PackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="$(PackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="$(PackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" Version="9.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="9.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.2.0" />
   </ItemGroup>
 
   <ItemGroup Label="For tests">


### PR DESCRIPTION
## Description

This change will flow the .NET Servicing versions shipped earlier today as well as stabilize packages for 9.2 release.

Fixes #8472 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
