### PR TITLE
Update templates descriptions to be more beginner-friendly 

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": ".NET Aspire App Host",
-  "description": "A project template for creating a .NET Aspire app host (orchestrator) project.",
+  "description": "Manages and runs multiple services in your .NET Aspire app from one place.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
@@ -8,7 +8,7 @@
   ],
   "name": ".NET Aspire App Host",
   "defaultName": "AppHost",
-  "description": "A project template for creating a .NET Aspire app host (orchestrator) project.",
+  "description": "Manages and runs multiple services in your .NET Aspire app from one place.",
   "shortName": "aspire-apphost",
   "sourceName": "Aspire.AppHost1",
   "preferNameDirectory": true,

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": ".NET Aspire Empty App",
-  "description": "A project template for creating an empty .NET Aspire app.",
+  "description": "Build cloud-native systems without preset services.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -12,7 +12,7 @@
   ],
   "name": ".NET Aspire Empty App",
   "defaultName": "AspireApp",
-  "description": "A project template for creating an empty .NET Aspire app.",
+  "description": "Build cloud-native systems without preset services.",
   "shortName": "aspire",
   "sourceName": "AspireApplication.1",
   "preferNameDirectory": true,

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": ".NET Aspire Test Project (MSTest)",
-  "description": "A project that contains MSTest integration tests of a .NET Aspire app host project.",
+  "description": "Beginner-friendly integration tests for your .NET Aspire app using MSTest.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -14,7 +14,7 @@
   ],
   "name": ".NET Aspire Test Project (MSTest)",
   "defaultName": "Tests",
-  "description": "A project that contains MSTest integration tests of a .NET Aspire app host project.",
+  "description": "Beginner-friendly integration tests for your .NET Aspire app using MSTest.",
   "shortName": "aspire-mstest",
   "sourceName": "Aspire.Tests.1",
   "preferNameDirectory": true,

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": ".NET Aspire Test Project (NUnit)",
-  "description": "A project that contains NUnit integration tests of a .NET Aspire app host project.",
+  "description": "Powerful integration testing for your app with the flexible and feature-rich NUnit framework.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -14,7 +14,7 @@
   ],
   "name": ".NET Aspire Test Project (NUnit)",
   "defaultName": "Tests",
-  "description": "A project that contains NUnit integration tests of a .NET Aspire app host project.",
+  "description": "Powerful integration testing for your app with the flexible and feature-rich NUnit framework.",
   "shortName": "aspire-nunit",
   "sourceName": "Aspire.Tests.1",
   "preferNameDirectory": true,

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": ".NET Aspire Service Defaults",
-  "description": "A project template for creating a .NET Aspire service defaults project.",
+  "description": "Service and cloud defaults wired up — just add your app logic.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
@@ -12,7 +12,7 @@
   ],
   "name": ".NET Aspire Service Defaults",
   "defaultName": "ServiceDefaults",
-  "description": "A project template for creating a .NET Aspire service defaults project.",
+  "description": "Service and cloud defaults wired up — just add your app logic.",
   "shortName": "aspire-servicedefaults",
   "sourceName": "Aspire.ServiceDefaults1",
   "preferNameDirectory": true,

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": ".NET Aspire Starter App",
-  "description": "A project template for creating a .NET Aspire app with a Blazor web frontend and web API backend service, optionally using Redis for caching.",
+  "description": "A complete web app setup: frontend, backend, and optional caching for faster responses.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -17,7 +17,7 @@
   ],
   "name": ".NET Aspire Starter App",
   "defaultName": "AspireApp",
-  "description": "A project template for creating a .NET Aspire app with a Blazor web frontend and web API backend service, optionally using Redis for caching.",
+  "description": "A complete web app setup: frontend, backend, and optional caching for faster responses.",
   "shortName": "aspire-starter",
   "sourceName": "Aspire-StarterApplication.1",
   "preferNameDirectory": false,

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": ".NET Aspire Test Project (xUnit)",
-  "description": "A project that contains xUnit.net integration tests of a .NET Aspire AppHost project.",
+  "description": "Modern, clean integration tests for your app using xUnit — great for scalable apps and teams.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -14,7 +14,7 @@
   ],
   "name": ".NET Aspire Test Project (xUnit)",
   "defaultName": "Tests",
-  "description": "A project that contains xUnit.net integration tests of a .NET Aspire AppHost project.",
+  "description": "Modern, clean integration tests for your app using xUnit — great for scalable apps and teams.",
   "shortName": "aspire-xunit",
   "sourceName": "Aspire.Tests.1",
   "preferNameDirectory": true,


### PR DESCRIPTION
## Description

Making this change so that template descriptions in the .NET template engine can be more beginner-friendly

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
