### PR TITLE
This change pushes container registry details to the outputs

### DIFF
--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -247,9 +247,9 @@ public sealed class AzurePublishingContext(
                 }
 
                 foreach (var parameter in br.Parameters)
-                    {
-                        Visit(parameter.Value, CaptureBicepOutputs);
-                    }
+                {
+                    Visit(parameter.Value, CaptureBicepOutputs);
+                }
             }
         }
 

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -217,9 +217,17 @@ public sealed class AzurePublishingContext(
 
         var outputs = new Dictionary<string, BicepOutputReference>();
 
+        void CaptureBicepOutputs(object value)
+        {
+            if (value is BicepOutputReference bo)
+            {
+                outputs[bo.ValueExpression] = bo;
+            }
+        }
+
         foreach (var resource in model.Resources)
         {
-            if (resource.GetDeploymentTargetAnnotation()?.DeploymentTarget is AzureBicepResource br)
+            if (resource.GetDeploymentTargetAnnotation() is { } annotation && annotation.DeploymentTarget is AzureBicepResource br)
             {
                 var moduleDirectory = outputDirectory.CreateSubdirectory(resource.Name);
 
@@ -229,16 +237,19 @@ public sealed class AzurePublishingContext(
 
                 File.Copy(file.Path, modulePath, true);
 
-                foreach (var parameter in br.Parameters)
+                // Capture any bicep outputs from the registry info as it may be needed
+                Visit(annotation.ContainerRegistryInfo?.Name, CaptureBicepOutputs);
+                Visit(annotation.ContainerRegistryInfo?.Endpoint, CaptureBicepOutputs);
+
+                if (annotation.ContainerRegistryInfo is IAzureContainerRegistry acr)
                 {
-                    Visit(parameter.Value, v =>
-                    {
-                        if (v is BicepOutputReference bo)
-                        {
-                            outputs[bo.ValueExpression] = bo;
-                        }
-                    });
+                    Visit(acr.ManagedIdentityId, CaptureBicepOutputs);
                 }
+
+                foreach (var parameter in br.Parameters)
+                    {
+                        Visit(parameter.Value, CaptureBicepOutputs);
+                    }
             }
         }
 
@@ -273,7 +284,7 @@ public sealed class AzurePublishingContext(
     }
 
     private static void Visit(object? value, Action<object> visitor) =>
-        Visit(value, visitor, new HashSet<object>());
+        Visit(value, visitor, []);
 
     private static void Visit(object? value, Action<object> visitor, HashSet<object> visited)
     {

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
@@ -110,29 +110,29 @@ public class AzurePublisherTests(ITestOutputHelper output)
             targetScope = 'subscription'
 
             param environmentName string
-
+            
             param location string
-
+            
             param principalId string
-
+            
             param kvRg string
-
+            
             param kvName string
-
+            
             param storageSku string = 'Standard_LRS'
-
+            
             param skuDescription string = 'The sku is '
-
+            
             var tags = {
               'aspire-env-name': environmentName
             }
-
+            
             resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
               name: 'rg-${environmentName}'
               location: location
               tags: tags
             }
-
+            
             module acaEnv 'acaEnv/acaEnv.bicep' = {
               name: 'acaEnv'
               scope: rg
@@ -141,7 +141,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 userPrincipalId: principalId
               }
             }
-
+            
             module kv 'kv/kv.bicep' = {
               name: 'kv'
               scope: resourceGroup(kvRg)
@@ -150,7 +150,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 kvName: kvName
               }
             }
-
+            
             module existing_storage 'existing-storage/existing-storage.bicep' = {
               name: 'existing-storage'
               scope: resourceGroup('rg-shared')
@@ -158,7 +158,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-
+            
             module pg 'pg/pg.bicep' = {
               name: 'pg'
               scope: rg
@@ -166,7 +166,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-
+            
             module account 'account/account.bicep' = {
               name: 'account'
               scope: rg
@@ -174,7 +174,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-
+            
             module storage 'storage/storage.bicep' = {
               name: 'storage'
               scope: rg
@@ -184,7 +184,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 sku_description: '${skuDescription} ${storageSku}'
               }
             }
-
+            
             module mod 'mod/mod.bicep' = {
               name: 'mod'
               scope: rg
@@ -193,7 +193,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 pgdb: '${pg.outputs.connectionString};Database=pgdb'
               }
             }
-
+            
             module myapp_identity 'myapp-identity/myapp-identity.bicep' = {
               name: 'myapp-identity'
               scope: rg
@@ -201,7 +201,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-
+            
             module myapp_roles_account 'myapp-roles-account/myapp-roles-account.bicep' = {
               name: 'myapp-roles-account'
               scope: rg
@@ -211,7 +211,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 principalId: myapp_identity.outputs.principalId
               }
             }
-
+            
             module fe_identity 'fe-identity/fe-identity.bicep' = {
               name: 'fe-identity'
               scope: rg
@@ -219,7 +219,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-
+            
             module fe_roles_storage 'fe-roles-storage/fe-roles-storage.bicep' = {
               name: 'fe-roles-storage'
               scope: rg
@@ -229,26 +229,28 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 principalId: fe_identity.outputs.principalId
               }
             }
-
-            output myapp_identity_id string = myapp_identity.outputs.id
-
-            output myapp_identity_clientId string = myapp_identity.outputs.clientId
-
-            output account_connectionString string = account.outputs.connectionString
-
-            output acaEnv_AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = acaEnv.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
-
-            output acaEnv_AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = acaEnv.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
-
-            output fe_identity_id string = fe_identity.outputs.id
-
-            output fe_identity_clientId string = fe_identity.outputs.clientId
-
-            output storage_blobEndpoint string = storage.outputs.blobEndpoint
-
+            
+            output acaEnv_AZURE_CONTAINER_REGISTRY_NAME string = acaEnv.outputs.AZURE_CONTAINER_REGISTRY_NAME
+            
             output acaEnv_AZURE_CONTAINER_REGISTRY_ENDPOINT string = acaEnv.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
-
+            
             output acaEnv_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = acaEnv.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
+            
+            output myapp_identity_id string = myapp_identity.outputs.id
+            
+            output myapp_identity_clientId string = myapp_identity.outputs.clientId
+            
+            output account_connectionString string = account.outputs.connectionString
+            
+            output acaEnv_AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = acaEnv.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+            
+            output acaEnv_AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = acaEnv.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
+            
+            output fe_identity_id string = fe_identity.outputs.id
+            
+            output fe_identity_clientId string = fe_identity.outputs.clientId
+            
+            output storage_blobEndpoint string = storage.outputs.blobEndpoint
             """;
         output.WriteLine(content);
         Assert.Equal(expectedBicep, content, ignoreAllWhiteSpace: true, ignoreLineEndingDifferences: true);

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
@@ -30,7 +30,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
 
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        // The azure publisher is not tied to azure container apps but this is 
+        // The azure publisher is not tied to azure container apps but this is
         // a good way to test the end to end scenario
         builder.AddAzureContainerAppEnvironment("acaEnv");
 
@@ -110,29 +110,29 @@ public class AzurePublisherTests(ITestOutputHelper output)
             targetScope = 'subscription'
 
             param environmentName string
-            
+
             param location string
-            
+
             param principalId string
-            
+
             param kvRg string
-            
+
             param kvName string
-            
+
             param storageSku string = 'Standard_LRS'
-            
+
             param skuDescription string = 'The sku is '
-            
+
             var tags = {
               'aspire-env-name': environmentName
             }
-            
+
             resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
               name: 'rg-${environmentName}'
               location: location
               tags: tags
             }
-            
+
             module acaEnv 'acaEnv/acaEnv.bicep' = {
               name: 'acaEnv'
               scope: rg
@@ -141,7 +141,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 userPrincipalId: principalId
               }
             }
-            
+
             module kv 'kv/kv.bicep' = {
               name: 'kv'
               scope: resourceGroup(kvRg)
@@ -150,7 +150,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 kvName: kvName
               }
             }
-            
+
             module existing_storage 'existing-storage/existing-storage.bicep' = {
               name: 'existing-storage'
               scope: resourceGroup('rg-shared')
@@ -158,7 +158,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-            
+
             module pg 'pg/pg.bicep' = {
               name: 'pg'
               scope: rg
@@ -166,7 +166,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-            
+
             module account 'account/account.bicep' = {
               name: 'account'
               scope: rg
@@ -174,7 +174,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-            
+
             module storage 'storage/storage.bicep' = {
               name: 'storage'
               scope: rg
@@ -184,7 +184,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 sku_description: '${skuDescription} ${storageSku}'
               }
             }
-            
+
             module mod 'mod/mod.bicep' = {
               name: 'mod'
               scope: rg
@@ -193,7 +193,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 pgdb: '${pg.outputs.connectionString};Database=pgdb'
               }
             }
-            
+
             module myapp_identity 'myapp-identity/myapp-identity.bicep' = {
               name: 'myapp-identity'
               scope: rg
@@ -201,7 +201,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-            
+
             module myapp_roles_account 'myapp-roles-account/myapp-roles-account.bicep' = {
               name: 'myapp-roles-account'
               scope: rg
@@ -211,7 +211,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 principalId: myapp_identity.outputs.principalId
               }
             }
-            
+
             module fe_identity 'fe-identity/fe-identity.bicep' = {
               name: 'fe-identity'
               scope: rg
@@ -219,7 +219,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 location: location
               }
             }
-            
+
             module fe_roles_storage 'fe-roles-storage/fe-roles-storage.bicep' = {
               name: 'fe-roles-storage'
               scope: rg
@@ -229,27 +229,27 @@ public class AzurePublisherTests(ITestOutputHelper output)
                 principalId: fe_identity.outputs.principalId
               }
             }
-            
+
             output acaEnv_AZURE_CONTAINER_REGISTRY_NAME string = acaEnv.outputs.AZURE_CONTAINER_REGISTRY_NAME
-            
+
             output acaEnv_AZURE_CONTAINER_REGISTRY_ENDPOINT string = acaEnv.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
-            
+
             output acaEnv_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = acaEnv.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
-            
+
             output myapp_identity_id string = myapp_identity.outputs.id
-            
+
             output myapp_identity_clientId string = myapp_identity.outputs.clientId
-            
+
             output account_connectionString string = account.outputs.connectionString
-            
+
             output acaEnv_AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = acaEnv.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
-            
+
             output acaEnv_AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = acaEnv.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
-            
+
             output fe_identity_id string = fe_identity.outputs.id
-            
+
             output fe_identity_clientId string = fe_identity.outputs.clientId
-            
+
             output storage_blobEndpoint string = storage.outputs.blobEndpoint
             """;
         output.WriteLine(content);


### PR DESCRIPTION
## Description
This change pushes container registry details to the outputs

- The assumption is that these are going to be needed to push the container image so they are made available as outputs in main.bicep.
- Updated tests

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
