### PR TITLE
Improve error display when sub-processes fail.

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Shared\KnownConfigNames.cs" Link="KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
+    <Compile Include="$(SharedDir)CircularBuffer.cs" Link="Utils\CircularBuffer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Cli/Certificates/CertificatesHelper.cs
+++ b/src/Aspire.Cli/Certificates/CertificatesHelper.cs
@@ -21,14 +21,17 @@ internal sealed class CertificateService(IInteractionService interactionService)
 
         var checkExitCode = await interactionService.ShowStatusAsync(
             ":locked_with_key: Checking certificates...",
-            () => runner.CheckHttpCertificateAsync(cancellationToken));
+            () => runner.CheckHttpCertificateAsync(
+                new DotNetCliRunnerInvocationOptions(),
+                cancellationToken));
 
         if (checkExitCode != 0)
         {
             var trustExitCode = await interactionService.ShowStatusAsync(
                 ":locked_with_key: Trusting certificates...",
-                () => runner.TrustHttpCertificateAsync(cancellationToken)
-            );
+                () => runner.TrustHttpCertificateAsync(
+                    new DotNetCliRunnerInvocationOptions(),
+                    cancellationToken));
 
             if (trustExitCode != 0)
             {

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -126,8 +126,8 @@ internal sealed class AddCommand : BaseCommand
                         effectiveAppHostProjectFile,
                         selectedNuGetPackage.Package.Id,
                         selectedNuGetPackage.Package.Version,
-                        cancellationToken
-                        );
+                        new DotNetCliRunnerInvocationOptions(),
+                        cancellationToken);
 
                     return addPackageResult == 0 ? ExitCodeConstants.Success : ExitCodeConstants.FailedToAddPackage;
                 }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -142,7 +142,7 @@ internal sealed class NewCommand : BaseCommand
 
         var templateInstallResult = await _interactionService.ShowStatusAsync(
             ":ice:  Getting latest templates...",
-            () => _runner.InstallTemplateAsync("Aspire.ProjectTemplates", version, source, true, cancellationToken));
+            () => _runner.InstallTemplateAsync("Aspire.ProjectTemplates", version, source, true, new DotNetCliRunnerInvocationOptions(), cancellationToken));
 
         if (templateInstallResult.ExitCode != 0)
         {
@@ -158,6 +158,7 @@ internal sealed class NewCommand : BaseCommand
                         template.TemplateName,
                         name,
                         outputPath,
+                        new DotNetCliRunnerInvocationOptions(),
                         cancellationToken));
 
         if (newProjectExitCode != 0)

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -125,6 +125,7 @@ internal sealed class PublishCommand : BaseCommand
                         ["--operation", "inspect"],
                         null,
                         backchannelCompletionSource,
+                        new DotNetCliRunnerInvocationOptions(),
                         cancellationToken).ConfigureAwait(false);
 
                     var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
@@ -187,6 +188,7 @@ internal sealed class PublishCommand : BaseCommand
                         ["--publisher", publisher ?? "manifest", "--output-path", fullyQualifiedOutputPath],
                         env,
                         backchannelCompletionSource,
+                        new DotNetCliRunnerInvocationOptions(),
                         cancellationToken);
 
                     var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -67,6 +67,8 @@ internal sealed class PublishCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        var outputCollector = new OutputCollector();
+
         (bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
 
         try
@@ -98,10 +100,17 @@ internal sealed class PublishCommand : BaseCommand
                 return ExitCodeConstants.AppHostIncompatible;
             }
 
-            var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, cancellationToken);
+            var buildOptions = new DotNetCliRunnerInvocationOptions
+            {
+                StandardOutputCallback = outputCollector.AppendOutput,
+                StandardErrorCallback = outputCollector.AppendError,
+            };
+
+            var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, buildOptions, cancellationToken);
 
             if (buildExitCode != 0)
             {
+                _interactionService.DisplayLines(outputCollector.GetLines());
                 _interactionService.DisplayError("The project could not be built. For more information run with --debug switch.");
                 return ExitCodeConstants.FailedToBuildArtifacts;
             }
@@ -117,6 +126,12 @@ internal sealed class PublishCommand : BaseCommand
                         $"{nameof(ExecuteAsync)}-Action-GetPublishers",
                         ActivityKind.Client);
 
+                    var getPublishersRunOptions = new DotNetCliRunnerInvocationOptions
+                    {
+                        StandardOutputCallback = outputCollector.AppendOutput,
+                        StandardErrorCallback = outputCollector.AppendError,
+                    };
+
                     var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
                     var pendingInspectRun = _runner.RunAsync(
                         effectiveAppHostProjectFile,
@@ -125,7 +140,7 @@ internal sealed class PublishCommand : BaseCommand
                         ["--operation", "inspect"],
                         null,
                         backchannelCompletionSource,
-                        new DotNetCliRunnerInvocationOptions(),
+                        getPublishersRunOptions,
                         cancellationToken).ConfigureAwait(false);
 
                     var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
@@ -140,6 +155,7 @@ internal sealed class PublishCommand : BaseCommand
 
             if (publishersResult.ExitCode != 0)
             {
+                _interactionService.DisplayLines(outputCollector.GetLines());
                 _interactionService.DisplayError($"The publisher inspection failed with exit code {publishersResult.ExitCode}. For more information run with --debug switch.");
                 return ExitCodeConstants.FailedToBuildArtifacts;
             }
@@ -181,6 +197,12 @@ internal sealed class PublishCommand : BaseCommand
                     launchingAppHostTask.IsIndeterminate();
                     launchingAppHostTask.StartTask();
 
+                    var publishRunOptions = new DotNetCliRunnerInvocationOptions
+                    {
+                        StandardOutputCallback = outputCollector.AppendOutput,
+                        StandardErrorCallback = outputCollector.AppendError,
+                    };
+
                     var pendingRun = _runner.RunAsync(
                         effectiveAppHostProjectFile,
                         false,
@@ -188,7 +210,7 @@ internal sealed class PublishCommand : BaseCommand
                         ["--publisher", publisher ?? "manifest", "--output-path", fullyQualifiedOutputPath],
                         env,
                         backchannelCompletionSource,
-                        new DotNetCliRunnerInvocationOptions(),
+                        publishRunOptions,
                         cancellationToken);
 
                     var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
@@ -264,6 +286,7 @@ internal sealed class PublishCommand : BaseCommand
 
             if (exitCode != 0)
             {
+                _interactionService.DisplayLines(outputCollector.GetLines());
                 _interactionService.DisplayError($"Publishing artifacts failed with exit code {exitCode}. For more information run with --debug switch.");
                 return ExitCodeConstants.FailedToBuildArtifacts;
             }
@@ -294,6 +317,11 @@ internal sealed class PublishCommand : BaseCommand
                 ex,
                 appHostCompatibilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
                 );
+        }
+        catch (Exception ex)
+        {
+            _interactionService.DisplayError($"An unexpected error occurred: {ex.Message}");
+            return ExitCodeConstants.FailedToBuildArtifacts;
         }
     }
 }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -120,6 +120,7 @@ internal sealed class RunCommand : BaseCommand
                 Array.Empty<string>(),
                 env,
                 backchannelCompletitionSource,
+                new DotNetCliRunnerInvocationOptions(),
                 cancellationToken);
 
             if (useRichConsole)

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -50,6 +50,8 @@ internal sealed class RunCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        var outputCollector = new OutputCollector();
+
         (bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
         try
         {
@@ -95,10 +97,17 @@ internal sealed class RunCommand : BaseCommand
 
             if (!watch)
             {
-                var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, cancellationToken);
+                var buildOptions = new DotNetCliRunnerInvocationOptions
+                {
+                    StandardOutputCallback = outputCollector.AppendOutput,
+                    StandardErrorCallback = outputCollector.AppendError,
+                };
+
+                var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, buildOptions, cancellationToken);
 
                 if (buildExitCode != 0)
                 {
+                    _interactionService.DisplayLines(outputCollector.GetLines());
                     _interactionService.DisplayError($"The project could not be built. For more information run with --debug switch.");
                     return ExitCodeConstants.FailedToBuildArtifacts;
                 }
@@ -111,6 +120,12 @@ internal sealed class RunCommand : BaseCommand
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
 
+            var runOptions = new DotNetCliRunnerInvocationOptions
+            {
+                StandardOutputCallback = outputCollector.AppendOutput,
+                StandardErrorCallback = outputCollector.AppendError,
+            };
+
             var backchannelCompletitionSource = new TaskCompletionSource<IAppHostBackchannel>();
 
             var pendingRun = _runner.RunAsync(
@@ -120,7 +135,7 @@ internal sealed class RunCommand : BaseCommand
                 Array.Empty<string>(),
                 env,
                 backchannelCompletitionSource,
-                new DotNetCliRunnerInvocationOptions(),
+                runOptions,
                 cancellationToken);
 
             if (useRichConsole)
@@ -208,7 +223,17 @@ internal sealed class RunCommand : BaseCommand
                     }
                 });
 
-                return await pendingRun;
+                var result =  await pendingRun;
+                if (result != 0)
+                {
+                    _interactionService.DisplayLines(outputCollector.GetLines());
+                    _interactionService.DisplayError($"The project could not be run. For more information run with --debug switch.");
+                    return result;
+                }
+                else
+                {
+                    return ExitCodeConstants.Success;
+                }
             }
             else
             {
@@ -241,6 +266,12 @@ internal sealed class RunCommand : BaseCommand
                 ex,
                 appHostCompatibilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
                 );
+        }
+        catch (Exception ex)
+        {
+            _interactionService.DisplayError($"An unexpected error occurred: {ex.Message}");
+            _interactionService.DisplayLines(outputCollector.GetLines());
+            return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
     }
 }

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.Sockets;
+using System.Text;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Hosting;
@@ -15,16 +16,22 @@ namespace Aspire.Cli;
 
 internal interface IDotNetCliRunner
 {
-    Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(FileInfo projectFile, CancellationToken cancellationToken);
-    Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, CancellationToken cancellationToken);
-    Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken);
-    Task<int> CheckHttpCertificateAsync(CancellationToken cancellationToken);
-    Task<int> TrustHttpCertificateAsync(CancellationToken cancellationToken);
-    Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, CancellationToken cancellationToken);
-    Task<int> NewProjectAsync(string templateName, string name, string outputPath, CancellationToken cancellationToken);
-    Task<int> BuildAsync(FileInfo projectFilePath, CancellationToken cancellationToken);
-    Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, CancellationToken cancellationToken);
-    Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(DirectoryInfo workingDirectory, string query, bool prerelease, int take, int skip, string? nugetSource, CancellationToken cancellationToken);
+    Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(FileInfo projectFile, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<int> CheckHttpCertificateAsync(DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<int> TrustHttpCertificateAsync(DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<int> NewProjectAsync(string templateName, string name, string outputPath, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<int> BuildAsync(FileInfo projectFilePath, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(DirectoryInfo workingDirectory, string query, bool prerelease, int take, int skip, string? nugetSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+}
+
+internal sealed class DotNetCliRunnerInvocationOptions
+{
+    public Action<string>? StandardOutputCallback { get; set; }
+    public Action<string>? StandardErrorCallback { get; set; }
 }
 
 internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider serviceProvider) : IDotNetCliRunner
@@ -33,33 +40,33 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
     internal Func<int> GetCurrentProcessId { get; set; } = () => Environment.ProcessId;
 
-    public async Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(FileInfo projectFile, CancellationToken cancellationToken)
+    public async Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(FileInfo projectFile, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
         string[] cliArgs = ["msbuild", "-getproperty:IsAspireHost,AspireHostingSDKVersion", projectFile.FullName];
 
-        string? stdout = null;
-        string? stderr = null;
+        // Syphon off the stdout from this execution to build the JSON document
+        // containing the information we need for the apphost, but allow it to
+        // flow up to the invoker if they have a callback.
+        var stdoutBuilder = new StringBuilder();
+        var existingStandardOutputCallback = options.StandardOutputCallback; // Preserve the existing callback if it exists.
+        options.StandardOutputCallback = (line) => {
+            stdoutBuilder.AppendLine(line);
+            existingStandardOutputCallback?.Invoke(line);
+        };
 
         var exitCode = await ExecuteAsync(
             args: cliArgs,
             env: null,
             workingDirectory: projectFile.Directory!,
             backchannelCompletionSource: null,
-            streamsCallback: (_, output, error) => {
-                stdout = output.ReadToEnd();
-                stderr = error.ReadToEnd();
-            },
+            options: options,
             cancellationToken: cancellationToken);
 
-        if (exitCode == 0 && stdout is null)
+        if (exitCode == 0)
         {
-            throw new InvalidOperationException("Failed to read stdout from the process. This should never happen.");
-        }
-
-        if (exitCode == 0 && stdout is not null)
-        {
+            var stdout = stdoutBuilder.ToString();
             var json = JsonDocument.Parse(stdout);
             var properties = json.RootElement.GetProperty("Properties");
 
@@ -91,7 +98,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         }
     }
 
-    public async Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, CancellationToken cancellationToken)
+    public async Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
         
@@ -102,19 +109,30 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             projectFile.FullName
             ];
 
-        string? stdout = null;
-        string? stderr = null;
+        var stdoutBuilder = new StringBuilder();
+        var existingStandardOutputCallback = options.StandardOutputCallback; // Preserve the existing callback if it exists.
+        options.StandardOutputCallback = (line) => {
+            stdoutBuilder.AppendLine(line);
+            existingStandardOutputCallback?.Invoke(line);
+        };
+
+        var stderrBuilder = new StringBuilder();
+        var existingStandardErrorCallback = options.StandardErrorCallback; // Preserve the existing callback if it exists.
+        options.StandardErrorCallback = (line) => {
+            stderrBuilder.AppendLine(line);
+            existingStandardErrorCallback?.Invoke(line);
+        };
 
         var exitCode = await ExecuteAsync(
-            cliArgs,
-            null,
-            projectFile.Directory!,
-            null,
-            (_, output, error) => {
-                stdout = output.ReadToEnd();
-                stderr = error.ReadToEnd();
-            },
+            args: cliArgs,
+            env: null,
+            workingDirectory: projectFile.Directory!,
+            backchannelCompletionSource: null,
+            options: options,
             cancellationToken);
+
+        var stdout = stdoutBuilder.ToString();
+        var stderr = stderrBuilder.ToString();
 
         if (exitCode != 0)
         {
@@ -134,7 +152,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         }
     }
 
-    public async Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
+    public async Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -153,11 +171,11 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             env: env,
             workingDirectory: projectFile.Directory!,
             backchannelCompletionSource: backchannelCompletionSource,
-            streamsCallback: null,
+            options: options,
             cancellationToken: cancellationToken);
     }
 
-    public async Task<int> CheckHttpCertificateAsync(CancellationToken cancellationToken)
+    public async Task<int> CheckHttpCertificateAsync(DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -167,11 +185,11 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             env: null,
             workingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
             backchannelCompletionSource: null,
-            streamsCallback: null,
+            options: options,
             cancellationToken: cancellationToken);
     }
 
-    public async Task<int> TrustHttpCertificateAsync(CancellationToken cancellationToken)
+    public async Task<int> TrustHttpCertificateAsync(DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -181,11 +199,11 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             env: null,
             workingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
             backchannelCompletionSource: null,
-            streamsCallback: null,
+            options: options,
             cancellationToken: cancellationToken);
     }
 
-    public async Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, CancellationToken cancellationToken)
+    public async Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity(nameof(InstallTemplateAsync), ActivityKind.Client);
 
@@ -202,21 +220,30 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             cliArgs.Add(nugetSource);
         }
 
-        string? stdout = null;
-        string? stderr = null;
+        var stdoutBuilder = new StringBuilder();
+        var existingStandardOutputCallback = options.StandardOutputCallback; // Preserve the existing callback if it exists.
+        options.StandardOutputCallback = (line) => {
+            stdoutBuilder.AppendLine(line);
+            existingStandardOutputCallback?.Invoke(line);
+        };
+
+        var stderrBuilder = new StringBuilder();
+        var existingStandardErrorCallback = options.StandardErrorCallback; // Preserve the existing callback if it exists.
+        options.StandardErrorCallback = (line) => {
+            stderrBuilder.AppendLine(line);
+            existingStandardErrorCallback?.Invoke(line);
+        };
 
         var exitCode = await ExecuteAsync(
             args: [.. cliArgs],
             env: null,
             workingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
             backchannelCompletionSource: null,
-            streamsCallback: (_, output, error) => {
-                // We need to read the output of the streams
-                // here otherwise th process will never exit.
-                stdout = output.ReadToEnd();
-                stderr = error.ReadToEnd();
-            },
+            options: options,
             cancellationToken: cancellationToken);
+
+        var stdout = stdoutBuilder.ToString();
+        var stderr = stderrBuilder.ToString();
 
         if (exitCode != 0)
         {
@@ -287,7 +314,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         }
     }
 
-    public async Task<int> NewProjectAsync(string templateName, string name, string outputPath, CancellationToken cancellationToken)
+    public async Task<int> NewProjectAsync(string templateName, string name, string outputPath, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -297,7 +324,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             env: null,
             workingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
             backchannelCompletionSource: null,
-            streamsCallback: null,
+            options: options,
             cancellationToken: cancellationToken);
     }
 
@@ -316,7 +343,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         return socketPath;
     }
 
-    public async Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, Action<StreamWriter, StreamReader, StreamReader>? streamsCallback, CancellationToken cancellationToken)
+    public async Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -366,24 +393,23 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             _ = StartBackchannelAsync(process, socketPath, backchannelCompletionSource, cancellationToken);
         }
 
-        if (streamsCallback is null)
-        {
-            var pendingStdoutStreamForwarder = Task.Run(async () => {
-                await ForwardStreamToLoggerAsync(
-                    process.StandardOutput,
-                    "stdout",
-                    process,
-                    cancellationToken);
-                }, cancellationToken);
+        var pendingStdoutStreamForwarder = Task.Run(async () => {
+            await ForwardStreamToLoggerAsync(
+                process.StandardOutput,
+                "stdout",
+                process,
+                options.StandardOutputCallback,
+                cancellationToken);
+            }, cancellationToken);
 
-            var pendingStderrStreamForwarder = Task.Run(async () => {
-                await ForwardStreamToLoggerAsync(
-                    process.StandardError,
-                    "stderr",
-                    process,
-                    cancellationToken);
-                }, cancellationToken);
-        }
+        var pendingStderrStreamForwarder = Task.Run(async () => {
+            await ForwardStreamToLoggerAsync(
+                process.StandardError,
+                "stderr",
+                process,
+                options.StandardOutputCallback,
+                cancellationToken);
+            }, cancellationToken);
 
         if (!started)
         {
@@ -394,10 +420,6 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         {
             logger.LogDebug("Started dotnet with PID: {ProcessId}", process.Id);
         }
-
-        // This is so that callers can get a handle to the raw stream output. This is important
-        // because some commmands (like package search) return JSON data that we need to parse.
-        streamsCallback?.Invoke(process.StandardInput, process.StandardOutput, process.StandardError);
 
         logger.LogDebug("Waiting for dotnet process to exit with PID: {ProcessId}", process.Id);
 
@@ -413,9 +435,12 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             logger.LogDebug("dotnet process with PID: {ProcessId} has exited with code: {ExitCode}", process.Id, process.ExitCode);
         }
 
+        // Wait for all the stream forwarders to finish so we know we've got everything
+        // fired off through the callbacks.
+        await Task.WhenAll([pendingStdoutStreamForwarder, pendingStderrStreamForwarder]);
         return process.ExitCode;
 
-        async Task ForwardStreamToLoggerAsync(StreamReader reader, string identifier, Process process, CancellationToken cancellationToken)
+        async Task ForwardStreamToLoggerAsync(StreamReader reader, string identifier, Process process, Action<string>? lineCallback, CancellationToken cancellationToken)
         {
             logger.LogDebug(
                 "Starting to forward stream with identifier '{Identifier}' on process '{ProcessId}' to logger",
@@ -426,12 +451,13 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             while (!cancellationToken.IsCancellationRequested && !reader.EndOfStream)
             {
                 var line = await reader.ReadLineAsync(cancellationToken);
-                logger.LogDebug(
+                logger.LogTrace(
                     "dotnet({ProcessId}) {Identifier}: {Line}",
                     process.Id,
                     identifier,
                     line
                     );
+                lineCallback?.Invoke(line!);
             }
         }
     }
@@ -510,7 +536,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         } while (await timer.WaitForNextTickAsync(cancellationToken));
     }
 
-    public async Task<int> BuildAsync(FileInfo projectFilePath, CancellationToken cancellationToken)
+    public async Task<int> BuildAsync(FileInfo projectFilePath, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -520,10 +546,10 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             env: null,
             workingDirectory: projectFilePath.Directory!,
             backchannelCompletionSource: null,
-            streamsCallback: null,
+            options: options,
             cancellationToken: cancellationToken);
     }
-    public async Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, CancellationToken cancellationToken)
+    public async Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -543,7 +569,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             env: null,
             workingDirectory: projectFilePath.Directory!,
             backchannelCompletionSource: null,
-            streamsCallback: null,
+            options: options,
             cancellationToken: cancellationToken);
 
         if (result != 0)
@@ -558,7 +584,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         return result;
     }
 
-    public async Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(DirectoryInfo workingDirectory, string query, bool prerelease, int take, int skip, string? nugetSource, CancellationToken cancellationToken)
+    public async Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(DirectoryInfo workingDirectory, string query, bool prerelease, int take, int skip, string? nugetSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -585,21 +611,30 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             cliArgs.Add("--prerelease");
         }
 
-        string? stdout = null;
-        string? stderr = null;
+        var stdoutBuilder = new StringBuilder();
+        var existingStandardOutputCallback = options.StandardOutputCallback; // Preserve the existing callback if it exists.
+        options.StandardOutputCallback = (line) => {
+            stdoutBuilder.AppendLine(line);
+            existingStandardOutputCallback?.Invoke(line);
+        };
+
+        var stderrBuilder = new StringBuilder();
+        var existingStandardErrorCallback = options.StandardErrorCallback; // Preserve the existing callback if it exists.
+        options.StandardErrorCallback = (line) => {
+            stderrBuilder.AppendLine(line);
+            existingStandardErrorCallback?.Invoke(line);
+        };
 
         var result = await ExecuteAsync(
             args: cliArgs.ToArray(),
             env: null,
             workingDirectory: workingDirectory!,
             backchannelCompletionSource: null,
-            streamsCallback: (_, output, _) => {
-                // We need to read the output of the streams
-                // here otherwise th process will never exit.
-                stdout = output.ReadToEnd();
-                stderr = output.ReadToEnd();
-            },
+            options: options,
             cancellationToken: cancellationToken);
+
+        var stdout = stdoutBuilder.ToString();
+        var stderr = stderrBuilder.ToString();
 
         if (result != 0)
         {

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -17,4 +17,5 @@ internal interface IInteractionService
     void DisplayMessage(string emoji, string message);
     void DisplaySuccess(string message);
     void DisplayDashboardUrls((string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken) dashboardUrls);
+    void DisplayLines(IEnumerable<(string Stream, string Line)> lines);
 }

--- a/src/Aspire.Cli/Interaction/InteractionService.cs
+++ b/src/Aspire.Cli/Interaction/InteractionService.cs
@@ -112,4 +112,19 @@ internal class InteractionService : IInteractionService
         }
         _ansiConsole.WriteLine();
     }
+
+    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines)
+    {
+        foreach (var (stream, line) in lines)
+        {
+            if (stream == "stdout")
+            {
+                _ansiConsole.MarkupLineInterpolated($"{line}");
+            }
+            else
+            {
+                _ansiConsole.MarkupLineInterpolated($"[red]{line}[/]");
+            }
+        }
+    }
 }

--- a/src/Aspire.Cli/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGetPackageCache.cs
@@ -48,6 +48,7 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, IDotN
                 SearchPageSize,
                 skip,
                 source,
+                new DotNetCliRunnerInvocationOptions(),
                 cancellationToken
                 );
 

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -29,7 +29,7 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
         foreach (var projectFile in projectFiles)
         {
             logger.LogDebug("Checking project file {ProjectFile}", projectFile.FullName);
-            var information = await runner.GetAppHostInformationAsync(projectFile, cancellationToken);
+            var information = await runner.GetAppHostInformationAsync(projectFile, new DotNetCliRunnerInvocationOptions(), cancellationToken);
 
             if (information.ExitCode == 0 && information.IsAspireHost)
             {

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -53,8 +53,10 @@ internal static class AppHostHelper
 
         var appHostInformationResult = await interactionService.ShowStatusAsync(
             ":microscope: Checking project type...",
-            () => runner.GetAppHostInformationAsync(projectFile, cancellationToken)
-        );
+            () => runner.GetAppHostInformationAsync(
+                projectFile,
+                new DotNetCliRunnerInvocationOptions(),
+                cancellationToken));
 
         return appHostInformationResult;
     }
@@ -63,6 +65,9 @@ internal static class AppHostHelper
     {
         return await interactionService.ShowStatusAsync(
             ":hammer_and_wrench:  Building app host...",
-            () => runner.BuildAsync(projectFile, cancellationToken));
+            () => runner.BuildAsync(
+                projectFile,
+                new DotNetCliRunnerInvocationOptions(),
+                cancellationToken));
     }
 }

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -61,13 +61,13 @@ internal static class AppHostHelper
         return appHostInformationResult;
     }
     
-    internal static async Task<int> BuildAppHostAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, CancellationToken cancellationToken)
+    internal static async Task<int> BuildAppHostAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return await interactionService.ShowStatusAsync(
             ":hammer_and_wrench:  Building app host...",
             () => runner.BuildAsync(
                 projectFile,
-                new DotNetCliRunnerInvocationOptions(),
+                options,
                 cancellationToken));
     }
 }

--- a/src/Aspire.Cli/Utils/OutputCollector.cs
+++ b/src/Aspire.Cli/Utils/OutputCollector.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Utils;
+
+internal sealed class OutputCollector
+{
+    private readonly CircularBuffer<(string Stream, string Line)> _lines = new(10000); // 10k lines.
+
+    public void AppendOutput(string line)
+    {
+        _lines.Add(("stdout", line));
+    }
+
+    public void AppendError(string line)
+    {
+        _lines.Add(("stderr", line));
+    }
+
+    public IEnumerable<(string Stream, string Line)> GetLines()
+    {
+        return _lines;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -41,7 +41,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var dockerPackage = new NuGetPackage()
                     {
@@ -70,7 +70,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, options, cancellationToken) =>
                 {
                     // Simulate adding the package.
                     return 0; // Success.
@@ -114,7 +114,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var redis92Package = new NuGetPackage()
                     {
@@ -136,7 +136,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, options, cancellationToken) =>
                 {
                     // Simulate adding the package.
                     return 0; // Success.
@@ -185,7 +185,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var redis92Package = new NuGetPackage()
                     {
@@ -214,7 +214,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, options, cancellationToken) =>
                 {
                     // Simulate adding the package.
                     return 0; // Success.
@@ -264,7 +264,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var dockerPackage = new NuGetPackage()
                     {
@@ -293,7 +293,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, options, cancellationToken) =>
                 {
                     // Simulate adding the package.
                     return 0; // Success.
@@ -345,7 +345,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var dockerPackage = new NuGetPackage()
                     {
@@ -374,7 +374,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, options, cancellationToken) =>
                 {
                     // Simulate adding the package.
                     return 0; // Success.
@@ -422,7 +422,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var dockerPackage = new NuGetPackage()
                     {
@@ -451,7 +451,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, options, cancellationToken) =>
                 {
                     addedPackageName = packageName;
                     addedPackageVersion = packageVersion;

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -40,7 +40,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var package = new NuGetPackage()
                     {
@@ -92,7 +92,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var package92 = new NuGetPackage()
                     {
@@ -157,7 +157,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var package92 = new NuGetPackage()
                     {
@@ -230,7 +230,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var package = new NuGetPackage()
                     {
@@ -283,7 +283,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var package = new NuGetPackage()
                     {
@@ -336,7 +336,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var package = new NuGetPackage()
                     {
@@ -389,7 +389,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, cancellationToken) =>
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
                 {
                     var package = new NuGetPackage()
                     {

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
@@ -153,7 +153,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
 
         // Assert
-        Assert.Equal(1, exitCode); // Ensure the command fails
+        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode); // Ensure the command fails
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
@@ -35,7 +35,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.GetAppHostInformationAsyncCallback = (projectFile, cancellationToken) =>
+                runner.GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
                 {
                     return (1, false, null); // Simulate failure to retrieve app host information
                 };
@@ -65,7 +65,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.GetAppHostInformationAsyncCallback = (projectFile, cancellationToken) =>
+                runner.GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
                 {
                     return (0, false, "9.0.0"); // Simulate an incompatible app host
                 };
@@ -95,7 +95,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.BuildAsyncCallback = (projectFile, cancellationToken) =>
+                runner.BuildAsyncCallback = (projectFile, options, cancellationToken) =>
                 {
                     return 1; // Simulate a build failure
                 };
@@ -127,10 +127,10 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
                 var runner = new TestDotNetCliRunner();
 
                 // Simulate a successful build
-                runner.BuildAsyncCallback = (projectFile, cancellationToken) => 0;
+                runner.BuildAsyncCallback = (projectFile, options, cancellationToken) => 0;
 
                 // Simulate apphost starting but crashing before backchannel is established
-                runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, cancellationToken) =>
+                runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
                 {
                     // Simulate a delay to mimic apphost starting
                     await Task.Delay(100, cancellationToken);
@@ -169,16 +169,16 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
                 var runner = new TestDotNetCliRunner();
 
                 // Simulate a successful build
-                runner.BuildAsyncCallback = (projectFile, cancellationToken) => 0;
+                runner.BuildAsyncCallback = (projectFile, options, cancellationToken) => 0;
                 
                 // Simulate a successful app host information retrieval
-                runner.GetAppHostInformationAsyncCallback = (projectFile, cancellationToken) =>
+                runner.GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
                 {
                     return (0, true, VersionHelper.GetDefaultTemplateVersion()); // Compatible app host with backchannel support
                 };
 
                 // Simulate apphost running successfully and establishing a backchannel
-                runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, cancellationToken) =>
+                runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
                 {
                     if (args.Any(a => a == "inspect"))
                     {

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -141,16 +141,16 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             var runner = new TestDotNetCliRunner();
 
             // Fake the certificate check to always succeed
-            runner.CheckHttpCertificateAsyncCallback = (ct) => 0;
+            runner.CheckHttpCertificateAsyncCallback = (options, ct) => 0;
 
             // Fake the build command to always succeed.
-            runner.BuildAsyncCallback = (projectFile, ct) => 0;
+            runner.BuildAsyncCallback = (projectFile, options, ct) => 0;
 
             // Fake apphost information to return a compatable app host.
-            runner.GetAppHostInformationAsyncCallback = (projectFile, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
             // public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
             {
                 // Make a backchannel and return it, but don't return from the run call until the backchannel 
                 var backchannel = sp.GetRequiredService<IAppHostBackchannel>();

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -136,7 +136,7 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
         await File.WriteAllTextAsync(webProject.FullName, "Not a real web project.");
 
         var runner = new TestDotNetCliRunner();
-        runner.GetAppHostInformationAsyncCallback = (projectFile, cancellationToken) => {
+        runner.GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) => {
             if (projectFile.FullName == appHostProject.FullName)
             {
                 return (0, true, VersionHelper.GetDefaultTemplateVersion());

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -9,86 +9,86 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class TestDotNetCliRunner : IDotNetCliRunner
 {
-    public Func<FileInfo, string, string, CancellationToken, int>? AddPackageAsyncCallback { get; set; }
-    public Func<FileInfo, CancellationToken, int>? BuildAsyncCallback { get; set; }
-    public Func<CancellationToken, int>? CheckHttpCertificateAsyncCallback { get; set; }
-    public Func<FileInfo, CancellationToken, (int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)>? GetAppHostInformationAsyncCallback { get; set; }
-    public Func<FileInfo, string[], string[], CancellationToken, (int ExitCode, JsonDocument? Output)>? GetProjectItemsAndPropertiesAsyncCallback { get; set; }
-    public Func<string, string, string?, bool, CancellationToken, (int ExitCode, string? TemplateVersion)>? InstallTemplateAsyncCallback { get; set; }
-    public Func<string, string, string, CancellationToken, int>? NewProjectAsyncCallback { get; set; }
-    public Func<FileInfo, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostBackchannel>?, CancellationToken, Task<int>>? RunAsyncCallback { get; set; }
-    public Func<DirectoryInfo, string, bool, int, int, string?, CancellationToken, (int ExitCode, NuGetPackage[]? Packages)>? SearchPackagesAsyncCallback { get; set; }
-    public Func<CancellationToken, int>? TrustHttpCertificateAsyncCallback { get; set; }
+    public Func<FileInfo, string, string, DotNetCliRunnerInvocationOptions, CancellationToken, int>? AddPackageAsyncCallback { get; set; }
+    public Func<FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, int>? BuildAsyncCallback { get; set; }
+    public Func<DotNetCliRunnerInvocationOptions, CancellationToken, int>? CheckHttpCertificateAsyncCallback { get; set; }
+    public Func<FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)>? GetAppHostInformationAsyncCallback { get; set; }
+    public Func<FileInfo, string[], string[], DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, JsonDocument? Output)>? GetProjectItemsAndPropertiesAsyncCallback { get; set; }
+    public Func<string, string, string?, bool, DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, string? TemplateVersion)>? InstallTemplateAsyncCallback { get; set; }
+    public Func<string, string, string, DotNetCliRunnerInvocationOptions, CancellationToken, int>? NewProjectAsyncCallback { get; set; }
+    public Func<FileInfo, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostBackchannel>?, DotNetCliRunnerInvocationOptions, CancellationToken, Task<int>>? RunAsyncCallback { get; set; }
+    public Func<DirectoryInfo, string, bool, int, int, string?, DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, NuGetPackage[]? Packages)>? SearchPackagesAsyncCallback { get; set; }
+    public Func<DotNetCliRunnerInvocationOptions, CancellationToken, int>? TrustHttpCertificateAsyncCallback { get; set; }
 
-    public Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, CancellationToken cancellationToken)
+    public Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return AddPackageAsyncCallback != null
-            ? Task.FromResult(AddPackageAsyncCallback(projectFilePath, packageName, packageVersion, cancellationToken))
+            ? Task.FromResult(AddPackageAsyncCallback(projectFilePath, packageName, packageVersion, options, cancellationToken))
             : throw new NotImplementedException();
     }
 
-    public Task<int> BuildAsync(FileInfo projectFilePath, CancellationToken cancellationToken)
+    public Task<int> BuildAsync(FileInfo projectFilePath, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return BuildAsyncCallback != null
-            ? Task.FromResult(BuildAsyncCallback(projectFilePath, cancellationToken))
+            ? Task.FromResult(BuildAsyncCallback(projectFilePath, options, cancellationToken))
             : throw new NotImplementedException();
     }
 
-    public Task<int> CheckHttpCertificateAsync(CancellationToken cancellationToken)
+    public Task<int> CheckHttpCertificateAsync(DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return CheckHttpCertificateAsyncCallback != null
-            ? Task.FromResult(CheckHttpCertificateAsyncCallback(cancellationToken))
+            ? Task.FromResult(CheckHttpCertificateAsyncCallback(options, cancellationToken))
             : Task.FromResult(0); // Return success if not overridden.
     }
 
-    public Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(FileInfo projectFile, CancellationToken cancellationToken)
+    public Task<(int ExitCode, bool IsAspireHost, string? AspireHostingSdkVersion)> GetAppHostInformationAsync(FileInfo projectFile, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         var informationalVersion = VersionHelper.GetDefaultTemplateVersion();
 
         return GetAppHostInformationAsyncCallback != null
-            ? Task.FromResult(GetAppHostInformationAsyncCallback(projectFile, cancellationToken))
+            ? Task.FromResult(GetAppHostInformationAsyncCallback(projectFile, options, cancellationToken))
             : Task.FromResult<(int, bool, string?)>((0, true, informationalVersion));
     }
 
-    public Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, CancellationToken cancellationToken)
+    public Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return GetProjectItemsAndPropertiesAsyncCallback != null
-            ? Task.FromResult(GetProjectItemsAndPropertiesAsyncCallback(projectFile, items, properties, cancellationToken))
+            ? Task.FromResult(GetProjectItemsAndPropertiesAsyncCallback(projectFile, items, properties, options, cancellationToken))
             : throw new NotImplementedException();
     }
 
-    public Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, CancellationToken cancellationToken)
+    public Task<(int ExitCode, string? TemplateVersion)> InstallTemplateAsync(string packageName, string version, string? nugetSource, bool force, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return InstallTemplateAsyncCallback != null
-            ? Task.FromResult(InstallTemplateAsyncCallback(packageName, version, nugetSource, force, cancellationToken))
+            ? Task.FromResult(InstallTemplateAsyncCallback(packageName, version, nugetSource, force, options, cancellationToken))
             : Task.FromResult<(int, string?)>((0, version)); // If not overridden, just return success for the version specified.
     }
 
-    public Task<int> NewProjectAsync(string templateName, string name, string outputPath, CancellationToken cancellationToken)
+    public Task<int> NewProjectAsync(string templateName, string name, string outputPath, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return NewProjectAsyncCallback != null
-            ? Task.FromResult(NewProjectAsyncCallback(templateName, name, outputPath, cancellationToken))
+            ? Task.FromResult(NewProjectAsyncCallback(templateName, name, outputPath, options, cancellationToken))
             : Task.FromResult(0); // If not overridden, just return success.
     }
 
-    public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
+    public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return RunAsyncCallback != null
-            ? RunAsyncCallback(projectFile, watch, noBuild, args, env, backchannelCompletionSource, cancellationToken)
+            ? RunAsyncCallback(projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken)
             : throw new NotImplementedException();
     }
 
-    public Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(DirectoryInfo workingDirectory, string query, bool prerelease, int take, int skip, string? nugetSource, CancellationToken cancellationToken)
+    public Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(DirectoryInfo workingDirectory, string query, bool prerelease, int take, int skip, string? nugetSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return SearchPackagesAsyncCallback != null
-            ? Task.FromResult(SearchPackagesAsyncCallback(workingDirectory, query, prerelease, take, skip, nugetSource, cancellationToken))
+            ? Task.FromResult(SearchPackagesAsyncCallback(workingDirectory, query, prerelease, take, skip, nugetSource, options, cancellationToken))
             : throw new NotImplementedException();
     }
 
-    public Task<int> TrustHttpCertificateAsync(CancellationToken cancellationToken)
+    public Task<int> TrustHttpCertificateAsync(DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return TrustHttpCertificateAsyncCallback != null
-            ? Task.FromResult(TrustHttpCertificateAsyncCallback(cancellationToken))
+            ? Task.FromResult(TrustHttpCertificateAsyncCallback(options, cancellationToken))
             : throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Fixes #8741 #8671

This PR improves error display when a sub-process fails. Its made up of a few elements that work together:

1. Removed steamsCallback in favor of introducing an options type that specifies two callback methods. These callback methods are invoked as we receive output from the sub-process and allow middleman processing of content (useful for things like adding package calls etc).
2. Introduced an OutputCollector which is basically a wrapper around our pre-existing CircularBuffer (to avoid OOM errors for long running Run tasks).

The general idea is this:

```csharp
// Create a collector.
var templateInstallCollector = new OutputCollector();

var templateInstallResult = await _interactionService.ShowStatusAsync<(int ExitCode, string? TemplateVersion)>(
    ":ice:  Getting latest templates...",
    async () => {

        // Link the append methods on the collector to the callbacks
        // on the options for the runner.
        var options = new DotNetCliRunnerInvocationOptions()
        {
            StandardOutputCallback = templateInstallCollector.AppendOutput,
            StandardErrorCallback = templateInstallCollector.AppendOutput,
        };

        // Run the code.
        var result = await _runner.InstallTemplateAsync("Aspire.ProjectTemplates", version, source, true, options, cancellationToken);
        return result;
    });

// Inspect the result, and if appropriate display the errors.
if (templateInstallResult.ExitCode != 0)
{
    _interactionService.DisplayLines(templateInstallCollector.GetLines());
    _interactionService.DisplayError($"The template installation failed with exit code {templateInstallResult.ExitCode}. For more information run with --debug switch.");
    return ExitCodeConstants.FailedToInstallTemplates;
}
```

The `OutputCollector` is more of a utility type that you can use in a couple of different ways. You can use a single output collector for multiple process runs, or you can have one per process run, it just depends on how your code is structured. you can also output the content from the collector in an exception hander or in an exit code check. This helps us cover the various scenarios that we have today in the code base without any massive restructuring.

Example from `aspire run` that fails to build:

https://github.com/user-attachments/assets/3d599d9c-ed55-47d8-a3d1-a61dfc25aeaa

Example from `aspire publish` that crashes during runtime (works for run too, but unless they are in the mainline the apphost doesn't crash:

https://github.com/user-attachments/assets/6f20ca20-9100-466f-8172-18e54df541f3
