### PR TITLE
Remove named overloads of publisher methods from Azure, Docker Compos…

### DIFF
--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -18,7 +18,11 @@ if (builder.ExecutionContext.PublisherName == "docker-compose" ||
     builder.AddDockerComposeEnvironment("docker-env");
 }
 
-builder.AddKubernetesPublisher();
+if (builder.ExecutionContext.PublisherName == "kubernetes" ||
+    builder.ExecutionContext.IsInspectMode)
+{
+    builder.AddKubernetesEnvironment("k8s-env");
+}
 
 builder.AddAzurePublisher();
 

--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -24,8 +24,6 @@ if (builder.ExecutionContext.PublisherName == "kubernetes" ||
     builder.AddKubernetesEnvironment("k8s-env");
 }
 
-builder.AddAzurePublisher();
-
 var param0 = builder.AddParameter("param0");
 var param1 = builder.AddParameter("param1", secret: true);
 var param2 = builder.AddParameter("param2", "default", publishValueAsDefault: true);

--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -2,12 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREAZURE001
+#pragma warning disable ASPIREPUBLISHERS001
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureContainerAppEnvironment("env");
+if (builder.ExecutionContext.PublisherName == "azure" ||
+    builder.ExecutionContext.IsInspectMode)
+{
+    builder.AddAzureContainerAppEnvironment("env");
+}
 
-builder.AddDockerComposeEnvironment("docker-env");
+if (builder.ExecutionContext.PublisherName == "docker-compose" ||
+    builder.ExecutionContext.IsInspectMode)
+{
+    builder.AddDockerComposeEnvironment("docker-env");
+}
 
 builder.AddKubernetesPublisher();
 

--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREPUBLISHERS001
+#pragma warning disable ASPIREAZURE001
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -11,7 +11,7 @@ builder.AddDockerComposeEnvironment("docker-env");
 
 builder.AddKubernetesPublisher();
 
-builder.AddAzurePublisher("azure");
+builder.AddAzurePublisher();
 
 var param0 = builder.AddParameter("param0");
 var param1 = builder.AddParameter("param1", secret: true);

--- a/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisherExtensions.cs
@@ -15,18 +15,6 @@ public static class AzurePublisherExtensions
     /// Adds an Azure Container Apps publisher to the application model.
     /// </summary>
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
-    /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
-    /// <param name="configureOptions">Callback to configure Azure Container Apps publisher options.</param>
-    [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
-    public static IDistributedApplicationBuilder AddAzurePublisher(this IDistributedApplicationBuilder builder, string name, Action<AzurePublisherOptions>? configureOptions = null)
-    {
-        return builder.AddPublisher<AzurePublisher, AzurePublisherOptions>(name, configureOptions);
-    }
-
-    /// <summary>
-    /// Adds an Azure Container Apps publisher to the application model.
-    /// </summary>
-    /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Azure Container Apps publisher options.</param>
     [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IDistributedApplicationBuilder AddAzurePublisher(this IDistributedApplicationBuilder builder, Action<AzurePublisherOptions>? configureOptions = null)

--- a/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerExtensions.cs
@@ -20,6 +20,11 @@ public static class AzureProvisionerExtensions
     /// </summary>
     public static IDistributedApplicationBuilder AddAzureProvisioning(this IDistributedApplicationBuilder builder)
     {
+        // Always add the Azure publisher, even if the user doesn't explicitly add it.
+#pragma warning disable ASPIREAZURE001
+        builder.AddAzurePublisher();
+#pragma warning restore ASPIREAZURE001
+
         builder.Services.TryAddLifecycleHook<AzureResourcePreparer>();
         builder.Services.TryAddLifecycleHook<AzureProvisioner>();
 

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -27,7 +27,7 @@ public static class DockerComposeEnvironmentExtensions
 
         var resource = new DockerComposeEnvironmentResource(name);
         builder.Services.TryAddLifecycleHook<DockerComposeInfrastructure>();
-        builder.AddDockerComposePublisher(name);
+        builder.AddDockerComposePublisher();
         if (builder.ExecutionContext.IsRunMode)
         {
 

--- a/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherExtensions.cs
@@ -16,17 +16,6 @@ public static class DockerComposePublisherExtensions
     /// Adds a Docker Compose publisher to the application model.
     /// </summary>
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
-    /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
-    /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
-    public static IDistributedApplicationBuilder AddDockerComposePublisher(this IDistributedApplicationBuilder builder, string name, Action<DockerComposePublisherOptions>? configureOptions = null)
-    {
-        return builder.AddPublisher<DockerComposePublisher, DockerComposePublisherOptions>(name, configureOptions);
-    }
-
-    /// <summary>
-    /// Adds a Docker Compose publisher to the application model.
-    /// </summary>
-    /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Docker Compose publisher options.</param>
     public static IDistributedApplicationBuilder AddDockerComposePublisher(this IDistributedApplicationBuilder builder, Action<DockerComposePublisherOptions>? configureOptions = null)
     {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
@@ -27,7 +27,7 @@ public static class KubernetesEnvironmentExtensions
 
         var resource = new KubernetesEnvironmentResource(name);
         builder.Services.TryAddLifecycleHook<KubernetesInfrastructure>();
-        builder.AddKubernetesPublisher(name);
+        builder.AddKubernetesPublisher();
         if (builder.ExecutionContext.IsRunMode)
         {
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublisherExtensions.cs
@@ -16,17 +16,6 @@ public static class KubernetesPublisherExtensions
     /// Adds a Kubernetes publisher to the application model.
     /// </summary>
     /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
-    /// <param name="name">The name of the publisher used when using the Aspire CLI.</param>
-    /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
-    public static IDistributedApplicationBuilder AddKubernetesPublisher(this IDistributedApplicationBuilder builder, string name, Action<KubernetesPublisherOptions>? configureOptions = null)
-    {
-        return builder.AddPublisher<KubernetesPublisher, KubernetesPublisherOptions>(name, configureOptions);
-    }
-
-    /// <summary>
-    /// Adds a Kubernetes publisher to the application model.
-    /// </summary>
-    /// <param name="builder">The <see cref="Aspire.Hosting.IDistributedApplicationBuilder"/>.</param>
     /// <param name="configureOptions">Callback to configure Kubernetes publisher options.</param>
     public static IDistributedApplicationBuilder AddKubernetesPublisher(this IDistributedApplicationBuilder builder, Action<KubernetesPublisherOptions>? configureOptions = null)
     {

--- a/src/Aspire.Hosting/Publishing/PublisherAdvertisementEvent.cs
+++ b/src/Aspire.Hosting/Publishing/PublisherAdvertisementEvent.cs
@@ -13,7 +13,7 @@ internal sealed class PublisherAdvertisementEvent : IDistributedApplicationEvent
         _advertisements.Add(advertisement);
     }
 
-    private readonly List<PublisherAdvertisement> _advertisements = [];
+    private readonly HashSet<PublisherAdvertisement> _advertisements = [];
 
     public IEnumerable<PublisherAdvertisement> Advertisements => _advertisements;
 }
@@ -21,4 +21,14 @@ internal sealed class PublisherAdvertisementEvent : IDistributedApplicationEvent
 internal sealed class PublisherAdvertisement(string name)
 {
     public string Name { get; } = name;
+
+    public override bool Equals(object? obj)
+    {
+        return obj is PublisherAdvertisement other && Name == other.Name;
+    }
+
+    public override int GetHashCode()
+    {
+        return Name.GetHashCode();
+    }
 }


### PR DESCRIPTION
## Description

Remove named overloads of publisher methods from Azure, Docker Compose, and Kubernetes extensions

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
