### PR TITLE
[tests] Disable some Quarantined tests

### DIFF
--- a/tests/Aspire.Hosting.NodeJs.Tests/NodeFunctionalTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/NodeFunctionalTests.cs
@@ -18,7 +18,7 @@ public class NodeFunctionalTests : IClassFixture<NodeAppFixture>
 
     [Fact]
     [RequiresTools(["node"])]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4508")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4508", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task VerifyNodeAppWorks()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
@@ -30,7 +30,7 @@ public class NodeFunctionalTests : IClassFixture<NodeAppFixture>
 
     [Fact]
     [RequiresTools(["npm"])]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4508")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4508", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task VerifyNpmAppWorks()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Aspire.Hosting.Oracle.Tests;
 
-[QuarantinedTest("https://github.com/dotnet/aspire/issues/5362")]
+[ActiveIssue("https://github.com/dotnet/aspire/issues/5362", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
 public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     // Folders created for mounted folders need to be granted specific permissions
@@ -26,7 +26,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
 
     private const string DatabaseReadyText = "Completed: ALTER DATABASE OPEN";
 
-    [Fact(Skip = "https://github.com/dotnet/aspire/issues/5362")]
+    [Fact]
     [RequiresDocker]
     public async Task VerifyEfOracle()
     {
@@ -67,7 +67,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("BatMobile", cars[0].Brand);
     }
 
-    [Theory(Skip = "https://github.com/dotnet/aspire/issues/5362")]
+    [Theory]
     [InlineData(true)]
     [InlineData(false, Skip = "https://github.com/dotnet/aspire/issues/5191")]
     [RequiresDocker]
@@ -242,7 +242,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
 
-    [Theory(Skip = "https://github.com/dotnet/aspire/issues/5362")]
+    [Theory]
     [InlineData(true)]
     [InlineData(false, Skip = "https://github.com/dotnet/aspire/issues/5190")]
     [RequiresDocker]
@@ -345,7 +345,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
 
-    [Fact(Skip = "https://github.com/dotnet/aspire/issues/5362")]
+    [Fact]
     [RequiresDocker]
     public async Task VerifyWaitForOnOracleBlocksDependentResources()
     {

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -914,6 +914,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8728")]
     public async Task ProxylessEndpointWorks()
     {
         const string testName = "proxyless-endpoint-works";

--- a/tests/Aspire.TestUtilities/PlatformDetection.cs
+++ b/tests/Aspire.TestUtilities/PlatformDetection.cs
@@ -9,6 +9,7 @@ public static class PlatformDetection
     public static bool IsRunningOnHelix => Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null;
     public static bool IsRunningOnGithubActions => Environment.GetEnvironmentVariable("GITHUB_JOB") is not null;
     public static bool IsRunningOnCI => IsRunningOnAzdoBuildMachine || IsRunningOnHelix || IsRunningOnGithubActions;
+    public static bool IsRunningFromAzdo => IsRunningOnAzdoBuildMachine || IsRunningOnHelix;
     public static bool IsRunningPRValidation => IsRunningOnGithubActions;
 
     public static bool IsWindows => OperatingSystem.IsWindows();


### PR DESCRIPTION
- **[tests] Use ActiveIssue for Hosting.NodeJs.Tests**
These tests work as expected except on azdo build machines, or helix
where node/npm is not installed. So, instead of Quarantining these tests
use `ActiveIssue` to specifically disable them on Azdo.

- **[tests] Use ActiveIssue for OracleFunctionalTests**

- New quarantined test - https://github.com/dotnet/aspire/issues/8728