### PR TITLE
Add display name for Qdrant's HTTP and GRPC endpoints

### DIFF
--- a/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
@@ -87,8 +87,15 @@ public static class QdrantBuilderExtensions
                 }
             })
             .WithHealthCheck(healthCheckKey)
-            .WithUrlForEndpoint(QdrantServerResource.PrimaryEndpointName, c => c.DisplayText = "Qdrant (GRPC)")
-            .WithUrlForEndpoint(QdrantServerResource.HttpEndpointName, c => c.DisplayText = "Qdrant (HTTP)");
+            .WithUrlForEndpoint(QdrantServerResource.PrimaryEndpointName, c =>
+            {
+                c.DisplayText = "Qdrant (GRPC)";
+                // https://github.com/dotnet/aspire/issues/8809
+                c.DisplayLocation = UrlDisplayLocation.DetailsOnly;
+            })
+            .WithUrlForEndpoint(QdrantServerResource.HttpEndpointName, c => c.DisplayText = "Qdrant (HTTP)")
+            .WithUrl(ReferenceExpression.Create($"{qdrant.HttpEndpoint.Property(EndpointProperty.Url)}/dashboard"), "Qdrant Dashboard");
+
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
@@ -86,7 +86,9 @@ public static class QdrantBuilderExtensions
                     context.EnvironmentVariables[EnableStaticContentEnvVarName] = "0";
                 }
             })
-            .WithHealthCheck(healthCheckKey);
+            .WithHealthCheck(healthCheckKey)
+            .WithUrlForEndpoint(QdrantServerResource.PrimaryEndpointName, c => c.DisplayText = "Qdrant (GRPC)")
+            .WithUrlForEndpoint(QdrantServerResource.HttpEndpointName, c => c.DisplayText = "Qdrant (HTTP)");
     }
 
     /// <summary>
@@ -179,7 +181,7 @@ public static class QdrantBuilderExtensions
         {
             throw new InvalidOperationException("Endpoint is unavailable");
         }
-        
+
         var client = new QdrantClient(endpoint, key);
         return client;
     }

--- a/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
@@ -94,8 +94,7 @@ public static class QdrantBuilderExtensions
                 c.DisplayLocation = UrlDisplayLocation.DetailsOnly;
             })
             .WithUrlForEndpoint(QdrantServerResource.HttpEndpointName, c => c.DisplayText = "Qdrant (HTTP)")
-            .WithUrl(ReferenceExpression.Create($"{qdrant.HttpEndpoint.Property(EndpointProperty.Url)}/dashboard"), "Qdrant Dashboard");
-
+            .WithUrlForEndpoint(QdrantServerResource.HttpEndpointName, e => new ResourceUrlAnnotation() { Url = "/dashboard", DisplayText = "Qdrant Dashboard" });
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -239,8 +239,9 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
         await tcs.Task;
 
         var urls = qdrant.Resource.Annotations.OfType<ResourceUrlAnnotation>();
-        Assert.Single(urls, u => u.Endpoint!.EndpointName == "grpc" && u.DisplayText == "Qdrant (GRPC)");
-        Assert.Single(urls, u => u.Endpoint!.EndpointName == "http" && u.DisplayText == "Qdrant (HTTP)");
+        Assert.Single(urls, u => u.Endpoint?.EndpointName == "grpc" && u.DisplayText == "Qdrant (GRPC)" && u.DisplayLocation == UrlDisplayLocation.DetailsOnly);
+        Assert.Single(urls, u => u.Endpoint?.EndpointName == "http" && u.DisplayText == "Qdrant (HTTP)");
+        Assert.Single(urls, u => u.DisplayText == "Qdrant Dashboard" && u.Url.EndsWith("/dashboard"));
 
         await app.StopAsync();
     }

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -221,7 +221,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
-    public async Task AddQudantWithDefaultsAddsUrlAnnotations()
+    public async Task AddQdrantWithDefaultsAddsUrlAnnotations()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 


### PR DESCRIPTION
## Description


This pull request enhances the `Qdrant` integration by adding URL annotations for endpoints and introducing a new functional test to verify the changes. The most important updates are as follows:

### Enhancements to `Qdrant` Integration:

* [`src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs`](diffhunk://#diff-398a2bf0e0f4ea0f871bf4978bac5cdd0cc4f4ef719a872c2d9adf3075a866fdL89-R91): Added `.WithUrlForEndpoint` calls to annotate the `PrimaryEndpointName` and `HttpEndpointName` with display text ("Qdrant (GRPC)" and "Qdrant (HTTP)", respectively). This provides more descriptive endpoint information.

### New Functional Test:

* [`tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs`](diffhunk://#diff-10dd0fb39ba29856d0ec984b2f3617021bbe5e56de21314c035c0b4c98873d91R222-R247): Introduced a new test, `AddQudantWithDefaultsAddsUrlAnnotations`, to validate that the URL annotations are correctly added for the `grpc` and `http` endpoints. This ensures the new feature works as intended.

Fixes #8809

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
