### PR TITLE
Add context menu to resource graph, improve console logs actions

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -1,0 +1,32 @@
+﻿@namespace Aspire.Dashboard.Components
+@using System.Collections.Immutable
+@using Aspire.Dashboard.Model
+@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens
+@inherits FluentComponentBase
+
+<FluentMenu @ref="_menu" Anchor="@Anchor" Anchored="@Anchored" Open="@Open" OpenChanged="OnOpenChanged" VerticalThreshold="200">
+    @foreach (var item in Items)
+    {
+        @if (item.IsDivider)
+        {
+            <FluentDivider />
+        }
+        else
+        {
+            var additionalMenuItemAttributes = new Dictionary<string, object>(item.AdditionalAttributes ?? ImmutableDictionary<string, object>.Empty)
+            {
+                { "title", item.Tooltip ?? item.Text ?? string.Empty }
+            };
+
+            <FluentMenuItem Id="@item.Id" Class="@item.Class" OnClick="() => HandleItemClicked(item)" Disabled="@item.IsDisabled" AdditionalAttributes="@additionalMenuItemAttributes">
+                @item.Text
+                @if (item.Icon != null)
+                {
+                    <span slot="start">
+                        <FluentIcon Value="@item.Icon" Style="vertical-align: text-bottom;" Width="16px" />
+                    </span>
+                }
+            </FluentMenuItem>
+        }
+    }
+</FluentMenu>

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -1,7 +1,6 @@
 ﻿@namespace Aspire.Dashboard.Components
 @using System.Collections.Immutable
 @using Aspire.Dashboard.Model
-@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens
 @inherits FluentComponentBase
 
 <FluentMenu @ref="_menu" Anchor="@Anchor" Anchored="@Anchored" Open="@Open" OpenChanged="OnOpenChanged" VerticalThreshold="200">

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components;
+
+public partial class AspireMenu : FluentComponentBase
+{
+    private FluentMenu? _menu;
+
+    [Parameter]
+    public string? Anchor { get; set; }
+
+    [Parameter]
+    public bool Open { get; set; }
+
+    [Parameter]
+    public bool Anchored { get; set; } = true;
+
+    /// <summary>
+    /// Raised when the <see cref="Open"/> property changed.
+    /// </summary>
+    [Parameter]
+    public EventCallback<bool> OpenChanged { get; set; }
+
+    [Parameter]
+    public required IList<MenuButtonItem> Items { get; set; }
+
+    public async Task CloseAsync()
+    {
+        if (_menu is { } menu)
+        {
+            await menu.CloseAsync();
+        }
+    }
+
+    public async Task OpenAsync(int clientX, int clientY)
+    {
+        if (_menu is { } menu)
+        {
+            await menu.OpenAsync(clientX, clientY);
+        }
+    }
+
+    private async Task HandleItemClicked(MenuButtonItem item)
+    {
+        if (item.OnClick is {} onClick)
+        {
+            await onClick();
+        }
+        Open = false;
+    }
+
+    private Task OnOpenChanged(bool open)
+    {
+        Open = open;
+
+        return OpenChanged.HasDelegate
+            ? OpenChanged.InvokeAsync(open)
+            : Task.CompletedTask;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -1,7 +1,6 @@
 ﻿@namespace Aspire.Dashboard.Components
 @using System.Collections.Immutable
 @using Aspire.Dashboard.Model
-@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens
 @inherits FluentComponentBase
 
 @{

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -29,29 +29,4 @@
     }
 </FluentButton>
 
-<FluentMenu Anchor="@MenuButtonId" aria-labelledby="button" @bind-Open="@_visible" VerticalThreshold="200">
-    @foreach (var item in Items)
-    {
-        @if (item.IsDivider)
-        {
-            <FluentDivider />
-        }
-        else
-        {
-            var additionalMenuItemAttributes = new Dictionary<string, object>(item.AdditionalAttributes ?? ImmutableDictionary<string, object>.Empty)
-            {
-                { "title", item.Tooltip ?? item.Text ?? string.Empty }
-            };
-
-            <FluentMenuItem Id="@item.Id" Class="@item.Class" OnClick="() => HandleItemClicked(item)" Disabled="@item.IsDisabled" AdditionalAttributes="@additionalMenuItemAttributes">
-                @item.Text
-                @if (item.Icon != null)
-                {
-                    <span slot="start">
-                        <FluentIcon Value="@item.Icon" Style="vertical-align: text-bottom;" Width="16px" />
-                    </span>
-                }
-            </FluentMenuItem>
-        }
-    }
-</FluentMenu>
+<AspireMenu Anchor="@MenuButtonId" @bind-Open="@_visible" Items="Items" />

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -56,15 +56,6 @@ public partial class AspireMenuButton : FluentComponentBase
         _visible = !_visible;
     }
 
-    private async Task HandleItemClicked(MenuButtonItem item)
-    {
-        if (item.OnClick is {} onClick)
-        {
-            await onClick();
-        }
-        _visible = false;
-    }
-
     private void OnKeyDown(KeyboardEventArgs args)
     {
         if (args is not null && args.Key == "Escape")

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -12,7 +12,7 @@
         {
             var highlightedCommand = _highlightedCommands[i];
 
-            <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
+            <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
                 @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && IconResolver.ResolveIconName(highlightedCommand.IconName, IconSize.Size16, highlightedCommand.IconVariant) is { } icon)
                 {
                     <FluentIcon Value="@icon" Width="16px" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Storage;
-using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -13,11 +12,7 @@ namespace Aspire.Dashboard.Components;
 
 public partial class ResourceActions : ComponentBase
 {
-    private static readonly Icon s_viewDetailsIcon = new Icons.Regular.Size16.Info();
     private static readonly Icon s_consoleLogsIcon = new Icons.Regular.Size16.SlideText();
-    private static readonly Icon s_structuredLogsIcon = new Icons.Regular.Size16.SlideTextSparkle();
-    private static readonly Icon s_tracesIcon = new Icons.Regular.Size16.GanttChart();
-    private static readonly Icon s_metricsIcon = new Icons.Regular.Size16.ChartMultiple();
 
     private AspireMenuButton? _menuButton;
 
@@ -62,7 +57,7 @@ public partial class ResourceActions : ComponentBase
         _menuItems.Clear();
         _highlightedCommands.Clear();
 
-        AddMenuItems(
+        ResourceMenuItems.AddMenuItems(
             _menuItems,
             _menuButton?.MenuButtonId,
             Resource,
@@ -80,105 +75,6 @@ public partial class ResourceActions : ComponentBase
         if (ViewportInformation.IsDesktop)
         {
             _highlightedCommands.AddRange(Resource.Commands.Where(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden).Take(MaxHighlightedCount));
-        }
-    }
-
-    public static void AddMenuItems(
-        List<MenuButtonItem> menuItems,
-        string? openingMenuButtonId,
-        ResourceViewModel resource,
-        NavigationManager navigationManager,
-        TelemetryRepository telemetryRepository,
-        Func<ResourceViewModel, string> getResourceName,
-        IStringLocalizer<Resources.ControlsStrings> controlLoc,
-        IStringLocalizer<Resources.Resources> loc,
-        Func<string?, Task> onViewDetails,
-        Func<CommandViewModel, Task> commandSelected,
-        Func<ResourceViewModel, CommandViewModel, bool> isCommandExecuting,
-        bool showConsoleLogsItem)
-    {
-        menuItems.Add(new MenuButtonItem
-        {
-            Text = controlLoc[nameof(Resources.ControlsStrings.ActionViewDetailsText)],
-            Icon = s_viewDetailsIcon,
-            OnClick = () => onViewDetails(openingMenuButtonId)
-        });
-
-        if (showConsoleLogsItem)
-        {
-            menuItems.Add(new MenuButtonItem
-            {
-                Text = loc[nameof(Resources.Resources.ResourceActionConsoleLogsText)],
-                Icon = s_consoleLogsIcon,
-                OnClick = () =>
-                {
-                    navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: resource.Name));
-                    return Task.CompletedTask;
-                }
-            });
-        }
-
-        // Show telemetry menu items if there is telemetry for the resource.
-        var hasTelemetryApplication = telemetryRepository.GetApplicationByCompositeName(resource.Name) != null;
-        if (hasTelemetryApplication)
-        {
-            menuItems.Add(new MenuButtonItem { IsDivider = true });
-            menuItems.Add(new MenuButtonItem
-            {
-                Text = loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
-                Tooltip = loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
-                Icon = s_structuredLogsIcon,
-                OnClick = () =>
-                {
-                    navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: getResourceName(resource)));
-                    return Task.CompletedTask;
-                }
-            });
-            menuItems.Add(new MenuButtonItem
-            {
-                Text = loc[nameof(Resources.Resources.ResourceActionTracesText)],
-                Tooltip = loc[nameof(Resources.Resources.ResourceActionTracesText)],
-                Icon = s_tracesIcon,
-                OnClick = () =>
-                {
-                    navigationManager.NavigateTo(DashboardUrls.TracesUrl(resource: getResourceName(resource)));
-                    return Task.CompletedTask;
-                }
-            });
-            menuItems.Add(new MenuButtonItem
-            {
-                Text = loc[nameof(Resources.Resources.ResourceActionMetricsText)],
-                Tooltip = loc[nameof(Resources.Resources.ResourceActionMetricsText)],
-                Icon = s_metricsIcon,
-                OnClick = () =>
-                {
-                    navigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: getResourceName(resource)));
-                    return Task.CompletedTask;
-                }
-            });
-        }
-
-        var menuCommands = resource.Commands
-            .Where(c => c.State != CommandViewModelState.Hidden)
-            .OrderBy(c => !c.IsHighlighted)
-            .ToList();
-        if (menuCommands.Count > 0)
-        {
-            menuItems.Add(new MenuButtonItem { IsDivider = true });
-
-            foreach (var command in menuCommands)
-            {
-                var icon = (!string.IsNullOrEmpty(command.IconName) && IconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) is { } i) ? i : null;
-
-                menuItems.Add(new MenuButtonItem
-                {
-                    Text = command.DisplayName,
-                    Tooltip = command.DisplayDescription,
-                    Icon = icon,
-                    OnClick = () => commandSelected(command),
-                    IsDisabled = command.State == CommandViewModelState.Disabled || isCommandExecuting(resource, command)
-                });
-            }
         }
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -34,7 +34,7 @@
             {
                 if (_highlightedCommands.Count > 0)
                 {
-                    <span style="margin-left: 10px;">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsResourceCommands)]</span>
+                    <span style="margin-left: 10px;">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsResourceActions)]</span>
 
                     @foreach (var command in _highlightedCommands)
                     {
@@ -60,7 +60,7 @@
                     <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                                       Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
                                       Items="@_resourceMenuItems"
-                                      Title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsResourceCommands)]" />
+                                      Title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsResourceActions)]" />
                 }
             }
 

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -336,7 +336,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                 _highlightedCommands.AddRange(PageViewModel.SelectedResource.Commands.Where(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden).Take(DashboardUIHelpers.MaxHighlightedCommands));
             }
 
-            ResourceActions.AddMenuItems(
+            ResourceMenuItems.AddMenuItems(
                 _resourceMenuItems,
                 openingMenuButtonId: null,
                 PageViewModel.SelectedResource,

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -6,6 +6,7 @@
 @using Aspire.Dashboard.Components.Controls.Grid
 @using Aspire.Dashboard.Model
 @using Humanizer
+@using System.Collections.Immutable
 @inject IStringLocalizer<Dashboard.Resources.Resources> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 @inject IStringLocalizer<Columns> ColumnsLoc
@@ -94,7 +95,7 @@
                                 ViewKey="ResourcesList"
                                 OnResize="@(r => _manager.SetWidthFraction(r.Orientation == Orientation.Horizontal ? r.Panel1Fraction : 1))">
                 <Summary>
-                    <div class="resources-summary-layout">
+                    <div id="resources-summary-layout-id" class="resources-summary-layout">
                         <div class="@(!_hideResourceGraph ? "resource-tabs" : string.Empty)">
                             @*
                                 Tab content isn't nested inside FluentTab elements. The tab control is just used to display the tabs.
@@ -177,8 +178,7 @@
                                             </AspireTemplateColumn>
                                             <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesActionsColumnHeader)]" Class="no-ellipsis">
                                                 <div class="grid-action-container" @onclick:stopPropagation="true">
-                                                    <ResourceActions Commands="@context.Resource.Commands"
-                                                                     CommandSelected="async (command) => await ExecuteResourceCommandAsync(context.Resource, command)"
+                                                    <ResourceActions CommandSelected="async (command) => await ExecuteResourceCommandAsync(context.Resource, command)"
                                                                      IsCommandExecuting="@((resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name))"
                                                                      OnViewDetails="@((buttonId) => ShowResourceDetailsAsync(context.Resource, buttonId))"
                                                                      Resource="context.Resource"
@@ -222,6 +222,8 @@
                             }
                         </div>
                     </div>
+                    <FluentOverlay @bind-Visible="_contextMenuOpen" OnClose="ContextMenuClosed" Transparent="true" FullScreen="true" />
+                    <AspireMenu @bind-Open="_contextMenuOpen" @ref="_contextMenu" Anchor="resources-summary-layout-id" Anchored="false" Items="_contextMenuItems" />
                 </Summary>
                 <Details>
                     <ResourceDetails Resource="context" ResourceByName="_resourceByName" ShowSpecOnlyToggle="true" />

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -6,7 +6,6 @@
 @using Aspire.Dashboard.Components.Controls.Grid
 @using Aspire.Dashboard.Model
 @using Humanizer
-@using System.Collections.Immutable
 @inject IStringLocalizer<Dashboard.Resources.Resources> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 @inject IStringLocalizer<Columns> ColumnsLoc

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -513,6 +513,9 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
 
     private async Task ShowContextMenuAsync(ResourceViewModel resource, int clientX, int clientY)
     {
+        // This is called when the browser requests to show the context menu for a resource.
+        // The method doesn't complete until the context menu is closed so the browser can await
+        // it and perform clean up when the context menu is closed.
         if (_contextMenu is { } contextMenu)
         {
             _contextMenuItems.Clear();

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -516,7 +516,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
         if (_contextMenu is { } contextMenu)
         {
             _contextMenuItems.Clear();
-            ResourceActions.AddMenuItems(
+            ResourceMenuItems.AddMenuItems(
                 _contextMenuItems,
                 openingMenuButtonId: null,
                 resource,

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -530,7 +530,9 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
                 showConsoleLogsItem: true);
 
-            Debug.Assert(_contextMenuClosedTcs == null, "Shouldn't be a TCS for an open context menu.");
+            // The previous context menu should always be closed by this point but complete just in case.
+            _contextMenuClosedTcs?.TrySetResult();
+
             _contextMenuClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await contextMenu.OpenAsync(clientX, clientY);
@@ -808,7 +810,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
             await menu.CloseAsync();
         }
 
-        _contextMenuClosedTcs?.SetResult();
+        _contextMenuClosedTcs?.TrySetResult();
         _contextMenuClosedTcs = null;
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
+
+namespace Aspire.Dashboard.Model;
+
+public static class ResourceMenuItems
+{
+    private static readonly Icon s_viewDetailsIcon = new Icons.Regular.Size16.Info();
+    private static readonly Icon s_consoleLogsIcon = new Icons.Regular.Size16.SlideText();
+    private static readonly Icon s_structuredLogsIcon = new Icons.Regular.Size16.SlideTextSparkle();
+    private static readonly Icon s_tracesIcon = new Icons.Regular.Size16.GanttChart();
+    private static readonly Icon s_metricsIcon = new Icons.Regular.Size16.ChartMultiple();
+
+    public static void AddMenuItems(
+        List<MenuButtonItem> menuItems,
+        string? openingMenuButtonId,
+        ResourceViewModel resource,
+        NavigationManager navigationManager,
+        TelemetryRepository telemetryRepository,
+        Func<ResourceViewModel, string> getResourceName,
+        IStringLocalizer<Resources.ControlsStrings> controlLoc,
+        IStringLocalizer<Resources.Resources> loc,
+        Func<string?, Task> onViewDetails,
+        Func<CommandViewModel, Task> commandSelected,
+        Func<ResourceViewModel, CommandViewModel, bool> isCommandExecuting,
+        bool showConsoleLogsItem)
+    {
+        menuItems.Add(new MenuButtonItem
+        {
+            Text = controlLoc[nameof(Resources.ControlsStrings.ActionViewDetailsText)],
+            Icon = s_viewDetailsIcon,
+            OnClick = () => onViewDetails(openingMenuButtonId)
+        });
+
+        if (showConsoleLogsItem)
+        {
+            menuItems.Add(new MenuButtonItem
+            {
+                Text = loc[nameof(Resources.Resources.ResourceActionConsoleLogsText)],
+                Icon = s_consoleLogsIcon,
+                OnClick = () =>
+                {
+                    navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: resource.Name));
+                    return Task.CompletedTask;
+                }
+            });
+        }
+
+        // Show telemetry menu items if there is telemetry for the resource.
+        var hasTelemetryApplication = telemetryRepository.GetApplicationByCompositeName(resource.Name) != null;
+        if (hasTelemetryApplication)
+        {
+            menuItems.Add(new MenuButtonItem { IsDivider = true });
+            menuItems.Add(new MenuButtonItem
+            {
+                Text = loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
+                Tooltip = loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
+                Icon = s_structuredLogsIcon,
+                OnClick = () =>
+                {
+                    navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: getResourceName(resource)));
+                    return Task.CompletedTask;
+                }
+            });
+            menuItems.Add(new MenuButtonItem
+            {
+                Text = loc[nameof(Resources.Resources.ResourceActionTracesText)],
+                Tooltip = loc[nameof(Resources.Resources.ResourceActionTracesText)],
+                Icon = s_tracesIcon,
+                OnClick = () =>
+                {
+                    navigationManager.NavigateTo(DashboardUrls.TracesUrl(resource: getResourceName(resource)));
+                    return Task.CompletedTask;
+                }
+            });
+            menuItems.Add(new MenuButtonItem
+            {
+                Text = loc[nameof(Resources.Resources.ResourceActionMetricsText)],
+                Tooltip = loc[nameof(Resources.Resources.ResourceActionMetricsText)],
+                Icon = s_metricsIcon,
+                OnClick = () =>
+                {
+                    navigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: getResourceName(resource)));
+                    return Task.CompletedTask;
+                }
+            });
+        }
+
+        var menuCommands = resource.Commands
+            .Where(c => c.State != CommandViewModelState.Hidden)
+            .OrderBy(c => !c.IsHighlighted)
+            .ToList();
+        if (menuCommands.Count > 0)
+        {
+            menuItems.Add(new MenuButtonItem { IsDivider = true });
+
+            foreach (var command in menuCommands)
+            {
+                var icon = (!string.IsNullOrEmpty(command.IconName) && IconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) is { } i) ? i : null;
+
+                menuItems.Add(new MenuButtonItem
+                {
+                    Text = command.DisplayName,
+                    Tooltip = command.DisplayDescription,
+                    Icon = icon,
+                    OnClick = () => commandSelected(command),
+                    IsDisabled = command.State == CommandViewModelState.Disabled || isCommandExecuting(resource, command)
+                });
+            }
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
@@ -151,11 +151,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Resource commands.
+        ///   Looks up a localized string similar to Resource actions.
         /// </summary>
-        public static string ConsoleLogsResourceCommands {
+        public static string ConsoleLogsResourceActions {
             get {
-                return ResourceManager.GetString("ConsoleLogsResourceCommands", resourceCulture);
+                return ResourceManager.GetString("ConsoleLogsResourceActions", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
@@ -160,8 +160,8 @@
   <data name="ConsoleLogsSettings" xml:space="preserve">
     <value>Console logs settings</value>
   </data>
-  <data name="ConsoleLogsResourceCommands" xml:space="preserve">
-    <value>Resource commands</value>
+  <data name="ConsoleLogsResourceActions" xml:space="preserve">
+    <value>Resource actions</value>
   </data>
   <data name="ConsoleLogsTimestampShow" xml:space="preserve">
     <value>Show timestamps</value>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;Zachytávání protokolů bylo pozastaveno mezi {0} a {1}, odfiltrované protokoly: {2} &gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">Příkazy prostředku</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;Protokollerfassung wurde zwischen {0} und {1} angehalten, {2} Protokoll(e) herausgefiltert&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">Ressourcenbefehle</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt; Captura de registro en pausa entre {0} y {1}, {2} registros filtrados&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">Comandos de recursos</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;Capture de journal suspendue entre le ou les journaux {0} et {1}, {2} filtrés&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">Commandes de ressource</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;L'acquisizione dei log è stata sospesa tra {0} e {1}, {2} log filtrati&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">Comandi risorsa</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;ログ キャプチャが {0} と {1} の間で一時停止されました。{2} 件のログがフィルターで除外されました&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">リソース コマンド</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;로그 캡처가 {0} 및 {1}간에 일시 중지되었습니다. {2} 로그가 필터링되었습니다&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">리소스 명령</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;Przechwytywanie dziennika zostało wstrzymane między {0} a {1}, liczba odfiltrowanych dzienników: {2}&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">Polecenia zasobów</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;Captura de log em pausa entre {0} e {1}, {2} logs filtrados&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">Comandos de recursos</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;Запись журнала приостановлена между {0} и {1}, отфильтровано журналов: {2}&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">Команды ресурсов</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;Günlük yakalama, {0} ile {1} arasında duraklatıldı, {2} günlük filtrelendi&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">Kaynak komutları</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;日志捕获已在 {0} 和 {1} 之间暂停，筛选掉 {2} 条日志&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">资源命令</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -52,9 +52,9 @@
         <target state="translated">&lt;{0} 與 {1} 之間的記錄擷取已暫停，篩選出了 {2} 筆記錄&gt;</target>
         <note>{0} is a date, {1} is a date, {2} is a number.</note>
       </trans-unit>
-      <trans-unit id="ConsoleLogsResourceCommands">
-        <source>Resource commands</source>
-        <target state="translated">資源命令</target>
+      <trans-unit id="ConsoleLogsResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
         <note />
       </trans-unit>
       <trans-unit id="ConsoleLogsSelectResourceToolbar">

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -487,6 +487,7 @@ class ResourceGraph {
         } finally {
             this.openContextMenu = false;
 
+            // Unselect the node when the context menu is closed to reset mouseover state.
             this.updateNodeHighlights(null);
         }
     };

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -31,6 +31,7 @@ class ResourceGraph {
     constructor(resourcesInterop) {
         this.resources = [];
         this.resourcesInterop = resourcesInterop;
+        this.openContextMenu = false;
 
         this.nodes = [];
         this.links = [];
@@ -311,6 +312,7 @@ class ResourceGraph {
             .append("g")
             .attr("class", "resource-scale")
             .on('click', this.selectNode)
+            .on('contextmenu', this.nodeContextMenu)
             .on('mouseover', this.hoverNode)
             .on('mouseout', this.unHoverNode);
         newNodesContainer
@@ -358,12 +360,10 @@ class ResourceGraph {
         var resourceNameGroup = newNodesContainer
             .append("g")
             .attr("transform", "translate(0,71)")
-            .attr("class", "resource-name")
-            .on('click', this.selectNode);
+            .attr("class", "resource-name");
         resourceNameGroup
             .append("text")
-            .text(n => trimText(n.label, 30))
-            .on('click', this.selectNode);
+            .text(n => trimText(n.label, 30));
         resourceNameGroup
             .append("title")
             .text(n => n.label);
@@ -473,6 +473,25 @@ class ResourceGraph {
         return 'resource-link';
     }
 
+    nodeContextMenu = async (event) => {
+        console.log(event);
+
+        var data = event.target.__data__;
+
+        event.preventDefault();
+
+        this.openContextMenu = true;
+
+        try {
+            // Wait for method completion. It completes when the context menu is closed.
+            await this.resourcesInterop.invokeMethodAsync('ResourceContextMenu', data.id, event.clientX, event.clientY);
+        } finally {
+            this.openContextMenu = false;
+
+            this.updateNodeHighlights(null);
+        }
+    };
+
     selectNode = (event) => {
         var data = event.target.__data__;
 
@@ -518,7 +537,11 @@ class ResourceGraph {
     }
 
     unHoverNode = (event) => {
-        this.updateNodeHighlights(null);
+        // Don't unhover the selected node when the context menu is open.
+        // This is done to keep the node selected until the context menu is closed.
+        if (!this.openContextMenu) {
+            this.updateNodeHighlights(null);
+        }
     };
 
     nodeEquals(resource1, resource2) {

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -474,10 +474,9 @@ class ResourceGraph {
     }
 
     nodeContextMenu = async (event) => {
-        console.log(event);
-
         var data = event.target.__data__;
 
+        // Prevent default browser context menu.
         event.preventDefault();
 
         this.openContextMenu = true;

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.BrowserStorage;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ConsoleLogs;
 using Aspire.Tests.Shared.DashboardModel;
@@ -538,6 +539,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         Services.AddSingleton<IToastService, ToastService>();
         Services.AddSingleton<IOptions<DashboardOptions>>(Options.Create(new DashboardOptions()));
         Services.AddSingleton<DimensionManager>();
+        Services.AddSingleton<TelemetryRepository>();
         Services.AddSingleton<IDialogService, DialogService>();
         Services.AddSingleton<ISessionStorage, TestSessionStorage>();
         Services.AddSingleton<ILocalStorage, TestLocalStorage>();


### PR DESCRIPTION
## Description

- Adds right click context menu to resource graph
- Splits AspireMenu out of AspireMenuButton
- Updates console logs to display all actions for a resource. Changed text from "Resource commands" to "Resource actions"
- Updates resources context menu to also show highlighted commands

![context-menu](https://github.com/user-attachments/assets/7a65474f-5eb7-4883-b8b2-3ec34fd10bc4)

![image](https://github.com/user-attachments/assets/99c482c5-6a05-46b3-9356-3c30ae163e4e)

Fixes https://github.com/dotnet/aspire/issues/8634 https://github.com/dotnet/aspire/issues/8145

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
