### PR TITLE
change verbose logging of update details to a single line

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -535,30 +535,22 @@ public class ResourceNotificationService : IDisposable
 
             if (_logger.IsEnabled(LogLevel.Trace))
             {
+                // This is all logged on a single line so that logs have a single event on a single line, which
+                // makes them more easily analyzed in a text editor
                 _logger.LogTrace(
-                    """
-                    Version: {Version}
-                    Resource {Resource}/{ResourceId} update published:
-                    ResourceType = {ResourceType},
-                    CreationTimeStamp = {CreationTimeStamp:s},
-                    State = {{ Text = {StateText}, Style = {StateStyle} }},
-                    HeathStatus = {HealthStatus},
-                    ResourceReady = {ResourceReady},
-                    ExitCode = {ExitCode},
-                    Urls = {{ {Urls} }},
-                    EnvironmentVariables = {{
-                    {EnvironmentVariables}
-                    }},
-                    Properties = {{
-                    {Properties}
-                    }},
-                    HealthReports = {{
-                    {HealthReports}
-                    }},
-                    Commands = {{
-                    {Commands}
-                    }}
-                    """,
+                    "Version: {Version} " +
+                    "Resource {Resource}/{ResourceId} update published: " +
+                    "ResourceType = {ResourceType}, " +
+                    "CreationTimeStamp = {CreationTimeStamp:s}, " +
+                    "State = {{ Text = {StateText}, Style = {StateStyle} }}, " +
+                    "HeathStatus = {HealthStatus}, " +
+                    "ResourceReady = {ResourceReady}, " +
+                    "ExitCode = {ExitCode}," +
+                    "Urls = {{ {Urls} }}, " +
+                    "EnvironmentVariables = {{ {EnvironmentVariables} }}, " +
+                    "Properties = {{ {Properties} }}, " +
+                    "HealthReports = {{ {HealthReports} }}, " +
+                    "Commands = {{ {Commands} }}",
                     newState.Version,
                     resource.Name,
                     resourceId,
@@ -569,11 +561,11 @@ public class ResourceNotificationService : IDisposable
                     newState.HealthStatus,
                     newState.ResourceReadyEvent is not null,
                     newState.ExitCode,
-                    string.Join(", ", newState.Urls.Select(u => $"{u.Name} = {u.Url}")),
-                    JoinIndentLines(newState.EnvironmentVariables.Where(e => e.IsFromSpec).Select(e => $"{e.Name} = {e.Value}")),
-                    JoinIndentLines(newState.Properties.Select(p => $"{p.Name} = {Stringify(p.Value)}")),
-                    JoinIndentLines(newState.HealthReports.Select(p => $"{p.Name} = {Stringify(p.Status)}")),
-                    JoinIndentLines(newState.Commands.Select(c => $"{c.DisplayName} ({c.Name}) = {Stringify(c.State)}")));
+                    string.Join(" ", newState.Urls.Select(u => $"{u.Name} = {u.Url}")),
+                    string.Join(" ", newState.EnvironmentVariables.Where(e => e.IsFromSpec).Select(e => $"{e.Name} = {e.Value}")),
+                    string.Join(" ", newState.Properties.Select(p => $"{p.Name} = {Stringify(p.Value)}")),
+                    string.Join(" ", newState.HealthReports.Select(p => $"{p.Name} = {Stringify(p.Status)}")),
+                    string.Join(" ", newState.Commands.Select(c => $"{c.DisplayName} ({c.Name}) = {Stringify(c.State)}")));
 
                 static string Stringify(object? o) => o switch
                 {
@@ -582,22 +574,6 @@ public class ResourceNotificationService : IDisposable
                     null => "(null)",
                     _ => o.ToString()!
                 };
-
-                static string JoinIndentLines(IEnumerable<string> values)
-                {
-                    const int spaces = 2;
-                    var indent = new string(' ', spaces);
-                    var separator = Environment.NewLine + indent;
-
-                    var result = string.Join(separator, values);
-                    if (string.IsNullOrEmpty(result))
-                    {
-                        return result;
-                    }
-
-                    // Indent first line.
-                    return indent + result;
-                }
             }
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -545,7 +545,7 @@ public class ResourceNotificationService : IDisposable
                     "State = {{ Text = {StateText}, Style = {StateStyle} }}, " +
                     "HeathStatus = {HealthStatus}, " +
                     "ResourceReady = {ResourceReady}, " +
-                    "ExitCode = {ExitCode}," +
+                    "ExitCode = {ExitCode}, " +
                     "Urls = {{ {Urls} }}, " +
                     "EnvironmentVariables = {{ {EnvironmentVariables} }}, " +
                     "Properties = {{ {Properties} }}, " +

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostBackchannelTests.cs
@@ -97,8 +97,9 @@ public class AppHostBackchannelTests(ITestOutputHelper outputHelper)
                .WithInitialState(new () {
                     ResourceType = "TestResource",
                     State = new ("Running", null),
-                   Properties = [new("A", "B")]
-                });
+                    Properties = [new("A", "B"), new("c", "d")],
+                    EnvironmentVariables = [new("e", "f", true), new("g", "h", false)]
+               });
 
         var backchannelReadyTaskCompletionSource = new TaskCompletionSource<BackchannelReadyEvent>();
         builder.Eventing.Subscribe<BackchannelReadyEvent>((e, ct) => {


### PR DESCRIPTION
In discussion, this will help reduce the extreme length of our logs to make it easier to diagnose tests. Essentially shorter logs will help more than making this a single line will hurt.

Verified output in debugger (that's why I added a few to a test)

example
```txt
| [2025-04-21T20:35:13] Aspire.Hosting.ApplicationModel.ResourceNotificationService Trace: Version: 1 Resource test/test update published: ResourceType = TestResource, CreationTimeStamp = (null), State = { Text = Running, Style = (null) }, HeathStatus = Healthy, ResourceReady = False, ExitCode = (null), Urls = {  }, EnvironmentVariables = { A = B }, Properties = { A = B c = d }, HealthReports = {  }, Commands = {  }
```