### PR TITLE
Order package versions in CLI.

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Text;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
+using Semver;
 using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
@@ -190,7 +191,8 @@ internal sealed class AddCommand : BaseCommand
         }
 
             // ... otherwise we had better prompt.
-        var version = await _prompter.PromptForIntegrationVersionAsync(packageVersions, cancellationToken);
+        var orderedPackageVersions = packageVersions.OrderByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer);
+        var version = await _prompter.PromptForIntegrationVersionAsync(orderedPackageVersions, cancellationToken);
 
         return version;
     }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.Diagnostics;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Interaction;
+using Semver;
 namespace Aspire.Cli.Commands;
 
 internal sealed class NewCommand : BaseCommand
@@ -122,7 +123,8 @@ internal sealed class NewCommand : BaseCommand
                 () => _nuGetPackageCache.GetTemplatePackagesAsync(workingDirectory, prerelease, source, cancellationToken)
                 );
 
-            var selectedPackage = await _prompter.PromptForTemplatesVersionAsync(candidatePackages, cancellationToken);
+            var orderedCandidatePackages = candidatePackages.OrderByDescending(p => SemVersion.Parse(p.Version), SemVersion.PrecedenceComparer);
+            var selectedPackage = await _prompter.PromptForTemplatesVersionAsync(orderedCandidatePackages, cancellationToken);
             return selectedPackage.Version;
         }
     }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -68,6 +68,144 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandOrdersTemplatePackageVersionsCorrectly()
+    {
+        IEnumerable<NuGetPackage>? promptedPackages = null;
+
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options => {
+
+            // Set of options that we'll give when prompted.
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter =  new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForTemplatesVersionCallback = (packages) =>
+                {
+                    promptedPackages = packages;
+                    return promptedPackages.First();
+                };
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                {
+                    var package92 = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "othernuget",
+                        Version = "9.2.0"
+                    };
+
+                    var package93 = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.3.0"
+                    };
+
+                    return (
+                        0, // Exit code.
+                        new NuGetPackage[] { package92, package93 }
+                        );
+                };
+
+                return runner;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new");
+
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(promptedPackages);
+        Assert.Collection(
+            promptedPackages,
+            package => Assert.Equal("9.3.0", package.Version),
+            package => Assert.Equal("9.2.0", package.Version)
+        );
+    }
+
+    [Fact]
+    public async Task NewCommandOrdersTemplatePackageVersionsCorrectlyWithPrerelease()
+    {
+        IEnumerable<NuGetPackage>? promptedPackages = null;
+
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options => {
+
+            // Set of options that we'll give when prompted.
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter =  new TestNewCommandPrompter(interactionService);
+
+                prompter.PromptForTemplatesVersionCallback = (packages) =>
+                {
+                    promptedPackages = packages;
+                    return promptedPackages.First();
+                };
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                {
+                    var package92 = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "othernuget",
+                        Version = "9.2.0"
+                    };
+
+                    var package94 = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "internalfeed",
+                        Version = "9.4.0-preview.1234"
+                    };
+
+                    var package93 = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.3.0"
+                    };
+
+                    return (
+                        0, // Exit code.
+                        new NuGetPackage[] { package92, package94, package93 }
+                        );
+                };
+
+                return runner;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new");
+
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(promptedPackages);
+        Assert.Collection(
+            promptedPackages,
+            package => Assert.Equal("9.4.0-preview.1234", package.Version),
+            package => Assert.Equal("9.3.0", package.Version),
+            package => Assert.Equal("9.2.0", package.Version)
+        );
+    }
+
+    [Fact]
     public async Task NewCommandDoesNotPromptForProjectNameIfSpecifiedOnCommandLine()
     {
         var promptedForName = false;


### PR DESCRIPTION
Fixes #8190

Just doing a semantic version sort on the packages before they are prompted.