### PR TITLE
Add URLs to console logs actions and context menu

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -73,7 +73,8 @@ public partial class ResourceActions : ComponentBase
             OnViewDetails,
             CommandSelected,
             IsCommandExecuting,
-            showConsoleLogsItem: true);
+            showConsoleLogsItem: true,
+            showUrls: false);
 
         // If display is desktop then we display highlighted commands next to the ... button.
         if (ViewportInformation.IsDesktop)

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -355,7 +355,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                 },
                 ExecuteResourceCommandAsync,
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
-                showConsoleLogsItem: false);
+                showConsoleLogsItem: false,
+                showUrls: true);
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -531,7 +531,8 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
                 (buttonId) => ShowResourceDetailsAsync(resource, buttonId),
                 (command) => ExecuteResourceCommandAsync(resource, command),
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
-                showConsoleLogsItem: true);
+                showConsoleLogsItem: true,
+                showUrls: true);
 
             // The previous context menu should always be closed by this point but complete just in case.
             _contextMenuClosedTcs?.TrySetResult();

--- a/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
@@ -131,6 +131,8 @@ public static class ResourceMenuItems
 
             foreach (var url in urls)
             {
+                // Opens the URL in a new window when clicked.
+                // It's important that this is done in the onclick event so the browser popup allows it.
                 menuItems.Add(new MenuButtonItem
                 {
                     Text = url.Text,

--- a/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
@@ -17,6 +17,7 @@ public static class ResourceMenuItems
     private static readonly Icon s_structuredLogsIcon = new Icons.Regular.Size16.SlideTextSparkle();
     private static readonly Icon s_tracesIcon = new Icons.Regular.Size16.GanttChart();
     private static readonly Icon s_metricsIcon = new Icons.Regular.Size16.ChartMultiple();
+    private static readonly Icon s_linkIcon = new Icons.Regular.Size16.Link();
 
     public static void AddMenuItems(
         List<MenuButtonItem> menuItems,
@@ -30,7 +31,8 @@ public static class ResourceMenuItems
         Func<string?, Task> onViewDetails,
         Func<CommandViewModel, Task> commandSelected,
         Func<ResourceViewModel, CommandViewModel, bool> isCommandExecuting,
-        bool showConsoleLogsItem)
+        bool showConsoleLogsItem,
+        bool showUrls)
     {
         menuItems.Add(new MenuButtonItem
         {
@@ -112,6 +114,34 @@ public static class ResourceMenuItems
                     Icon = icon,
                     OnClick = () => commandSelected(command),
                     IsDisabled = command.State == CommandViewModelState.Disabled || isCommandExecuting(resource, command)
+                });
+            }
+        }
+
+        if (showUrls)
+        {
+            var urls = ResourceUrlHelpers.GetUrls(resource, includeInternalUrls: false, includeNonEndpointUrls: true)
+                .Where(u => !string.IsNullOrEmpty(u.Url))
+                .ToList();
+
+            if (urls.Count > 0)
+            {
+                menuItems.Add(new MenuButtonItem { IsDivider = true });
+            }
+
+            foreach (var url in urls)
+            {
+                menuItems.Add(new MenuButtonItem
+                {
+                    Text = url.Text,
+                    Tooltip = url.Url,
+                    Icon = s_linkIcon,
+                    AdditionalAttributes = new Dictionary<string, object>
+                    {
+                        ["data-openbutton"] = "true",
+                        ["data-url"] = url.Url!,
+                        ["data-target"] = "_blank"
+                    }
                 });
             }
         }

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -37,13 +37,17 @@ function getFluentMenuItemForTarget(element) {
     return null;
 }
 
-// Register a global click event listener to handle copy button clicks.
+// Register a global click event listener to handle copy/open button clicks.
 // Required because an "onclick" attribute is denied by CSP.
 document.addEventListener("click", function (e) {
     // The copy 'button' could either be a button or a menu item.
-    const targetElement = isElementTagName(e.target, "fluent-button") ? e.target : getFluentMenuItemForTarget(e.target)
-    if (targetElement && targetElement.getAttribute("data-copybutton")) {
-        buttonCopyTextToClipboard(targetElement);
+    const targetElement = isElementTagName(e.target, "fluent-button") ? e.target : getFluentMenuItemForTarget(e.target);
+    if (targetElement) {
+        if (targetElement.getAttribute("data-copybutton")) {
+            buttonCopyTextToClipboard(targetElement);
+        } else if (targetElement.getAttribute("data-openbutton")) {
+            buttonOpenLink(targetElement);
+        }
         e.stopPropagation();
     }
 });
@@ -112,6 +116,13 @@ function isScrolledToBottom(container) {
     const difference = containerScrollBottom - container.scrollTop;
 
     return difference < marginOfError;
+}
+
+window.buttonOpenLink = function (element) {
+    const url = element.getAttribute("data-url");
+    const target = element.getAttribute("data-target");
+
+    window.open(url, target, "noopener,noreferrer");
 }
 
 window.buttonCopyTextToClipboard = function(element) {


### PR DESCRIPTION
## Description

Added URLs to menus in console logs and the graph context menu. URLs open in a new window when clicked.

![image](https://github.com/user-attachments/assets/27fd1b83-c6f6-42d8-bc11-f973ace9a7ae)

![image](https://github.com/user-attachments/assets/3e2d7f29-c68e-44a2-9c7b-5de050fdfe02)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
