### PR TITLE
Don't fail for Azure role assignments in run mode

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -190,6 +190,19 @@ internal sealed class AzureResourcePreparer(
                     }
                 }
             }
+
+            if (executionContext.IsRunMode)
+            {
+                // in RunMode, any Azure resources that are not referenced by a compute resource should have their default role assignments applied
+                foreach (var azureResource in azureResources.Select(r => r.AzureResource).OfType<AzureProvisioningResource>())
+                {
+                    if (!globalRoleAssignments.TryGetValue(azureResource, out _) &&
+                        azureResource.TryGetLastAnnotation<DefaultRoleAssignmentsAnnotation>(out var defaultRoleAssignments))
+                    {
+                        AppendGlobalRoleAssignments(globalRoleAssignments, azureResource, defaultRoleAssignments.Roles);
+                    }
+                }
+            }
         }
 
         if (globalRoleAssignments.Count > 0)

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -30,7 +30,7 @@ internal sealed class AzureResourcePreparer(
         }
 
         var options = provisioningOptions.Value;
-        if (!options.SupportsTargetedRoleAssignments)
+        if (!EnvironmentSupportsTargetedRoleAssignments(options))
         {
             // If the app infrastructure does not support targeted role assignments, then we need to ensure that
             // there are no role assignment annotations in the app model because they won't be honored otherwise.
@@ -79,6 +79,13 @@ internal sealed class AzureResourcePreparer(
         return azureResources;
     }
 
+    private bool EnvironmentSupportsTargetedRoleAssignments(AzureProvisioningOptions options)
+    {
+        // run mode always supports targeted role assignments
+        // publish mode only supports targeted role assignments if the environment supports it
+        return executionContext.IsRunMode || options.SupportsTargetedRoleAssignments;
+    }
+
     private static void EnsureNoRoleAssignmentAnnotations(DistributedApplicationModel appModel)
     {
         foreach (var resource in appModel.Resources)
@@ -94,7 +101,7 @@ internal sealed class AzureResourcePreparer(
     {
         var globalRoleAssignments = new Dictionary<AzureProvisioningResource, HashSet<RoleDefinition>>();
 
-        if (!options.SupportsTargetedRoleAssignments)
+        if (!EnvironmentSupportsTargetedRoleAssignments(options))
         {
             // when the app infrastructure doesn't support targeted role assignments, just copy all the default role assignments to applied role assignments
             foreach (var resource in azureResources.Select(r => r.AzureResource).OfType<AzureProvisioningResource>())

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -13,10 +13,12 @@ namespace Aspire.Hosting.Azure.Tests;
 
 public class AzureResourcePreparerTests(ITestOutputHelper output)
 {
-    [Fact]
-    public void ThrowsExceptionsIfRoleAssignmentUnsupported()
+    [Theory]
+    [InlineData(DistributedApplicationOperation.Publish)]
+    [InlineData(DistributedApplicationOperation.Run)]
+    public async Task ThrowsExceptionsIfRoleAssignmentUnsupported(DistributedApplicationOperation operation)
     {
-        using var builder = TestDistributedApplicationBuilder.Create();
+        using var builder = TestDistributedApplicationBuilder.Create(operation);
 
         var storage = builder.AddAzureStorage("storage");
 
@@ -25,8 +27,16 @@ public class AzureResourcePreparerTests(ITestOutputHelper output)
 
         var app = builder.Build();
 
-        var ex = Assert.Throws<InvalidOperationException>(app.Start);
-        Assert.Contains("role assignments", ex.Message);
+        if (operation == DistributedApplicationOperation.Publish)
+        {
+            var ex = Assert.Throws<InvalidOperationException>(app.Start);
+            Assert.Contains("role assignments", ex.Message);
+        }
+        else
+        {
+            await app.StartAsync();
+            // no exception is thrown in Run mode
+        }
     }
 
     [Theory]


### PR DESCRIPTION
## Description

We are throwing too early. When users only want to dotnet run their app and use role assignments, we shouldn't be blocking them on using role assignments. Only when you go to publish, should we throw saying that your infrastructure doesn't support targeted role assignments.

Fix #8778

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
