### PR TITLE
Add properties to DockerComposeEnvironmentResource 

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -41,9 +41,9 @@ public static class DockerComposeEnvironmentExtensions
     }
 
     /// <summary>
-    /// Allows setting the properties of a Docker compose environment resource.
+    /// Allows setting the properties of a Docker Compose environment resource.
     /// </summary>
-    /// <param name="builder">The Docker compose environment resource builder.</param>
+    /// <param name="builder">The Docker Compose environment resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the <see cref="DockerComposeEnvironmentResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<DockerComposeEnvironmentResource> WithProperties(this IResourceBuilder<DockerComposeEnvironmentResource> builder, Action<DockerComposeEnvironmentResource> configure)

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -38,4 +38,20 @@ public static class DockerComposeEnvironmentExtensions
         }
         return builder.AddResource(resource);
     }
+
+    /// <summary>
+    /// Allows setting the properties of a Docker compose environment resource.
+    /// </summary>
+    /// <param name="builder">The Docker compose environment resource builder.</param>
+    /// <param name="configure">A method that can be used for customizing the <see cref="DockerComposeEnvironmentResource"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DockerComposeEnvironmentResource> WithProperties(this IResourceBuilder<DockerComposeEnvironmentResource> builder, Action<DockerComposeEnvironmentResource> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        configure(builder.Resource);
+
+        return builder;
+    }
 }

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Docker;
+using Aspire.Hosting.Docker.Resources;
 using Aspire.Hosting.Lifecycle;
 
 namespace Aspire.Hosting;
@@ -52,6 +53,21 @@ public static class DockerComposeEnvironmentExtensions
 
         configure(builder.Resource);
 
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the Docker Compose file for the environment resource.
+    /// </summary>
+    /// <param name="builder"> The Docker compose environment resource builder.</param>
+    /// <param name="configure">A method that can be used for customizing the <see cref="ComposeFile"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DockerComposeEnvironmentResource> ConfigureComposeFile(this IResourceBuilder<DockerComposeEnvironmentResource> builder, Action<ComposeFile> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        builder.Resource.ConfigureComposeFile += configure;
         return builder;
     }
 }

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -17,6 +17,16 @@ namespace Aspire.Hosting.Docker;
 public class DockerComposeEnvironmentResource(string name) : Resource(name), IComputeEnvironmentResource
 {
     /// <summary>
+    /// The container registry to use.
+    /// </summary>
+    public string? DefaultContainerRegistry { get; set; }
+
+    /// <summary>
+    /// The name of an existing network to be used.
+    /// </summary>
+    public string? DefaultNetworkName { get; set; }
+
+    /// <summary>
     /// Gets the collection of environment variables captured from the Docker Compose environment.
     /// These will be populated into a top-level .env file adjacent to the Docker Compose file.
     /// </summary>

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIRECOMPUTE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Docker.Resources;
 
 namespace Aspire.Hosting.Docker;
 
@@ -25,6 +26,8 @@ public class DockerComposeEnvironmentResource(string name) : Resource(name), ICo
     /// The name of an existing network to be used.
     /// </summary>
     public string? DefaultNetworkName { get; set; }
+
+    internal Action<ComposeFile>? ConfigureComposeFile { get; set; }
 
     /// <summary>
     /// Gets the collection of environment variables captured from the Docker Compose environment.

--- a/src/Aspire.Hosting.Docker/DockerComposePublisherOptions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublisherOptions.cs
@@ -11,16 +11,6 @@ namespace Aspire.Hosting.Docker;
 public sealed class DockerComposePublisherOptions : PublishingOptions
 {
     /// <summary>
-    /// The container registry to use.
-    /// </summary>
-    public string? DefaultContainerRegistry { get; set; }
-
-    /// <summary>
-    /// The name of an existing network to be used.
-    /// </summary>
-    public string? ExistingNetworkName { get; set; }
-
-    /// <summary>
     /// Indicates whether to build container images during the publishing process.
     /// </summary>
     public bool BuildImages { get; set; } = true;

--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -110,6 +110,9 @@ internal sealed class DockerComposePublishingContext(
             }
         }
 
+        // Call the environment's ConfigureComposeFile method to allow for custom modifications
+        environment.ConfigureComposeFile?.Invoke(composeFile);
+
         var composeOutput = composeFile.ToYaml();
         var outputFile = Path.Combine(PublisherOptions.OutputPath!, "docker-compose.yaml");
         Directory.CreateDirectory(PublisherOptions.OutputPath!);

--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -73,7 +73,7 @@ internal sealed class DockerComposePublishingContext(
 
         var defaultNetwork = new Network
         {
-            Name = PublisherOptions.ExistingNetworkName ?? "aspire",
+            Name = environment.DefaultNetworkName ?? "aspire",
             Driver = "bridge",
         };
 

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -285,7 +285,8 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         var options = new OptionsMonitor(new DockerComposePublisherOptions { OutputPath = tempDir.Path });
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        builder.AddDockerComposeEnvironment("docker-compose");
+        builder.AddDockerComposeEnvironment("docker-compose")
+               .WithProperties(e => e.DefaultNetworkName = "default-network");
 
         // Add a container to the application
         var container = builder.AddContainer("service", "nginx")
@@ -336,13 +337,13 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
                   ORIGINAL_ENV: "value"
                   CUSTOM_ENV: "custom-value"
                 networks:
-                  - "aspire"
-                    - "custom-network"
+                  - "default-network"
+                  - "custom-network"
                 restart: "always"
                 labels:
                   custom-label: "test-value"
             networks:
-              aspire:
+              default-network:
                 driver: "bridge"
 
             """,


### PR DESCRIPTION
## Description

- Introduced DefaultContainerRegistry and DefaultNetworkName properties in DockerComposeEnvironmentResource.
- Added WithProperties and ConfigureComposeFile extension methods for configuring DockerComposeEnvironmentResource.
- Updated DockerComposePublishingContext to utilize DefaultNetworkName.
- Modified tests to validate new properties and ensure correct Docker Compose output.

Fixes #8845

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
