### PR TITLE
Spike: Set the client id for functions configuration

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -98,6 +98,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
         // Always inject the connection string associated with the top-level resource
         // for the Azure Functions host.
         target[$"{connectionName}__accountEndpoint"] = ConnectionStringExpression;
+        target[$"{connectionName}__clientId"] = default!;
         // Injected to support Aspire client integration for CosmosDB in Azure Functions projects.
         target[$"Aspire__Microsoft__EntityFrameworkCore__Cosmos__{connectionName}__AccountEndpoint"] = ConnectionStringExpression;
         target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__AccountEndpoint"] = ConnectionStringExpression;

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -224,6 +224,14 @@ public static class AzureFunctionsProjectResourceExtensions
         {
             connectionName ??= source.Resource.Name;
             source.Resource.ApplyAzureFunctionsConfiguration(context.EnvironmentVariables, connectionName);
+
+            // https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob&pivots=programming-language-csharp#azure-sdk-environment-variables
+            if (context.EnvironmentVariables.TryGetValue($"{connectionName}__clientId", out var clientId) &&
+                clientId is null &&
+                context.Resource.TryGetLastAnnotation<AppIdentityAnnotation>(out var appIdentityResourceAnnotation))
+            {
+                context.EnvironmentVariables[$"{connectionName}__clientId"] = appIdentityResourceAnnotation.IdentityResource.ClientId;
+            }
         });
     }
 


### PR DESCRIPTION
## Description

This pull request introduces changes to enhance Azure Functions integration by adding support for the `clientId` environment variable. The updates ensure that the `clientId` is correctly injected into the environment variables for Azure Functions projects when applicable.

Fixes #8116

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
