### PR TITLE
`aspire run` test coverage

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -9,7 +9,19 @@ using StreamJsonRpc;
 
 namespace Aspire.Cli.Backchannel;
 
-internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, CliRpcTarget target)
+internal interface IAppHostBackchannel
+{
+    Task<long> PingAsync(long timestamp, CancellationToken cancellationToken);
+    Task RequestStopAsync(CancellationToken cancellationToken);
+    Task<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)> GetDashboardUrlsAsync(CancellationToken cancellationToken);
+    IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> GetResourceStatesAsync(CancellationToken cancellationToken);
+    Task ConnectAsync(Process process, string socketPath, CancellationToken cancellationToken);
+    Task<string[]> GetPublishersAsync(CancellationToken cancellationToken);
+    IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync(CancellationToken cancellationToken);
+    Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken);
+}
+
+internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, CliRpcTarget target) : IAppHostBackchannel
 {
     private readonly ActivitySource _activitySource = new(nameof(AppHostBackchannel));
     private readonly TaskCompletionSource<JsonRpc> _rpcTaskCompletionSource = new();

--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -15,7 +15,7 @@ internal interface IAppHostBackchannel
     Task RequestStopAsync(CancellationToken cancellationToken);
     Task<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)> GetDashboardUrlsAsync(CancellationToken cancellationToken);
     IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> GetResourceStatesAsync(CancellationToken cancellationToken);
-    Task ConnectAsync(Process process, string socketPath, CancellationToken cancellationToken);
+    Task ConnectAsync(string socketPath, CancellationToken cancellationToken);
     Task<string[]> GetPublishersAsync(CancellationToken cancellationToken);
     IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync(CancellationToken cancellationToken);
     Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken);
@@ -25,7 +25,6 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
 {
     private readonly ActivitySource _activitySource = new(nameof(AppHostBackchannel));
     private readonly TaskCompletionSource<JsonRpc> _rpcTaskCompletionSource = new();
-    private Process? _process;
 
     public async Task<long> PingAsync(long timestamp, CancellationToken cancellationToken)
     {
@@ -98,13 +97,11 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         }
     }
 
-    public async Task ConnectAsync(Process process, string socketPath, CancellationToken cancellationToken)
+    public async Task ConnectAsync(string socketPath, CancellationToken cancellationToken)
     {
         try
         {
             using var activity = _activitySource.StartActivity();
-
-            _process = process;
 
             if (_rpcTaskCompletionSource.Task.IsCompleted)
             {

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -94,7 +94,7 @@ internal sealed class PublishCommand : BaseCommand
                         $"{nameof(ExecuteAsync)}-Action-GetPublishers",
                         ActivityKind.Client);
 
-                    var backchannelCompletionSource = new TaskCompletionSource<AppHostBackchannel>();
+                    var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
                     var pendingInspectRun = _runner.RunAsync(
                         effectiveAppHostProjectFile,
                         false,
@@ -156,7 +156,7 @@ internal sealed class PublishCommand : BaseCommand
                         $"{nameof(ExecuteAsync)}-Action-GenerateArtifacts",
                         ActivityKind.Internal);
                     
-                    var backchannelCompletionSource = new TaskCompletionSource<AppHostBackchannel>();
+                    var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
 
                     var launchingAppHostTask = context.AddTask(":play_button:  Launching apphost");
                     launchingAppHostTask.IsIndeterminate();

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -106,7 +106,7 @@ internal sealed class RunCommand : BaseCommand
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
 
-            var backchannelCompletitionSource = new TaskCompletionSource<AppHostBackchannel>();
+            var backchannelCompletitionSource = new TaskCompletionSource<IAppHostBackchannel>();
 
             var pendingRun = _runner.RunAsync(
                 effectiveAppHostProjectFile,

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -17,7 +17,7 @@ internal interface IDotNetCliRunner
 {
     Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(FileInfo projectFile, CancellationToken cancellationToken);
     Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, CancellationToken cancellationToken);
-    Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken);
+    Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken);
     Task<int> CheckHttpCertificateAsync(CancellationToken cancellationToken);
     Task<int> TrustHttpCertificateAsync(CancellationToken cancellationToken);
     Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, CancellationToken cancellationToken);
@@ -134,7 +134,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         }
     }
 
-    public async Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
+    public async Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -316,7 +316,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         return socketPath;
     }
 
-    public async Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, Action<StreamWriter, StreamReader, StreamReader>? streamsCallback, CancellationToken cancellationToken)
+    public async Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, Action<StreamWriter, StreamReader, StreamReader>? streamsCallback, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -436,7 +436,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         }
     }
 
-    private async Task StartBackchannelAsync(Process process, string socketPath, TaskCompletionSource<AppHostBackchannel> backchannelCompletionSource, CancellationToken cancellationToken)
+    private async Task StartBackchannelAsync(Process process, string socketPath, TaskCompletionSource<IAppHostBackchannel> backchannelCompletionSource, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -442,7 +442,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
         using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
 
-        var backchannel = serviceProvider.GetRequiredService<AppHostBackchannel>();
+        var backchannel = serviceProvider.GetRequiredService<IAppHostBackchannel>();
         var connectionAttempts = 0;
 
         logger.LogDebug("Starting backchannel connection to AppHost at {SocketPath}", socketPath);

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -454,7 +454,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             try
             {
                 logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts++);
-                await backchannel.ConnectAsync(process, socketPath, cancellationToken).ConfigureAwait(false);
+                await backchannel.ConnectAsync(socketPath, cancellationToken).ConfigureAwait(false);
                 backchannelCompletionSource.SetResult(backchannel);
                 logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
                 return;

--- a/src/Aspire.Cli/Interaction/InteractionService.cs
+++ b/src/Aspire.Cli/Interaction/InteractionService.cs
@@ -11,10 +11,6 @@ internal class InteractionService : IInteractionService
 {
     private readonly IAnsiConsole _ansiConsole;
 
-    public InteractionService() : this(AnsiConsole.Console)
-    {
-    }
-
     public InteractionService(IAnsiConsole ansiConsole)
     {
         ArgumentNullException.ThrowIfNull(ansiConsole);

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -17,6 +17,8 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Spectre.Console;
+
 #endif
 
 using RootCommand = Aspire.Cli.Commands.RootCommand;
@@ -75,6 +77,7 @@ public class Program
         }
 
         // Shared services.
+        builder.Services.AddSingleton(BuildAnsiConsole);
         builder.Services.AddSingleton(BuildProjectLocator);
         builder.Services.AddSingleton<INewCommandPrompter, NewCommandPrompter>();
         builder.Services.AddSingleton<IAddCommandPrompter, AddCommandPrompter>();
@@ -94,6 +97,18 @@ public class Program
 
         var app = builder.Build();
         return app;
+    }
+
+    private static IAnsiConsole BuildAnsiConsole(IServiceProvider serviceProvider)
+    {
+        AnsiConsoleSettings settings = new AnsiConsoleSettings()
+        {
+            Ansi = AnsiSupport.Detect,
+            Interactive = InteractionSupport.Detect,
+            ColorSystem = ColorSystemSupport.Detect
+        };
+        var ansiConsole = AnsiConsole.Create(settings);
+        return ansiConsole;
     }
 
     private static IProjectLocator BuildProjectLocator(IServiceProvider serviceProvider)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -81,7 +81,7 @@ public class Program
         builder.Services.AddSingleton<IInteractionService, InteractionService>();
         builder.Services.AddSingleton<ICertificateService, CertificateService>();
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
-        builder.Services.AddTransient<AppHostBackchannel>();
+        builder.Services.AddTransient<IAppHostBackchannel, AppHostBackchannel>();
         builder.Services.AddSingleton<CliRpcTarget>();
         builder.Services.AddTransient<INuGetPackageCache, NuGetPackageCache>();
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -12,13 +12,12 @@ using Aspire.Cli.Projects;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Spectre.Console;
 
 #if DEBUG
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using Spectre.Console;
-
 #endif
 
 using RootCommand = Aspire.Cli.Commands.RootCommand;

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,7 +36,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return new TestAddCommandPrompter(interactionService);
             };
 
-            options.ProjectLocatorFactory = _ => new FakeProjectLocator();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
@@ -110,7 +109,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return prompter;
             };
 
-            options.ProjectLocatorFactory = _ => new FakeProjectLocator();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
@@ -191,7 +190,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return prompter;
             };
 
-            options.ProjectLocatorFactory = _ => new FakeProjectLocator();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
@@ -268,7 +267,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                 return prompter;
             };
 
-            options.ProjectLocatorFactory = _ => new FakeProjectLocator();
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
 
             options.DotNetCliRunnerFactory = (sp) =>
             {
@@ -328,20 +327,6 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("9.2.0", addedPackageVersion);
     }
 
-}
-
-internal sealed class FakeProjectLocator : IProjectLocator
-{
-    public FileInfo? UseOrFindAppHostProjectFile(FileInfo? projectFile)
-    {
-        if (projectFile != null)
-        {
-            return projectFile;
-        }
-
-        var fakeProjectFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "AppHost.csproj");
-        return new FileInfo(fakeProjectFilePath);
-    }
 }
 
 internal sealed class TestAddCommandPrompter(IInteractionService interactionService) : AddCommandPrompter(interactionService)

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -22,4 +22,100 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
         Assert.Equal(0, exitCode);
     }
+
+    [Fact]
+    public async Task RunCommand_WhenNoProjectFileFound_ReturnsNonZeroExitCode()
+    {
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run");
+
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        Assert.NotEqual(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunCommand_WhenMultipleProjectFilesFound_ReturnsNonZeroExitCode()
+    {
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new MultipleProjectFilesProjectLocator();
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run");
+
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        Assert.NotEqual(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunCommand_WhenProjectFileDoesNotExist_ReturnsNonZeroExitCode()
+    {
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new ProjectFileDoesNotExistLocator();
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run --project /tmp/doesnotexist.csproj");
+
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        Assert.NotEqual(0, exitCode);
+    }
+
+    private sealed class ProjectFileDoesNotExistLocator : Aspire.Cli.Projects.IProjectLocator
+    {
+        public FileInfo? UseOrFindAppHostProjectFile(FileInfo? projectFile)
+        {
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.");
+        }
+    }
+
+    [Fact]
+    public async Task RunCommand_WhenCertificateServiceThrows_ReturnsNonZeroExitCode()
+    {
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.CertificateServiceFactory = _ => new ThrowingCertificateService();
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run");
+
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        Assert.NotEqual(0, exitCode);
+    }
+
+    private sealed class ThrowingCertificateService : Aspire.Cli.Certificates.ICertificateService
+    {
+        public Task EnsureCertificatesTrustedAsync(IDotNetCliRunner runner, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    private sealed class NoProjectFileProjectLocator : Aspire.Cli.Projects.IProjectLocator
+    {
+        public FileInfo? UseOrFindAppHostProjectFile(FileInfo? projectFile)
+        {
+            throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.");
+        }
+    }
+
+    private sealed class MultipleProjectFilesProjectLocator : Aspire.Cli.Projects.IProjectLocator
+    {
+        public FileInfo? UseOrFindAppHostProjectFile(FileInfo? projectFile)
+        {
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.");
+        }
+    }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostBackchannel.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Aspire.Cli.Backchannel;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestAppHostBackchannel : IAppHostBackchannel
+{
+    public Func<long, CancellationToken, long>? PingAsyncCallback { get; set; }
+    public Action<CancellationToken>? RequestStopAsyncCallback { get; set; }
+    public Func<CancellationToken, (string, string?)>? GetDashboardUrlsAsyncCallback { get; set; }
+    public Func<CancellationToken, IAsyncEnumerable<(string, string, string, string[])>>? GetResourceStatesAsyncCallback { get; set; }
+    public Action<Process, string, CancellationToken>? ConnectAsyncCallback { get; set; }
+    public Func<CancellationToken, string[]>? GetPublishersAsyncCallback { get; set; }
+    public Func<CancellationToken, IAsyncEnumerable<(string, string, bool, bool)>>? GetPublishingActivitiesAsyncCallback { get; set; }
+    public Func<CancellationToken, string[]>? GetCapabilitiesAsyncCallback { get; set; }
+
+    public Task<long> PingAsync(long timestamp, CancellationToken cancellationToken) =>
+        Task.FromResult(PingAsyncCallback?.Invoke(timestamp, cancellationToken) ?? timestamp);
+
+    public Task RequestStopAsync(CancellationToken cancellationToken)
+    {
+        RequestStopAsyncCallback?.Invoke(cancellationToken);
+        return Task.CompletedTask;
+    }
+
+    public Task<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)> GetDashboardUrlsAsync(CancellationToken cancellationToken) =>
+        Task.FromResult(GetDashboardUrlsAsyncCallback?.Invoke(cancellationToken) ?? ("http://localhost", null));
+
+    public IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> GetResourceStatesAsync(CancellationToken cancellationToken)
+    {
+        if (GetResourceStatesAsyncCallback != null)
+        {
+            return GetResourceStatesAsyncCallback.Invoke(cancellationToken);
+        }
+        return DefaultResourceStatesAsync(cancellationToken);
+    }
+
+    private static IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> DefaultResourceStatesAsync(CancellationToken cancellationToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        return DefaultResourceStatesAsyncImpl(timer, cancellationToken);
+    }
+
+    private static async IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> DefaultResourceStatesAsyncImpl(PeriodicTimer timer, [EnumeratorCancellation]CancellationToken cancellationToken)
+    {
+        while (await timer.WaitForNextTickAsync(cancellationToken))
+        {
+            yield return ("default-resource", "default-type", "default-state", Array.Empty<string>());
+        }
+    }
+
+    public Task ConnectAsync(Process process, string socketPath, CancellationToken cancellationToken)
+    {
+        ConnectAsyncCallback?.Invoke(process, socketPath, cancellationToken);
+        return Task.CompletedTask;
+    }
+
+    public Task<string[]> GetPublishersAsync(CancellationToken cancellationToken) =>
+        Task.FromResult(GetPublishersAsyncCallback?.Invoke(cancellationToken) ?? Array.Empty<string>());
+
+    public IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync(CancellationToken cancellationToken)
+    {
+        if (GetPublishingActivitiesAsyncCallback != null)
+        {
+            return GetPublishingActivitiesAsyncCallback.Invoke(cancellationToken);
+        }
+        return DefaultPublishingActivitiesAsync();
+    }
+
+    private static IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> DefaultPublishingActivitiesAsync()
+    {
+        var rootId = "root-activity";
+        var childActivities = new[]
+        {
+            (Id: "child-1", Status: "Generating YAML goodness", IsComplete: true, IsError: false),
+            (Id: "child-2", Status: "Building image 1", IsComplete: true, IsError: false),
+            (Id: "child-3", Status: "Building image 2", IsComplete: true, IsError: false)
+        };
+
+        return DefaultPublishingActivitiesAsyncImpl(rootId, childActivities);
+    }
+
+#pragma warning disable CS1998
+    private static async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> DefaultPublishingActivitiesAsyncImpl(string rootId, (string Id, string Status, bool IsComplete, bool IsError)[] childActivities)
+    {
+        yield return (rootId, "Publishing artifacts", false, false);
+        foreach (var child in childActivities)
+        {
+            yield return (child.Id, child.Status, child.IsComplete, child.IsError);
+        }
+        yield return (rootId, "Publishing artifacts", true, false);
+    }
+#pragma warning restore CS1998
+
+    public Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken) =>
+        Task.FromResult(GetCapabilitiesAsyncCallback?.Invoke(cancellationToken) ?? new[] { "baseline.v0" });
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -16,7 +16,7 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     public Func<FileInfo, string[], string[], CancellationToken, (int ExitCode, JsonDocument? Output)>? GetProjectItemsAndPropertiesAsyncCallback { get; set; }
     public Func<string, string, string?, bool, CancellationToken, (int ExitCode, string? TemplateVersion)>? InstallTemplateAsyncCallback { get; set; }
     public Func<string, string, string, CancellationToken, int>? NewProjectAsyncCallback { get; set; }
-    public Func<FileInfo, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostBackchannel>?, CancellationToken, int>? RunAsyncCallback { get; set; }
+    public Func<FileInfo, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostBackchannel>?, CancellationToken, Task<int>>? RunAsyncCallback { get; set; }
     public Func<DirectoryInfo, string, bool, int, int, string?, CancellationToken, (int ExitCode, NuGetPackage[]? Packages)>? SearchPackagesAsyncCallback { get; set; }
     public Func<CancellationToken, int>? TrustHttpCertificateAsyncCallback { get; set; }
 
@@ -74,7 +74,7 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
     {
         return RunAsyncCallback != null
-            ? Task.FromResult(RunAsyncCallback(projectFile, watch, noBuild, args, env, backchannelCompletionSource, cancellationToken))
+            ? RunAsyncCallback(projectFile, watch, noBuild, args, env, backchannelCompletionSource, cancellationToken)
             : throw new NotImplementedException();
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -16,7 +16,7 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     public Func<FileInfo, string[], string[], CancellationToken, (int ExitCode, JsonDocument? Output)>? GetProjectItemsAndPropertiesAsyncCallback { get; set; }
     public Func<string, string, string?, bool, CancellationToken, (int ExitCode, string? TemplateVersion)>? InstallTemplateAsyncCallback { get; set; }
     public Func<string, string, string, CancellationToken, int>? NewProjectAsyncCallback { get; set; }
-    public Func<FileInfo, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<AppHostBackchannel>?, CancellationToken, int>? RunAsyncCallback { get; set; }
+    public Func<FileInfo, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostBackchannel>?, CancellationToken, int>? RunAsyncCallback { get; set; }
     public Func<DirectoryInfo, string, bool, int, int, string?, CancellationToken, (int ExitCode, NuGetPackage[]? Packages)>? SearchPackagesAsyncCallback { get; set; }
     public Func<CancellationToken, int>? TrustHttpCertificateAsyncCallback { get; set; }
 
@@ -71,7 +71,7 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
             : Task.FromResult(0); // If not overridden, just return success.
     }
 
-    public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
+    public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
     {
         return RunAsyncCallback != null
             ? Task.FromResult(RunAsyncCallback(projectFile, watch, noBuild, args, env, backchannelCompletionSource, cancellationToken))

--- a/tests/Aspire.Cli.Tests/TestServices/TestProjectLocator.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProjectLocator.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Projects;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestProjectLocator : IProjectLocator
+{
+    public Func<FileInfo?, FileInfo?>? UseOrFindAppHostProjectFileCallback { get; set; }
+
+    public FileInfo? UseOrFindAppHostProjectFile(FileInfo? projectFile)
+    {
+        if (UseOrFindAppHostProjectFileCallback != null)
+        {
+            return UseOrFindAppHostProjectFileCallback(projectFile);
+        }
+
+        // Fallback behavior if not overridden.
+        if (projectFile != null)
+        {
+            return projectFile;
+        }
+
+        var fakeProjectFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "AppHost.csproj");
+        return new FileInfo(fakeProjectFilePath);
+    }
+}
+

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
@@ -35,6 +36,7 @@ internal static class CliTestHelper
         services.AddTransient<RunCommand>();
         services.AddTransient<AddCommand>();
         services.AddTransient<PublishCommand>();
+        services.AddTransient(options.AppHostBackchannelFactory);
 
         return services;
     }
@@ -84,6 +86,13 @@ internal sealed class CliServiceCollectionTestOptions(ITestOutputHelper outputHe
         var logger = serviceProvider.GetRequiredService<ILogger<NuGetPackageCache>>();
         var runner = serviceProvider.GetRequiredService<IDotNetCliRunner>();
         return new NuGetPackageCache(logger, runner);
+    };
+
+    public Func<IServiceProvider, IAppHostBackchannel> AppHostBackchannelFactory { get; set; } = (IServiceProvider serviceProvider) =>
+    {
+        var logger = serviceProvider.GetRequiredService<ILogger<AppHostBackchannel>>();
+        var rpcTarget = serviceProvider.GetService<CliRpcTarget>() ?? throw new InvalidOperationException("CliRpcTarget not registered");
+        return new AppHostBackchannel(logger, rpcTarget);
     };
 }
 


### PR DESCRIPTION
This PR introduces test coverage for the `aspire run` command. Here is a summary of the changes:

1. Introduces the IAppHostBackchannel interface so we can mock out backchannel behavior. There is a reusable test implementation of this that should allow us to simulate any behaviors we want.
2. Changed `ConnectAsync(...)` so it no longer takes a process, it wasn't using it.
3. Injects `IAnsiConsole` as a dependency to `RunCommand`. This is temporary as eventually the direct usage that RunCommand has on the ansi console will move into `IInteractonService` but I didn't want to tackle that in this PR. This was necessary to avoid some threading issues in the unit tests (seen that issue before in other areas with Spectre Console).
4. Added an explicit catch for `OperationCancelledException`. We were incorrectly returning error code 1 when the user did CTRL-C (writing the tests picked this up).
5. Relocated some of the existing test services since they are used in multiple places.
6. Copilot added some negative test cases for simple arg validation scenarios.
7. Added a end to end success test (which is fully mocked out so it should run quick).