### PR TITLE
(Re)enable running tests from cli without specifying build infra

### DIFF
--- a/eng/Testing.targets
+++ b/eng/Testing.targets
@@ -29,7 +29,15 @@
     <!-- See https://learn.microsoft.com/azure/devops/pipelines/build/variables#system-variables -->
     <IsAzdoCIRunner Condition=" '$(SYSTEM_TEAMPROJECT)' != '' ">true</IsAzdoCIRunner>
 
+    <!-- See https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Helix/Sdk/Readme.md#common-helix-client-environment-variables -->
+    <IsHelix Condition=" '$(HELIX_CORRELATION_ID)' != '' ">true</IsHelix>
+
     <IsAzdoHelixRunner Condition=" '$(PrepareForHelix)' == 'true' ">true</IsAzdoHelixRunner>
+
+    <!--
+      If we haven't detected the tests are run on build agents, then we presume we're running tests locally.
+      -->
+    <IsLocalDevLoop Condition=" '$(IsGitHubActionsRunner)' != 'true' and '$(IsAzdoCIRunner)' != 'true' and '$(IsHelix)' != 'true' and '$(IsAzdoHelixRunner)' != 'true' ">true</IsLocalDevLoop>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -57,6 +65,9 @@
 
     <!-- Otherwise, run tests on AzDO CI agents -->
     <SkipTests Condition=" '$(IsAzdoCIRunner)' == 'true' and '$(RunOnAzdoCI)' == 'true' ">false</SkipTests>
+
+    <!-- If we're running locally, we don't skip tests -->
+    <SkipTests Condition=" '$(IsLocalDevLoop)' == 'true' ">false</SkipTests>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' and '$(IncludeTestUtilities)' == 'true' ">


### PR DESCRIPTION
Working in GHA for the past few weeks, I completely missed that running tests locally became impossible without passing an infra flag.
With this change it will now be possible to run tests again with just:

    .\build.cmd -test -projects .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj

...instead of requiring `/p:GITHUB_ACTIONS=true` or `/p:SYSTEM_TEAMPROJECT=foo` to indicate the test is run in GHA or AzDO.

## Before
```pwoershell
PS D:\Development\dotnet-aspire> .\build.cmd -test -projects .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj -c Release /bl
& "D:\Development\dotnet-aspire\eng/common/build.ps1"  /p:test=True -configuration Release -projects .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj /bl

Build succeeded in 0.4s
PS D:\Development\dotnet-aspire> .\build.cmd -test -projects .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj -c Release /bl /p:GITHUB_ACTIONS=true                            
& "D:\Development\dotnet-aspire\eng/common/build.ps1"  /p:test=True -configuration Release -projects .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj /bl /p:GITHUB_ACTIONS=true

Build succeeded in 5.4s
```

## After
```pwoershell
PS D:\Development\dotnet-aspire> .\build.cmd -test -projects .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj -c Release /bl      
& "D:\Development\dotnet-aspire\eng/common/build.ps1"  /p:test=True -configuration Release -projects .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj /bl

Build succeeded in 2.0s
```