### PR TITLE
Hide keycloak management URL from summary

### DIFF
--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -69,7 +69,8 @@ public static class KeycloakResourceBuilderExtensions
                 context.EnvironmentVariables[AdminEnvVarName] = resource.AdminReference;
                 context.EnvironmentVariables[AdminPasswordEnvVarName] = resource.AdminPasswordParameter;
                 context.EnvironmentVariables[HealthCheckEnvVarName] = "true";
-            });
+            })
+            .WithUrlForEndpoint(ManagementEndpointName, u => u.DisplayLocation = UrlDisplayLocation.DetailsOnly);
 
         if (builder.ExecutionContext.IsRunMode)
         {


### PR DESCRIPTION
## Description

Following up on changes from #8743, hides `Keycloak`'s management URL from summary,

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
- Did you add public API?
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] No

/cc @DamianEdwards @davidfowl 