### PR TITLE
Fix console page not matching resource for non-running resources

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelectOptionTemplate.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelectOptionTemplate.razor
@@ -15,8 +15,7 @@
     }
     else if (ViewModel.Id?.Type is OtlpApplicationType.Instance)
     {
-        <div style="width: 20px;"></div>
-        <span aria-label="@string.Format(@Loc[nameof(ControlsStrings.ResourceDropdownReplicaAccessibleTitle)], ViewModel.Name, ViewModel.Id.ReplicaSetName)">@ViewModel.Name</span>
+        <span style="padding-left: 20px;" aria-label="@string.Format(@Loc[nameof(ControlsStrings.ResourceDropdownReplicaAccessibleTitle)], ViewModel.Name, ViewModel.Id.ReplicaSetName)">@ViewModel.Name</span>
     }
     else
     {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -717,9 +717,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     public ConsoleLogsPageState ConvertViewModelToSerializable()
     {
-        var selectedResourceName = PageViewModel.SelectedOption.Id is not null
-            ? PageViewModel.SelectedOption.Name
-            // _noSelection, which doesn't have a resource attached to it
+        var selectedResourceName = PageViewModel.SelectedResource is { } selectedResource
+            ? GetResourceName(selectedResource)
             : null;
         return new ConsoleLogsPageState(selectedResourceName);
     }

--- a/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
+++ b/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
@@ -27,6 +27,10 @@ public class ResourceTypeDetails : IEquatable<ResourceTypeDetails>
         {
             throw new InvalidOperationException($"Can't get ApplicationKey from resource type details '{ToString()}' because {nameof(ReplicaSetName)} is null.");
         }
+        if (InstanceId != null)
+        {
+            return ApplicationKey.Create(InstanceId);
+        }
 
         return new ApplicationKey(ReplicaSetName, InstanceId);
     }

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -22,42 +22,42 @@ public sealed class ApplicationsSelectHelpersTests
         // Arrange
         var appVMs = ApplicationsSelectHelpers.CreateApplications(new List<OtlpApplication>
         {
-            CreateOtlpApplication(name: "app", instanceId: "app"),
-            CreateOtlpApplication(name: "app", instanceId: "app-abc"),
-            CreateOtlpApplication(name: "singleton", instanceId: "singleton-abc")
+            CreateOtlpApplication(name: "multiple", instanceId: "instance"),
+            CreateOtlpApplication(name: "multiple", instanceId: "instanceabc"),
+            CreateOtlpApplication(name: "singleton", instanceId: "instanceabc")
         });
 
         Assert.Collection(appVMs,
             app =>
             {
-                Assert.Equal("app", app.Name);
+                Assert.Equal("multiple", app.Name);
                 Assert.Equal(OtlpApplicationType.ResourceGrouping, app.Id!.Type);
                 Assert.Null(app.Id!.InstanceId);
             },
             app =>
             {
-                Assert.Equal("app-app", app.Name);
+                Assert.Equal("multiple-instance", app.Name);
                 Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
-                Assert.Equal("app", app.Id!.InstanceId);
+                Assert.Equal("multiple-instance", app.Id!.InstanceId);
             },
             app =>
             {
-                Assert.Equal("app-app-abc", app.Name);
+                Assert.Equal("multiple-instanceabc", app.Name);
                 Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
-                Assert.Equal("app-abc", app.Id!.InstanceId);
+                Assert.Equal("multiple-instanceabc", app.Id!.InstanceId);
             },
             app =>
             {
                 Assert.Equal("singleton", app.Name);
                 Assert.Equal(OtlpApplicationType.Singleton, app.Id!.Type);
-                Assert.Equal("singleton-abc", app.Id!.InstanceId);
+                Assert.Equal("singleton-instanceabc", app.Id!.InstanceId);
             });
 
         // Act
-        var app = appVMs.GetApplication(NullLogger.Instance, "app-app-abc", canSelectGrouping: false, null!);
+        var app = appVMs.GetApplication(NullLogger.Instance, "multiple-instanceabc", canSelectGrouping: false, null!);
 
         // Assert
-        Assert.Equal("app-abc", app.Id!.InstanceId);
+        Assert.Equal("multiple-instanceabc", app.Id!.InstanceId);
         Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
     }
 
@@ -67,38 +67,38 @@ public sealed class ApplicationsSelectHelpersTests
         // Arrange
         var appVMs = ApplicationsSelectHelpers.CreateApplications(new List<OtlpApplication>
         {
-            CreateOtlpApplication(name: "app", instanceId: "app"),
-            CreateOtlpApplication(name: "APP", instanceId: "app-abc")
+            CreateOtlpApplication(name: "name", instanceId: "instance"),
+            CreateOtlpApplication(name: "NAME", instanceId: "instanceabc")
         });
 
         Assert.Collection(appVMs,
             app =>
             {
-                Assert.Equal("app", app.Name);
+                Assert.Equal("name", app.Name);
                 Assert.Equal(OtlpApplicationType.ResourceGrouping, app.Id!.Type);
                 Assert.Null(app.Id!.InstanceId);
             },
             app =>
             {
-                Assert.Equal("APP-app", app.Name);
+                Assert.Equal("NAME-instance", app.Name);
                 Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
-                Assert.Equal("app", app.Id!.InstanceId);
+                Assert.Equal("name-instance", app.Id!.InstanceId);
             },
             app =>
             {
-                Assert.Equal("APP-app-abc", app.Name);
+                Assert.Equal("NAME-instanceabc", app.Name);
                 Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
-                Assert.Equal("app-abc", app.Id!.InstanceId);
+                Assert.Equal("name-instanceabc", app.Id!.InstanceId);
             });
 
         var testSink = new TestSink();
         var factory = LoggerFactory.Create(b => b.AddProvider(new TestLoggerProvider(testSink)));
 
         // Act
-        var app = appVMs.GetApplication(factory.CreateLogger("Test"), "app-app", canSelectGrouping: false, null!);
+        var app = appVMs.GetApplication(factory.CreateLogger("Test"), "name-instance", canSelectGrouping: false, null!);
 
         // Assert
-        Assert.Equal("app", app.Id!.InstanceId);
+        Assert.Equal("name-instance", app.Id!.InstanceId);
         Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
         Assert.Empty(testSink.Writes);
     }
@@ -148,13 +148,13 @@ public sealed class ApplicationsSelectHelpersTests
             {
                 Assert.Equal("app-123", app.Name);
                 Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
-                Assert.Equal("123", app.Id!.InstanceId);
+                Assert.Equal("app-123", app.Id!.InstanceId);
             },
             app =>
             {
                 Assert.Equal("app-456", app.Name);
                 Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
-                Assert.Equal("456", app.Id!.InstanceId);
+                Assert.Equal("app-456", app.Id!.InstanceId);
             });
 
         // Act
@@ -185,13 +185,13 @@ public sealed class ApplicationsSelectHelpersTests
             {
                 Assert.Equal("app-123", app.Name);
                 Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
-                Assert.Equal("123", app.Id!.InstanceId);
+                Assert.Equal("app-123", app.Id!.InstanceId);
             },
             app =>
             {
                 Assert.Equal("app-456", app.Name);
                 Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
-                Assert.Equal("456", app.Id!.InstanceId);
+                Assert.Equal("app-456", app.Id!.InstanceId);
             });
 
         // Act


### PR DESCRIPTION
Fix regression. The option display name is no longer used to match or be persisted.

Fixes https://github.com/dotnet/aspire/issues/8831

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
