### PR TITLE
Generate tests runsheet using Arcade SDK

### DIFF
--- a/.github/workflows/tests-runner.yml
+++ b/.github/workflows/tests-runner.yml
@@ -12,6 +12,9 @@ jobs:
   # Duplicated jobs so their dependencies are not blocked on both the
   # setup jobs
 
+  # Generates a runsheet for all the tests in the solution that do not require
+  # NuGet packages to be built.
+  # The runsheet generation is expected to be fast.
   generate_tests_matrix:
     name: Generate test runsheet
     runs-on: windows-latest
@@ -20,6 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      # In order to build the solution, we need to install the SDK and the toolsets first
+      # as defined in global.json. For this, create a temporary project file and run the
+      # build command with the -restore option. This will install the SDK and toolsets.
+      #
+      # We don't want to run 'build.cmd -restore' as it will also restore all the packages,
+      # which takes a long time and is not needed for this job.
       - name: Install toolsets
         shell: pwsh
         run: |
@@ -44,6 +53,10 @@ jobs:
             ${{ github.workspace }}/artifacts/tmp/*/combined_runsheet.json
           retention-days: 3
 
+  # Generates a runsheet for all the tests in the solution that DO require
+  # NuGet packages to be built.
+  # The runsheet generation is expected to be slow as we need to restore and build
+  # the whole solution and publish all the packages.
   generate_e2e_matrix:
     name: Generate E2E test runsheet
     runs-on: windows-latest
@@ -119,7 +132,7 @@ jobs:
           path: |
             ${{ github.workspace }}/artifacts/TestResults/*/*.trx
             ${{ github.workspace }}/artifacts/log/*/TestLogs/**
-          retention-days: 3
+          retention-days: 30
 
       - name: Upload logs
         if: failure()
@@ -183,7 +196,7 @@ jobs:
           path: |
             ${{ github.workspace }}/artifacts/TestResults/*/*.trx
             ${{ github.workspace }}/artifacts/log/*/TestLogs/**
-          retention-days: 3
+          retention-days: 30
 
       - name: Upload logs
         if: failure()

--- a/.github/workflows/tests-runner.yml
+++ b/.github/workflows/tests-runner.yml
@@ -1,0 +1,195 @@
+# Executes all the tests on all the platforms
+name: Tests
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Duplicated jobs so their dependencies are not blocked on both the
+  # setup jobs
+
+  generate_tests_matrix:
+    name: Generate test runsheet
+    runs-on: windows-latest
+    outputs:
+      runsheet: ${{ steps.generate_tests_matrix.outputs.runsheet }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install toolsets
+        shell: pwsh
+        run: |
+          mkdir ./artifacts/tmp -force | Out-Null
+          '<Project />' | Out-File -FilePath ./artifacts/tmp/install-toolset.proj -Encoding utf8
+          ./build.cmd -restore -projects ./artifacts/tmp/install-toolset.proj
+
+      - name: Generate test runsheet
+        id: generate_tests_matrix
+        shell: pwsh
+        run: |
+          ./build.cmd -test /p:TestRunnerName=TestRunsheetBuilder -bl -c Release
+
+      - name: Upload logs, and test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: runsheet-logs
+          path: |
+            ${{ github.workspace }}/artifacts/log/*/*.binlog
+            ${{ github.workspace }}/artifacts/log/*/TestLogs/**
+            ${{ github.workspace }}/artifacts/tmp/*/combined_runsheet.json
+          retention-days: 3
+
+  generate_e2e_matrix:
+    name: Generate E2E test runsheet
+    runs-on: windows-latest
+    outputs:
+      runsheet: ${{ steps.generate_e2e_matrix.outputs.runsheet }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build with packages
+        run: |
+          ./build.cmd -restore -build -pack -c Release -ci -bl /p:InstallBrowsersForPlaywright=false /p:SkipTestProjects=true /p:CI=false
+
+      - name: Generate test runsheet
+        id: generate_e2e_matrix
+        run: |
+          ./build.cmd -test /p:TestRunnerName=TestRunsheetBuilder /p:FullE2e=true -bl -c Release
+
+      - name: Upload built NuGets
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: built-nugets
+          path: artifacts/packages
+          retention-days: 3
+
+      - name: Upload logs, and test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: runsheet-e2e-logs
+          path: |
+            ${{ github.workspace }}/artifacts/log/*/*.binlog
+            ${{ github.workspace }}/artifacts/log/*/TestLogs/**
+            ${{ github.workspace }}/artifacts/tmp/*/combined_runsheet.json
+          retention-days: 3
+
+  run_tests:
+    name: Test
+    needs: generate_tests_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        tests: ${{ fromJson(needs.generate_tests_matrix.outputs.runsheet) }}
+
+    runs-on: ${{ matrix.tests.os }} # Use the OS from the matrix
+
+    steps:
+      - name: Trust HTTPS development certificate
+        if: runner.os == 'Linux'
+        run: dotnet dev-certs https --trust
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Verify Docker is running
+        # nested docker containers not supported on windows
+        if: runner.os == 'Linux'
+        run: docker info
+
+      - name: Install Azure Functions Core Tools
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y azure-functions-core-tools-4
+
+      - name: Test ${{ matrix.tests.project }}
+        run: |
+          ${{ matrix.tests.command }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: ${{ matrix.tests.project }}-${{ matrix.tests.os }}-logs
+          path: |
+            ${{ github.workspace }}/artifacts/TestResults/*/*.trx
+            ${{ github.workspace }}/artifacts/log/*/TestLogs/**
+          retention-days: 3
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: ${{ matrix.tests.project }}-${{ matrix.tests.os }}-binlogs
+          path: |
+            ${{ github.workspace }}/artifacts/log/*/*.binlog
+          retention-days: 3
+
+  run_e2e_tests:
+    name: E2ETest
+    needs: generate_e2e_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        tests: ${{ fromJson(needs.generate_e2e_matrix.outputs.runsheet) }}
+
+    runs-on: ${{ matrix.tests.os }} # Use the OS from the matrix
+
+    steps:
+      - name: Trust HTTPS development certificate
+        if: runner.os == 'Linux'
+        run: dotnet dev-certs https --trust
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download built NuGets
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          pattern: built-nugets
+          path: ${{ github.workspace }}/artifacts/packages
+
+      - name: Copy NuGets to the correct location
+        shell: pwsh
+        run:
+          Move-Item -Path "${{ github.workspace }}/artifacts/packages/built-nugets/Release" -Destination "${{ github.workspace }}/artifacts/packages"
+
+      - name: Verify Docker is running
+        # nested docker containers not supported on windows
+        if: runner.os == 'Linux'
+        run: docker info
+
+      - name: Install Azure Functions Core Tools
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y azure-functions-core-tools-4
+
+      - name: Test ${{ matrix.tests.project }}
+        env:
+          BUILT_NUGETS_PATH: ${{ github.workspace }}/artifacts/packages/Release/Shipping
+        run: |
+          ${{ matrix.tests.command }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: ${{ matrix.tests.project }}-${{ matrix.tests.os }}-logs
+          path: |
+            ${{ github.workspace }}/artifacts/TestResults/*/*.trx
+            ${{ github.workspace }}/artifacts/log/*/TestLogs/**
+          retention-days: 3
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: ${{ matrix.tests.project }}-${{ matrix.tests.os }}-binlogs
+          path: |
+            ${{ github.workspace }}/artifacts/log/*/*.binlog
+          retention-days: 3

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -50,7 +50,7 @@
       ```
 
     -->
-  <Target Name="_GenerateTestMatrix" BeforeTargets="Test" Condition=" '$(TestRunnerName)' == 'QuarantinedTestRunsheetBuilder' ">
+  <Target Name="_GenerateTestMatrix" BeforeTargets="Test" Condition=" '$(TestRunnerName)' == 'TestRunsheetBuilder' or  '$(TestRunnerName)' == 'QuarantinedTestRunsheetBuilder' ">
     <PropertyGroup>
       <_CombinedRunsheetFile>$(ArtifactsTmpDir)/combined_runsheet.json</_CombinedRunsheetFile>
       <_Command>
@@ -65,7 +65,9 @@
                     $combined += @($content)
                 }
             }
-        $jsonString = ($combined | ConvertTo-Json -Depth 10 -Compress)
+
+        # See https://collectingwisdom.com/powershell-convertto-json-single-item-array/
+        $jsonString = (ConvertTo-Json $combined -Depth 10 -Compress)
         $jsonString | Set-Content '$(_CombinedRunsheetFile)';
 
         # determine if the script is running in a GitHub Actions environment

--- a/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
+++ b/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
@@ -1,0 +1,109 @@
+<Project>
+  <!--
+
+    This file is used to generate a list of tests to run on GitHub Actions.
+
+    - For projects not requiring packages:
+         .\build.cmd -test /p:TestRunnerName=TestRunsheetBuilder [/bl /p:GITHUB_ACTIONS=true]
+
+    - For projects requiring packages (e.g., E2E, templates and playground):
+         .\build.cmd -test /p:TestRunnerName=TestRunsheetBuilder /p:FullE2e=true [/bl /p:GITHUB_ACTIONS=true]
+
+    For the large part this is a copy of the Arcade SDK's implementations:
+      - https://github.com/dotnet/arcade/blob/b888df17/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.Runner.targets
+      - https://github.com/dotnet/arcade/blob/b888df17/src/Microsoft.DotNet.Arcade.Sdk/tools/VSTest.targets
+   -->
+
+  <Target Name="RunTests"
+          Outputs="%(TestToRun.ResultsStdOutPath)"
+          Condition=" '$(SkipTests)' != 'true' and '$(IsGitHubActionsRunner)' == 'true' and '$(RunOnGithubActions)' == 'true' ">
+
+    <PropertyGroup>
+      <!--
+
+        The runsheet is created in two scenarios:
+        - For projects requiring packages, only if full end-to-end tests (`FullE2e`) are enabled.
+        - For projects not requiring packages, only if full end-to-end tests (`FullE2e`) are disabled.
+
+        This logic ensures runsheets are generated appropriately based on the project's characteristics and the testing scenario.
+
+        FIXME: Aspire.Playground.Tests are currently not running in "out of repo" mode.
+        FIXME: Aspire.Templates.Tests are currently left alone.
+
+        -->
+      <_RequiresPackages Condition=" '$(MSBuildProjectName)' == 'Aspire.EndToEnd.Tests' ">true</_RequiresPackages>
+
+      <_CreateRunsheet>false</_CreateRunsheet>
+      <_CreateRunsheet Condition=" '$(_RequiresPackages)' == 'true' and '$(FullE2e)' == 'true' ">true</_CreateRunsheet>
+      <_CreateRunsheet Condition=" '$(_RequiresPackages)' != 'true' and '$(FullE2e)' != 'true' ">true</_CreateRunsheet>
+
+      <_CreateRunsheet Condition=" '$(MSBuildProjectName)' == 'Aspire.Templates.Tests' ">false</_CreateRunsheet>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <!--
+        We do not care whether the project is multi-targeting, we're only generating a command to kick off the testing sequence,
+        which in turn will run the tests for all the target frameworks.
+
+        So, instead of using "%(TestToRun.ResultsFilePathWithoutExtension)" (which looks something like "Aspire.Cli.Tests_net8.0_x64")
+        we use the project name (which looks something like "Aspire.Cli.Tests").
+        -->
+      <_TestRunsheet>$(MSBuildProjectName)</_TestRunsheet>
+      <_TestRunsheetFileNameWindows>$(ArtifactsTmpDir)\$(_TestRunsheet).win.runsheet.json</_TestRunsheetFileNameWindows>
+      <_TestRunsheetFileNameLinux>$(ArtifactsTmpDir)\$(_TestRunsheet).linux.runsheet.json</_TestRunsheetFileNameLinux>
+
+      <_TestBinLog>$([MSBuild]::NormalizePath($(ArtifactsLogDir), '$(_TestRunsheet).binlog'))</_TestBinLog>
+
+      <_RelativeTestProjectPath>$([System.String]::Copy('$(MSBuildProjectFullPath)').Replace('$(RepoRoot)', '%24(pwd)/'))</_RelativeTestProjectPath>
+      <_RelativeTestBinLog>$([System.String]::Copy('$(_TestBinLog)').Replace('$(RepoRoot)', '%24(pwd)/'))</_RelativeTestBinLog>
+
+      <_TestRunnerWindows>./eng/build.ps1</_TestRunnerWindows>
+      <_TestRunnerLinux>./eng/build.sh</_TestRunnerLinux>
+      <_TestCommand>-restore -build -test -projects &quot;$(_RelativeTestProjectPath)&quot; /bl:&quot;$(_RelativeTestBinLog)&quot; -c $(Configuration) -ci /p:CI=false</_TestCommand>
+
+      <!-- Tests requiring packages must be run in the "out of repo" mode -->
+      <_TestCommand Condition=" '$(_RequiresPackages)' == 'true' ">$(_TestCommand) /p:TestsRunningOutsideOfRepo=true</_TestCommand>
+
+      <!-- Replace \ with /, and then escape " with \", so we have a compliant JSON -->
+      <_TestCommand>$([System.String]::Copy($(_TestCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_TestCommand>
+
+      <_TestRunsheetWindows>{ "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
+      <_TestRunsheetLinux>{ "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_OutputFiles Include="$(_TestRunsheetFileNameWindows)" />
+      <_OutputFiles Include="$(_TestRunsheetFileNameLinux)" />
+    </ItemGroup>
+
+    <MakeDir Directories="@(_OutputFiles->'%(RootDir)%(Directory)')"/>
+    <Delete Files="@(_OutputFiles)" />
+
+    <WriteLinesToFile
+            Condition=" '$(RunOnGithubActionsWindows)' == 'true' and '$(_CreateRunsheet)' == 'true' "
+            File="$(_TestRunsheetFileNameWindows)"
+            Lines="$(_TestRunsheetWindows)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile
+            Condition=" '$(RunOnGithubActionsLinux)' == 'true' and '$(_CreateRunsheet)' == 'true' "
+            File="$(_TestRunsheetFileNameLinux)"
+            Lines="$(_TestRunsheetLinux)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
+
+    <!--
+      On Linux there's a bug in MSBuild, which "normalises" all slashes (see https://github.com/dotnet/msbuild/issues/3468).
+      This is a workaround to replace `/"` with the required `\"`.
+      -->
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameWindows)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameWindows)'&quot; "
+          Condition=" Exists('$(_TestRunsheetFileNameWindows)') and '$(BuildOs)' != 'windows' " />
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameLinux)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameLinux)'&quot; "
+          Condition=" Exists('$(_TestRunsheetFileNameLinux)') and '$(BuildOs)' != 'windows' " />
+
+    <!--
+      The final piece of the puzzle is in eng/AfterSolutionBuild.targets, where we combine the runsheets from all the test projects into a single runsheet.
+      -->
+  </Target>
+
+</Project>

--- a/eng/Testing.targets
+++ b/eng/Testing.targets
@@ -58,8 +58,7 @@
     <SkipTests>true</SkipTests>
 
     <!-- Only run tests if the build is running on GitHub Actions  -->
-    <SkipTests Condition=" '$(IsGitHubActionsRunner)' == 'true' and '$(BuildOs)' == 'windows' and '$(RunOnGithubActionsWindows)' == 'true' ">false</SkipTests>
-    <SkipTests Condition=" '$(IsGitHubActionsRunner)' == 'true' and '$(BuildOs)' != 'windows' and '$(RunOnGithubActionsLinux)' == 'true' ">false</SkipTests>
+    <SkipTests Condition=" '$(IsGitHubActionsRunner)' == 'true' and '$(RunOnGithubActions)' == 'true' ">false</SkipTests>
 
     <!-- Only run tests if the build is running on Helix infra  -->
     <SkipTests Condition=" '$(IsAzdoHelixRunner)' == 'true' and '$(RunOnAzdoHelix)' == 'true' ">false</SkipTests>

--- a/eng/Xunit3/Microsoft.Testing.Platform.targets
+++ b/eng/Xunit3/Microsoft.Testing.Platform.targets
@@ -78,6 +78,14 @@
       <_ResultsFileToDisplay Condition="!Exists('$(_ResultsFileToDisplay)')">%(TestToRun.ResultsStdOutPath)</_ResultsFileToDisplay>
     </PropertyGroup>
 
+    <!-- Generate a test report -->
+    <Exec Command="pwsh -command &quot;$(RepoRoot)eng/scripts/gha-testreport.ps1 -TestResultsFolder '$(_TestResultDirectory)' -TestSummaryOutputFolder '$(TestResultsLogDir)'&quot;"
+          Condition=" '$(IsGitHubActionsRunner)' == 'true' "
+          WorkingDirectory="$(RepoRoot)"
+          IgnoreExitCode="true"
+          ContinueOnError="WarnAndContinue"
+          />
+
     <!--
       Ideally we would set ContinueOnError="ErrorAndContinue" so that when a test fails in multi-targeted test project
       we'll still run tests for all target frameworks. ErrorAndContinue doesn't work well on Linux though: https://github.com/Microsoft/msbuild/issues/3961.

--- a/eng/scripts/gha-testreport.ps1
+++ b/eng/scripts/gha-testreport.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Generates a summary report from .trx test result files.
+
+.DESCRIPTION
+    This script scans a source folder for .trx test result files, parses them, and generates a summary log file in the specified destination folder.
+    The summary includes test counts, outcomes, and a formatted table of results.
+
+.PARAMETER TestResultsFolder
+    The folder path where .trx test result files are located. The script will search recursively.
+
+.PARAMETER TestSummaryOutputFolder
+    The folder path where the summary log file (summary.log) will be saved. The folder will be created if it does not exist.
+
+.EXAMPLE
+    .\gha-testreport.ps1 -TestResultsFolder "C:\tests\results" -TestSummaryOutputFolder "C:\tests\summary"
+#>
+param(
+    [Parameter(Mandatory = $true, HelpMessage = "Path to the folder containing .trx test result files.")]
+    [string]$TestResultsFolder,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Path to the folder where the summary log will be saved.")]
+    [string]$TestSummaryOutputFolder
+)
+
+# Ensure destination folder exists
+if (-not (Test-Path $TestSummaryOutputFolder)) {
+    New-Item -ItemType Directory -Path $TestSummaryOutputFolder | Out-Null
+}
+
+$trxFiles = Get-ChildItem -Path $TestResultsFolder -Filter *.trx -Recurse
+
+$testResults = @() # Initialize an array to store test results
+
+foreach ($trxFile in $trxFiles) {
+    # Load the .trx file as XML
+    $xmlContent = [xml](Get-Content -Path $trxFile.FullName)
+
+    # Extract test results from the XML
+    foreach ($testResult in $xmlContent.TestRun.Results.UnitTestResult) {
+        $testName = $testResult.testName
+        $outcome = $testResult.outcome
+        $duration = $testResult.duration
+
+        # Map outcome to emoji
+        switch ($outcome) {
+            "Passed" { $emoji = "✔️" }
+            "Failed" { $emoji = "❌" }
+            default { $emoji = "❔" }
+        }
+
+        # Normalize the duration to a consistent format (mm:ss.fff)
+        $normalizedDuration = [TimeSpan]::Parse($duration).ToString("mm\:ss\.fff")
+
+        # Add the test result to the array
+        $testResults += [PSCustomObject]@{
+            TestName    = $testName
+            Outcome     = $outcome
+            OutcomeIcon = $emoji
+            Duration    = $normalizedDuration
+        }
+    }
+}
+
+if ($testResults.Length -lt 1) {
+    echo "::notice:: Tests Summary: no tests found"
+    return;
+}
+
+# Sort the test results by test name
+$testResults = $testResults | Sort-Object -Property TestName
+
+# Calculate summary statistics
+$totalTests = $testResults.Count
+$passedTests = ($testResults | Where-Object { $_.Outcome -eq "Passed" }).Count
+$failedTests = ($testResults | Where-Object { $_.Outcome -eq "Failed" }).Count
+$skippedTests = ($testResults | Where-Object { $_.Outcome -eq "NotExecuted" }).Count
+
+# Add the summary to the annotation
+$summary = "total: $totalTests, passed: $passedTests, failed: $failedTests, skipped: $skippedTests"
+if ($failedTests -gt 0) {
+    echo "::warning:: Tests Summary: $summary"
+} else {
+    echo "::notice:: Tests Summary: $summary"
+}
+
+# Format the test results as a console-friendly table
+$tableHeader = "{0,-16} {1,-150} {2,-20}" -f "Duration", "Test Name", "Result"
+$tableSeparator = "-" * 185
+$tableRows = $testResults | ForEach-Object { "{0,-16} {1,-150} {2,-20}" -f $_.Duration, $_.TestName, "$($_.OutcomeIcon) $($_.Outcome)" }
+$table = "$tableHeader`n$tableSeparator`n" + ($tableRows -join "`n") + "`n$tableSeparator`n"
+echo "`nTest Results:`n$table"
+
+# Save the results to a file for further processing
+$outputPath = Join-Path $TestSummaryOutputFolder "summary.log"
+$table | Out-File -FilePath $outputPath -Encoding utf8
+
+echo "Test results saved to $outputPath"

--- a/tests/Aspire.EndToEnd.Tests/Directory.Build.props
+++ b/tests/Aspire.EndToEnd.Tests/Directory.Build.props
@@ -4,5 +4,9 @@
     <IsTemplateTestProject>true</IsTemplateTestProject>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(BaseOutputPath)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true' and '$(PrepareForHelix)' != 'true' ">
+    <BaseOutputPath >$([MSBuild]::NormalizeDirectory($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</BaseOutputPath>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 </Project>

--- a/tests/Shared/RepoTesting/README.md
+++ b/tests/Shared/RepoTesting/README.md
@@ -1,17 +1,17 @@
 # Running tests outside-of-repo
 
 This provides support for running tests outside of the repo, for example on a helix agent.
-    - For this you need the source of the tests, and any dependencies.
-    - Instead of direct `ProjectReferences` to the various Aspire hosting, and component projects use
-    `@(AspireProjectOrPackageReference)`.
-        - These are converted to `ProjectReference` when `$(TestsRunningOutsideOfRepo) != true`.
-        - But converted to `PackageReference` when `$(TestsRunningOutsideOfRepo) == true`.
 
-    - To allow building such test projects, the build is isolated and patched to build outside the
-    repo by adding appropriate `Directory.Build.{props,targets}`, and `Directory.Packages.props`
-            - and using a custom `nuget.config` which resolves the Aspire packages from the locally built packages
-            - and a `Directory.Packages.Versions.props` is generated with PackageVersions taken from the repo
-        - This also adds properties named in `@(PropertyForHelixRun)` from the repo, like `$(DefaultTargetFramework)`.
+- For this you need the source of the tests, and any dependencies.
+- Instead of direct `ProjectReferences` to the various Aspire hosting, and component projects use `@(AspireProjectOrPackageReference)`.
+    - These are converted to `ProjectReference` when `$(TestsRunningOutsideOfRepo) != true`.
+    - But converted to `PackageReference` when `$(TestsRunningOutsideOfRepo) == true`.
+
+- To allow building such test projects, the build is isolated and patched to build outside the
+repo by adding appropriate `Directory.Build.{props,targets}`, and `Directory.Packages.props`
+    - and using a custom `nuget.config` which resolves the Aspire packages from the locally built packages
+    - and a `Directory.Packages.Versions.props` is generated with PackageVersions taken from the repo
+    - This also adds properties named in `@(PropertyForHelixRun)` from the repo, like `$(DefaultTargetFramework)`.
 
 ## Adding new package versions
 


### PR DESCRIPTION
Generate a runsheet for all tests using the Arcade SDK, similar to how we generate runsheets for quarantined tests.

There are two parallel workflows:

![image](https://github.com/user-attachments/assets/e7ce4a7d-1bba-410d-bcbc-baf2d00fd5da)


1\. generate a runsheet for all tests that must be run in "out of repo" mode and depend on nupkgs. These tests include the E2E and the Template tests, though the Template tests are currently excluded (per @radical's ask).
The first step of the flow is expensive because we need to generate all nupkgs, however, the second step of the flow is generally fast.

2\. generate a runsheet for all other tests.
The first part is reasonably fast (it takes ~1min to install all toolsets); and the second part is as long as the longest test (considering we get all test projects run concurrently; subject to VM pool availability).

This implementation avoids a lot of existing test-related infra. One of the key changes, is that instead of archiving and unarchiving the E2E tests it is published to and executed from a temporary location.