### PR TITLE
Copy config starting with ASPIRE_DASHBOARD to the dashboard

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -40,7 +40,7 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
 {
     private static readonly HashSet<string> s_suppressAutomaticConfigurationCopy = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
-        KnownConfigNames.DashboardCorsAllowedOrigins // Set on the dashboard on Dashboard:Otlp:Cors type
+        KnownConfigNames.DashboardCorsAllowedOrigins // Set on the dashboard's Dashboard:Otlp:Cors type
     };
 
     private Task? _dashboardLogsTask;

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -211,9 +211,14 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
         context.EnvironmentVariables["ASPNETCORE_ENVIRONMENT"] = environment;
         context.EnvironmentVariables[DashboardConfigNames.DashboardFrontendUrlName.EnvVarName] = options.DashboardUrl;
         context.EnvironmentVariables[DashboardConfigNames.ResourceServiceUrlName.EnvVarName] = resourceServiceUrl;
-
+        if (options.OtlpGrpcEndpointUrl != null)
+        {
+            context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpGrpcUrlName.EnvVarName] = options.OtlpGrpcEndpointUrl;
+        }
         if (options.OtlpHttpEndpointUrl != null)
         {
+            context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpHttpUrlName.EnvVarName] = options.OtlpHttpEndpointUrl;
+
             // Use explicitly defined allowed origins if configured.
             var allowedOrigins = configuration.GetString(KnownConfigNames.DashboardCorsAllowedOrigins, KnownConfigNames.Legacy.DashboardCorsAllowedOrigins);
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -330,6 +330,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         var expectedAllowedOrigins = !string.IsNullOrEmpty(explicitCorsAllowedOrigins) ? explicitCorsAllowedOrigins : "http://localhost:8081,http://localhost:58080";
         Assert.Equal(expectedAllowedOrigins, config.Single(e => e.Key == DashboardConfigNames.DashboardOtlpCorsAllowedOriginsKeyName.EnvVarName).Value);
         Assert.Equal("*", config.Single(e => e.Key == DashboardConfigNames.DashboardOtlpCorsAllowedHeadersKeyName.EnvVarName).Value);
+        Assert.DoesNotContain(config, e => e.Key == corsAllowedOriginsKey);
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -107,9 +107,21 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         Assert.Same(container.Resource, dashboard);
 
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
+        var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout())
+            .OrderBy(c => c.Key)
+            .ToList();
 
         Assert.Collection(config,
+            e =>
+            {
+                Assert.Equal(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, e.Key);
+                Assert.Equal("http://localhost", e.Value);
+            },
+            e =>
+            {
+                Assert.Equal(KnownConfigNames.ResourceServiceEndpointUrl, e.Key);
+                Assert.Equal("http://localhost:5000", e.Value);
+            },
             e =>
             {
                 Assert.Equal("ASPNETCORE_ENVIRONMENT", e.Key);
@@ -122,27 +134,17 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
             },
             e =>
             {
-                Assert.Equal(KnownConfigNames.ResourceServiceEndpointUrl, e.Key);
-                Assert.Equal("http://localhost:5000", e.Value);
-            },
-            e =>
-            {
-                Assert.Equal(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, e.Key);
-                Assert.Equal("http://localhost", e.Value);
-            },
-            e =>
-            {
                 Assert.Equal("DASHBOARD__FRONTEND__AUTHMODE", e.Key);
                 Assert.Equal("Unsecured", e.Value);
             },
             e =>
             {
-                Assert.Equal("DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE", e.Key);
+                Assert.Equal("DASHBOARD__OTLP__AUTHMODE", e.Key);
                 Assert.Equal("Unsecured", e.Value);
             },
             e =>
             {
-                Assert.Equal("DASHBOARD__OTLP__AUTHMODE", e.Key);
+                Assert.Equal("DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE", e.Key);
                 Assert.Equal("Unsecured", e.Value);
             },
             e =>


### PR DESCRIPTION
Configuration starting with `ASPIRE_DASHBOARD_` in the app host are automatically copied to the dashboard. Allows us to add new configuration values without having to explicitly update the dashboard lifecycle host.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
