### PR TITLE
[CI] Switch to using Ubuntu 22.04 from 20.04

### DIFF
--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -146,7 +146,7 @@ stages:
 
           pool:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals build.ubuntu.2004.amd64.open
+            demands: ImageOverride -equals build.ubuntu.2204.amd64.open
 
           variables:
             - name: _buildScript


### PR DESCRIPTION
Ubuntu 2004 image has been deprecated, and will be completely removed on
April 30 2025.

Fixes issue https://github.com/dotnet/aspire/issues/8186
