### PR TITLE
Disable testing platform protocol mode in Workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "dotnet.previewSolution-freeWorkspaceMode": true,
-    "dotnet.testWindow.useTestingPlatformProtocol": true
+    "dotnet.testWindow.useTestingPlatformProtocol": false
 }


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/aspire/pull/8802.

Explicitly disabling MTP mode in all cases since I observed a different set of issues with testing locally after consuming the change above.