### PR TITLE
Turn on MTP and solution free workspace mode.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "dotnet.previewSolution-freeWorkspaceMode": true,
+    "dotnet.testWindow.useTestingPlatformProtocol": true
+}


### PR DESCRIPTION
We turned on MTP last week, the workspace needs this setting to enable test detection. Also enabling solution free workspace mode since DevKit creating random solution files breaks stuff.