### PR TITLE
Treat uninstrumented outgoing peers are instrumented resources in dashboard UI

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -51,7 +51,7 @@
                     </FluentBadge>
                 </div>
                 <PropertyGrid
-                    TItem="ResourcePropertyViewModel"
+                    TItem="DisplayedResourcePropertyViewModel"
                     Items="@FilteredResourceProperties"
                     IsValueMaskedChanged="@OnValueMaskedChanged"
                     HighlightText="@_filter"

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -182,7 +182,7 @@ public partial class TraceDetail : ComponentBase, IDisposable
         }
 
         Logger.LogInformation("Trace '{TraceId}' has {SpanCount} spans.", _trace.TraceId, _trace.Spans.Count);
-        _spanWaterfallViewModels = SpanWaterfallViewModel.Create(_trace, new SpanWaterfallViewModel.TraceDetailState(OutgoingPeerResolvers, _collapsedSpanIds));
+        _spanWaterfallViewModels = SpanWaterfallViewModel.Create(_trace, new SpanWaterfallViewModel.TraceDetailState(_collapsedSpanIds));
         _maxDepth = _spanWaterfallViewModels.Max(s => s.Depth);
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -187,7 +187,7 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
 
     private void UpdateApplications()
     {
-        _applications = TelemetryRepository.GetApplications();
+        _applications = TelemetryRepository.GetApplications(includeUninstrumentedPeers: true);
         _applicationViewModels = ApplicationsSelectHelpers.CreateApplications(_applications);
         _applicationViewModels.Insert(0, _allApplication);
         UpdateSubscription();

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -228,7 +228,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
 
         // Data from the server.
-        builder.Services.TryAddScoped<IDashboardClient, DashboardClient>();
+        builder.Services.TryAddSingleton<IDashboardClient, DashboardClient>();
         builder.Services.TryAddSingleton<IDashboardClientStatus, DashboardClientStatus>();
         builder.Services.TryAddScoped<DashboardCommandExecutor>();
 
@@ -244,8 +244,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddTransient<OtlpMetricsService>();
 
         builder.Services.AddTransient<TracesViewModel>();
-        builder.Services.TryAddEnumerable(ServiceDescriptor.Scoped<IOutgoingPeerResolver, ResourceOutgoingPeerResolver>());
-        builder.Services.TryAddEnumerable(ServiceDescriptor.Scoped<IOutgoingPeerResolver, BrowserLinkOutgoingPeerResolver>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOutgoingPeerResolver, ResourceOutgoingPeerResolver>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOutgoingPeerResolver, BrowserLinkOutgoingPeerResolver>());
 
         builder.Services.AddFluentUIComponents();
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -261,7 +261,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddScoped<ILocalStorage, LocalBrowserStorage>();
         builder.Services.AddScoped<ISessionStorage, SessionBrowserStorage>();
 
-        builder.Services.AddScoped<IKnownPropertyLookup, KnownPropertyLookup>();
+        builder.Services.AddSingleton<IKnownPropertyLookup, KnownPropertyLookup>();
 
         builder.Services.AddScoped<DimensionManager>();
 

--- a/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
@@ -19,7 +19,7 @@ public sealed class BrowserLinkOutgoingPeerResolver : IOutgoingPeerResolver
         }
     }
 
-    public bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResource)
+    public bool TryResolvePeer(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResource)
     {
         // There isn't a good way to identify the HTTP request the BrowserLink middleware makes to
         // the IDE to get the script tag. The logic below looks at the host and URL and identifies

--- a/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Aspire.Dashboard.Otlp.Model;
 
 namespace Aspire.Dashboard.Model;
@@ -20,7 +19,7 @@ public sealed class BrowserLinkOutgoingPeerResolver : IOutgoingPeerResolver
         }
     }
 
-    public bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, [NotNullWhen(true)] out string? name)
+    public bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResource)
     {
         // There isn't a good way to identify the HTTP request the BrowserLink middleware makes to
         // the IDE to get the script tag. The logic below looks at the host and URL and identifies
@@ -48,6 +47,7 @@ public sealed class BrowserLinkOutgoingPeerResolver : IOutgoingPeerResolver
                     if (Guid.TryParse(parts[0], out _) && string.Equals(parts[1], lastSegment, StringComparisons.UrlPath))
                     {
                         name = "Browser Link";
+                        matchedResource = null;
                         return true;
                     }
                 }
@@ -55,6 +55,7 @@ public sealed class BrowserLinkOutgoingPeerResolver : IOutgoingPeerResolver
         }
 
         name = null;
+        matchedResource = null;
         return false;
     }
 }

--- a/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
@@ -5,6 +5,6 @@ namespace Aspire.Dashboard.Model;
 
 public interface IOutgoingPeerResolver
 {
-    bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, out string? name);
+    bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResourced);
     IDisposable OnPeerChanges(Func<Task> callback);
 }

--- a/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
@@ -5,6 +5,6 @@ namespace Aspire.Dashboard.Model;
 
 public interface IOutgoingPeerResolver
 {
-    bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResourced);
+    bool TryResolvePeer(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResourced);
     IDisposable OnPeerChanges(Func<Task> callback);
 }

--- a/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
+++ b/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Localization;
 using static Aspire.Dashboard.Resources.Resources;
 
 namespace Aspire.Dashboard.Model;
@@ -18,43 +17,43 @@ public sealed class KnownPropertyLookup : IKnownPropertyLookup
     private readonly List<KnownProperty> _executableProperties;
     private readonly List<KnownProperty> _containerProperties;
 
-    public KnownPropertyLookup(IStringLocalizer<Resources.Resources> loc)
+    public KnownPropertyLookup()
     {
         _resourceProperties =
         [
-            new(KnownProperties.Resource.DisplayName, loc[nameof(ResourcesDetailsDisplayNameProperty)]),
-            new(KnownProperties.Resource.State, loc[nameof(ResourcesDetailsStateProperty)]),
-            new(KnownProperties.Resource.StartTime, loc[nameof(ResourcesDetailsStartTimeProperty)]),
-            new(KnownProperties.Resource.StopTime, loc[nameof(ResourcesDetailsStopTimeProperty)]),
-            new(KnownProperties.Resource.ExitCode, loc[nameof(ResourcesDetailsExitCodeProperty)]),
-            new(KnownProperties.Resource.HealthState, loc[nameof(ResourcesDetailsHealthStateProperty)])
+            new(KnownProperties.Resource.DisplayName, loc => loc[nameof(ResourcesDetailsDisplayNameProperty)]),
+            new(KnownProperties.Resource.State, loc => loc[nameof(ResourcesDetailsStateProperty)]),
+            new(KnownProperties.Resource.StartTime, loc => loc[nameof(ResourcesDetailsStartTimeProperty)]),
+            new(KnownProperties.Resource.StopTime, loc => loc[nameof(ResourcesDetailsStopTimeProperty)]),
+            new(KnownProperties.Resource.ExitCode, loc => loc[nameof(ResourcesDetailsExitCodeProperty)]),
+            new(KnownProperties.Resource.HealthState, loc => loc[nameof(ResourcesDetailsHealthStateProperty)])
         ];
 
         _projectProperties =
         [
             .. _resourceProperties,
-            new(KnownProperties.Project.Path, loc[nameof(ResourcesDetailsProjectPathProperty)]),
-            new(KnownProperties.Executable.Pid, loc[nameof(ResourcesDetailsExecutableProcessIdProperty)]),
+            new(KnownProperties.Project.Path, loc => loc[nameof(ResourcesDetailsProjectPathProperty)]),
+            new(KnownProperties.Executable.Pid, loc => loc[nameof(ResourcesDetailsExecutableProcessIdProperty)]),
         ];
 
         _executableProperties =
         [
             .. _resourceProperties,
-            new(KnownProperties.Executable.Path, loc[nameof(ResourcesDetailsExecutablePathProperty)]),
-            new(KnownProperties.Executable.WorkDir, loc[nameof(ResourcesDetailsExecutableWorkingDirectoryProperty)]),
-            new(KnownProperties.Executable.Args, loc[nameof(ResourcesDetailsExecutableArgumentsProperty)]),
-            new(KnownProperties.Executable.Pid, loc[nameof(ResourcesDetailsExecutableProcessIdProperty)]),
+            new(KnownProperties.Executable.Path, loc => loc[nameof(ResourcesDetailsExecutablePathProperty)]),
+            new(KnownProperties.Executable.WorkDir, loc => loc[nameof(ResourcesDetailsExecutableWorkingDirectoryProperty)]),
+            new(KnownProperties.Executable.Args, loc => loc[nameof(ResourcesDetailsExecutableArgumentsProperty)]),
+            new(KnownProperties.Executable.Pid, loc => loc[nameof(ResourcesDetailsExecutableProcessIdProperty)]),
         ];
 
         _containerProperties =
         [
             .. _resourceProperties,
-            new(KnownProperties.Container.Image, loc[nameof(ResourcesDetailsContainerImageProperty)]),
-            new(KnownProperties.Container.Id, loc[nameof(ResourcesDetailsContainerIdProperty)]),
-            new(KnownProperties.Container.Command, loc[nameof(ResourcesDetailsContainerCommandProperty)]),
-            new(KnownProperties.Container.Args, loc[nameof(ResourcesDetailsContainerArgumentsProperty)]),
-            new(KnownProperties.Container.Ports, loc[nameof(ResourcesDetailsContainerPortsProperty)]),
-            new(KnownProperties.Container.Lifetime, loc[nameof(ResourcesDetailsContainerLifetimeProperty)]),
+            new(KnownProperties.Container.Image, loc => loc[nameof(ResourcesDetailsContainerImageProperty)]),
+            new(KnownProperties.Container.Id, loc => loc[nameof(ResourcesDetailsContainerIdProperty)]),
+            new(KnownProperties.Container.Command, loc => loc[nameof(ResourcesDetailsContainerCommandProperty)]),
+            new(KnownProperties.Container.Args, loc => loc[nameof(ResourcesDetailsContainerArgumentsProperty)]),
+            new(KnownProperties.Container.Ports, loc => loc[nameof(ResourcesDetailsContainerPortsProperty)]),
+            new(KnownProperties.Container.Lifetime, loc => loc[nameof(ResourcesDetailsContainerLifetimeProperty)]),
         ];
     }
 

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -178,7 +178,7 @@ public sealed class SpanWaterfallViewModel
         // Attempt to resolve uninstrumented peer to a friendly name from the span.
         foreach (var resolver in outgoingPeerResolvers)
         {
-            if (resolver.TryResolvePeerName(span.Attributes, out var name))
+            if (resolver.TryResolvePeerName(span.Attributes, out var name, out var _))
             {
                 return name;
             }

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -132,8 +132,28 @@ public class TelemetryFilter : IEquatable<TelemetryFilter>
     public bool Apply(OtlpSpan span)
     {
         var fieldValue = OtlpSpan.GetFieldValue(span, Field);
-        var func = ConditionToFuncString(Condition);
-        return func(fieldValue, Value);
+        if (fieldValue.Value1 == null)
+        {
+            return false;
+        }
+
+        if (!IsMatch(fieldValue.Value1, Value, Condition))
+        {
+            return false;
+        }
+
+        if (fieldValue.Value2 != null && !IsMatch(fieldValue.Value2, Value, Condition))
+        {
+            return false;
+        }
+
+        return true;
+
+        static bool IsMatch(string fieldValue, string filterValue, FilterCondition condition)
+        {
+            var func = ConditionToFuncString(condition);
+            return func(fieldValue, filterValue);
+        }
     }
 
     public bool Equals(TelemetryFilter? other)

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Dashboard.Otlp.Model;
@@ -41,36 +42,67 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
 
             await foreach (var changes in subscription.WithCancellation(_watchContainersTokenSource.Token).ConfigureAwait(false))
             {
+                var hasUrlChanges = false;
+
                 foreach (var (changeType, resource) in changes)
                 {
                     if (changeType == ResourceViewModelChangeType.Upsert)
                     {
+                        if (!_resourceByName.TryGetValue(resource.Name, out var existingResource) || !AreEquivalent(resource.Urls, existingResource.Urls))
+                        {
+                            hasUrlChanges = true;
+                        }
+
                         _resourceByName[resource.Name] = resource;
                     }
                     else if (changeType == ResourceViewModelChangeType.Delete)
                     {
+                        hasUrlChanges = true;
+
                         var removed = _resourceByName.TryRemove(resource.Name, out _);
                         Debug.Assert(removed, "Cannot remove unknown resource.");
                     }
                 }
 
-                await RaisePeerChangesAsync().ConfigureAwait(false);
+                if (hasUrlChanges)
+                {
+                    await RaisePeerChangesAsync().ConfigureAwait(false);
+                }
             }
         });
     }
 
-    public bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, [NotNullWhen(true)] out string? name)
+    private static bool AreEquivalent(ImmutableArray<UrlViewModel> urls1, ImmutableArray<UrlViewModel> urls2)
     {
-        return TryResolvePeerNameCore(_resourceByName, attributes, out name);
+        // Compare if the two sets of URLs are equivalent.
+        if (urls1.Length != urls2.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < urls1.Length; i++)
+        {
+            if (!urls1[i].Equals(urls2[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
-    internal static bool TryResolvePeerNameCore(IDictionary<string, ResourceViewModel> resources, KeyValuePair<string, string>[] attributes, out string? name)
+    public bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResource)
+    {
+        return TryResolvePeerNameCore(_resourceByName, attributes, out name, out matchedResource);
+    }
+
+    internal static bool TryResolvePeerNameCore(IDictionary<string, ResourceViewModel> resources, KeyValuePair<string, string>[] attributes, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out ResourceViewModel? resourceMatch)
     {
         var address = OtlpHelpers.GetPeerAddress(attributes);
         if (address != null)
         {
             // Match exact value.
-            if (TryMatchResourceAddress(address, out name))
+            if (TryMatchResourceAddress(address, out name, out resourceMatch))
             {
                 return true;
             }
@@ -82,7 +114,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
             foreach (var transformer in s_addressTransformers)
             {
                 transformedAddress = transformer(transformedAddress);
-                if (TryMatchResourceAddress(transformedAddress, out name))
+                if (TryMatchResourceAddress(transformedAddress, out name, out resourceMatch))
                 {
                     return true;
                 }
@@ -90,9 +122,10 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
         }
 
         name = null;
+        resourceMatch = null;
         return false;
 
-        bool TryMatchResourceAddress(string value, [NotNullWhen(true)] out string? name)
+        bool TryMatchResourceAddress(string value, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out ResourceViewModel? resourceMatch)
         {
             foreach (var (resourceName, resource) in resources)
             {
@@ -103,12 +136,14 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
                     if (string.Equals(hostAndPort, value, StringComparison.OrdinalIgnoreCase))
                     {
                         name = ResourceViewModel.GetResourceName(resource, resources);
+                        resourceMatch = resource;
                         return true;
                     }
                 }
             }
 
             name = null;
+            resourceMatch = null;
             return false;
         }
     }

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -82,7 +82,10 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
 
         for (var i = 0; i < urls1.Length; i++)
         {
-            if (!urls1[i].Equals(urls2[i]))
+            var url1 = urls1[i].Url;
+            var url2 = urls2[i].Url;
+
+            if (!url1.Equals(url2))
             {
                 return false;
             }
@@ -91,7 +94,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
         return true;
     }
 
-    public bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResource)
+    public bool TryResolvePeer(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResource)
     {
         return TryResolvePeerNameCore(_resourceByName, attributes, out name, out matchedResource);
     }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -220,7 +220,7 @@ public sealed class EnvironmentVariableViewModel : IPropertyGridItem
     }
 }
 
-[DebuggerDisplay("Name = {Name}, Value = {Value}, IsValueSensitive = {IsValueSensitive}, IsValueMasked = {IsValueMasked}")]
+[DebuggerDisplay("{_propertyViewModel}")]
 public sealed class DisplayedResourcePropertyViewModel : IPropertyGridItem
 {
     private readonly Lazy<string> _displayValue;

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -4,7 +4,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Utils;
@@ -239,16 +238,12 @@ public sealed class ResourcePropertyViewModel : IPropertyGridItem
 
     object IPropertyGridItem.Key => _key;
 
-    public ResourcePropertyViewModel(string name, Value value, bool isValueSensitive, KnownProperty? knownProperty, int priority, BrowserTimeProvider timeProvider)
+    public ResourcePropertyViewModel(string name, Value value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         Name = name;
         Value = value;
-        IsValueSensitive = isValueSensitive;
-        KnownProperty = knownProperty;
-        Priority = priority;
-        IsValueMasked = isValueSensitive;
 
         // Known and unknown properties are displayed together. Avoid any duplicate keys.
         _key = KnownProperty != null ? KnownProperty.Key : $"unknown-{Name}";
@@ -269,14 +264,6 @@ public sealed class ResourcePropertyViewModel : IPropertyGridItem
                 if (value.Length > 12)
                 {
                     value = value[..12];
-                }
-            }
-            else
-            {
-                // Dates are returned as ISO 8601 text. Try to parse. If successful, format with the current culture.
-                if (DateTime.TryParseExact(value, "o", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
-                {
-                    value = FormatHelpers.FormatDateTime(timeProvider, date, cultureInfo: CultureInfo.CurrentCulture);
                 }
             }
 

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -4,12 +4,14 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Utils;
 using Google.Protobuf.WellKnownTypes;
 using Humanizer;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Model;
@@ -219,51 +221,59 @@ public sealed class EnvironmentVariableViewModel : IPropertyGridItem
 }
 
 [DebuggerDisplay("Name = {Name}, Value = {Value}, IsValueSensitive = {IsValueSensitive}, IsValueMasked = {IsValueMasked}")]
-public sealed class ResourcePropertyViewModel : IPropertyGridItem
+public sealed class DisplayedResourcePropertyViewModel : IPropertyGridItem
 {
     private readonly Lazy<string> _displayValue;
     private readonly Lazy<string> _tooltip;
 
-    public string Name { get; }
-    public Value Value { get; }
-    public KnownProperty? KnownProperty { get; }
-    public string ToolTip => _tooltip.Value;
-    public bool IsValueSensitive { get; }
-    public bool IsValueMasked { get; set; }
-    internal int Priority { get; }
     private readonly string _key;
+    private readonly ResourcePropertyViewModel _propertyViewModel;
+    private readonly IStringLocalizer<Resources.Resources> _loc;
+    private readonly BrowserTimeProvider _browserTimeProvider;
 
-    string IPropertyGridItem.Name => KnownProperty?.DisplayName ?? Name;
+    public string ToolTip => _tooltip.Value;
+    public KnownProperty? KnownProperty => _propertyViewModel.KnownProperty;
+    public int Priority => _propertyViewModel.Priority;
+    public Value Value => _propertyViewModel.Value;
+    public string DisplayName => _propertyViewModel.KnownProperty?.GetDisplayName(_loc) ?? _propertyViewModel.Name;
+
+    string IPropertyGridItem.Name => DisplayName;
     string? IPropertyGridItem.Value => _displayValue.Value;
-
     object IPropertyGridItem.Key => _key;
 
-    public ResourcePropertyViewModel(string name, Value value)
+    public DisplayedResourcePropertyViewModel(ResourcePropertyViewModel propertyViewModel, IStringLocalizer<Resources.Resources> loc, BrowserTimeProvider browserTimeProvider)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
-
-        Name = name;
-        Value = value;
+        _propertyViewModel = propertyViewModel;
+        _loc = loc;
+        _browserTimeProvider = browserTimeProvider;
 
         // Known and unknown properties are displayed together. Avoid any duplicate keys.
-        _key = KnownProperty != null ? KnownProperty.Key : $"unknown-{Name}";
+        _key = propertyViewModel.KnownProperty != null ? propertyViewModel.KnownProperty.Key : $"unknown-{propertyViewModel.Name}";
 
-        _tooltip = new(() => value.HasStringValue ? value.StringValue : value.ToString());
+        _tooltip = new(() => propertyViewModel.Value.HasStringValue ? propertyViewModel.Value.StringValue : propertyViewModel.Value.ToString());
 
         _displayValue = new(() =>
         {
-            var value = Value is { HasStringValue: true, StringValue: var stringValue }
+            var value = propertyViewModel.Value is { HasStringValue: true, StringValue: var stringValue }
                 ? stringValue
                 // Complex values such as arrays and objects will be output as JSON.
                 // Consider how complex values are rendered in the future.
-                : Value.ToString();
+                : propertyViewModel.Value.ToString();
 
-            if (Name == KnownProperties.Container.Id)
+            if (propertyViewModel.Name == KnownProperties.Container.Id)
             {
                 // Container images have a short ID of 12 characters
                 if (value.Length > 12)
                 {
                     value = value[..12];
+                }
+            }
+            else
+            {
+                // Dates are returned as ISO 8601 text. Try to parse. If successful, format with the current culture.
+                if (DateTime.TryParseExact(value, "o", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+                {
+                    value = FormatHelpers.FormatDateTime(_browserTimeProvider, date, cultureInfo: CultureInfo.CurrentCulture);
                 }
             }
 
@@ -272,11 +282,34 @@ public sealed class ResourcePropertyViewModel : IPropertyGridItem
     }
 
     public bool MatchesFilter(string filter) =>
-        Name.Contains(filter, StringComparison.CurrentCultureIgnoreCase) ||
+        _propertyViewModel.Name.Contains(filter, StringComparison.CurrentCultureIgnoreCase) ||
         ToolTip.Contains(filter, StringComparison.CurrentCultureIgnoreCase);
 }
 
-public sealed record KnownProperty(string Key, string DisplayName);
+[DebuggerDisplay("Name = {Name}, Value = {Value}, IsValueSensitive = {IsValueSensitive}, IsValueMasked = {IsValueMasked}")]
+public sealed class ResourcePropertyViewModel
+{
+    public string Name { get; }
+    public Value Value { get; }
+    public KnownProperty? KnownProperty { get; }
+    public bool IsValueSensitive { get; }
+    public bool IsValueMasked { get; set; }
+    public int Priority { get; }
+
+    public ResourcePropertyViewModel(string name, Value value, bool isValueSensitive, KnownProperty? knownProperty, int priority)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        Name = name;
+        Value = value;
+        IsValueSensitive = isValueSensitive;
+        KnownProperty = knownProperty;
+        Priority = priority;
+        IsValueMasked = isValueSensitive;
+    }
+}
+
+public sealed record KnownProperty(string Key, Func<IStringLocalizer<Resources.Resources>, string> GetDisplayName);
 
 [DebuggerDisplay("EndpointName = {EndpointName}, Url = {Url}, IsInternal = {IsInternal}")]
 public sealed class UrlViewModel

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -42,6 +42,8 @@ public class OtlpSpan
     public OtlpScope Scope { get; }
     public TimeSpan Duration => EndTime - StartTime;
 
+    public OtlpApplication? UninstrumentedPeer { get; internal set; }
+
     public IEnumerable<OtlpSpan> GetChildSpans() => GetChildSpans(this, Trace.Spans);
     public static IEnumerable<OtlpSpan> GetChildSpans(OtlpSpan parentSpan, OtlpSpanCollection spans) => spans.Where(s => s.ParentSpanId == parentSpan.SpanId);
 
@@ -86,6 +88,7 @@ public class OtlpSpan
             Events = item.Events,
             Links = item.Links,
             BackLinks = item.BackLinks,
+            UninstrumentedPeer = item.UninstrumentedPeer
         };
     }
 
@@ -118,7 +121,7 @@ public class OtlpSpan
 
     private string DebuggerToString()
     {
-        return $@"SpanId = {SpanId}, StartTime = {StartTime.ToLocalTime():h:mm:ss.fff tt}, ParentSpanId = {ParentSpanId}, TraceId = {Trace.TraceId}";
+        return $@"SpanId = {SpanId}, StartTime = {StartTime.ToLocalTime():h:mm:ss.fff tt}, ParentSpanId = {ParentSpanId}, Application = {Source.ApplicationKey}, UninstrumentedPeerApplication = {UninstrumentedPeer?.ApplicationKey}, TraceId = {Trace.TraceId}";
     }
 
     public string GetDisplaySummary()
@@ -180,11 +183,13 @@ public class OtlpSpan
         }
     }
 
-    public static string? GetFieldValue(OtlpSpan span, string field)
+    public static FieldValues GetFieldValue(OtlpSpan span, string field)
     {
+        // FieldValues is a hack to support two values in a single field.
+        // Find a better way to do this if more than two values are needed.
         return field switch
         {
-            KnownResourceFields.ServiceNameField => span.Source.Application.ApplicationName,
+            KnownResourceFields.ServiceNameField => new FieldValues(span.Source.Application.ApplicationName, span.UninstrumentedPeer?.ApplicationName),
             KnownTraceFields.TraceIdField => span.TraceId,
             KnownTraceFields.SpanIdField => span.SpanId,
             KnownTraceFields.KindField => span.Kind.ToString(),
@@ -193,5 +198,10 @@ public class OtlpSpan
             KnownTraceFields.NameField => span.Name,
             _ => span.Attributes.GetValue(field)
         };
+    }
+
+    public record struct FieldValues(string? Value1, string? Value2 = null)
+    {
+        public static implicit operator FieldValues(string? value) => new FieldValues(value);
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
@@ -5,17 +5,6 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public readonly record struct ApplicationKey(string Name, string? InstanceId) : IComparable<ApplicationKey>
 {
-    public int CompareTo(ApplicationKey other)
-    {
-        var c = string.Compare(Name, other.Name, StringComparisons.ResourceName);
-        if (c != 0)
-        {
-            return c;
-        }
-
-        return string.Compare(InstanceId, other.InstanceId, StringComparisons.ResourceName);
-    }
-
     public static ApplicationKey Create(string name)
     {
         var separator = name.LastIndexOf('-');
@@ -25,6 +14,17 @@ public readonly record struct ApplicationKey(string Name, string? InstanceId) : 
         }
 
         return new ApplicationKey(Name: name.Substring(0, separator), InstanceId: name.Substring(separator + 1));
+    }
+
+    public int CompareTo(ApplicationKey other)
+    {
+        var c = string.Compare(Name, other.Name, StringComparisons.ResourceName);
+        if (c != 0)
+        {
+            return c;
+        }
+
+        return string.Compare(InstanceId, other.InstanceId, StringComparisons.ResourceName);
     }
 
     public bool EqualsCompositeName(string name)

--- a/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
@@ -16,6 +16,17 @@ public readonly record struct ApplicationKey(string Name, string? InstanceId) : 
         return string.Compare(InstanceId, other.InstanceId, StringComparisons.ResourceName);
     }
 
+    public static ApplicationKey Create(string name)
+    {
+        var separator = name.LastIndexOf('-');
+        if (separator == -1)
+        {
+            return new ApplicationKey(Name: name, InstanceId: null);
+        }
+
+        return new ApplicationKey(Name: name.Substring(0, separator), InstanceId: name.Substring(separator + 1));
+    }
+
     public bool EqualsCompositeName(string name)
     {
         if (name == null)

--- a/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
@@ -48,8 +48,6 @@ internal sealed class DashboardClient : IDashboardClient
 
     private readonly ILoggerFactory _loggerFactory;
     private readonly IDashboardClientStatus _dashboardClientStatus;
-    private readonly BrowserTimeProvider _timeProvider;
-    private readonly IKnownPropertyLookup _knownPropertyLookup;
     private readonly DashboardOptions _dashboardOptions;
     private readonly ILogger<DashboardClient> _logger;
 
@@ -73,14 +71,10 @@ internal sealed class DashboardClient : IDashboardClient
         IConfiguration configuration,
         IOptions<DashboardOptions> dashboardOptions,
         IDashboardClientStatus dashboardClientStatus,
-        BrowserTimeProvider timeProvider,
-        IKnownPropertyLookup knownPropertyLookup,
         Action<SocketsHttpHandler>? configureHttpHandler = null)
     {
         _loggerFactory = loggerFactory;
         _dashboardClientStatus = dashboardClientStatus;
-        _timeProvider = timeProvider;
-        _knownPropertyLookup = knownPropertyLookup;
         _dashboardOptions = dashboardOptions.Value;
 
         // Take a copy of the token and always use it to avoid race between disposal of CTS and usage of token.
@@ -341,7 +335,7 @@ internal sealed class DashboardClient : IDashboardClient
                                 foreach (var resource in response.InitialData.Resources)
                                 {
                                     // Add to map.
-                                    var viewModel = resource.ToViewModel(_timeProvider, _knownPropertyLookup, _logger);
+                                    var viewModel = resource.ToViewModel(_logger);
                                     _resourceByName[resource.Name] = viewModel;
 
                                     // Send this update to any subscribers too.
@@ -361,7 +355,7 @@ internal sealed class DashboardClient : IDashboardClient
                                     if (change.KindCase == WatchResourcesChange.KindOneofCase.Upsert)
                                     {
                                         // Upsert (i.e. add or replace)
-                                        var viewModel = change.Upsert.ToViewModel(_timeProvider, _knownPropertyLookup, _logger);
+                                        var viewModel = change.Upsert.ToViewModel(_logger);
                                         _resourceByName[change.Upsert.Name] = viewModel;
                                         changes.Add(new(ResourceViewModelChangeType.Upsert, viewModel));
                                     }
@@ -606,7 +600,7 @@ internal sealed class DashboardClient : IDashboardClient
             {
                 foreach (var data in initialData)
                 {
-                    _resourceByName[data.Name] = data.ToViewModel(_timeProvider, _knownPropertyLookup, _logger);
+                    _resourceByName[data.Name] = data.ToViewModel(_logger);
                 }
             }
         }

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -18,7 +18,7 @@ partial class Resource
     /// <summary>
     /// Converts this gRPC message object to a view model for use in the dashboard UI.
     /// </summary>
-    public ResourceViewModel ToViewModel(BrowserTimeProvider timeProvider, IKnownPropertyLookup knownPropertyLookup, ILogger logger)
+    public ResourceViewModel ToViewModel(ILogger logger)
     {
         try
         {
@@ -31,7 +31,7 @@ partial class Resource
                 CreationTimeStamp = ValidateNotNull(CreatedAt).ToDateTime(),
                 StartTimeStamp = StartedAt?.ToDateTime(),
                 StopTimeStamp = StoppedAt?.ToDateTime(),
-                Properties = CreatePropertyViewModels(Properties, timeProvider, knownPropertyLookup, logger),
+                Properties = CreatePropertyViewModels(Properties, logger),
                 Environment = GetEnvironment(),
                 Urls = GetUrls(),
                 Volumes = GetVolumes(),
@@ -149,20 +149,15 @@ partial class Resource
         }
     }
 
-    private ImmutableDictionary<string, ResourcePropertyViewModel> CreatePropertyViewModels(RepeatedField<ResourceProperty> properties, BrowserTimeProvider timeProvider, IKnownPropertyLookup knownPropertyLookup, ILogger logger)
+    private ImmutableDictionary<string, ResourcePropertyViewModel> CreatePropertyViewModels(RepeatedField<ResourceProperty> properties, ILogger logger)
     {
         var builder = ImmutableDictionary.CreateBuilder<string, ResourcePropertyViewModel>(StringComparers.ResourcePropertyName);
 
         foreach (var property in properties)
         {
-            var (priority, knownProperty) = knownPropertyLookup.FindProperty(ResourceType, property.Name);
             var propertyViewModel = new ResourcePropertyViewModel(
                 name: ValidateNotNull(property.Name),
-                value: ValidateNotNull(property.Value),
-                isValueSensitive: property.IsSensitive,
-                knownProperty: knownProperty,
-                priority: priority,
-                timeProvider: timeProvider);
+                value: ValidateNotNull(property.Value));
 
             if (builder.ContainsKey(propertyViewModel.Name))
             {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/StructuredLogDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/StructuredLogDetailsTests.cs
@@ -23,7 +23,7 @@ public class StructuredLogDetailsTests : DashboardTestContext
         StructuredLogsSetupHelpers.SetupStructuredLogsDetails(this);
 
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app = new OtlpApplication("app1", "instance1", context);
+        var app = new OtlpApplication("app1", "instance1", uninstrumentedPeer: false, context);
         var view = new OtlpApplicationView(app, new RepeatedField<KeyValue>
         {
             new KeyValue { Key = "Message", Value = new AnyValue { StringValue = "value1" } },

--- a/tests/Aspire.Dashboard.Tests/BrowserLinkOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/BrowserLinkOutgoingPeerResolverTests.cs
@@ -113,6 +113,6 @@ public class BrowserLinkOutgoingPeerResolverTests
 
     private static bool TryResolvePeerName(IOutgoingPeerResolver resolver, KeyValuePair<string, string>[] attributes, out string? peerName)
     {
-        return resolver.TryResolvePeerName(attributes, out peerName, out _);
+        return resolver.TryResolvePeer(attributes, out peerName, out _);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/BrowserLinkOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/BrowserLinkOutgoingPeerResolverTests.cs
@@ -113,6 +113,6 @@ public class BrowserLinkOutgoingPeerResolverTests
 
     private static bool TryResolvePeerName(IOutgoingPeerResolver resolver, KeyValuePair<string, string>[] attributes, out string? peerName)
     {
-        return resolver.TryResolvePeerName(attributes, out peerName);
+        return resolver.TryResolvePeerName(attributes, out peerName, out _);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
 using DashboardServiceBase = Aspire.ResourceService.Proto.V1.DashboardService.DashboardServiceBase;
@@ -131,7 +130,6 @@ public sealed class DashboardClientAuthTests
             configuration: new ConfigurationManager(),
             dashboardOptions: Options.Create(options),
             dashboardClientStatus: new TestDashboardClientStatus(),
-            timeProvider: new BrowserTimeProvider(NullLoggerFactory.Instance),
             knownPropertyLookup: new MockKnownPropertyLookup(),
             configureHttpHandler: handler => handler.SslOptions.RemoteCertificateValidationCallback = (sender, cert, chain, sslPolicyErrors) => true);
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
@@ -58,7 +58,7 @@ public class DashboardServerFixture : IAsyncLifetime
             {
                 builder.Configuration.AddConfiguration(config);
                 builder.Services.AddSingleton<IDashboardClientStatus, MockDashboardClientStatus>();
-                builder.Services.AddScoped<IDashboardClient, MockDashboardClient>();
+                builder.Services.AddSingleton<IDashboardClient, MockDashboardClient>();
             });
 
         await DashboardApp.StartAsync();

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -4,7 +4,6 @@
 using Aspire.Dashboard.Model;
 using Aspire.Tests.Shared.DashboardModel;
 using Google.Protobuf.WellKnownTypes;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
 
@@ -15,8 +14,6 @@ public sealed class MockDashboardClientStatus : IDashboardClientStatus
 
 public sealed class MockDashboardClient : IDashboardClient
 {
-    private static readonly BrowserTimeProvider s_timeProvider = new(NullLoggerFactory.Instance);
-
     public MockDashboardClient(IDashboardClientStatus dashboardClientStatus)
     {
         _dashboardClientStatus = dashboardClientStatus;
@@ -36,9 +33,8 @@ public sealed class MockDashboardClient : IDashboardClient
                         StringValue = "C:/MyProjectPath/Project.csproj"
                     },
                     isValueSensitive: false,
-                    knownProperty: new(KnownProperties.Project.Path, "Path"),
-                    priority: 0,
-                    timeProvider: s_timeProvider))
+                    knownProperty: new(KnownProperties.Project.Path, loc => "Path"),
+                    priority: 0))
         }.ToDictionary(),
         state: KnownResourceState.Running);
 

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -214,6 +214,6 @@ public sealed class ApplicationsSelectHelpersTests
         };
         var applicationKey = OtlpHelpers.GetApplicationKey(resource);
 
-        return new OtlpApplication(applicationKey.Name, applicationKey.InstanceId!, TelemetryTestHelpers.CreateContext());
+        return new OtlpApplication(applicationKey.Name, applicationKey.InstanceId!, uninstrumentedPeer: false, TelemetryTestHelpers.CreateContext());
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -16,8 +16,6 @@ namespace Aspire.Dashboard.Tests.Model;
 
 public sealed class DashboardClientTests
 {
-    private static readonly BrowserTimeProvider s_timeProvider = new(NullLoggerFactory.Instance);
-
     private readonly IConfiguration _configuration;
     private readonly IOptions<DashboardOptions> _dashboardOptions;
 
@@ -152,7 +150,7 @@ public sealed class DashboardClientTests
 
     private DashboardClient CreateResourceServiceClient()
     {
-        return new DashboardClient(NullLoggerFactory.Instance, _configuration, _dashboardOptions, new TestDashboardClientStatus(), s_timeProvider, new MockKnownPropertyLookup());
+        return new DashboardClient(NullLoggerFactory.Instance, _configuration, _dashboardOptions, new TestDashboardClientStatus(), new MockKnownPropertyLookup());
     }
 
     private sealed class TestDashboardClientStatus : IDashboardClientStatus

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -5,7 +5,6 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Aspire.Tests.Shared.DashboardModel;
 using Google.Protobuf.WellKnownTypes;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.Model;
@@ -24,17 +23,17 @@ public class ResourceSourceViewModelTests
 
         if (testData.ExecutableArguments is not null)
         {
-            properties.TryAdd(KnownProperties.Executable.Args, new ResourcePropertyViewModel(KnownProperties.Executable.Args, Value.ForList(testData.ExecutableArguments.Select(Value.ForString).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
+            properties.TryAdd(KnownProperties.Executable.Args, new ResourcePropertyViewModel(KnownProperties.Executable.Args, Value.ForList(testData.ExecutableArguments.Select(Value.ForString).ToArray()), false, null, 0));
         }
 
         if (testData.AppArgs is not null)
         {
-            properties.TryAdd(KnownProperties.Resource.AppArgs, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgs, Value.ForList(testData.AppArgs.Select(Value.ForString).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
+            properties.TryAdd(KnownProperties.Resource.AppArgs, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgs, Value.ForList(testData.AppArgs.Select(Value.ForString).ToArray()), false, null, 0));
         }
 
         if (testData.AppArgsSensitivity is not null)
         {
-            properties.TryAdd(KnownProperties.Resource.AppArgsSensitivity, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgsSensitivity, Value.ForList(testData.AppArgsSensitivity.Select(b => Value.ForNumber(Convert.ToInt32(b))).ToArray()), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
+            properties.TryAdd(KnownProperties.Resource.AppArgsSensitivity, new ResourcePropertyViewModel(KnownProperties.Resource.AppArgsSensitivity, Value.ForList(testData.AppArgsSensitivity.Select(b => Value.ForNumber(Convert.ToInt32(b))).ToArray()), false, null, 0));
         }
 
         var resource = ModelTestHelpers.CreateResource(
@@ -57,7 +56,7 @@ public class ResourceSourceViewModelTests
 
         void AddStringProperty(string propertyName, string? propertyValue)
         {
-            properties.TryAdd(propertyName, new ResourcePropertyViewModel(propertyName, propertyValue is null ? Value.ForNull() : Value.ForString(propertyValue), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
+            properties.TryAdd(propertyName, new ResourcePropertyViewModel(propertyName, propertyValue is null ? Value.ForNull() : Value.ForString(propertyValue), false, null, 0));
         }
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
@@ -6,7 +6,6 @@ using Aspire.Dashboard.Resources;
 using Aspire.Tests.Shared.DashboardModel;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
 using Enum = System.Enum;
@@ -73,7 +72,7 @@ public class ResourceStateViewModelTests
         var propertiesDictionary = new Dictionary<string, ResourcePropertyViewModel>();
         if (exitCode is not null)
         {
-            propertiesDictionary.TryAdd(KnownProperties.Resource.ExitCode, new ResourcePropertyViewModel(KnownProperties.Resource.ExitCode, Value.ForNumber((double)exitCode), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
+            propertiesDictionary.TryAdd(KnownProperties.Resource.ExitCode, new ResourcePropertyViewModel(KnownProperties.Resource.ExitCode, Value.ForNumber((double)exitCode), false, null, 0));
         }
 
         var resource = ModelTestHelpers.CreateResource(
@@ -86,7 +85,7 @@ public class ResourceStateViewModelTests
 
         if (exitCode is not null)
         {
-            resource.Properties.TryAdd(KnownProperties.Resource.ExitCode, new ResourcePropertyViewModel(KnownProperties.Resource.ExitCode, Value.ForNumber((double)exitCode), false, null, 0, new BrowserTimeProvider(new NullLoggerFactory())));
+            resource.Properties.TryAdd(KnownProperties.Resource.ExitCode, new ResourcePropertyViewModel(KnownProperties.Resource.ExitCode, Value.ForNumber((double)exitCode), false, null, 0));
         }
 
         var localizer = new TestStringLocalizer<Columns>();

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -14,7 +14,6 @@ namespace Aspire.Dashboard.Tests.Model;
 public sealed class ResourceViewModelTests
 {
     private static readonly DateTime s_dateTime = new(2000, 12, 30, 23, 59, 59, DateTimeKind.Utc);
-    private static readonly BrowserTimeProvider s_timeProvider = new(NullLoggerFactory.Instance);
 
     [Theory]
     [InlineData(KnownResourceState.Starting, null, null)]
@@ -48,7 +47,7 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var vm = resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup(), NullLogger.Instance);
+        var vm = resource.ToViewModel(new MockKnownPropertyLookup(), NullLogger.Instance);
 
         // Assert
         Assert.Collection(vm.Environment,
@@ -76,7 +75,7 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var vm = resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup(), NullLogger.Instance);
+        var vm = resource.ToViewModel(new MockKnownPropertyLookup(), NullLogger.Instance);
 
         // Assert
         Assert.Collection(vm.Properties,
@@ -100,7 +99,7 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var ex = Assert.Throws<InvalidOperationException>(() => resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup(), NullLogger.Instance));
+        var ex = Assert.Throws<InvalidOperationException>(() => resource.ToViewModel(new MockKnownPropertyLookup(), NullLogger.Instance));
 
         // Assert
         Assert.Equal(@"Error converting resource ""TestName-abc"" to ResourceViewModel.", ex.Message);
@@ -123,10 +122,10 @@ public sealed class ResourceViewModelTests
             }
         };
 
-        var kp = new KnownProperty("foo", "bar");
+        var kp = new KnownProperty("foo", loc => "bar");
 
         // Act
-        var viewModel = resource.ToViewModel(s_timeProvider, new MockKnownPropertyLookup(123, kp), NullLogger.Instance);
+        var viewModel = resource.ToViewModel(new MockKnownPropertyLookup(123, kp), NullLogger.Instance);
 
         // Assert
         Assert.Collection(

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Tests.Shared.Telemetry;
@@ -26,7 +25,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc)));
 
         // Act
-        var vm = SpanWaterfallViewModel.Create(trace, new SpanWaterfallViewModel.TraceDetailState([], []));
+        var vm = SpanWaterfallViewModel.Create(trace, new SpanWaterfallViewModel.TraceDetailState([]));
 
         // Assert
         Assert.Collection(vm,
@@ -78,10 +77,7 @@ public sealed class SpanWaterfallViewModelTests
 
         var vm = SpanWaterfallViewModel.Create(
             trace,
-            new SpanWaterfallViewModel.TraceDetailState(
-                [new TestPeerResolver()],
-                []
-            )).First();
+            new SpanWaterfallViewModel.TraceDetailState([])).First();
 
         // Act
         var result = vm.MatchesFilter(filter, a => a.Application.ApplicationName, out _);
@@ -103,7 +99,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(parentSpan);
         trace.AddSpan(childSpan);
 
-        var vms = SpanWaterfallViewModel.Create(trace, new SpanWaterfallViewModel.TraceDetailState([], []));
+        var vms = SpanWaterfallViewModel.Create(trace, new SpanWaterfallViewModel.TraceDetailState([]));
         var parent = vms[0];
         var child = vms[1];
 
@@ -125,7 +121,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(parentSpan);
         trace.AddSpan(childSpan);
 
-        var vms = SpanWaterfallViewModel.Create(trace, new SpanWaterfallViewModel.TraceDetailState([], []));
+        var vms = SpanWaterfallViewModel.Create(trace, new SpanWaterfallViewModel.TraceDetailState([]));
         var parent = vms[0];
         var child = vms[1];
 
@@ -133,27 +129,6 @@ public sealed class SpanWaterfallViewModelTests
         Assert.True(parent.MatchesFilter("parent", a => a.Application.ApplicationName, out var descendents));
         Assert.Equal("child", Assert.Single(descendents).Span.SpanId);
         Assert.False(child.MatchesFilter("parent", a => a.Application.ApplicationName, out _));
-    }
-
-    private sealed class TestPeerResolver : IOutgoingPeerResolver
-    {
-        public bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, out string? name)
-        {
-            var peerService = attributes.FirstOrDefault(a => a.Key == "peer.service");
-            if (!string.IsNullOrEmpty(peerService.Value))
-            {
-                name = peerService.Value;
-                return true;
-            }
-
-            name = null;
-            return false;
-        }
-
-        public IDisposable OnPeerChanges(Func<Task> callback)
-        {
-            return EmptyDisposable.Instance;
-        }
     }
 
     private sealed class EmptyDisposable : IDisposable

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -16,8 +16,8 @@ public sealed class SpanWaterfallViewModelTests
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app1 = new OtlpApplication("app1", "instance", context);
-        var app2 = new OtlpApplication("app2", "instance", context);
+        var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
+        var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
 
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
@@ -51,7 +51,7 @@ public sealed class SpanWaterfallViewModelTests
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app = new OtlpApplication("app1", "instance", context);
+        var app = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
 
@@ -91,7 +91,7 @@ public sealed class SpanWaterfallViewModelTests
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app1 = new OtlpApplication("app1", "instance", context);
+        var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
         var parentSpan = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "parent", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc));
@@ -113,7 +113,7 @@ public sealed class SpanWaterfallViewModelTests
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app1 = new OtlpApplication("app1", "instance", context);
+        var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
         var parentSpan = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "parent", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc));

--- a/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
@@ -16,7 +16,7 @@ public sealed class TraceHelpersTests
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app1 = new OtlpApplication("app1", "instance", context);
+        var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
@@ -37,8 +37,8 @@ public sealed class TraceHelpersTests
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app1 = new OtlpApplication("app1", "instance", context);
-        var app2 = new OtlpApplication("app2", "instance", context);
+        var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
+        var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "1-2", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
@@ -64,8 +64,8 @@ public sealed class TraceHelpersTests
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app1 = new OtlpApplication("app1", "instance", context);
-        var app2 = new OtlpApplication("app2", "instance", context);
+        var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
+        var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
@@ -91,9 +91,9 @@ public sealed class TraceHelpersTests
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app1 = new OtlpApplication("app1", "instance", context);
-        var app2 = new OtlpApplication("app2", "instance", context);
-        var app3 = new OtlpApplication("app3", "instance", context);
+        var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
+        var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
+        var app3 = new OtlpApplication("app3", "instance", uninstrumentedPeer: false, context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -194,7 +194,7 @@ public class ResourceOutgoingPeerResolverTests
 
     private static bool TryResolvePeerName(IDictionary<string, ResourceViewModel> resources, KeyValuePair<string, string>[] attributes, out string? peerName)
     {
-        return ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, attributes, out peerName);
+        return ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, attributes, out peerName, out _);
     }
 
     private sealed class MockDashboardClient(Task<ResourceViewModelSubscription> subscribeResult) : IDashboardClient

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -12,11 +12,12 @@ namespace Aspire.Dashboard.Tests;
 
 public class ResourceOutgoingPeerResolverTests
 {
-    private static ResourceViewModel CreateResource(string name, string? serviceAddress = null, int? servicePort = null, string? displayName = null)
+    private static ResourceViewModel CreateResource(string name, string? serviceAddress = null, int? servicePort = null, string? displayName = null, KnownResourceState? state = null)
     {
         return ModelTestHelpers.CreateResource(
             appName: name,
             displayName: displayName,
+            state: state,
             urls: serviceAddress is null || servicePort is null ? [] : [new UrlViewModel(name, new($"http://{serviceAddress}:{servicePort}"), isInternal: false, isInactive: false, displayProperties: UrlDisplayPropertiesViewModel.Empty)]);
     }
 
@@ -124,18 +125,19 @@ public class ResourceOutgoingPeerResolverTests
         var resultChannel = Channel.CreateUnbounded<int>();
         var dashboardClient = new MockDashboardClient(tcs.Task);
         var resolver = new ResourceOutgoingPeerResolver(dashboardClient);
-        var changeCount = 1;
+        var changeCount = 0;
         resolver.OnPeerChanges(async () =>
         {
-            await resultChannel.Writer.WriteAsync(changeCount++);
+            await resultChannel.Writer.WriteAsync(++changeCount);
         });
 
         var readValue = 0;
         Assert.False(resultChannel.Reader.TryRead(out readValue));
 
         // Act 1
+        // Initial resource causes change.
         tcs.SetResult(new ResourceViewModelSubscription(
-            [CreateResource("test")],
+            [CreateResource("test", serviceAddress: "localhost", servicePort: 8080)],
             GetChanges()));
 
         // Assert 1
@@ -143,13 +145,32 @@ public class ResourceOutgoingPeerResolverTests
         Assert.Equal(1, readValue);
 
         // Act 2
-        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2")));
+        // New resource causes change.
+        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2", serviceAddress: "localhost", servicePort: 8080, state: KnownResourceState.Starting)));
 
         // Assert 2
         readValue = await resultChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(2, readValue);
 
+        // Act 3
+        // URL change causes change.
+        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2", serviceAddress: "localhost", servicePort: 8081, state: KnownResourceState.Starting)));
+
+        // Assert 3
+        readValue = await resultChannel.Reader.ReadAsync().DefaultTimeout();
+        Assert.Equal(3, readValue);
+
+        // Act 4
+        // Resource update doesn't cause change.
+        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2", serviceAddress: "localhost", servicePort: 8081, state: KnownResourceState.Running)));
+
+        // Dispose so that we know that all changes are processed.
         await resolver.DisposeAsync().DefaultTimeout();
+        resultChannel.Writer.Complete();
+
+        // Assert 4
+        Assert.False(await resultChannel.Reader.WaitToReadAsync().DefaultTimeout());
+        Assert.Equal(3, changeCount);
 
         async IAsyncEnumerable<IReadOnlyList<ResourceViewModelChange>> GetChanges([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
@@ -18,7 +18,7 @@ public class OtlpSpanTests
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
-        var app1 = new OtlpApplication("app1", "instance", context);
+        var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
 

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -1234,13 +1234,15 @@ public class TraceTests
     [InlineData(KnownTraceFields.TraceIdField, "31")]
     [InlineData(KnownTraceFields.SpanIdField, "312d31")]
     [InlineData(KnownTraceFields.StatusField, "Unset")]
-    [InlineData(KnownTraceFields.KindField, "Internal")]
+    [InlineData(KnownTraceFields.KindField, "Client")]
     [InlineData(KnownResourceFields.ServiceNameField, "app1")]
+    [InlineData(KnownResourceFields.ServiceNameField, "TestPeer")]
     [InlineData(KnownSourceFields.NameField, "TestScope")]
     public void GetTraces_KnownFilters(string name, string value)
     {
         // Arrange
-        var repository = CreateRepository();
+        var outgoingPeerResolver = new TestOutgoingPeerResolver();
+        var repository = CreateRepository(outgoingPeerResolvers: [outgoingPeerResolver]);
 
         var addContext = new AddContext();
         repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
@@ -1253,7 +1255,7 @@ public class TraceTests
                     new ScopeSpans
                     {
                         Scope = CreateScope(),
-                        Spans = { CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: [KeyValuePair.Create("key1", "value1")]) }
+                        Spans = { CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: [KeyValuePair.Create("key1", "value1"), KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "value-1")], kind: Span.Types.SpanKind.Client) }
                     }
                 }
             }

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -145,7 +145,7 @@ internal static class TelemetryTestHelpers
         return e;
     }
 
-    public static Span CreateSpan(string traceId, string spanId, DateTime startTime, DateTime endTime, string? parentSpanId = null, List<Span.Types.Event>? events = null, List<Span.Types.Link>? links = null, IEnumerable<KeyValuePair<string, string>>? attributes = null)
+    public static Span CreateSpan(string traceId, string spanId, DateTime startTime, DateTime endTime, string? parentSpanId = null, List<Span.Types.Event>? events = null, List<Span.Types.Link>? links = null, IEnumerable<KeyValuePair<string, string>>? attributes = null, Span.Types.SpanKind? kind = null)
     {
         var span = new Span
         {
@@ -154,7 +154,8 @@ internal static class TelemetryTestHelpers
             ParentSpanId = parentSpanId is null ? ByteString.Empty : ByteString.CopyFrom(Encoding.UTF8.GetBytes(parentSpanId)),
             StartTimeUnixNano = DateTimeToUnixNanoseconds(startTime),
             EndTimeUnixNano = DateTimeToUnixNanoseconds(endTime),
-            Name = $"Test span. Id: {spanId}"
+            Name = $"Test span. Id: {spanId}",
+            Kind = kind ?? Span.Types.SpanKind.Internal
         };
         if (events != null)
         {
@@ -227,7 +228,8 @@ internal static class TelemetryTestHelpers
         int? maxTraceCount = null,
         TimeSpan? subscriptionMinExecuteInterval = null,
         ILoggerFactory? loggerFactory = null,
-        PauseManager? pauseManager = null)
+        PauseManager? pauseManager = null,
+        IOutgoingPeerResolver[]? outgoingPeerResolvers = null)
     {
         var options = new TelemetryLimitOptions();
         if (maxMetricsCount != null)
@@ -255,7 +257,7 @@ internal static class TelemetryTestHelpers
             loggerFactory ?? NullLoggerFactory.Instance,
             Options.Create(new DashboardOptions { TelemetryLimits = options }),
             pauseManager ?? new PauseManager(),
-            []);
+            outgoingPeerResolvers ?? []);
         if (subscriptionMinExecuteInterval != null)
         {
             repository._subscriptionMinExecuteInterval = subscriptionMinExecuteInterval.Value;

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -254,7 +254,8 @@ internal static class TelemetryTestHelpers
         var repository = new TelemetryRepository(
             loggerFactory ?? NullLoggerFactory.Instance,
             Options.Create(new DashboardOptions { TelemetryLimits = options }),
-            pauseManager ?? new PauseManager());
+            pauseManager ?? new PauseManager(),
+            []);
         if (subscriptionMinExecuteInterval != null)
         {
             repository._subscriptionMinExecuteInterval = subscriptionMinExecuteInterval.Value;

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -294,7 +294,8 @@ internal static class TelemetryTestHelpers
     }
 
     public static OtlpSpan CreateOtlpSpan(OtlpApplication app, OtlpTrace trace, OtlpScope scope, string spanId, string? parentSpanId, DateTime startDate,
-        KeyValuePair<string, string>[]? attributes = null, OtlpSpanStatusCode? statusCode = null, string? statusMessage = null, OtlpSpanKind kind = OtlpSpanKind.Unspecified)
+        KeyValuePair<string, string>[]? attributes = null, OtlpSpanStatusCode? statusCode = null, string? statusMessage = null, OtlpSpanKind kind = OtlpSpanKind.Unspecified,
+        OtlpApplication? uninstrumentedPeer = null)
     {
         return new OtlpSpan(app.GetView([]), trace, scope)
         {
@@ -310,7 +311,8 @@ internal static class TelemetryTestHelpers
             StartTime = startDate,
             State = null,
             Status = statusCode ?? OtlpSpanStatusCode.Unset,
-            StatusMessage = statusMessage
+            StatusMessage = statusMessage,
+            UninstrumentedPeer = uninstrumentedPeer
         };
     }
 }


### PR DESCRIPTION
Support for showing uninstrumented outgoing peers in traces page. A fair number of changes were required here because resources are scoped to a browser window (was required because browser language and time was used in some places) while telemetry is static.

- Telemetry changes
  - Resolving uninstrumented peers now happens during data load
  - Peers are re-resolved when resources change
  - Telemetry application is created for uninstrumented peers
  - Traces UI displays peer apps in filter dropdown
  - Traces UI displays peer apps in span summary
- Resource data changes
  - Resource change event for peers now only happens when the resource URLs change, rather than on every change. Perf improvement to prevent it triggering on every status change
  - Dashboard resource client is now a singleton. Done so it can be used from telemetry repository (already singleton) but has the benefit of sharing data if you have multiple browser windows open
  - Dashboard properties has a new display VM. This is so that scoped data (e.g. culture, time) is only applied on display. This change allows resource client to be a singleton

Peers displayed in traces UI:
![image](https://github.com/user-attachments/assets/1267bd46-3b8c-4d0e-b988-5ffcf754c416)

Filtering to a peer:
![image](https://github.com/user-attachments/assets/746f1ede-947e-48d5-8c0e-0b7f7e329123)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
