### PR TITLE
Mark Inspect operation as experimental and enhance AddPublisher API

### DIFF
--- a/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
@@ -18,9 +18,9 @@ public static class AzurePublisherExtensions
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Azure Container Apps publisher options.</param>
     [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
-    public static void AddAzurePublisher(this IDistributedApplicationBuilder builder, string name, Action<AzurePublisherOptions>? configureOptions = null)
+    public static IDistributedApplicationBuilder AddAzurePublisher(this IDistributedApplicationBuilder builder, string name, Action<AzurePublisherOptions>? configureOptions = null)
     {
-        builder.AddPublisher<AzurePublisher, AzurePublisherOptions>(name, configureOptions);
+        return builder.AddPublisher<AzurePublisher, AzurePublisherOptions>(name, configureOptions);
     }
 
     /// <summary>
@@ -29,8 +29,8 @@ public static class AzurePublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Azure Container Apps publisher options.</param>
     [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
-    public static void AddAzurePublisher(this IDistributedApplicationBuilder builder, Action<AzurePublisherOptions>? configureOptions = null)
+    public static IDistributedApplicationBuilder AddAzurePublisher(this IDistributedApplicationBuilder builder, Action<AzurePublisherOptions>? configureOptions = null)
     {
-        builder.AddPublisher<AzurePublisher, AzurePublisherOptions>("azure", configureOptions);
+        return builder.AddPublisher<AzurePublisher, AzurePublisherOptions>("azure", configureOptions);
     }
 }

--- a/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
@@ -18,9 +18,9 @@ public static class DockerComposePublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
-    public static void AddDockerComposePublisher(this IDistributedApplicationBuilder builder, string name, Action<DockerComposePublisherOptions>? configureOptions = null)
+    public static IDistributedApplicationBuilder AddDockerComposePublisher(this IDistributedApplicationBuilder builder, string name, Action<DockerComposePublisherOptions>? configureOptions = null)
     {
-        builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>(name, configureOptions);
+        return builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>(name, configureOptions);
     }
 
     /// <summary>
@@ -28,8 +28,8 @@ public static class DockerComposePublisherExtensions
     /// </summary>
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
-    public static void AddDockerComposePublisher(this IDistributedApplicationBuilder builder, Action<DockerComposePublisherOptions>? configureOptions = null)
+    public static IDistributedApplicationBuilder AddDockerComposePublisher(this IDistributedApplicationBuilder builder, Action<DockerComposePublisherOptions>? configureOptions = null)
     {
-        builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>("docker-compose", configureOptions);
+        return builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>("docker-compose", configureOptions);
     }
 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
@@ -18,9 +18,9 @@ public static class KubernetesPublisherExtensions
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
     /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
-    public static void AddKubernetesPublisher(this IDistributedApplicationBuilder builder, string name, Action<KubernetesPublisherOptions>? configureOptions = null)
+    public static IDistributedApplicationBuilder AddKubernetesPublisher(this IDistributedApplicationBuilder builder, string name, Action<KubernetesPublisherOptions>? configureOptions = null)
     {
-        builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>(name, configureOptions);
+        return builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>(name, configureOptions);
     }
 
     /// <summary>
@@ -28,8 +28,8 @@ public static class KubernetesPublisherExtensions
     /// </summary>
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
-    public static void AddKubernetesPublisher(this IDistributedApplicationBuilder builder, Action<KubernetesPublisherOptions>? configureOptions = null)
+    public static IDistributedApplicationBuilder AddKubernetesPublisher(this IDistributedApplicationBuilder builder, Action<KubernetesPublisherOptions>? configureOptions = null)
     {
-        builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>("kubernetes", configureOptions);
+        return builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>("kubernetes", configureOptions);
     }
 }

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Hosting;
 
 /// <summary>
@@ -89,5 +91,6 @@ public class DistributedApplicationExecutionContext
     /// <summary>
     /// Returns true if the current operation is inspecting.
     /// </summary>
+    [Experimental("ASPIREPUBLISHERS001")]
     public bool IsInspectMode => Operation == DistributedApplicationOperation.Inspect;
 }

--- a/src/Aspire.Hosting/DistributedApplicationOperation.cs
+++ b/src/Aspire.Hosting/DistributedApplicationOperation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Hosting;
 
 /// <summary>
@@ -21,5 +23,6 @@ public enum DistributedApplicationOperation
     /// <summary>
     /// AppHost is being run for the purpose of inspecting the application model from the launcher.
     /// </summary>
+    [Experimental("ASPIREPUBLISHERS001")]
     Inspect
 }

--- a/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
@@ -21,7 +21,7 @@ public static class PublisherDistributedApplicationBuilderExtensions
     /// <param name="name">The name of the publisher.</param>
     /// <param name="configureOptions">Callback to configure options for the publisher.</param>
     [Experimental("ASPIREPUBLISHERS001")]
-    public static void AddPublisher<TPublisher, TPublisherOptions>(this IDistributedApplicationBuilder builder, string name, Action<TPublisherOptions>? configureOptions = null)
+    public static IDistributedApplicationBuilder AddPublisher<TPublisher, TPublisherOptions>(this IDistributedApplicationBuilder builder, string name, Action<TPublisherOptions>? configureOptions = null)
         where TPublisher : class, IDistributedApplicationPublisher
         where TPublisherOptions : class
     {
@@ -43,5 +43,7 @@ public static class PublisherDistributedApplicationBuilderExtensions
         {
             configureOptions?.Invoke(options);
         });
+
+        return builder;
     }
 }

--- a/tests/Aspire.Hosting.Tests/OperationModesTests.cs
+++ b/tests/Aspire.Hosting.Tests/OperationModesTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001
+
 using Aspire.Hosting.Backchannel;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;


### PR DESCRIPTION
Mark the `Inspect` operation and related methods as experimental, while updating the `AddPublisher` API to return the builder for improved method chaining.