### PR TITLE
[release/9.2]: Ensure visible trace spans stay sorted by start time

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -76,7 +76,8 @@ public partial class TraceDetail : ComponentBase, IDisposable
         }
     }
 
-    private ValueTask<GridItemsProviderResult<SpanWaterfallViewModel>> GetData(GridItemsProviderRequest<SpanWaterfallViewModel> request)
+    // Internal to be used in unit tests
+    internal ValueTask<GridItemsProviderResult<SpanWaterfallViewModel>> GetData(GridItemsProviderRequest<SpanWaterfallViewModel> request)
     {
         Debug.Assert(_spanWaterfallViewModels != null);
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -80,7 +80,7 @@ public partial class TraceDetail : ComponentBase, IDisposable
     {
         Debug.Assert(_spanWaterfallViewModels != null);
 
-        var visibleViewModels = new HashSet<SpanWaterfallViewModel>();
+        var visibleViewModels = new SortedSet<SpanWaterfallViewModel>(Comparer<SpanWaterfallViewModel>.Create((a, b) => a.Span.StartTime.CompareTo(b.Span.StartTime)));
         foreach (var viewModel in _spanWaterfallViewModels)
         {
             if (!viewModel.IsHidden && viewModel.MatchesFilter(_filter, GetResourceName, out var matchedDescendents))

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -137,6 +137,62 @@ public partial class TraceDetailsTests : DashboardTestContext
         await AsyncTestHelpers.AssertIsTrueRetryAsync(() => rows.Count == 2, "Expected rows to be rendered.");
     }
 
+    [Fact]
+    public async Task Render_SpansOrderedByStartTime_RowsRenderedInCorrectOrder()
+    {
+        // Arrange
+        SetupTraceDetailsServices();
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+        telemetryRepository.AddTraces(new AddContext(),
+            new RepeatedField<ResourceSpans>
+            {
+                new ResourceSpans
+                {
+                    Resource = CreateResource(),
+                    ScopeSpans =
+                    {
+                        new ScopeSpans
+                        {
+                            Scope = CreateScope(),
+                            Spans =
+                            {
+                                CreateSpan(traceId: "1", spanId: "1-1",
+                                    startTime: s_testTime.AddMinutes(1),
+                                    endTime: s_testTime.AddMinutes(10)),
+                                CreateSpan(traceId: "1", spanId: "1-2",
+                                    startTime: s_testTime.AddMinutes(5),
+                                    endTime: s_testTime.AddMinutes(10), parentSpanId: "1-1"),
+                                CreateSpan(traceId: "1", spanId: "1-3",
+                                    startTime: s_testTime.AddMinutes(2),
+                                    endTime: s_testTime.AddMinutes(6), parentSpanId: "1-1")
+                            }
+                        }
+                    }
+                }
+            });
+
+        // Act
+        var traceId = Convert.ToHexString(Encoding.UTF8.GetBytes("1"));
+        var cut = RenderComponent<TraceDetail>(builder =>
+        {
+            builder.Add(p => p.TraceId, traceId);
+            builder.AddCascadingValue(viewport);
+        });
+
+        var data = await cut.Instance.GetData(new GridItemsProviderRequest<SpanWaterfallViewModel>());
+
+        Assert.Collection(data.Items,
+            item => Assert.Equal("Test span. Id: 1-1", item.Span.Name),
+            item => Assert.Equal("Test span. Id: 1-3", item.Span.Name),
+            item => Assert.Equal("Test span. Id: 1-2", item.Span.Name));
+    }
+
     private void SetupTraceDetailsServices()
     {
         var version = typeof(FluentMain).Assembly.GetName().Version!;


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspire/pull/8771 to release/9.2

Customer Impact
This PR changes the dashboard trace detail data provider to replace an unordered data structure with an ordered one w/comparer to ensure that span ordering by time is preserved.

Testing
A unit test has been added and a diff is included in the original PR if manual testing is desired as well.

Risk
This is a small, isolated, tested change where the root cause is well understood.

Regression?
Yes