### PR TITLE
Fix AE in ExecutableResource

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="command">The command to execute.</param>
-/// <param name="workingDirectory">The working directory of the executable. Can be empty.</param>
+/// <param name="workingDirectory">The working directory of the executable.</param>
 public class ExecutableResource(string name, string command, string workingDirectory)
     : Resource(name), IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints, IResourceWithWaitSupport
 {
@@ -23,7 +23,7 @@ public class ExecutableResource(string name, string command, string workingDirec
     /// <summary>
     /// Gets the working directory for the executable resource.
     /// </summary>
-    public string WorkingDirectory { get; } = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
+    public string WorkingDirectory { get; } = ThrowIfNullOrEmpty(workingDirectory);
 
     private static string ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="command">The command to execute.</param>
-/// <param name="workingDirectory">The working directory of the executable.</param>
+/// <param name="workingDirectory">The working directory of the executable. Can be empty.</param>
 public class ExecutableResource(string name, string command, string workingDirectory)
     : Resource(name), IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints, IResourceWithWaitSupport
 {
@@ -23,7 +23,7 @@ public class ExecutableResource(string name, string command, string workingDirec
     /// <summary>
     /// Gets the working directory for the executable resource.
     /// </summary>
-    public string WorkingDirectory { get; } = ThrowIfNullOrEmpty(workingDirectory);
+    public string WorkingDirectory { get; } = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory));
 
     private static string ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {

--- a/tests/Aspire.Hosting.NodeJs.Tests/NodeJsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/NodeJsPublicApiTests.cs
@@ -42,20 +42,16 @@ public class NodeJsPublicApiTests
         Assert.Equal(nameof(command), exception.ParamName);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void CtorNodeAppResourceShouldThrowWhenWorkingDirectoryIsNullOrEmpty(bool isNull)
+    [Fact]
+    public void CtorNodeAppResourceShouldThrowWhenWorkingDirectoryIsNull()
     {
         const string name = "NodeApp";
         const string command = "npm";
-        var workingDirectory = isNull ? null! : string.Empty;
+        string workingDirectory = null!;
 
         var action = () => new NodeAppResource(name, command, workingDirectory);
 
-        var exception = isNull
-            ? Assert.Throws<ArgumentNullException>(action)
-            : Assert.Throws<ArgumentException>(action);
+        var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(workingDirectory), exception.ParamName);
     }
 
@@ -136,20 +132,16 @@ public class NodeJsPublicApiTests
         Assert.Equal(nameof(name), exception.ParamName);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void AddNpmAppShouldThrowWhenWorkingDirectoryIsNullOrEmpty(bool isNull)
+    [Fact]
+    public void AddNpmAppShouldThrowWhenWorkingDirectoryIsNull()
     {
         var builder = TestDistributedApplicationBuilder.Create();
         const string name = "NpmApp";
-        var workingDirectory = isNull ? null! : string.Empty;
+        string workingDirectory = null!;
 
         var action = () => builder.AddNpmApp(name, workingDirectory);
 
-        var exception = isNull
-             ? Assert.Throws<ArgumentNullException>(action)
-             : Assert.Throws<ArgumentException>(action);
+        var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(workingDirectory), exception.ParamName);
     }
 

--- a/tests/Aspire.Hosting.NodeJs.Tests/NodeJsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/NodeJsPublicApiTests.cs
@@ -42,16 +42,20 @@ public class NodeJsPublicApiTests
         Assert.Equal(nameof(command), exception.ParamName);
     }
 
-    [Fact]
-    public void CtorNodeAppResourceShouldThrowWhenWorkingDirectoryIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorNodeAppResourceShouldThrowWhenWorkingDirectoryIsNullOrEmpty(bool isNull)
     {
         const string name = "NodeApp";
         const string command = "npm";
-        string workingDirectory = null!;
+        var workingDirectory = isNull ? null! : string.Empty;
 
         var action = () => new NodeAppResource(name, command, workingDirectory);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(workingDirectory), exception.ParamName);
     }
 
@@ -132,16 +136,20 @@ public class NodeJsPublicApiTests
         Assert.Equal(nameof(name), exception.ParamName);
     }
 
-    [Fact]
-    public void AddNpmAppShouldThrowWhenWorkingDirectoryIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddNpmAppShouldThrowWhenWorkingDirectoryIsNullOrEmpty(bool isNull)
     {
         var builder = TestDistributedApplicationBuilder.Create();
         const string name = "NpmApp";
-        string workingDirectory = null!;
+        var workingDirectory = isNull ? null! : string.Empty;
 
         var action = () => builder.AddNpmApp(name, workingDirectory);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+             ? Assert.Throws<ArgumentNullException>(action)
+             : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(workingDirectory), exception.ParamName);
     }
 

--- a/tests/Aspire.Hosting.Python.Tests/PythonPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/PythonPublicApiTests.cs
@@ -42,20 +42,15 @@ public class PythonPublicApiTests
         Assert.Equal("command", exception.ParamName);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void CtorPythonAppResourceShouldThrowWhenAppDirectoryIsNullOrEmpty(bool isNull)
+    [Fact]
+    public void CtorPythonAppResourceShouldThrowWhenAppDirectoryIsNull()
     {
         const string name = "Python";
         const string executablePath = "/src/python";
-        var appDirectory = isNull ? null! : string.Empty;
 
-        var action = () => new PythonAppResource(name, executablePath, appDirectory);
+        var action = () => new PythonAppResource(name, executablePath, appDirectory: null!);
 
-        var exception = isNull
-            ? Assert.Throws<ArgumentNullException>(action)
-            : Assert.Throws<ArgumentException>(action);
+        var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal("workingDirectory", exception.ParamName);
     }
 
@@ -379,21 +374,16 @@ public class PythonPublicApiTests
         Assert.Equal("command", exception.ParamName);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
+    [Fact]
     [Obsolete("PythonProjectResource is deprecated. Please use PythonAppResource instead.")]
-    public void CtorPythonProjectResourceShouldThrowWhenAppDirectoryIsNullOrEmpty(bool isNull)
+    public void CtorPythonProjectResourceShouldThrowWhenAppDirectoryIsNull()
     {
         const string name = "Python";
         const string executablePath = "/src/python";
-        var projectDirectory = isNull ? null! : string.Empty;
 
-        var action = () => new PythonProjectResource(name, executablePath, projectDirectory);
+        var action = () => new PythonProjectResource(name, executablePath, projectDirectory: null!);
 
-        var exception = isNull
-            ? Assert.Throws<ArgumentNullException>(action)
-            : Assert.Throws<ArgumentException>(action);
+        var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal("workingDirectory", exception.ParamName);
     }
 

--- a/tests/Aspire.Hosting.Python.Tests/PythonPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/PythonPublicApiTests.cs
@@ -42,15 +42,20 @@ public class PythonPublicApiTests
         Assert.Equal("command", exception.ParamName);
     }
 
-    [Fact]
-    public void CtorPythonAppResourceShouldThrowWhenAppDirectoryIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorPythonAppResourceShouldThrowWhenAppDirectoryIsNullOrEmpty(bool isNull)
     {
         const string name = "Python";
         const string executablePath = "/src/python";
+        var appDirectory = isNull ? null! : string.Empty;
 
-        var action = () => new PythonAppResource(name, executablePath, appDirectory: null!);
+        var action = () => new PythonAppResource(name, executablePath, appDirectory);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
         Assert.Equal("workingDirectory", exception.ParamName);
     }
 
@@ -374,16 +379,21 @@ public class PythonPublicApiTests
         Assert.Equal("command", exception.ParamName);
     }
 
-    [Fact]
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
     [Obsolete("PythonProjectResource is deprecated. Please use PythonAppResource instead.")]
-    public void CtorPythonProjectResourceShouldThrowWhenAppDirectoryIsNull()
+    public void CtorPythonProjectResourceShouldThrowWhenAppDirectoryIsNullOrEmpty(bool isNull)
     {
         const string name = "Python";
         const string executablePath = "/src/python";
+        var projectDirectory = isNull ? null! : string.Empty;
 
-        var action = () => new PythonProjectResource(name, executablePath, projectDirectory: null!);
+        var action = () => new PythonProjectResource(name, executablePath, projectDirectory);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
         Assert.Equal("workingDirectory", exception.ParamName);
     }
 

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -10,6 +10,7 @@ namespace Aspire.Hosting.Tests;
 
 public class ExecutableResourceTests
 {
+    // comment to trigger build
     [Fact]
     public async Task AddExecutableWithArgs()
     {
@@ -80,25 +81,6 @@ public class ExecutableResourceTests
         """;
 
         Assert.Equal(expectedManifest, manifest.ToString());
-    }
-
-    [Fact]
-    public void ExecutableResourceNullCommand()
-        => Assert.Throws<ArgumentNullException>("command", () => new ExecutableResource("name", command: null!, workingDirectory: "."));
-
-    [Fact]
-    public void ExecutableResourceEmptyCommand()
-        => Assert.Throws<ArgumentException>("command", () => new ExecutableResource("name", command: "", workingDirectory: "."));
-
-    [Fact]
-    public void ExecutableResourceNullWorkingDirectory()
-        => Assert.Throws<ArgumentNullException>("workingDirectory", () => new ExecutableResource("name", command: "cmd", workingDirectory: null!));
-
-    [Fact]
-    public void ExecutableResourceEmptyWorkingDirectory()
-    {
-        var er = new ExecutableResource("name", command: "cmd", workingDirectory: "");
-        Assert.Empty(er.WorkingDirectory);
     }
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -82,6 +82,25 @@ public class ExecutableResourceTests
         Assert.Equal(expectedManifest, manifest.ToString());
     }
 
+    [Fact]
+    public void ExecutableResourceNullCommand()
+        => Assert.Throws<ArgumentNullException>("command", () => new ExecutableResource("name", command: null!, workingDirectory: "."));
+
+    [Fact]
+    public void ExecutableResourceEmptyCommand()
+        => Assert.Throws<ArgumentException>("command", () => new ExecutableResource("name", command: "", workingDirectory: "."));
+
+    [Fact]
+    public void ExecutableResourceNullWorkingDirectory()
+        => Assert.Throws<ArgumentNullException>("workingDirectory", () => new ExecutableResource("name", command: "cmd", workingDirectory: null!));
+
+    [Fact]
+    public void ExecutableResourceEmptyWorkingDirectory()
+    {
+        var er = new ExecutableResource("name", command: "cmd", workingDirectory: "");
+        Assert.Empty(er.WorkingDirectory);
+    }
+
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
         public ReferenceExpression ConnectionStringExpression =>

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -10,7 +10,6 @@ namespace Aspire.Hosting.Tests;
 
 public class ExecutableResourceTests
 {
-    // comment to trigger build
     [Fact]
     public async Task AddExecutableWithArgs()
     {


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/8732

We made the same 9.1->9.2 break in the Command property also but I think that should be maintained since Process.Start requires one (unless there's a Windows shell style verb, which we don't use)

I looked through the [original change ](https://github.com/dotnet/aspire/commit/22d5ec4c07d614c6b5551acf95df4fa9b575d144#diff-c1fff1268af848145409d984d2b73e685934ed339bb7c4b3dc8a9867d16d714d) and found no other examples of empty string becoming disallowed beyond these two

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
