### PR TITLE
Do not override test log output

### DIFF
--- a/eng/Xunit3/Microsoft.Testing.Platform.targets
+++ b/eng/Xunit3/Microsoft.Testing.Platform.targets
@@ -37,7 +37,7 @@
         Redirect std output of the runner.
         Note that xUnit outputs failure info to both STDOUT (stack trace, message) and STDERR (failed test name)
       -->
-      <_TestRunnerCommand Condition="'$(TestCaptureOutput)' != 'false'">$(_TestRunnerCommand) > "%(TestToRun.ResultsStdOutPath)" 2>&amp;1</_TestRunnerCommand>
+      <_TestRunnerCommand Condition="'$(TestCaptureOutput)' != 'false'">$(_TestRunnerCommand) >> "%(TestToRun.ResultsStdOutPath)" 2>&amp;1</_TestRunnerCommand>
     </PropertyGroup>
 
     <ItemGroup>
@@ -54,7 +54,7 @@
     -->
     <WriteLinesToFile File="%(TestToRun.ResultsStdOutPath)"
                       Overwrite="false"
-                      Lines=";=== COMMAND LINE ===;$(_TestRunnerCommand)"
+                      Lines=";=== COMMAND LINE ===;$(_TestRunnerCommand);=== END COMMAND LINE ===;%20;"
                       Condition="'$(TestCaptureOutput)' != 'false'" />
 
     <Message Text="Running tests: $(_TestAssembly) [$(_TestEnvironment)]" Importance="high"/>


### PR DESCRIPTION
Currently the test output stomps over the existing log. Restoring the correct behaviour.
Add a new line for better presentation (by adding a space).


### Before
![image](https://github.com/user-attachments/assets/856d5090-ba07-4d20-8205-b45deb3448b1)


### After
![image](https://github.com/user-attachments/assets/37fd5bdf-6d9c-4c16-88f1-8a7243425568)
