### PR TITLE
Custom URLs improvements

### DIFF
--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -66,7 +66,12 @@ var frontend = builder.AddProject<Projects.MyFrontend>("frontend")
        .WithExternalHttpEndpoints()
        .WithReference(basketService)
        .WithReference(catalogService)
-       .WithUrls(c => c.Urls.ForEach(u => u.DisplayText = $"Online store ({u.Endpoint?.EndpointName})"));
+       // Modify the display text of the URLs
+       .WithUrls(c => c.Urls.ForEach(u => u.DisplayText = $"Online store ({u.Endpoint?.EndpointName})"))
+       // Don't show the non-HTTPS link on the resources page (details only)
+       .WithUrlForEndpoint("http", url => url.ShowOnResourcesPage = false)
+       // Add health relative URL (show in details only)
+       .WithUrlForEndpoint("https", ep => new() { Url = "/health", DisplayText = "Health", ShowOnResourcesPage = false });
 
 var _ = frontend.GetEndpoint("https").Exists ? frontend.WithHttpsHealthCheck("/health") : frontend.WithHttpHealthCheck("/health");
 

--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -69,9 +69,9 @@ var frontend = builder.AddProject<Projects.MyFrontend>("frontend")
        // Modify the display text of the URLs
        .WithUrls(c => c.Urls.ForEach(u => u.DisplayText = $"Online store ({u.Endpoint?.EndpointName})"))
        // Don't show the non-HTTPS link on the resources page (details only)
-       .WithUrlForEndpoint("http", url => url.ShowOnResourcesPage = false)
+       .WithUrlForEndpoint("http", url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)
        // Add health relative URL (show in details only)
-       .WithUrlForEndpoint("https", ep => new() { Url = "/health", DisplayText = "Health", ShowOnResourcesPage = false });
+       .WithUrlForEndpoint("https", ep => new() { Url = "/health", DisplayText = "Health", DisplayLocation = UrlDisplayLocation.DetailsOnly });
 
 var _ = frontend.GetEndpoint("https").Exists ? frontend.WithHttpsHealthCheck("/health") : frontend.WithHttpHealthCheck("/health");
 

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -74,17 +74,25 @@
                                 ResizeType="DataGridResizeType.Discrete"
                                 Style="width:100%"
                                 RowSize="DataGridRowSize.Medium"
-                                GridTemplateColumns="1fr 1.5fr"
+                                GridTemplateColumns="1fr 1fr 0.5fr"
                                 ShowHover="true">
-                    <AspireTemplateColumn Sortable="true" SortBy="@_urlValueSort" Title="@ControlStringsLoc[nameof(ControlsStrings.LinkColumnHeader)]">
-                        <GridValue ValueDescription="@ControlStringsLoc[nameof(ControlsStrings.LinkColumnHeader)]"
+                    <AspireTemplateColumn Sortable="true" SortBy="@_urlValueSort" Title="@ControlStringsLoc[nameof(ControlsStrings.LinkAddressColumnHeader)]">
+                        <GridValue ValueDescription="@ControlStringsLoc[nameof(ControlsStrings.LinkAddressColumnHeader)]"
                                    Value="@context.OriginalUrlString"
                                    ValueTemplate="@(_ => RenderUrlValue(context, _filter))"
                                    EnableHighlighting="@(!string.IsNullOrEmpty(_filter))"
                                    IsMaskedChanged="@(_ => OnValueMaskedChanged(context))"
                                    HighlightText="@_filter" />
                     </AspireTemplateColumn>
-                                <AspireTemplateColumn Sortable="true" SortBy="@(GridSort<DisplayedUrl>.ByAscending(i => i.DisplayName))" Title="@ControlStringsLoc[nameof(ControlsStrings.EndpointNameColumnHeader)]">
+                    <AspireTemplateColumn Sortable="true" SortBy="@_urlValueSort" Title="@ControlStringsLoc[nameof(ControlsStrings.LinkTextColumnHeader)]">
+                        <GridValue ValueDescription="@ControlStringsLoc[nameof(ControlsStrings.LinkTextColumnHeader)]"
+                                   Value="@context.Text"
+                                   ValueTemplate="@(_ => RenderTextValue(context, _filter))"
+                                   EnableHighlighting="@(!string.IsNullOrEmpty(_filter))"
+                                   IsMaskedChanged="@(_ => OnValueMaskedChanged(context))"
+                                   HighlightText="@_filter" />
+                    </AspireTemplateColumn>
+                    <AspireTemplateColumn Sortable="true" SortBy="@(GridSort<DisplayedUrl>.ByAscending(i => i.DisplayName))" Title="@ControlStringsLoc[nameof(ControlsStrings.EndpointNameColumnHeader)]">
                         <GridValue ValueDescription="@ControlStringsLoc[nameof(ControlsStrings.EndpointNameColumnHeader)]"
                                    Value="@context.Name"
                                    EnableHighlighting="@(!string.IsNullOrEmpty(_filter) && context.Name != "-")"
@@ -292,14 +300,25 @@
             }
             return @<span>@vm.Text</span>;
         }
-        // If the URL and text are the same, render a link for the URL
-        else if (string.Equals(vm.Url, vm.Text, StringComparison.Ordinal))
+        // Otherwise, render a link for the URL
+        else
         {
             if (highlighting)
             {
                 return @<a href="@vm.Url" target="_blank"><FluentHighlighter HighlightedText="@filter" Text="@vm.Url" /></a>;
             }
             return @<a href="@vm.Url" target="_blank">@vm.Url</a>;
+        }
+    }
+
+    private static RenderFragment RenderTextValue(DisplayedUrl vm, string filter)
+    {
+        var highlighting = !string.IsNullOrEmpty(filter) && vm.Text != "-";
+
+        // If there's no URL, e.g. this is a tcp:// URI, show nothing, or URL is same as Text, then show nothing
+        if (vm.Url is null || string.Equals(vm.Url, vm.Text, StringComparison.Ordinal))
+        {
+            return @<span></span>;
         }
         // Otherwise, render a link with the text as the anchor text & title as the URL
         else

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -511,11 +511,20 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Link.
+        ///   Looks up a localized string similar to Address.
         /// </summary>
-        public static string LinkColumnHeader {
+        public static string LinkAddressColumnHeader {
             get {
-                return ResourceManager.GetString("LinkColumnHeader", resourceCulture);
+                return ResourceManager.GetString("LinkAddressColumnHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Text.
+        /// </summary>
+        public static string LinkTextColumnHeader {
+            get {
+                return ResourceManager.GetString("LinkTextColumnHeader", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -466,8 +466,8 @@
   <data name="EndpointNameColumnHeader" xml:space="preserve">
     <value>Endpoint name</value>
   </data>
-  <data name="LinkColumnHeader" xml:space="preserve">
-    <value>Link</value>
+  <data name="LinkAddressColumnHeader" xml:space="preserve">
+    <value>Address</value>
   </data>
   <data name="ResourceGraphNoEndpoints" xml:space="preserve">
     <value>No endpoints</value>
@@ -483,5 +483,8 @@
   </data>
   <data name="TotalItemsFooterCapturePaused" xml:space="preserve">
     <value>Capture paused</value>
+  </data>
+  <data name="LinkTextColumnHeader" xml:space="preserve">
+    <value>Text</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(nenastaveno)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">Propojit</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(Nicht festgelegt)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">Link</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(Anular)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">Vínculo</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(Annuler)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">Lien</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(Annulla)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">Collega</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(設定解除)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">リンク</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(설정 해제)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">링크</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(Cofnij ustawienie)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">Link</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(Remover definição)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">Link</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(Удалить)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">Ссылка</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(Ayarı Kaldır)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">Bağlantı</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(取消设置)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">链接</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -252,9 +252,14 @@
         <target state="translated">(取消設定)</target>
         <note />
       </trans-unit>
-      <trans-unit id="LinkColumnHeader">
-        <source>Link</source>
-        <target state="translated">連結</target>
+      <trans-unit id="LinkAddressColumnHeader">
+        <source>Address</source>
+        <target state="new">Address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LinkTextColumnHeader">
+        <source>Text</source>
+        <target state="new">Text</target>
         <note />
       </trans-unit>
       <trans-unit id="Loading">

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -172,11 +172,11 @@ public sealed record ResourceStateSnapshot(string Text, string? Style)
 public sealed record EnvironmentVariableSnapshot(string Name, string? Value, bool IsFromSpec);
 
 /// <summary>
-/// A snapshot of the url.
+/// A snapshot of the URL.
 /// </summary>
-/// <param name="Name">Name of the endpoint associated with the url.</param>
-/// <param name="Url">The full uri.</param>
-/// <param name="IsInternal">Determines if this url is internal.</param>
+/// <param name="Name">Name of the endpoint associated with the URL.</param>
+/// <param name="Url">The full URL.</param>
+/// <param name="IsInternal">Determines if this URL is internal. Internal URLs are only shown in the details grid for a resource.</param>
 [DebuggerDisplay("{Url}", Name = "{Name}")]
 public sealed record UrlSnapshot(string? Name, string Url, bool IsInternal)
 {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
@@ -30,4 +30,12 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
     /// The display order the URL. Higher values mean sort higher in the list.
     /// </summary>
     public int? DisplayOrder;
+
+    /// <summary>
+    /// Whether this URL should be shown on the dashboard resources page. Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <see langword="false"/> to only show this URL in the resource details grid.
+    /// </remarks>
+    public bool ShowOnResourcesPage { get; set; } = true;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
@@ -32,12 +32,11 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
     public int? DisplayOrder;
 
     /// <summary>
-    /// Whether this URL should be shown on the dashboard resources page. Defaults to <see langword="true"/>.
+    /// Locations where this URL should be shown on the dashboard. Defaults to <see cref="UrlDisplayLocation.SummaryAndDetails"/>.
     /// </summary>
-    /// <remarks>
-    /// Set this to <see langword="false"/> to only show this URL in the resource details grid.
-    /// </remarks>
-    public bool ShowOnResourcesPage { get; set; } = true;
+    public UrlDisplayLocation DisplayLocation { get; set; } = UrlDisplayLocation.SummaryAndDetails;
+
+    internal bool IsInternal => DisplayLocation == UrlDisplayLocation.DetailsOnly;
 
     internal ResourceUrlAnnotation WithEndpoint(EndpointReference endpoint)
     {
@@ -47,7 +46,22 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
             DisplayText = DisplayText,
             Endpoint = endpoint,
             DisplayOrder = DisplayOrder,
-            ShowOnResourcesPage = ShowOnResourcesPage
+            DisplayLocation = DisplayLocation
         };
     }
+}
+
+/// <summary>
+/// Specifies where the URL should be displayed.
+/// </summary>
+public enum UrlDisplayLocation
+{
+    /// <summary>
+    /// Show the URL in locations where either the resource summary or resource details are being displayed.
+    /// </summary>
+    SummaryAndDetails,
+    /// <summary>
+    /// Show the URL in locations where the full details of the resource are being displayed.
+    /// </summary>
+    DetailsOnly
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
@@ -38,4 +38,16 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
     /// Set this to <see langword="false"/> to only show this URL in the resource details grid.
     /// </remarks>
     public bool ShowOnResourcesPage { get; set; } = true;
+
+    internal ResourceUrlAnnotation WithEndpoint(EndpointReference endpoint)
+    {
+        return new()
+        {
+            Url = Url,
+            DisplayText = DisplayText,
+            Endpoint = endpoint,
+            DisplayOrder = DisplayOrder,
+            ShowOnResourcesPage = ShowOnResourcesPage
+        };
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUrlsCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUrlsCallbackContext.cs
@@ -21,6 +21,19 @@ public class ResourceUrlsCallbackContext(DistributedApplicationExecutionContext 
     public IResource Resource { get; } = resource;
 
     /// <summary>
+    /// Gets an endpoint reference from <see cref="Resource"/> for the specified endpoint name.<br/>
+    /// If <see cref="Resource"/> does not implement <see cref="IResourceWithEndpoints"/> then returns <c>null</c>.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public EndpointReference? GetEndpoint(string name) =>
+        Resource switch
+        {
+            IResourceWithEndpoints resourceWithEndpoints => resourceWithEndpoints.GetEndpoint(name),
+            _ => null
+        };
+
+    /// <summary>
     /// Gets the URLs associated with the callback context.
     /// </summary>
     public List<ResourceUrlAnnotation> Urls { get; } = urls ?? [];

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -210,7 +210,7 @@ internal class ResourceSnapshotBuilder
                     var activeEndpoint = _resourceState.EndpointsMap.SingleOrDefault(e => e.Value.Spec.ServiceName == serviceName && e.Value.Metadata.OwnerReferences?.Any(or => or.Kind == resource.Kind && or.Name == name) == true).Value;
                     var isInactive = activeEndpoint is null;
 
-                    urls.Add(new(Name: endpointUrl.Endpoint!.EndpointName, Url: endpointUrl.Url, IsInternal: false) { IsInactive = isInactive, DisplayProperties = new(endpointUrl.DisplayText ?? "", endpointUrl.DisplayOrder ?? 0) });
+                    urls.Add(new(Name: endpointUrl.Endpoint!.EndpointName, Url: endpointUrl.Url, IsInternal: !endpointUrl.ShowOnResourcesPage) { IsInactive = isInactive, DisplayProperties = new(endpointUrl.DisplayText ?? "", endpointUrl.DisplayOrder ?? 0) });
                 }
             }
 
@@ -218,7 +218,7 @@ internal class ResourceSnapshotBuilder
             var resourceRunning = string.Equals(resourceState, KnownResourceStates.Running, StringComparisons.ResourceState);
             foreach (var url in nonEndpointUrls)
             {
-                urls.Add(new(Name: null, Url: url.Url, IsInternal: false) { IsInactive = !resourceRunning, DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0) });
+                urls.Add(new(Name: null, Url: url.Url, IsInternal: !url.ShowOnResourcesPage) { IsInactive = !resourceRunning, DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0) });
             }
         }
 

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -210,7 +210,7 @@ internal class ResourceSnapshotBuilder
                     var activeEndpoint = _resourceState.EndpointsMap.SingleOrDefault(e => e.Value.Spec.ServiceName == serviceName && e.Value.Metadata.OwnerReferences?.Any(or => or.Kind == resource.Kind && or.Name == name) == true).Value;
                     var isInactive = activeEndpoint is null;
 
-                    urls.Add(new(Name: endpointUrl.Endpoint!.EndpointName, Url: endpointUrl.Url, IsInternal: !endpointUrl.ShowOnResourcesPage) { IsInactive = isInactive, DisplayProperties = new(endpointUrl.DisplayText ?? "", endpointUrl.DisplayOrder ?? 0) });
+                    urls.Add(new(Name: endpointUrl.Endpoint!.EndpointName, Url: endpointUrl.Url, IsInternal: endpointUrl.IsInternal) { IsInactive = isInactive, DisplayProperties = new(endpointUrl.DisplayText ?? "", endpointUrl.DisplayOrder ?? 0) });
                 }
             }
 
@@ -218,7 +218,7 @@ internal class ResourceSnapshotBuilder
             var resourceRunning = string.Equals(resourceState, KnownResourceStates.Running, StringComparisons.ResourceState);
             foreach (var url in nonEndpointUrls)
             {
-                urls.Add(new(Name: null, Url: url.Url, IsInternal: !url.ShowOnResourcesPage) { IsInactive = !resourceRunning, DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0) });
+                urls.Add(new(Name: null, Url: url.Url, IsInternal: url.IsInternal) { IsInactive = !resourceRunning, DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0) });
             }
         }
 

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -200,6 +200,18 @@ internal sealed class ApplicationOrchestrator
             }
         }
 
+        // Convert relative endpoint URLs to absolute URLs
+        foreach (var url in urls)
+        {
+            if (url.Endpoint is { } endpoint)
+            {
+                if (url.Url.StartsWith('/') && endpoint.AllocatedEndpoint is { } allocatedEndpoint)
+                {
+                    url.Url = allocatedEndpoint.UriString.TrimEnd('/') + url.Url;
+                }
+            }
+        }
+
         // Add URLs
         foreach (var url in urls)
         {

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -944,9 +944,9 @@ public static class ResourceBuilderExtensions
         builder.WithUrls(context =>
         {
             var endpoint = builder.GetEndpoint(endpointName);
-            if (endpoint is not null)
+            if (endpoint.Exists)
             {
-                var url = callback(endpoint);
+                var url = callback(endpoint).WithEndpoint(endpoint);
                 if (url.Url.StartsWith('/'))
                 {
                     // Url is relative, update it to be absolute using the endpoint URL

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -896,11 +896,6 @@ public static class ResourceBuilderExtensions
             if (urlForEndpoint is not null)
             {
                 callback(urlForEndpoint);
-                if (urlForEndpoint.Endpoint is not null && urlForEndpoint.Url.StartsWith('/'))
-                {
-                    // Url is relative, update it to be absolute using the endpoint URL
-                    urlForEndpoint.Url = urlForEndpoint.Endpoint.Url.TrimEnd('/') + urlForEndpoint.Url;
-                }
             }
             else
             {
@@ -947,11 +942,6 @@ public static class ResourceBuilderExtensions
             if (endpoint.Exists)
             {
                 var url = callback(endpoint).WithEndpoint(endpoint);
-                if (url.Url.StartsWith('/'))
-                {
-                    // Url is relative, update it to be absolute using the endpoint URL
-                    url.Url = endpoint.Url.TrimEnd('/') + url.Url;
-                }
                 context.Urls.Add(url);
             }
             else

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -414,15 +414,16 @@ public class WithUrlsTests
     }
 
     [Fact]
-    public async Task UrlsAreMarkedAsInternalDependingOnShowOnResourcesPage()
+    public async Task UrlsAreMarkedAsInternalDependingOnDisplayLocation()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         builder.AddProject<Projects.ServiceA>("servicea")
             .WithUrls(c =>
             {
-                c.Urls.Add(new() { Url = "http://example.com/", ShowOnResourcesPage = true });
-                c.Urls.Add(new() { Url = "http://example.com/internal", ShowOnResourcesPage = false });
+                c.Urls.Add(new() { Url = "http://example.com/", DisplayLocation = UrlDisplayLocation.SummaryAndDetails });
+                c.Urls.Add(new() { Url = "http://example.com/internal", DisplayLocation = UrlDisplayLocation.DetailsOnly });
+                c.Urls.Add(new() { Url = "http://example.com/out-of-range", DisplayLocation = (UrlDisplayLocation)100 });
             });
 
         var app = await builder.BuildAsync();
@@ -456,7 +457,8 @@ public class WithUrlsTests
         Assert.Collection(urlSnapshot,
             url => { Assert.Equal("http", url.Name); Assert.False(url.IsInternal); },
             url => { Assert.Equal("http://example.com/", url.Url); Assert.False(url.IsInternal); },
-            url => { Assert.Equal("http://example.com/internal", url.Url); Assert.True(url.IsInternal); }
+            url => { Assert.Equal("http://example.com/internal", url.Url); Assert.True(url.IsInternal); },
+            url => { Assert.Equal("http://example.com/out-of-range", url.Url); Assert.False(url.IsInternal); }
         );
     }
 

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -551,7 +551,7 @@ public class WithUrlsTests
     }
 
     [Fact]
-    public async Task WithUrlForEndpointaddTurnsRelativeUrlIntoAbsoluteUrl()
+    public async Task WithUrlForEndpointAddTurnsRelativeUrlIntoAbsoluteUrl()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -414,7 +414,54 @@ public class WithUrlsTests
     }
 
     [Fact]
-    public async Task WithUrlForEndpointDoesNotThrowOrCallCallbackIfEndpointNotFound()
+    public async Task UrlsAreMarkedAsInternalDependingOnShowOnResourcesPage()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddProject<Projects.ServiceA>("servicea")
+            .WithUrls(c =>
+            {
+                c.Urls.Add(new() { Url = "http://example.com/", ShowOnResourcesPage = true });
+                c.Urls.Add(new() { Url = "http://example.com/internal", ShowOnResourcesPage = false });
+            });
+
+        var app = await builder.BuildAsync();
+
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        ImmutableArray<UrlSnapshot> urlSnapshot = default;
+        var cts = new CancellationTokenSource();
+        var watchTask = Task.Run(async () =>
+        {
+            await foreach (var notification in rns.WatchAsync(cts.Token).WithCancellation(cts.Token))
+            {
+                if (string.Equals(notification.Snapshot.State?.Text, KnownResourceStates.Running))
+                {
+                    if (notification.Snapshot.Urls.Length > 1 && urlSnapshot == default)
+                    {
+                        urlSnapshot = notification.Snapshot.Urls;
+                        break;
+                    }
+                }
+            }
+        });
+
+        await app.StartAsync();
+
+        await rns.WaitForResourceAsync("servicea", KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await watchTask.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        cts.Cancel();
+
+        await app.StopAsync();
+
+        Assert.Collection(urlSnapshot,
+            url => { Assert.Equal("http", url.Name); Assert.False(url.IsInternal); },
+            url => { Assert.Equal("http://example.com/", url.Url); Assert.False(url.IsInternal); },
+            url => { Assert.Equal("http://example.com/internal", url.Url); Assert.True(url.IsInternal); }
+        );
+    }
+
+    [Fact]
+    public async Task WithUrlForEndpointUpdateDoesNotThrowOrCallCallbackIfEndpointNotFound()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
@@ -438,6 +485,98 @@ public class WithUrlsTests
         await tcs.Task;
 
         Assert.False(called);
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task WithUrlForEndpointAddDoesNotThrowOrCallCallbackIfEndpointNotFound()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var called = false;
+        var projectA = builder.AddProject<ProjectA>("projecta")
+            .WithHttpEndpoint(name: "test")
+            .WithUrlForEndpoint("non-existant", ep =>
+            {
+                called = true;
+                return new() { Url = "https://example.com" };
+            });
+
+        var tcs = new TaskCompletionSource();
+        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
+        {
+            tcs.SetResult();
+            return Task.CompletedTask;
+        });
+
+        var app = await builder.BuildAsync();
+        await app.StartAsync();
+        await tcs.Task;
+
+        Assert.False(called);
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task WithUrlForEndpointUpdateTurnsRelativeUrlIntoAbsoluteUrl()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var projectA = builder.AddProject<ProjectA>("projecta")
+            .WithHttpEndpoint(name: "test")
+            .WithUrlForEndpoint("test", url =>
+            {
+                url.Url = "/sub-path";
+            });
+
+        var tcs = new TaskCompletionSource();
+        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
+        {
+            tcs.SetResult();
+            return Task.CompletedTask;
+        });
+
+        var app = await builder.BuildAsync();
+        await app.StartAsync();
+        await tcs.Task;
+
+        var endpointUrl = projectA.Resource.Annotations.OfType<ResourceUrlAnnotation>().FirstOrDefault(u => u.Endpoint?.EndpointName == "test");
+
+        Assert.NotNull(endpointUrl);
+        Assert.True(endpointUrl.Url.StartsWith("http://localhost") && endpointUrl.Url.EndsWith("/sub-path"));
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task WithUrlForEndpointaddTurnsRelativeUrlIntoAbsoluteUrl()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var projectA = builder.AddProject<ProjectA>("projecta")
+            .WithHttpEndpoint(name: "test")
+            .WithUrlForEndpoint("test", ep =>
+            {
+                return new() { Url = "/sub-path" };
+            });
+
+        var tcs = new TaskCompletionSource();
+        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
+        {
+            tcs.SetResult();
+            return Task.CompletedTask;
+        });
+
+        var app = await builder.BuildAsync();
+        await app.StartAsync();
+        await tcs.Task;
+
+        var endpointUrl = projectA.Resource.Annotations.OfType<ResourceUrlAnnotation>().FirstOrDefault(u => u.Endpoint?.EndpointName == "test" && u.Url.EndsWith("/sub-path"));
+
+        Assert.NotNull(endpointUrl);
+        Assert.True(endpointUrl.Url.StartsWith("http://localhost") && endpointUrl.Url.EndsWith("/sub-path"));
 
         await app.StopAsync();
     }


### PR DESCRIPTION
## Description

Bunch of changes to resource URL customization based on user feedback in 9.2:

- Control whether URL is visible on resources page or not
- Add helper method to get resource endpoint from `ResourceUrlsCallbackContext`
- Support relative URLs for endpoints
- Add overload of `WithUrlForEndpoint` for adding extra endpoint URLs

Fixes #8725, #8636, #8640, #8638, #6454

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] No
        - Link to aspire-docs issue: dotnet/docs-aspire#3078

Image shows the Frontend resource in TestShop only showing one URL in the Resources table but all URLs in the details view. The details view has been updated to show three columns so that the URL address, text, and endpoint are now clear.

![image](https://github.com/user-attachments/assets/eb5d4c03-3a6c-4e40-916e-057e5490e99a)

Here's an example of the details view for a resource with a non-HTTP URL:

![image](https://github.com/user-attachments/assets/5862cc91-dda6-43fa-ad19-e40f729b3b48)

