### PR TITLE
[tests] Quarantine OperationModesTests.VerifyExplicitRunModeWithPublisherInvocation

### DIFF
--- a/tests/Aspire.Hosting.Tests/OperationModesTests.cs
+++ b/tests/Aspire.Hosting.Tests/OperationModesTests.cs
@@ -72,7 +72,7 @@ public class OperationModesTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/8223", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8223")]
     public async Task VerifyExplicitRunModeWithPublisherInvocation()
     {
         // The purpose of this test is to verify that the apphost executable will enter


### PR DESCRIPTION
This test is being changed from ActiveIssue to QuarantinedTest because
it fails with a timeout and is likely a flaky test.

Issue: https://github.com/dotnet/aspire/issues/8223
