### PR TITLE
Update console logs rendering to skip default background color

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -471,7 +471,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                 // Console logs are filtered in the UI by the timestamp of the log entry.
                 var timestampFilterDate = GetFilteredDateFromRemove();
 
-                var logParser = new LogParser();
+                var logParser = new LogParser(ConsoleColor.Black);
                 await foreach (var batch in subscription.ConfigureAwait(true))
                 {
                     if (batch.Count is 0)

--- a/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
@@ -64,7 +64,7 @@ public class AnsiParser
         return outputBuilder?.ToString() ?? text;
     }
 
-    public static ConversionResult ConvertToHtml(string? text, ParserState? priorResidualState = null)
+    public static ConversionResult ConvertToHtml(string? text, ParserState? priorResidualState = null, ConsoleColor? defaultBackgroundColor = null)
     {
         var textStartIndex = -1;
         var textLength = 0;
@@ -147,7 +147,7 @@ public class AnsiParser
                 // Ignore everything else and don't write sequence to the output.
                 if (finalByte == DisplayAttributesFinalByte)
                 {
-                    ProcessParameters(ref newState, parameters);
+                    ProcessParameters(defaultBackgroundColor, ref newState, parameters);
                 }
 
                 continue;
@@ -197,7 +197,7 @@ public class AnsiParser
         return new(outputBuilder.ToString(), currentState);
     }
 
-    private static void ProcessParameters(ref ParserState newState, int[] parameters)
+    private static void ProcessParameters(ConsoleColor? defaultBackgroundColor, ref ParserState newState, int[] parameters)
     {
         for (var i = 0; i < parameters.Length; i++)
         {
@@ -228,7 +228,12 @@ public class AnsiParser
             }
             else if (TryGetBackgroundColor(parameter, out color))
             {
-                newState.BackgroundColor = color;
+                // Don't set the background color if it matches the default background color.
+                // Skipping setting it improves appearance when row mouseover slightly changes color.
+                if (color != defaultBackgroundColor)
+                {
+                    newState.BackgroundColor = color;
+                }
             }
             else if (parameter == DefaultBackgroundCode)
             {
@@ -516,14 +521,14 @@ public class AnsiParser
     {
         return state.ForegroundColor switch
         {
-            ConsoleColor.Black   => state.Bright ? "ansi-fg-brightblack"   : "ansi-fg-black",
-            ConsoleColor.Blue    => state.Bright ? "ansi-fg-brightblue"    : "ansi-fg-blue",
-            ConsoleColor.Cyan    => state.Bright ? "ansi-fg-brightcyan"    : "ansi-fg-cyan",
-            ConsoleColor.Green   => state.Bright ? "ansi-fg-brightgreen"   : "ansi-fg-green",
+            ConsoleColor.Black => state.Bright ? "ansi-fg-brightblack" : "ansi-fg-black",
+            ConsoleColor.Blue => state.Bright ? "ansi-fg-brightblue" : "ansi-fg-blue",
+            ConsoleColor.Cyan => state.Bright ? "ansi-fg-brightcyan" : "ansi-fg-cyan",
+            ConsoleColor.Green => state.Bright ? "ansi-fg-brightgreen" : "ansi-fg-green",
             ConsoleColor.Magenta => state.Bright ? "ansi-fg-brightmagenta" : "ansi-fg-magenta",
-            ConsoleColor.Red     => state.Bright ? "ansi-fg-brightred"     : "ansi-fg-red",
-            ConsoleColor.White   => state.Bright ? "ansi-fg-brightwhite"   : "ansi-fg-white",
-            ConsoleColor.Yellow  => state.Bright ? "ansi-fg-brightyellow"  : "ansi-fg-yellow",
+            ConsoleColor.Red => state.Bright ? "ansi-fg-brightred" : "ansi-fg-red",
+            ConsoleColor.White => state.Bright ? "ansi-fg-brightwhite" : "ansi-fg-white",
+            ConsoleColor.Yellow => state.Bright ? "ansi-fg-brightyellow" : "ansi-fg-yellow",
             _ => ""
         };
     }
@@ -532,14 +537,14 @@ public class AnsiParser
     {
         return state.BackgroundColor switch
         {
-            ConsoleColor.Black   => "ansi-bg-black",
-            ConsoleColor.Blue    => "ansi-bg-blue",
-            ConsoleColor.Cyan    => "ansi-bg-cyan",
-            ConsoleColor.Green   => "ansi-bg-green",
+            ConsoleColor.Black => "ansi-bg-black",
+            ConsoleColor.Blue => "ansi-bg-blue",
+            ConsoleColor.Cyan => "ansi-bg-cyan",
+            ConsoleColor.Green => "ansi-bg-green",
             ConsoleColor.Magenta => "ansi-bg-magenta",
-            ConsoleColor.Red     => "ansi-bg-red",
-            ConsoleColor.White   => "ansi-bg-white",
-            ConsoleColor.Yellow  => "ansi-bg-yellow",
+            ConsoleColor.Red => "ansi-bg-red",
+            ConsoleColor.White => "ansi-bg-white",
+            ConsoleColor.Yellow => "ansi-bg-yellow",
             _ => ""
         };
     }

--- a/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
@@ -230,10 +230,7 @@ public class AnsiParser
             {
                 // Don't set the background color if it matches the default background color.
                 // Skipping setting it improves appearance when row mouseover slightly changes color.
-                if (color != defaultBackgroundColor)
-                {
-                    newState.BackgroundColor = color;
-                }
+                newState.BackgroundColor = (color != defaultBackgroundColor) ? color : null;
             }
             else if (parameter == DefaultBackgroundCode)
             {

--- a/src/Aspire.Dashboard/ConsoleLogs/LogParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogParser.cs
@@ -8,7 +8,13 @@ namespace Aspire.Dashboard.ConsoleLogs;
 
 internal sealed class LogParser
 {
+    private readonly ConsoleColor _defaultBackgroundColor;
     private AnsiParser.ParserState? _residualState;
+
+    public LogParser(ConsoleColor defaultBackgroundColor)
+    {
+        _defaultBackgroundColor = defaultBackgroundColor;
+    }
 
     public LogEntry CreateLogEntry(string rawText, bool isErrorOutput)
     {
@@ -39,7 +45,7 @@ internal sealed class LogParser
             var updatedText = WebUtility.HtmlEncode(s);
 
             // 3b. Parse the content to look for ANSI Control Sequences and color them if possible
-            var conversionResult = AnsiParser.ConvertToHtml(updatedText, _residualState);
+            var conversionResult = AnsiParser.ConvertToHtml(updatedText, _residualState, _defaultBackgroundColor);
             updatedText = conversionResult.ConvertedText;
             _residualState = conversionResult.ResidualState;
 

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
@@ -18,7 +18,7 @@ public class LogEntriesTests
 
     private static void AddLogLine(LogEntries logEntries, string content, bool isError)
     {
-        var logParser = new LogParser();
+        var logParser = new LogParser(ConsoleColor.Black);
         var logEntry = logParser.CreateLogEntry(content, isError);
         logEntries.InsertSorted(logEntry);
     }
@@ -268,7 +268,7 @@ public class LogEntriesTests
     public void CreateLogEntry_AnsiAndUrl_HasUrlAnchor()
     {
         // Arrange
-        var parser = new LogParser();
+        var parser = new LogParser(ConsoleColor.Black);
 
         // Act
         var entry = parser.CreateLogEntry("\x1b[36mhttps://www.example.com\u001b[0m", isErrorOutput: false);

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
@@ -276,4 +276,19 @@ public class LogEntriesTests
         // Assert
         Assert.Equal("<span class=\"ansi-fg-cyan\"></span><a target=\"_blank\" href=\"https://www.example.com\" rel=\"noopener noreferrer nofollow\">https://www.example.com</a>", entry.Content);
     }
+
+    [Theory]
+    [InlineData(ConsoleColor.Black, @"<span class=""ansi-fg-green"">info</span>: LoggerName")]
+    [InlineData(ConsoleColor.Blue, @"<span class=""ansi-fg-green ansi-bg-black"">info</span>: LoggerName")]
+    public void CreateLogEntry_DefaultBackgroundColor_SkipMatchingColor(ConsoleColor defaultBackgroundColor, string output)
+    {
+        // Arrange
+        var parser = new LogParser(defaultBackgroundColor);
+
+        // Act
+        var entry = parser.CreateLogEntry("\u001b[40m\u001b[32minfo\u001b[39m\u001b[22m\u001b[49m: LoggerName", isErrorOutput: false);
+
+        // Assert
+        Assert.Equal(output, entry.Content);
+    }
 }


### PR DESCRIPTION
## Description

I noticed that `info` in logs had an explicit black background which you could see when hovering over a row. `info` would have a black background that would be different to the rest of the hovered row.

The fix is to add the idea of a default background color and explicit background that matches is skipped (i.e. black on black is converted to transparent)

After:
![image](https://github.com/user-attachments/assets/0072fc22-4c23-4838-af15-c8d31f5750eb)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
