### PR TITLE
Remove -w short option for --wait-for-debugger.

### DIFF
--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -22,7 +22,7 @@ internal sealed class RootCommand : BaseRootCommand
         debugOption.Recursive = true;
         Options.Add(debugOption);
         
-        var waitForDebuggerOption = new Option<bool>("--wait-for-debugger", "-w");
+        var waitForDebuggerOption = new Option<bool>("--wait-for-debugger");
         waitForDebuggerOption.Description = "Wait for a debugger to attach before executing the command.";
         waitForDebuggerOption.Recursive = true;
         waitForDebuggerOption.DefaultValueFactory = (result) => false;


### PR DESCRIPTION
This PR removes the `-w` shortcut from `--wait-for-debugger`. This is because the -w switch conflicts with `--watch` on `aspire run`. It probably makes sense for `-w` to be reserved for `--watch` on `aspire run`.

Fixes: #8632