### PR TITLE
Fix diagnostics URL error

### DIFF
--- a/src/Aspire.Hosting.Analyzers/AppHostAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Analyzers/AppHostAnalyzer.Diagnostics.cs
@@ -18,7 +18,7 @@ public partial class AppHostAnalyzer
             category: "Design",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            helpLinkUri: $"https://aka.ms/dotnet/aspire/{ModelNameMustBeValidId}");
+            helpLinkUri: $"https://aka.ms/dotnet/aspire/diagnostics#{ModelNameMustBeValidId}");
 
         public static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics = ImmutableArray.Create(
             s_modelNameMustBeValid


### PR DESCRIPTION
## Description

I noticed that the diagnostics help URL for `AZURE006` is invalid. This fixes it.

Depends on dotnet/docs-aspire#3145

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
