### PR TITLE
Basic implementation of build cache.

### DIFF
--- a/src/Aspire.Cli/Builds/AppHostBuilder.cs
+++ b/src/Aspire.Cli/Builds/AppHostBuilder.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Builds;
+
+internal interface IAppHostBuilder
+{
+    Task<int> BuildAppHostAsync(FileInfo projectFile, bool useCache, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+}
+
+internal sealed class AppHostBuilder(ILogger<AppHostBuilder> logger, IDotNetCliRunner runner) : IAppHostBuilder
+{
+    private readonly ActivitySource _activitySource = new ActivitySource(nameof(AppHostBuilder));
+    private readonly SHA256 _sha256 = SHA256.Create();
+
+    private async Task<string> GetBuildFingerprintAsync(FileInfo projectFile, CancellationToken cancellationToken)
+    {
+        using var activity = _activitySource.StartActivity();
+
+        _ = logger;
+
+        var msBuildResult = await runner.GetProjectItemsAndPropertiesAsync(
+            projectFile,
+            ["ProjectReference", "PackageReference", "Compile"],
+            ["OutputPath"],
+            new DotNetCliRunnerInvocationOptions(),
+            cancellationToken
+            );
+
+        var json = msBuildResult.Output?.RootElement.ToString();
+
+        var jsonBytes = Encoding.UTF8.GetBytes(json!);
+        var hash = _sha256.ComputeHash(jsonBytes);
+        var hashString = Convert.ToHexString(hash);
+ 
+        return hashString;
+    }
+
+    private string GetAppHostStateBasePath(FileInfo projectFile)
+    {
+        var fullPath = projectFile.FullName;
+        var fullPathBytes = Encoding.UTF8.GetBytes(fullPath);
+        var hash = _sha256.ComputeHash(fullPathBytes);
+        var hashString = Convert.ToHexString(hash);
+
+        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var appHostStatePath = Path.Combine(homeDirectory, ".aspire", "apphosts", hashString);
+        
+        if (Directory.Exists(appHostStatePath))
+        {
+            return appHostStatePath;
+        }
+        else
+        {
+            Directory.CreateDirectory(appHostStatePath);
+            return appHostStatePath;
+        }
+    }
+
+    public async Task<int> BuildAppHostAsync(FileInfo projectFile, bool useCache, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+    {
+        using var activity = _activitySource.StartActivity();
+
+        var currentFingerprint = await GetBuildFingerprintAsync(projectFile, cancellationToken);
+        var appHostStatePath = GetAppHostStateBasePath(projectFile);
+        var buildFingerprintFile = Path.Combine(appHostStatePath, "fingerprint.txt");
+
+        if (File.Exists(buildFingerprintFile) && useCache)
+        {
+            var lastFingerprint = await File.ReadAllTextAsync(buildFingerprintFile, cancellationToken);
+            if (lastFingerprint == currentFingerprint)
+            {
+                return 0;
+            }
+        }
+
+        var exitCode = await runner.BuildAsync(projectFile, options, cancellationToken);
+
+        await File.WriteAllTextAsync(buildFingerprintFile, currentFingerprint, cancellationToken);
+
+        return exitCode;
+    }
+}

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -331,7 +331,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
     internal static string GetBackchannelSocketPath()
     {
         var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var dotnetCliPath = Path.Combine(homeDirectory, ".dotnet", "aspire", "cli", "backchannels");
+        var dotnetCliPath = Path.Combine(homeDirectory, ".aspire", "cli", "backchannels");
 
         if (!Directory.Exists(dotnetCliPath))
         {

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Microsoft.Extensions.Configuration;
+using Aspire.Cli.Builds;
 
 #if DEBUG
 using OpenTelemetry;
@@ -120,7 +121,8 @@ public class Program
         builder.Services.AddSingleton<IPublishCommandPrompter, PublishCommandPrompter>();
         builder.Services.AddSingleton<IInteractionService, InteractionService>();
         builder.Services.AddSingleton<ICertificateService, CertificateService>();
-        builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
+        builder.Services.AddSingleton<IAppHostBuilder, AppHostBuilder>();
+        builder.Services.AddSingleton<IDotNetCliRunner, DotNetCliRunner>();
         builder.Services.AddTransient<IAppHostBackchannel, AppHostBackchannel>();
         builder.Services.AddSingleton<CliRpcTarget>();
         builder.Services.AddTransient<INuGetPackageCache, NuGetPackageCache>();

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Builds;
 using Aspire.Cli.Interaction;
 using Semver;
 using System.Diagnostics;
@@ -61,13 +62,14 @@ internal static class AppHostHelper
         return appHostInformationResult;
     }
     
-    internal static async Task<int> BuildAppHostAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+    internal static async Task<int> BuildAppHostAsync(IAppHostBuilder builder, bool useCache, IInteractionService interactionService, FileInfo projectFile, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return await interactionService.ShowStatusAsync(
             ":hammer_and_wrench:  Building app host...",
-            () => runner.BuildAsync(
-                projectFile,
-                options,
-                cancellationToken));
+            () => builder.BuildAppHostAsync(
+                    projectFile,
+                    useCache,
+                    options,
+                    cancellationToken));
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -50,11 +50,25 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
             : Task.FromResult<(int, bool, string?)>((0, true, informationalVersion));
     }
 
+    private static JsonDocument GetProjectItemsAndPropertiesJsonDocument()
+    {
+        var json = $$"""
+        {
+            "CacheBuster": "{{Guid.NewGuid().ToString()}}",
+            "ProjectReference": [],
+            "PackageReference": [],
+            "Compile": []
+        }
+        """;
+
+        return JsonDocument.Parse(json);
+    }
+
     public Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return GetProjectItemsAndPropertiesAsyncCallback != null
             ? Task.FromResult(GetProjectItemsAndPropertiesAsyncCallback(projectFile, items, properties, options, cancellationToken))
-            : throw new NotImplementedException();
+            : Task.FromResult<(int, JsonDocument?)>((0, GetProjectItemsAndPropertiesJsonDocument()));
     }
 
     public Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Builds;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
@@ -29,6 +30,7 @@ internal static class CliTestHelper
 
         services.AddLogging();
 
+        services.AddSingleton(options.AppHostBuilderFactory);
         services.AddSingleton(options.AnsiConsoleFactory);
         services.AddSingleton(options.ProjectLocatorFactory);
         services.AddSingleton(options.InteractionServiceFactory);
@@ -36,7 +38,7 @@ internal static class CliTestHelper
         services.AddSingleton(options.NewCommandPrompterFactory);
         services.AddSingleton(options.AddCommandPrompterFactory);
         services.AddSingleton(options.PublishCommandPrompterFactory);
-        services.AddTransient(options.DotNetCliRunnerFactory);
+        services.AddSingleton(options.DotNetCliRunnerFactory);
         services.AddTransient(options.NuGetPackageCacheFactory);
         services.AddTransient<RootCommand>();
         services.AddTransient<NewCommand>();
@@ -51,6 +53,12 @@ internal static class CliTestHelper
 
 internal sealed class CliServiceCollectionTestOptions(ITestOutputHelper outputHelper)
 {
+    public Func<IServiceProvider, IAppHostBuilder> AppHostBuilderFactory { get; set; } = (IServiceProvider serviceProvider) => {
+        var logger = serviceProvider.GetRequiredService<ILogger<AppHostBuilder>>();
+        var runner = serviceProvider.GetRequiredService<IDotNetCliRunner>();
+        return new AppHostBuilder(logger, runner);
+    };
+
     public Func<IServiceProvider, IAnsiConsole> AnsiConsoleFactory { get; set; } = (IServiceProvider serviceProvider) =>
     {
         AnsiConsoleSettings settings = new AnsiConsoleSettings()


### PR DESCRIPTION
Fixes: #8990 

This PR introduces a build cache for the Aspire CLI. It works by first executing msbuild to get a collection of properties and items and computing a hash of that content. If the inputs to the build have not changed, then they should remain the same. If a build has successfully completed successfully previously with the same hash then we don't bother triggering a build again.

This implementation has a few problems (not quite ready yet):

- [ ] If the build completed successfully (so fingerprint created) and a `dotnet clean` is performed then the fingerprint will match but the outputs won't be available. We need to figure out  the best way of validating that build outputs are available to run.
- [x] We need to add a `--no-cache` option to both `aspire run` and `aspire publish`.
- [x] Need to update unit tests and add more test coverage for run/publish commands.


https://github.com/user-attachments/assets/8fde1e8b-e6b6-463e-afd3-1c6b4151f24b

