### PR TITLE
Make IPublishingActivityProgressReporter mockable

### DIFF
--- a/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
@@ -11,6 +11,15 @@ namespace Aspire.Hosting.Publishing;
 [Experimental("ASPIREPUBLISHERS001")]
 public sealed class NullPublishingActivityProgressReporter : IPublishingActivityProgressReporter
 {
+    /// <summary>
+    /// Gets the singleton instance of <see cref="NullPublishingActivityProgressReporter"/>.
+    /// </summary>
+    public static NullPublishingActivityProgressReporter Instance { get; } = new NullPublishingActivityProgressReporter();
+
+    private NullPublishingActivityProgressReporter()
+    {
+    }
+
     /// <inheritdoc/>
     public Task<PublishingActivity> CreateActivityAsync(string id, string initialStatusText, bool isPrimary, CancellationToken cancellationToken)
     {

--- a/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.Publishing;
+
+/// <summary>
+/// Minimalistic reporter that does nothing.
+/// </summary>
+[Experimental("ASPIREPUBLISHERS001")]
+public sealed class NullPublishingActivityProgressReporter : IPublishingActivityProgressReporter
+{
+    /// <inheritdoc/>
+    public Task<PublishingActivity> CreateActivityAsync(string id, string initialStatusText, bool isPrimary, CancellationToken cancellationToken)
+    {
+        var activity = new PublishingActivity(id, isPrimary);
+        activity.LastStatus = new PublishingActivityStatus
+        {
+            Activity = activity,
+            StatusText = initialStatusText,
+            IsComplete = false,
+            IsError = false
+        };
+
+        return Task.FromResult(activity);
+    }
+
+    /// <inheritdoc/>
+    public Task UpdateActivityStatusAsync(PublishingActivity publishingActivity, Func<PublishingActivityStatus, PublishingActivityStatus> statusUpdate, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -14,7 +14,12 @@ namespace Aspire.Hosting.Publishing;
 [Experimental("ASPIREPUBLISHERS001")]
 public sealed class PublishingActivity
 {
-    internal PublishingActivity(string id, bool isPrimary = false)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublishingActivity"/> class.
+    /// </summary>
+    /// <param name="id">The unique identifier for the publishing activity.</param>
+    /// <param name="isPrimary">Indicates whether this activity is the primary activity.</param>
+    public PublishingActivity(string id, bool isPrimary = false)
     {
         Id = id;
         IsPrimary = isPrimary;
@@ -33,7 +38,7 @@ public sealed class PublishingActivity
     /// <summary>
     /// The status text of the publishing activity.
     /// </summary>
-    public PublishingActivityStatus? LastStatus { get; internal set; }
+    public PublishingActivityStatus? LastStatus { get; set; }
 }
 
 /// <summary>
@@ -79,7 +84,7 @@ public interface IPublishingActivityProgressReporter
     /// <returns>The publishing activity</returns>
     /// <remarks>
     /// When an activity is created the <paramref name="isPrimary"/> flag indicates whether this
-    /// activity is the primary activity. When the primary activity is completed any laumcher
+    /// activity is the primary activity. When the primary activity is completed any launcher
     /// which is reading activities will stop listening for updates.
     /// </remarks>
     Task<PublishingActivity> CreateActivityAsync(string id, string initialStatusText, bool isPrimary, CancellationToken cancellationToken);

--- a/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPUBLISHERS001
+
+using Aspire.Hosting.Publishing;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Publishing;
+
+public class NullPublishingActivityProgressReporterTests
+{
+    [Fact]
+    public async Task CanUseNullReporter()
+    {
+        var reporter = new NullPublishingActivityProgressReporter();
+        var activity = await reporter.CreateActivityAsync("1", "initial", isPrimary: true, default);
+        await reporter.UpdateActivityStatusAsync(activity, (status) => status with { IsComplete = true }, default);
+
+        Assert.NotNull(activity);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
@@ -13,7 +13,7 @@ public class NullPublishingActivityProgressReporterTests
     [Fact]
     public async Task CanUseNullReporter()
     {
-        var reporter = new NullPublishingActivityProgressReporter();
+        var reporter = NullPublishingActivityProgressReporter.Instance;
         var activity = await reporter.CreateActivityAsync("1", "initial", isPrimary: true, default);
         await reporter.UpdateActivityStatusAsync(activity, (status) => status with { IsComplete = true }, default);
 


### PR DESCRIPTION
Trying to test components that need an IPublishingActivityProgressReporter isn't currently possible without reflection.

Also add a Null reporter to easily use in tests. Just like NullLogger.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
