### PR TITLE
Position the context menu inside the screen bounds

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -3,7 +3,7 @@
 @using Aspire.Dashboard.Model
 @inherits FluentComponentBase
 
-<FluentMenu @ref="_menu" Anchor="@Anchor" Anchored="@Anchored" Open="@Open" OpenChanged="OnOpenChanged" Style="@Style" VerticalThreshold="200" HorizontalThreshold="200">
+<FluentMenu @ref="_menu" Anchor="@Anchor" Anchored="@Anchored" Open="@Open" OpenChanged="OnOpenChanged" Style="@Style" VerticalThreshold="@VerticalThreshold" HorizontalThreshold="200">
     @foreach (var item in Items)
     {
         @if (item.IsDivider)

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -3,7 +3,7 @@
 @using Aspire.Dashboard.Model
 @inherits FluentComponentBase
 
-<FluentMenu @ref="_menu" Anchor="@Anchor" Anchored="@Anchored" Open="@Open" OpenChanged="OnOpenChanged" VerticalThreshold="200">
+<FluentMenu @ref="_menu" Anchor="@Anchor" Anchored="@Anchored" Open="@Open" OpenChanged="OnOpenChanged" Style="@Style" VerticalThreshold="200" HorizontalThreshold="200">
     @foreach (var item in Items)
     {
         @if (item.IsDivider)

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -21,6 +21,9 @@ public partial class AspireMenu : FluentComponentBase
     [Parameter]
     public bool Anchored { get; set; } = true;
 
+    [Parameter]
+    public int VerticalThreshold { get; set; } = 200;
+
     /// <summary>
     /// Raised when the <see cref="Open"/> property changed.
     /// </summary>

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -43,7 +43,7 @@ public partial class AspireMenu : FluentComponentBase
 
     public async Task OpenAsync(int screenWidth, int screenHeight, int clientX, int clientY)
     {
-        if (_menu is not null)
+        if (_menu is { } menu)
         {
             // Calculate the position to display the context menu using the cursor position (clientX, clientY)
             // together with the screen width and height.
@@ -53,7 +53,7 @@ public partial class AspireMenu : FluentComponentBase
             var top = 0;
             var bottom = 0;
 
-            if (clientX + _menu.HorizontalThreshold > screenWidth)
+            if (clientX + menu.HorizontalThreshold > screenWidth)
             {
                 right = screenWidth - clientX;
             }
@@ -62,7 +62,7 @@ public partial class AspireMenu : FluentComponentBase
                 left = clientX;
             }
 
-            if (clientY + _menu.VerticalThreshold > screenHeight)
+            if (clientY + menu.VerticalThreshold > screenHeight)
             {
                 bottom = screenHeight - clientY;
             }

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace Aspire.Dashboard.Components;
 
@@ -37,11 +38,51 @@ public partial class AspireMenu : FluentComponentBase
         }
     }
 
-    public async Task OpenAsync(int clientX, int clientY)
+    public async Task OpenAsync(int screenWidth, int screenHeight, int clientX, int clientY)
     {
-        if (_menu is { } menu)
+        if (_menu is not null)
         {
-            await menu.OpenAsync(clientX, clientY);
+            // Calculate the position to display the context menu using the cursor position (clientX, clientY)
+            // together with the screen width and height.
+            // The menu may need to be displayed above or left of the cursor to fit in the screen.
+            var left = 0;
+            var right = 0;
+            var top = 0;
+            var bottom = 0;
+
+            if (clientX + _menu.HorizontalThreshold > screenWidth)
+            {
+                right = screenWidth - clientX;
+            }
+            else
+            {
+                left = clientX;
+            }
+
+            if (clientY + _menu.VerticalThreshold > screenHeight)
+            {
+                bottom = screenHeight - clientY;
+            }
+            else
+            {
+                top = clientY;
+            }
+
+            Style = string.Empty;
+            Style = new StyleBuilder(Style)
+                .AddStyle("left", $"{left}px", left != 0)
+                .AddStyle("right", $"{right}px", right != 0)
+                .AddStyle("top", $"{top}px", top != 0)
+                .AddStyle("bottom", $"{bottom}px", bottom != 0)
+                .Build();
+
+            Open = true;
+            if (OpenChanged.HasDelegate)
+            {
+                await OpenChanged.InvokeAsync(Open);
+            }
+
+            StateHasChanged();
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -71,8 +71,8 @@ public partial class AspireMenu : FluentComponentBase
                 top = clientY;
             }
 
-            Style = string.Empty;
-            Style = new StyleBuilder(Style)
+            // Overwrite the style. We don't want to add new position values each time the menu is opened.
+            Style = new StyleBuilder()
                 .AddStyle("left", $"{left}px", left != 0)
                 .AddStyle("right", $"{right}px", right != 0)
                 .AddStyle("top", $"{top}px", top != 0)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -223,7 +223,7 @@
                         </div>
                     </div>
                     <FluentOverlay @bind-Visible="_contextMenuOpen" OnClose="ContextMenuClosed" Transparent="true" FullScreen="true" />
-                    <AspireMenu @bind-Open="_contextMenuOpen" @ref="_contextMenu" Anchor="resources-summary-layout-id" Anchored="false" Items="_contextMenuItems" />
+                    <AspireMenu @bind-Open="_contextMenuOpen" @ref="_contextMenu" Anchor="resources-summary-layout-id" Anchored="false" Items="_contextMenuItems" VerticalThreshold="300" />
                 </Summary>
                 <Details>
                     <ResourceDetails Resource="context" ResourceByName="_resourceByName" ShowSpecOnlyToggle="true" />

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -353,13 +353,13 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
         }
 
         [JSInvokable]
-        public async Task ResourceContextMenu(string id, int clientX, int clientY)
+        public async Task ResourceContextMenu(string id, int screenWidth, int screenHeight, int clientX, int clientY)
         {
             if (resources._resourceByName.TryGetValue(id, out var resource))
             {
                 await resources.InvokeAsync(async () =>
                 {
-                    await resources.ShowContextMenuAsync(resource, clientX, clientY);
+                    await resources.ShowContextMenuAsync(resource, screenWidth, screenHeight, clientX, clientY);
                 });
             }
         }
@@ -511,7 +511,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
         return false;
     }
 
-    private async Task ShowContextMenuAsync(ResourceViewModel resource, int clientX, int clientY)
+    private async Task ShowContextMenuAsync(ResourceViewModel resource, int screenWidth, int screenHeight, int clientX, int clientY)
     {
         // This is called when the browser requests to show the context menu for a resource.
         // The method doesn't complete until the context menu is closed so the browser can await
@@ -539,7 +539,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable, IPageWithSessi
 
             _contextMenuClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            await contextMenu.OpenAsync(clientX, clientY);
+            await contextMenu.OpenAsync(screenWidth, screenHeight, clientX, clientY);
             StateHasChanged();
 
             // Completed when the overlay closes.

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -483,7 +483,7 @@ class ResourceGraph {
 
         try {
             // Wait for method completion. It completes when the context menu is closed.
-            await this.resourcesInterop.invokeMethodAsync('ResourceContextMenu', data.id, event.clientX, event.clientY);
+            await this.resourcesInterop.invokeMethodAsync('ResourceContextMenu', data.id, window.innerWidth, window.innerHeight, event.clientX, event.clientY);
         } finally {
             this.openContextMenu = false;
 


### PR DESCRIPTION
## Description

Use screen size to calculate the position of the context menu. Can now be displayed to the left or above the cursor.

![image](https://github.com/user-attachments/assets/64bb3439-5582-4555-9e44-3ee975ce477e)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
