### PR TITLE
Convert tests to snapshot-based tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ node_modules/
 
 # Publisher Outputs
 playground/**/publish/
+
+# Verify
+*.received.*

--- a/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
@@ -5,32 +5,34 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppConfiguration\Aspire.Hosting.Azure.AppConfiguration.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppContainers\Aspire.Hosting.Azure.AppContainers.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Redis\Aspire.Hosting.Azure.Redis.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.KeyVault\Aspire.Hosting.Azure.KeyVault.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ApplicationInsights\Aspire.Hosting.Azure.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.CognitiveServices\Aspire.Hosting.Azure.CognitiveServices.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.PostgreSQL\Aspire.Hosting.Azure.PostgreSQL.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.CosmosDB\Aspire.Hosting.Azure.CosmosDB.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.EventHubs\Aspire.Hosting.Azure.EventHubs.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Functions\Aspire.Hosting.Azure.Functions.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Storage\Aspire.Hosting.Azure.Storage.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ServiceBus\Aspire.Hosting.Azure.ServiceBus.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.WebPubSub\Aspire.Hosting.Azure.WebPubSub.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Sql\Aspire.Hosting.Azure.Sql.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.SignalR\Aspire.Hosting.Azure.SignalR.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Search\Aspire.Hosting.Azure.Search.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.KeyVault\Aspire.Hosting.Azure.KeyVault.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.OperationalInsights\Aspire.Hosting.Azure.OperationalInsights.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ApplicationInsights\Aspire.Hosting.Azure.ApplicationInsights.csproj" />
-    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppConfiguration\Aspire.Hosting.Azure.AppConfiguration.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.PostgreSQL\Aspire.Hosting.Azure.PostgreSQL.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Redis\Aspire.Hosting.Azure.Redis.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Search\Aspire.Hosting.Azure.Search.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ServiceBus\Aspire.Hosting.Azure.ServiceBus.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.SignalR\Aspire.Hosting.Azure.SignalR.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Sql\Aspire.Hosting.Azure.Sql.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Storage\Aspire.Hosting.Azure.Storage.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.WebPubSub\Aspire.Hosting.Azure.WebPubSub.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Messaging.EventHubs\Aspire.Azure.Messaging.EventHubs.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Messaging.ServiceBus\Aspire.Azure.Messaging.ServiceBus.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Storage.Blobs\Aspire.Azure.Storage.Blobs.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Microsoft.Azure.Cosmos\Aspire.Microsoft.Azure.Cosmos.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Microsoft.EntityFrameworkCore.Cosmos\Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
+  </ItemGroup>
 
+  <ItemGroup>
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.Azure.EventHubs\EventHubsEmulatorContainerImageTags.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.Azure.ServiceBus\ServiceBusEmulatorContainerImageTags.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.Azure.Storage\AzureStorageEmulatorConnectionString.cs" />
@@ -39,6 +41,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" />
+    <PackageReference Include="Verify.XunitV3" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -8,7 +8,6 @@ using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -17,7 +17,6 @@ using Azure.Provisioning.Roles;
 using Azure.Provisioning.Search;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -14,7 +14,6 @@ using Azure.Provisioning.KeyVault;
 using Azure.Provisioning.Primitives;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Polly;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -6,7 +6,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -13,7 +13,6 @@ using Azure.Messaging.EventHubs.Producer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -8,7 +8,6 @@ using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
@@ -5,7 +5,6 @@ using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.AsProvisioningParameterTests.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.AsProvisioningParameterTests.verified.bicep
@@ -1,0 +1,29 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param endpointAddressParam string
+
+param someExpressionParam string
+
+resource app 'Microsoft.App/containerApps@2024-03-01' = {
+  name: take('app-${uniqueString(resourceGroup().id)}', 32)
+  location: location
+  properties: {
+    template: {
+      scale: {
+        rules: [
+          {
+            name: 'temp'
+            custom: {
+              type: 'external'
+              metadata: {
+                address: endpointAddressParam
+                someExpression: someExpressionParam
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.cs
@@ -4,11 +4,10 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.AppContainers;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 
-public class AzureProvisioningResourceExtensionsTests(ITestOutputHelper output)
+public class AzureProvisioningResourceExtensionsTests
 {
     [Fact]
     public async Task AsProvisioningParameterTests()
@@ -60,39 +59,7 @@ public class AzureProvisioningResourceExtensionsTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        var expectedBicep = """
-            @description('The location for the resource(s) to be deployed.')
-            param location string = resourceGroup().location
-
-            param endpointAddressParam string
-
-            param someExpressionParam string
-
-            resource app 'Microsoft.App/containerApps@2024-03-01' = {
-              name: take('app-${uniqueString(resourceGroup().id)}', 32)
-              location: location
-              properties: {
-                template: {
-                  scale: {
-                    rules: [
-                      {
-                        name: 'temp'
-                        custom: {
-                          type: 'external'
-                          metadata: {
-                            address: endpointAddressParam
-                            someExpression: someExpressionParam
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-            """;
-        output.WriteLine(manifest.BicepText);
-        Assert.Equal(expectedBicep, manifest.BicepText);
+        await Verifier.Verify(manifest.BicepText, extension: "bicep");
     }
 
     private sealed class Project : IProjectMetadata

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
@@ -10,7 +10,6 @@ using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -5,7 +5,6 @@ using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -6,7 +6,6 @@ using Aspire.Hosting.Utils;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSchemaTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSchemaTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Tests.Schema;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -10,7 +10,6 @@ using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSignalREmulatorFunctionalTest.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSignalREmulatorFunctionalTest.cs
@@ -11,7 +11,6 @@ using Microsoft.Azure.SignalR.Management;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Polly;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 public class AzureSignalREmulatorFunctionalTest(ITestOutputHelper testOutputHelper)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSignalRExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSignalRExtensionsTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
@@ -4,7 +4,6 @@
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageEmulatorFunctionalTests.cs
@@ -8,7 +8,6 @@ using Azure.Storage.Blobs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
@@ -6,8 +6,6 @@ using Aspire.Hosting.Utils;
 
 using Azure.Provisioning.WebPubSub;
 
-using Xunit;
-
 namespace Aspire.Hosting.Azure.Tests;
 
 public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)

--- a/tests/Aspire.Hosting.Azure.Tests/BicepIdentifierHelpersTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/BicepIdentifierHelpersTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Azure.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/ContainerRegistryTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ContainerRegistryTests.cs
@@ -9,7 +9,6 @@ using Aspire.Hosting.Azure.AppContainers;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.Utils;
 using Aspire.Hosting.ApplicationModel;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppConfigurationPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppConfigurationPublicApiTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.AppContainers;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ApplicationInsightsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ApplicationInsightsPublicApiTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CognitiveServicesPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CognitiveServicesPublicApiTests.cs
@@ -5,7 +5,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/EventHubsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/EventHubsPublicApiTests.cs
@@ -4,7 +4,6 @@
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/FunctionsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/FunctionsPublicApiTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/KeyVaultPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/KeyVaultPublicApiTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/OperationalInsightsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/OperationalInsightsPublicApiTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/PostgreSQLPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/PostgreSQLPublicApiTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/RedisPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/RedisPublicApiTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/SearchPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/SearchPublicApiTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/ServiceBusPublicApiTests.cs
@@ -4,7 +4,6 @@
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/SignalRPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/SignalRPublicApiTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/SqlPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/SqlPublicApiTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/WebPubSubPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/WebPubSubPublicApiTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 using static Aspire.Hosting.ApplicationModel.ReferenceExpression;
 
 namespace Aspire.Hosting.Azure.Tests.PublicApiTests;

--- a/tests/Aspire.Hosting.Azure.Tests/ResourceGroupNameHelpersTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ResourceGroupNameHelpersTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Azure.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ResourceWithAzureFunctionsConfigTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Xunit;
 
 namespace Aspire.Hosting.Azure.Tests;
 

--- a/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
@@ -13,7 +13,6 @@ using Azure.Provisioning.ServiceBus;
 using Azure.Provisioning.SignalR;
 using Azure.Provisioning.WebPubSub;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/TestModuleInitializer.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/TestModuleInitializer.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using EmptyFiles;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+sealed class TestModuleInitializer
+{
+    [ModuleInitializer]
+    internal static void Setup()
+    {
+        FileExtensions.AddTextExtension("bicep");
+    }
+}

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -23,6 +23,6 @@
     <PackageVersion Include="Testcontainers.Oracle" Version="$(TestcontainersPackageVersion)" />
     <PackageVersion Include="Testcontainers.Elasticsearch" Version="$(TestcontainersPackageVersion)" />
     <PackageVersion Include="Testcontainers" Version="$(TestcontainersPackageVersion)" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageVersion Include="Verify.XunitV3" Version="29.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Convert _selected_ tests to the snapshot-based testing to simplify the tests and simplify and improve the test experience - whenever a test fails you won't need to guess where, you'll see it in a diff tool of your choice.
E.g.:
![image](https://github.com/user-attachments/assets/aafd6f8a-c09c-4ea8-a85d-fd751b87715b)
