### PR TITLE
Revert "Migrate from VSTest to Microsoft.Testing.Platform (#8498)"

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,10 +13,10 @@ on:
         # relative the repo root
         required: false
         type: string
-      testSessionTimeout:
+      testSessionTimeoutMs:
         required: false
         type: string
-        default: "15m"
+        default: "900000"
       testHangTimeout:
         required: false
         type: string
@@ -220,14 +220,18 @@ jobs:
           TEST_LOG_PATH: ${{ github.workspace }}/artifacts/log/test-logs
           TestsRunningOutsideOfRepo: true
         run: >
-          dotnet ${{ env.TEST_ASSEMBLY_NAME }}.dll
-          --report-trx --report-trx-filename "${{ inputs.testShortName }}.trx"
-          --hangdump --hangdump-timeout ${{ inputs.testHangTimeout }}
-          --crashdump
+          dotnet test -s .runsettings -v:n ${{ env.TEST_ASSEMBLY_NAME }}.dll
+          -l "console;verbosity=normal"
+          -l "trx;LogFilePrefix=${{ inputs.testShortName }}"
+          -l "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+          --blame
+          --blame-hang-timeout ${{ inputs.testHangTimeout }}
+          --blame-crash
           --results-directory ${{ github.workspace }}/testresults
-          --filter-not-trait "category=failing"
-          --timeout ${{ inputs.testSessionTimeout }}
           ${{ inputs.extraTestArgs }}
+          --
+          RunConfiguration.CollectSourceInformation=true
+          RunConfiguration.TestSessionTimeout=${{ inputs.testSessionTimeoutMs }}
 
       - name: Run tests
         if: ${{ ! inputs.requiresNugets }}
@@ -236,24 +240,24 @@ jobs:
           CI: false
           DCP_DIAGNOSTICS_LOG_LEVEL: debug
           DCP_DIAGNOSTICS_LOG_FOLDER: ${{ github.workspace }}/testresults/dcp
-          # During restore and build, we use -ci, which causes NUGET_PACKAGES to point to a local cache (Arcade behavior).
-          # In this step, we are not using Arcade, but want to make sure that MSBuild is able to evaluate correctly.
-          # So, we manually set NUGET_PACKAGES
-          NUGET_PACKAGES: ${{ github.workspace }}/.packages
         run: >
           ${{ env.DOTNET_SCRIPT }} test ${{ env.TEST_PROJECT_PATH }}
           /p:ContinuousIntegrationBuild=true
-          /p:TrxFileNamePrefix="${{ inputs.testShortName }}"
-          -bl:${{ github.workspace }}/testresults/test.binlog
+          -s eng/testing/.runsettings
+          -l "console;verbosity=normal"
+          -l "trx;LogFilePrefix=${{ inputs.testShortName }}"
+          -l "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+          "--blame"
+          --blame-hang-timeout ${{ inputs.testHangTimeout }}
+          --blame-crash
+          --results-directory testresults
           --no-restore
           --no-build
-          --
-          --report-trx
-          --hangdump --hangdump-timeout ${{ inputs.testHangTimeout }}
-          --crashdump
-          --results-directory ${{ github.workspace }}/testresults
-          --timeout ${{ inputs.testSessionTimeout }}
+          -bl:${{ github.workspace }}/testresults/test.binlog
           ${{ inputs.extraTestArgs }}
+          --
+          RunConfiguration.CollectSourceInformation=true
+          RunConfiguration.TestSessionTimeout=${{ inputs.testSessionTimeoutMs }}
 
       # Save the result of the previous steps - success or failure
       # in the form of a file result-success/result-failure -{name}.rst

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
     with:
       testShortName: ${{ matrix.shortname }}
       os: "ubuntu-latest"
-      extraTestArgs: "--filter-not-trait \"quarantined=true\""
+      extraTestArgs: "--filter \"(quarantined!=true)\""
 
   integrations_test_win:
     uses: ./.github/workflows/run-tests.yml
@@ -90,7 +90,7 @@ jobs:
     with:
       testShortName: ${{ matrix.shortname }}
       os: "windows-latest"
-      extraTestArgs: "--filter-not-trait \"quarantined=true\""
+      extraTestArgs: "--filter \"(quarantined!=true)\""
 
   templates_test_lin:
     name: Templates Linux
@@ -103,9 +103,10 @@ jobs:
       testShortName: ${{ matrix.shortname }}
       os: "ubuntu-latest"
       testProjectPath: tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
-      testSessionTimeout: 20m
+      testSessionTimeoutMs: 1200000
       testHangTimeout: 12m
-      extraTestArgs: "--filter-not-trait quarantined=true --filter-class Aspire.Templates.Tests.${{ matrix.shortname }}"
+      # append '.' to the name so only the test class with exactly that name is run
+      extraTestArgs: "--filter \"(quarantined!=true)&(FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}.)\""
       requiresNugets: true
       requiresTestSdk: true
 
@@ -120,9 +121,10 @@ jobs:
       testShortName: ${{ matrix.shortname }}
       os: "windows-latest"
       testProjectPath: tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
-      testSessionTimeout: 20m
+      testSessionTimeoutMs: 1200000
       testHangTimeout: 12m
-      extraTestArgs: "--filter-not-trait quarantined=true --filter-class Aspire.Templates.Tests.${{ matrix.shortname }}"
+      # append '.' to the name so only the test class with exactly that name is run
+      extraTestArgs: "--filter \"(quarantined!=true)&(FullyQualifiedName~Aspire.Templates.Tests.${{ matrix.shortname }}.)\""
       requiresNugets: true
       requiresTestSdk: true
 

--- a/eng/.runsettings
+++ b/eng/.runsettings
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Filter out failing (wrong framework, platform, runtime or activeissue) tests -->
+    <TestCaseFilter>category!=failing</TestCaseFilter>
+  </RunConfiguration>
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="trx" />
+      <Logger friendlyName="html" />
+      <Logger friendlyName="console">
+        <Configuration>
+          <Verbosity>Minimal</Verbosity>
+        </Configuration>
+      </Logger>
+    </Loggers>
+    <Logger friendlyName="blame" enabled="True" />
+  </LoggerRunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <!-- Enables blame -->
+      <DataCollector friendlyName="blame" enabled="True">
+        <Configuration>
+          <!-- Enables crash dump, with dump type "Full" or "Mini". -->
+          <CollectDump DumpType="Full" />
+          <!-- Enables hang dump or testhost and its child processes
+          when a test hangs for more than 10 minutes. -->
+          <CollectDumpOnTestSessionHang TestTimeout="10min" HangDumpType="Full" />
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
+++ b/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
@@ -58,13 +58,14 @@
     <PropertyGroup>
       <_TestEnvironment>%(TestToRun.EnvironmentDisplay)</_TestEnvironment>
       <_TestAssembly>%(TestToRun.Identity)</_TestAssembly>
-      <_TestAssembly Condition="'$(OS)'=='Windows_NT'">$([System.IO.Path]::ChangeExtension($(_TestAssembly), '.exe'))</_TestAssembly>
-      <_TestAssembly Condition="'$(OS)'!='Windows_NT'">$(_TestAssembly.TrimEnd('.dll'))</_TestAssembly>
       <_TestTimeout>%(TestToRun.TestTimeout)</_TestTimeout>
+      <_TestRunnerAdditionalArguments>%(TestToRun.TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
 
       <_TargetDir>$([System.IO.Path]::GetDirectoryName('$(_TestAssembly)'))\</_TargetDir>
 
-      <_TestRunnerCommand>$(_TestAssembly) --list-tests $(_QuarantinedTestRunAdditionalArgs)</_TestRunnerCommand>
+      <_TestRunnerCommand>&quot;$(DotNetTool)&quot; test $(_TestAssembly) --list-tests --logger:"console%3Bverbosity=normal" "--Framework:%(TestToRun.TargetFrameworkIdentifier),Version=%(TestToRun.TargetFrameworkVersion)"</_TestRunnerCommand>
+      <_TestRunnerCommand Condition="'$(VSTestRunSettingsFile)' != ''">$(_TestRunnerCommand) "--settings:$(VSTestRunSettingsFile)"</_TestRunnerCommand>
+      <_TestRunnerCommand Condition="'$(_TestRunnerAdditionalArguments)' != ''">$(_TestRunnerCommand) $(_TestRunnerAdditionalArguments)</_TestRunnerCommand>
 
       <!--
         Redirect std output of the runner.
@@ -91,26 +92,52 @@
           WorkingDirectory="$(_TargetDir)"
           IgnoreExitCode="true"
           Timeout="$(_TestTimeout)"
-          EnvironmentVariables="DOTNET_ROOT=$(DotNetRoot);DOTNET_ROOT_X86=$(DotNetRoot)x86"
           ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
     </Exec>
+
+    <!--
+      Report test status.
+      -->
+    <Message Text="Search complete: $(_TestAssembly) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' == '0'" Importance="high" />
 
     <PropertyGroup>
       <_ResultsFileToDisplay>%(TestToRun.ResultsStdOutPath)</_ResultsFileToDisplay>
     </PropertyGroup>
 
     <!--
-      Report test status.
+      Ideally we would set ContinueOnError="ErrorAndContinue" so that when a test fails in multi-targeted test project
+      we'll still run tests for all target frameworks. ErrorAndContinue doesn't work well on Linux though: https://github.com/Microsoft/msbuild/issues/3961.
+    -->
+    <Error Text="Search failed: $(_ResultsFileToDisplay) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' != '0'" File="QuarantinedTestRunsheetBuilder" />
+
+    <!--
+      Read the test result and see if the string "No test matches the given testcase filter" is present.
+      This indicates that there are no quarantined tests to run.
       -->
-    <Message Text="Search complete, no quarantined tests found: $(_TestAssembly) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' == '8'" Importance="high" />
-    <Message Text="💡 Search complete, quarantined tests found: $(_TestAssembly) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' == '0'" Importance="high" />
-    <Error Text="Search failed: $(_ResultsFileToDisplay) [$(_TestEnvironment)]" Condition=" '$(_TestErrorCode)' != '0' and '$(_TestErrorCode)' != '8' " File="QuarantinedTestRunsheetBuilder" />
+    <ReadLinesFromFile File="$(_ResultsFileToDisplay)">
+      <Output TaskParameter="Lines" ItemName="FileLines" />
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <Lines Include="@(FileLines)" >
+        <Sanitized>$([System.String]::Copy('%(FileLines.Identity)').Replace('`', ''))</Sanitized>
+      </Lines>
+
+      <_UnhandledExceptionLines Include="@(Lines)" Condition=" $([MSBuild]::ValueOrDefault(`%(Lines.Sanitized)`, '').Contains(`Unhandled exception`)) " />
+      <_ExceptionDiscoveringTestsLines Include="@(Lines)" Condition=" $([MSBuild]::ValueOrDefault(`%(Lines.Sanitized)`, '').Contains(`Exception discovering tests`)) " />
+      <_NoTestMatchesLines Include="@(Lines)" Condition=" $([MSBuild]::ValueOrDefault(`%(Lines.Sanitized)`, '').Contains(`No test matches the given testcase filter`)) " />
+    </ItemGroup>
 
     <PropertyGroup>
+      <_FailedToEnumerateTests Condition=" '@(_UnhandledExceptionLines)' != '' or '@(_ExceptionDiscoveringTestsLines)' != '' ">true</_FailedToEnumerateTests>
+
       <_HasQuarantinedTests>true</_HasQuarantinedTests>
-      <_HasQuarantinedTests Condition=" '$(_TestErrorCode)' == '8' ">false</_HasQuarantinedTests>
+      <_HasQuarantinedTests Condition=" '@(_NoTestMatchesLines)' != '' ">false</_HasQuarantinedTests>
     </PropertyGroup>
+
+    <Error Text="Search failed: $(_ResultsFileToDisplay) [$(_TestEnvironment)]" Condition="'$(_FailedToEnumerateTests)' == 'true'" File="QuarantinedTestRunsheetBuilder" />
+    <Message Text="💡 Quarantined tests found in $(_TestAssembly) [$(_TestEnvironment)]" Condition=" '$(_HasQuarantinedTests)' == 'true' " Importance="high" />
 
     <!--
       Generate test runsheet, if there are quarantined tests.
@@ -132,12 +159,6 @@
       <_TestRunnerWindows>./eng/build.ps1</_TestRunnerWindows>
       <_TestRunnerLinux>./eng/build.sh</_TestRunnerLinux>
       <_TestCommand>-restore -build -test -projects &quot;$(_RelativeTestProjectPath)&quot; /bl:&quot;$(_RelativeTestBinLog)&quot; -c $(Configuration) -ci /p:RunQuarantinedTests=true /p:CI=false</_TestCommand>
-
-      <!--
-        Some quarantinted test may only be executable on Windows or Linux, however we can't possibly know that at this time.
-        The MTP runner will return exit code 8 if no tests are found, and we need to ignore it instead of failing the test.
-        -->
-      <_TestCommand>$(_TestCommand) /p:IgnoreZeroTestResult=true</_TestCommand>
 
       <!-- Replace \ with /, and then escape " with \", so we have a compliant JSON -->
       <_TestCommand>$([System.String]::Copy($(_TestCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_TestCommand>

--- a/eng/Testing.props
+++ b/eng/Testing.props
@@ -9,19 +9,23 @@
     <RunOnAzdoCILinux>true</RunOnAzdoCILinux>
     <RunOnAzdoHelixWindows>true</RunOnAzdoHelixWindows>
     <RunOnAzdoHelixLinux>true</RunOnAzdoHelixLinux>
+  </PropertyGroup>
 
-    <_QuarantinedTestRunAdditionalArgs>--filter-trait "quarantined=true"</_QuarantinedTestRunAdditionalArgs>
-    <_NonQuarantinedTestRunAdditionalArgs>--filter-not-trait "quarantined=true"</_NonQuarantinedTestRunAdditionalArgs>
+  <PropertyGroup Condition="'$(UseVSTestRunner)' != 'true'">
+    <_QuarantinedTestRunAdditionalArgs>-trait "quarantined=true"</_QuarantinedTestRunAdditionalArgs>
+    <_NonQuarantinedTestRunAdditionalArgs>-notrait "quarantined=true"</_NonQuarantinedTestRunAdditionalArgs>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseVSTestRunner)' == 'true'">
+    <_QuarantinedTestRunAdditionalArgs>--filter "quarantined=true"</_QuarantinedTestRunAdditionalArgs>
+    <_NonQuarantinedTestRunAdditionalArgs>--filter "quarantined!=true"</_NonQuarantinedTestRunAdditionalArgs>
   </PropertyGroup>
 
   <PropertyGroup>
     <BlameHangTimeout Condition="'$(BlameHangTimeout)' == ''">10m</BlameHangTimeout>
-    <_BlameArgs>--hangdump --hangdump-timeout $(BlameHangTimeout) --crashdump</_BlameArgs>
+    <_BlameArgs>--blame --blame-hang-timeout $(BlameHangTimeout) --blame-crash</_BlameArgs>
 
-    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --filter-not-trait &quot;category=failing&quot;</TestRunnerAdditionalArguments>
-    <TestRunnerAdditionalArguments Condition=" '$(IgnoreZeroTestResult)' == 'true' ">$(TestRunnerAdditionalArguments) --ignore-exit-code 8</TestRunnerAdditionalArguments>
-
-    <TestRunnerAdditionalArguments Condition="'$(RunQuarantinedTests)' != 'true'">$(TestRunnerAdditionalArguments) $(_NonQuarantinedTestRunAdditionalArgs) $(_BlameArgs)</TestRunnerAdditionalArguments>
-    <TestRunnerAdditionalArguments Condition="'$(RunQuarantinedTests)' == 'true'">$(TestRunnerAdditionalArguments) $(_QuarantinedTestRunAdditionalArgs) $(_BlameArgs)</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments Condition="'$(RunQuarantinedTests)' == ''">$(TestRunnerAdditionalArguments) $(_NonQuarantinedTestRunAdditionalArgs) $(TestRunnerAdditionalArguments) $(_BlameArgs)</TestRunnerAdditionalArguments>
+    <TestRunnerAdditionalArguments Condition="'$(RunQuarantinedTests)' == 'true'">$(TestRunnerAdditionalArguments) $(_QuarantinedTestRunAdditionalArgs) $(TestRunnerAdditionalArguments) $(_BlameArgs)</TestRunnerAdditionalArguments>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,10 +12,10 @@
     <DotNetRuntimePreviousVersionForTesting>8.0.13</DotNetRuntimePreviousVersionForTesting>
     <!-- dotnet 8.0 versions for running tests - used for templates tests -->
     <DotNetSdkPreviousVersionForTesting>8.0.406</DotNetSdkPreviousVersionForTesting>
+    <UseVSTestRunner>true</UseVSTestRunner>
     <XunitV3Version>2.0.0</XunitV3Version>
     <XUnitAnalyzersVersion>1.20.0</XUnitAnalyzersVersion>
     <XunitRunnerVisualStudioVersion>3.0.2</XunitRunnerVisualStudioVersion>
-    <MicrosoftTestingPlatformVersion>1.6.3</MicrosoftTestingPlatformVersion>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/eng/Xunit3/Xunit3.targets
+++ b/eng/Xunit3/Xunit3.targets
@@ -4,23 +4,15 @@
     <PackageVersion Include="xunit.v3.core" Version="$(XunitV3Version)" />
     <PackageVersion Include="xunit.analyzers" Version="$(XunitAnalyzersVersion)" />
     <PackageVersion Include="xunit.v3.assert" Version="$(XunitV3Version)" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioVersion)" />
     <PackageVersion Include="xunit.v3.runner.console" Version="$(XunitV3Version)" />
-    <PackageVersion Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
-    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="$(MicrosoftTestingPlatformVersion)" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
 
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.v3.core" />
     <PackageReference Include="xunit.analyzers" />
     <PackageReference Include="xunit.v3.assert" />
-    <PackageReference Include="Microsoft.Testing.Platform" />
-    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
-  <Import Project="Microsoft.Testing.Platform.targets" />
+  <Import Project="..\tools\VSTest.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 </Project>

--- a/eng/testing/.runsettings
+++ b/eng/testing/.runsettings
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Timeout in ms, 20 minutes -->
+    <TestSessionTimeout>1200000</TestSessionTimeout>
+    <!-- Filter out failing (wrong framework, platform, runtime or activeissue) tests -->
+    <TestCaseFilter>category!=failing</TestCaseFilter>
+  </RunConfiguration>
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="trx">
+        <Configuration>
+          <LogFileName>TestResults.trx</LogFileName>
+        </Configuration>
+      </Logger>
+      <Logger friendlyName="console">
+        <Configuration>
+          <Verbosity>normal</Verbosity>
+        </Configuration>
+      </Logger>
+      <Logger friendlyName="blame" enabled="True" />
+    </Loggers>
+  </LoggerRunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <!-- Enables blame -->
+      <DataCollector friendlyName="blame" enabled="True">
+        <Configuration>
+          <CollectDump DumpType="Full" />
+          <CollectDumpOnTestSessionHang TestTimeout="7min" HangDumpType="Full" />
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/tests/Aspire.Components.Common.Tests/Aspire.Components.Common.Tests.csproj
+++ b/tests/Aspire.Components.Common.Tests/Aspire.Components.Common.Tests.csproj
@@ -2,6 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+
+    <!--
+      Whilst this looks like a test project, it is not... https://github.com/dotnet/aspire/pull/8498/files#r2029349258
+      -->
+    <IsTestUtilityProject>true</IsTestUtilityProject>
+    <SkipTests>true</SkipTests>
+    <DeployOutsideOfRepoSupportFiles>false</DeployOutsideOfRepoSupportFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Components.Common.Tests/Aspire.Components.Common.Tests.csproj
+++ b/tests/Aspire.Components.Common.Tests/Aspire.Components.Common.Tests.csproj
@@ -2,18 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
-
-    <!--
-      Whilst this looks like a test project, it is not... https://github.com/dotnet/aspire/pull/8498/files#r2029349258
-      -->
-    <IsTestUtilityProject>true</IsTestUtilityProject>
-    <SkipTests>true</SkipTests>
-    <DeployOutsideOfRepoSupportFiles>false</DeployOutsideOfRepoSupportFiles>
-
-    <!-- https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-exit-codes -->
-    <!-- Exit code 8 is "zero tests ran" -->
-    <!-- Currently, none of the tests in this project run in CI. All are ignored -->
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --ignore-exit-code 8</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.EndToEnd.Tests/.runsettings
+++ b/tests/Aspire.EndToEnd.Tests/.runsettings
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <xUnit>
+    <ShowLiveOutput>true</ShowLiveOutput>
+  </xUnit>
+  <RunConfiguration>
+    <!-- Timeout in ms, 15 minutes -->
+    <TestSessionTimeout>900000</TestSessionTimeout>
+    <!-- Filter out failing (wrong framework, platform, runtime or activeissue) tests -->
+    <TestCaseFilter>category!=failing</TestCaseFilter>
+  </RunConfiguration>
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="trx">
+        <Configuration>
+          <LogFileName>TestResults.trx</LogFileName>
+        </Configuration>
+      </Logger>
+      <Logger friendlyName="console">
+        <Configuration>
+          <Verbosity>normal</Verbosity>
+        </Configuration>
+      </Logger>
+    </Loggers>
+  </LoggerRunSettings>
+</RunSettings>

--- a/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
+++ b/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
@@ -20,6 +20,7 @@
     <DefineConstants Condition="'$(_BuildForTestsRunningOutsideOfRepo)' == 'true'">BUILD_FOR_TESTS_RUNNING_OUTSIDE_OF_REPO;$(DefineConstants)</DefineConstants>
 
     <XunitRunnerJson>xunit.runner.json</XunitRunnerJson>
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory).runsettings</RunSettingsFilePath>
     <TestArchiveTestsDir>$(TestArchiveTestsDirForEndToEndTests)</TestArchiveTestsDir>
   </PropertyGroup>
 

--- a/tests/Aspire.Hosting.Containers.Tests/.runsettings
+++ b/tests/Aspire.Hosting.Containers.Tests/.runsettings
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Timeout in ms, 15 minutes -->
+    <TestSessionTimeout>900000</TestSessionTimeout>
+    <!-- Filter out failing (wrong framework, platform, runtime or activeissue) tests -->
+    <TestCaseFilter>category!=failing</TestCaseFilter>
+  </RunConfiguration>
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="trx">
+        <Configuration>
+          <LogFileName>TestResults.trx</LogFileName>
+        </Configuration>
+      </Logger>
+      <Logger friendlyName="console">
+        <Configuration>
+          <Verbosity>normal</Verbosity>
+        </Configuration>
+      </Logger>
+    </Loggers>
+  </LoggerRunSettings>
+</RunSettings>

--- a/tests/Aspire.Hosting.Keycloak.Tests/.runsettings
+++ b/tests/Aspire.Hosting.Keycloak.Tests/.runsettings
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Timeout in ms, 15 minutes -->
+    <TestSessionTimeout>900000</TestSessionTimeout>
+    <!-- Filter out failing (wrong framework, platform, runtime or activeissue) tests -->
+    <TestCaseFilter>category!=failing</TestCaseFilter>
+  </RunConfiguration>
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="trx">
+        <Configuration>
+          <LogFileName>TestResults.trx</LogFileName>
+        </Configuration>
+      </Logger>
+      <Logger friendlyName="console">
+        <Configuration>
+          <Verbosity>normal</Verbosity>
+        </Configuration>
+      </Logger>
+    </Loggers>
+  </LoggerRunSettings>
+</RunSettings>

--- a/tests/Aspire.Playground.Tests/.runsettings
+++ b/tests/Aspire.Playground.Tests/.runsettings
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <xUnit>
+    <ShowLiveOutput>true</ShowLiveOutput>
+  </xUnit>
+  <RunConfiguration>
+    <!-- Timeout in ms, 20 minutes -->
+    <TestSessionTimeout>1200000</TestSessionTimeout>
+    <!-- Filter out failing (wrong framework, platform, runtime or activeissue) tests -->
+    <TestCaseFilter>category!=failing</TestCaseFilter>
+  </RunConfiguration>
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="trx">
+        <Configuration>
+          <LogFileName>TestResults.trx</LogFileName>
+        </Configuration>
+      </Logger>
+      <Logger friendlyName="console">
+        <Configuration>
+          <Verbosity>normal</Verbosity>
+        </Configuration>
+      </Logger>
+    </Loggers>
+  </LoggerRunSettings>
+</RunSettings>

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -17,6 +17,7 @@
 
     <PlaygroundSourceDir>$(MSBuildThisFileDirectory)..\..\playground\</PlaygroundSourceDir>
     <TestsSharedDir>$(MSBuildThisFileDirectory)..\Shared\</TestsSharedDir>
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory).runsettings</RunSettingsFilePath>
     <!-- Skip emulators that don't start consistently when running in CI. -->
     <SkipUnstableEmulators Condition="'$(SkipUnstableEmulators)' == '' and ('$(RepoRoot)' == '' or '$(ContinuousIntegrationBuild)' == 'true' or '$(CODESPACES)' == 'true')">true</SkipUnstableEmulators>
 

--- a/tests/Aspire.Templates.Tests/.runsettings
+++ b/tests/Aspire.Templates.Tests/.runsettings
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <xUnit>
+    <ShowLiveOutput>true</ShowLiveOutput>
+  </xUnit>
+  <RunConfiguration>
+    <!-- Timeout in ms, 20 minutes -->
+    <TestSessionTimeout>1200000</TestSessionTimeout>
+    <!-- Filter out failing (wrong framework, platform, runtime or activeissue) tests -->
+    <TestCaseFilter>category!=failing</TestCaseFilter>
+  </RunConfiguration>
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="trx">
+        <Configuration>
+          <LogFileName>TestResults.trx</LogFileName>
+        </Configuration>
+      </Logger>
+      <Logger friendlyName="console">
+        <Configuration>
+          <Verbosity>normal</Verbosity>
+        </Configuration>
+      </Logger>
+    </Loggers>
+  </LoggerRunSettings>
+</RunSettings>

--- a/tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
+++ b/tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
@@ -7,6 +7,7 @@
     <InstallWorkloadForTesting>true</InstallWorkloadForTesting>
 
     <XunitRunnerJson>xunit.runner.json</XunitRunnerJson>
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory).runsettings</RunSettingsFilePath>
     <TestArchiveTestsDir>$(TestArchiveTestsDirForTemplateTests)</TestArchiveTestsDir>
 
     <InstallBrowsersForPlaywright Condition="'$(InstallBrowsersForPlaywright)' == '' and '$(CODESPACES)' == 'true'">true</InstallBrowsersForPlaywright>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,6 +5,8 @@
   <Import Project="$(TestsSharedRepoTestingDir)Aspire.RepoTesting.props" />
 
   <PropertyGroup>
+    <!-- Set RunSettingsFilePath property which is read by VSTest. -->
+    <RunSettingsFilePath>$(RepositoryEngineeringDir)testing\.runsettings</RunSettingsFilePath>
     <TestArchiveTestsDir Condition="'$(TestArchiveTestsDir)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'tests'))</TestArchiveTestsDir>
     <TestArchiveTestsDirForTemplateTests Condition="'$(TestArchiveTestsDirForTemplateTests)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'templates-tests'))</TestArchiveTestsDirForTemplateTests>
     <TestArchiveTestsDirForEndToEndTests Condition="'$(TestArchiveTestsDirForEndToEndTests)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'e2e-tests'))</TestArchiveTestsDirForEndToEndTests>
@@ -14,7 +16,13 @@
 
     <!-- This is useful for local runs -->
     <VSTestResultsDirectory>$(ArtifactsTestResultsDir)</VSTestResultsDirectory>
+
+    <OutputType Condition="$(MSBuildProjectName.EndsWith('.Tests'))">Exe</OutputType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+  </ItemGroup>
 
   <PropertyGroup>
     <UsePublicApiAnalyzers>false</UsePublicApiAnalyzers>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -4,12 +4,17 @@
   <Import Project="$(TestsSharedRepoTestingDir)Aspire.RepoTesting.targets" />
 
   <PropertyGroup>
+    <!-- forward the settings file path to RunTests target in arcade -->
+    <VSTestRunSettingsFile Condition="'$(VSTestRunSettingsFile)' == ''">$(RunSettingsFilePath)</VSTestRunSettingsFile>
+
+    <DeployRunSettingsFile Condition="'$(DeployRunSettingsFile)' == ''">true</DeployRunSettingsFile>
     <!-- Use a separate xunit.runner.json for helix that disables parallel test runs -->
     <XunitRunnerJson Condition="'$(XunitRunnerJson)' == '' and '$(PrepareForHelix)' == 'true'">$(RepoRoot)tests\helix\xunit.runner.json</XunitRunnerJson>
     <XunitRunnerJson Condition="'$(XunitRunnerJson)' == ''">$(RepositoryEngineeringDir)testing\xunit.runner.json</XunitRunnerJson>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(RunSettingsFilePath)" CopyToOutputDirectory="PreserveNewest" Condition="'$(DeployRunSettingsFile)' == 'true'" />
     <None Include="$(XunitRunnerJson)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
@@ -36,7 +41,7 @@
     <Error Condition="'$(ExtractTestClassNamesPrefix)' == ''"
            Text="%24(ExtractTestClassNamesPrefix) should be set, for example - Aspire.Templates.Tests" />
 
-    <Exec Command="&quot;$(RunCommand)&quot; --filter-not-trait category=failing --list-tests" ConsoleToMSBuild="true" EnvironmentVariables="DOTNET_ROOT=$(DotNetRoot);DOTNET_ROOT_X86=$(DotNetRoot)x86">
+    <Exec Command="&quot;$(DotNetTool)&quot; test --no-build -c $(Configuration) -s $(RunSettingsFilePath) --list-tests --nologo -v:q -p:VsTestUseMSBuildOutput=false" ConsoleToMSBuild="true" EnvironmentVariables="DOTNET_ROOT=$(DotNetRoot);DOTNET_ROOT_X86=$(DotNetRoot)x86">
       <Output TaskParameter="ConsoleOutput" ItemName="_ListOfTestsLines" />
     </Exec>
 
@@ -61,8 +66,7 @@
 
   <Target Name="GetRunTestsOnGithubActions" Returns="@(TestProject)">
     <ItemGroup>
-      <TestProject Condition="'$(OS)' == 'Windows_NT'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsWindows)" />
-      <TestProject Condition="'$(OS)' != 'Windows_NT'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsLinux)" />
+      <TestProject Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActions)" />
     </ItemGroup>
   </Target>
 

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.props
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.props
@@ -14,12 +14,6 @@
     <!-- https://github.com/dotnet/arcade/issues/15654 -->
     <!-- We currently have our own Xunit3.targets in eng/Xunit3, which Arcade will import -->
     <TestRunnerName>Xunit3</TestRunnerName>
-
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformCaptureOutput>false</TestingPlatformCaptureOutput>
-    <OutputType Condition="$(MSBuildProjectName.EndsWith('.Tests'))">Exe</OutputType>
-
   </PropertyGroup>
 
   <!-- IsAspireHost property might not be available here, so allow infering that from the project name -->

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -41,9 +41,6 @@
 
     <IncludeTestPackages Condition="'$(IncludeTestPackages)' == '' and ('$(IsTestProject)' == 'true' or '$(IsTestUtilityProject)' == 'true')">true</IncludeTestPackages>
     <GeneratedPackagesVersionsPropsPath Condition="'$(GeneratedPackagesVersionsPropsPath)' == ''">$(IntermediateOutputPath)Directory.Packages.Versions.props</GeneratedPackagesVersionsPropsPath>
-
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --filter-not-trait "category=failing"</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments Condition="'$(TrxFileNamePrefix)' != ''">$(TestingPlatformCommandLineArguments) --report-trx-filename  "$(TrxFileNamePrefix)_$(TargetFramework)_$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss')).trx"</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TestsRunningOutsideOfRepo)' != 'true'">
@@ -70,11 +67,8 @@
     <PackageReference Include="xunit.v3.core" />
     <PackageReference Include="xunit.analyzers" />
     <PackageReference Include="xunit.v3.assert" />
-    <PackageReference Include="Microsoft.Testing.Platform" />
-    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DeployOutsideOfRepoSupportFiles)' == 'true'">

--- a/tests/Shared/RepoTesting/Directory.Packages.Helix.props
+++ b/tests/Shared/RepoTesting/Directory.Packages.Helix.props
@@ -86,5 +86,7 @@
 
   <ItemGroup Label="For tests">
     <PackageVersion Include="mstest.testadapter" Version="$(MSTestTestAdapterVersion)" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageVersion Include="Microsoft.DotNet.XUnitAssert" Version="$(MicrosoftDotNetXUnitAssertVersion)" />
   </ItemGroup>
 </Project>

--- a/tests/Shared/TemplatesTesting/BuildEnvironment.cs
+++ b/tests/Shared/TemplatesTesting/BuildEnvironment.cs
@@ -158,6 +158,8 @@ public class BuildEnvironment
         // Avoid using the msbuild terminal logger, so the output can be read
         // in the tests
         EnvVars["_MSBUILDTLENABLED"] = "0";
+        // .. and disable new output style for vstest
+        EnvVars["VsTestUseMSBuildOutput"] = "false";
         EnvVars["SkipAspireWorkloadManifest"] = "true";
 
         DotNet = Path.Combine(sdkForTemplatePath!, "dotnet");

--- a/tests/helix/send-to-helix-basictests.targets
+++ b/tests/helix/send-to-helix-basictests.targets
@@ -21,7 +21,8 @@
       <!-- needed for Aspire.Hosting.Container.Tests -->
       <HelixPreCommand Include="$(_EnvVarSetKeyword) DOCKER_BUILDKIT=1" />
 
-      <_TestRunCommandArguments Include="--filter-not-trait &quot;quarantined=true&quot;" />
+      <_TestRunCommandArguments Condition="'$(OS)' != 'Windows_NT'" Include="--filter &quot;quarantined!=true&quot; -- RunConfiguration.TestSessionTimeout=$TEST_TIMEOUT" />
+      <_TestRunCommandArguments Condition="'$(OS)' == 'Windows_NT'" Include="--filter &quot;quarantined!=true&quot; -- RunConfiguration.TestSessionTimeout=%TEST_TIMEOUT%" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -36,9 +37,16 @@
       <_DefaultWorkItems TestName="$([System.Text.RegularExpressions.Regex]::Replace(%(FileName), $(TargetFrameworkSuffixRegex), '$1'))" />
       <_DefaultWorkItems TestNameSuffix="$([System.Text.RegularExpressions.Regex]::Replace(%(FileName), $(TargetFrameworkSuffixRegex), '$2'))" />
 
+      <!-- runsettings timeout in ms, default to 15 mins -->
+      <_DefaultWorkItems TimeoutMs="900000" />
+
+      <_DefaultWorkItems Condition="$([System.String]::new('%(FileName)').StartsWith('Aspire.Hosting.Elasticsearch.Tests'))" TimeoutMs="3600000" />
+      <_DefaultWorkItems Condition="$([System.String]::new('%(FileName)').StartsWith('Aspire.Hosting.Oracle.Tests'))" TimeoutMs="1200000" />
+      <_DefaultWorkItems Condition="$([System.String]::new('%(FileName)').StartsWith('Aspire.Pomelo.EntityFrameworkCore.MySql.Tests'))" TimeoutMs="1200000" />
+
       <HelixWorkItem Include="@(_DefaultWorkItems -> '%(FileName)')">
         <PayloadArchive>%(Identity)</PayloadArchive>
-        <PreCommands>$(_EnvVarSetKeyword) &quot;TEST_NAME=%(TestName)&quot; $(_ShellCommandSeparator) $(_EnvVarSetKeyword) $(_ShellCommandSeparator) $(_EnvVarSetKeyword) &quot;TEST_NAME_SUFFIX=%(TestNameSuffix)&quot; $(_ShellCommandSeparator) $(_EnvVarSetKeyword) &quot;CODE_COV_FILE_SUFFIX=%(TestNameSuffix)&quot;</PreCommands>
+        <PreCommands>$(_EnvVarSetKeyword) &quot;TEST_NAME=%(TestName)&quot; $(_ShellCommandSeparator) $(_EnvVarSetKeyword) TEST_TIMEOUT=%(TimeoutMs) $(_ShellCommandSeparator) $(_EnvVarSetKeyword) &quot;TEST_NAME_SUFFIX=%(TestNameSuffix)&quot; $(_ShellCommandSeparator) $(_EnvVarSetKeyword) &quot;CODE_COV_FILE_SUFFIX=%(TestNameSuffix)&quot;</PreCommands>
 
         <Command>$(_TestRunCommand)</Command>
         <Timeout>$(_workItemTimeout)</Timeout>

--- a/tests/helix/send-to-helix-buildonhelixtests.targets
+++ b/tests/helix/send-to-helix-buildonhelixtests.targets
@@ -31,14 +31,14 @@
       <_TestRunCommandArguments Remove="@(_TestRunCommandArguments)" />
 
       <_TestBlameArguments Remove="@(_TestBlameArguments)" />
-      <_TestBlameArguments Include="--crashdump" />
-      <_TestBlameArguments Include="--crashdump-type Full" />
+      <_TestBlameArguments Include="--blame-crash" />
+      <_TestBlameArguments Include="--blame-crash-dump-type full" />
 
       <!-- Using `dotnet test` for the project directly here -->
-      <_TestRunCommandArguments Include="dotnet test -- --results-directory $(_HelixLogsPath) --report-trx --report-trx-filename TestResults.trx" />
+      <_TestRunCommandArguments Include="dotnet test -s .runsettings --results-directory $(_HelixLogsPath) -v:n" />
       <_TestRunCommandArguments Include="@(_TestBlameArguments, ' ')" />
 
-      <_TestRunCommandArguments Include="--filter-not-trait &quot;quarantined=true&quot;" />
+      <_TestRunCommandArguments Include="--filter &quot;quarantined!=true&quot;" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/tests/helix/send-to-helix-endtoendtests.targets
+++ b/tests/helix/send-to-helix-endtoendtests.targets
@@ -21,7 +21,7 @@
            Text="Could not find EndToEnd tests at %24(_E2ETestsArchivePath)=$(_E2ETestsArchivePath)" />
 
     <ItemGroup>
-      <_TestRunCommandArguments Include="--filter-not-trait &quot;quarantined=true&quot; --filter-trait &quot;scenario=$(_TestScenarioEnvVar)&quot;" />
+      <_TestRunCommandArguments Include="--filter &quot;(quarantined!=true)&amp;(scenario=$(_TestScenarioEnvVar))&quot;" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -58,19 +58,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <_TestBlameArguments Include="--hangdump" />
-    <_TestBlameArguments Include="--hangdump-type Full" />
-    <_TestBlameArguments Include="--hangdump-timeout 10m" />
-    <_TestBlameArguments Include="--crashdump" />
-    <_TestBlameArguments Include="--crashdump-type Full" />
+    <_TestBlameArguments Include="--blame-hang" />
+    <_TestBlameArguments Include="--blame-hang-dump-type full" />
+    <_TestBlameArguments Include="--blame-hang-timeout 10m" />
+    <_TestBlameArguments Include="--blame-crash" />
+    <_TestBlameArguments Include="--blame-crash-dump-type full" />
 
-    <!--
-      At time of writing, Aspire.Components.Common.Tests doesn't have runnable tests in CI. In that case, we don't want to fail.
-      Also EndToEnd.Tests doesn't have tests matching scenario=cosmos
-      So, ignore exit code 8 (zero tests ran)
-      https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-exit-codes
-    -->
-    <_TestRunCommandArguments Include="$(_SetExecutableBitCommand)dotnet exec $(_TestNameEnvVar).dll --results-directory:$(_HelixLogsPath) --report-trx --report-trx-filename TestResults.trx --filter-not-trait &quot;category=failing&quot; --ignore-exit-code 8" />
+    <_TestRunCommandArguments Include="$(_SetExecutableBitCommand)dotnet test -s .runsettings $(_TestNameEnvVar).dll --ResultsDirectory:$(_HelixLogsPath) -v:n" />
     <_TestRunCommandArguments Include="@(_TestBlameArguments, ' ')" />
   </ItemGroup>
 

--- a/tests/helix/send-to-helix-templatestests.targets
+++ b/tests/helix/send-to-helix-templatestests.targets
@@ -59,8 +59,8 @@
 
           To fix that, append '.' to the name so only the test class with exactly that name is run.
         -->
-        <PreCommands Condition="'$(OS)' == 'Windows_NT'">%(PreCommands) $(_ShellCommandSeparator) set &quot;TEST_ARGS=--filter-not-trait quarantined=true --filter-not-trait category=failing --filter-class %(Identity)&quot;</PreCommands>
-        <PreCommands Condition="'$(OS)' != 'Windows_NT'">%(PreCommands) $(_ShellCommandSeparator) export &quot;TEST_ARGS=--filter-not-trait quarantined=true --filter-not-trait category=failing --filter-class %(Identity)&quot;</PreCommands>
+        <PreCommands Condition="'$(OS)' == 'Windows_NT'">%(PreCommands) $(_ShellCommandSeparator) set &quot;TEST_ARGS=--filter quarantined^^!=true^&amp;category^^!=failing^&amp;FullyQualifiedName~%(Identity).&quot;</PreCommands>
+        <PreCommands Condition="'$(OS)' != 'Windows_NT'">%(PreCommands) $(_ShellCommandSeparator) export &quot;TEST_ARGS=--filter quarantined!=true&amp;category!=failing&amp;FullyQualifiedName~%(Identity).&quot;</PreCommands>
 
         <Command>$(_TestRunCommand)</Command>
         <Timeout>$(_workItemTimeout)</Timeout>


### PR DESCRIPTION
This reverts commit ac098f78e71602efa45f94bfb2918e0103e809a0 (#8498) as it hits https://github.com/microsoft/vscode-dotnettools/issues/1922

cc @radical @Youssef1313 @captainsafia 

It wasn't a clean revert because of some subsequent changes by @RussKie in #8706 -- is this right @RussKie 

Before merging:
- [ ] Run all the tests on azdo
- [ ] Run the Outerloop tests workflow
- [ ] Confirm that local runs are not broken
- [ ] Check running from VS?
- [ ] check build/test/debug in Codespaces