### PR TITLE
Use assets collection to import blazor.web.js

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.1/Aspire-StarterApplication.1.Web/Components/App.razor
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.1/Aspire-StarterApplication.1.Web/Components/App.razor
@@ -21,7 +21,11 @@
 
 <body>
     <Routes />
+    @*#if (Framework == 'net8.0')
     <script src="_framework/blazor.web.js"></script>
+    ##else
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
+    ##endif*@
 </body>
 
 </html>

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.Web/Components/App.razor
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.2/Aspire-StarterApplication.1.Web/Components/App.razor
@@ -21,7 +21,11 @@
 
 <body>
     <Routes />
+    @*#if (Framework == 'net8.0')
     <script src="_framework/blazor.web.js"></script>
+    ##else
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
+    ##endif*@
 </body>
 
 </html>


### PR DESCRIPTION
## Description

The `blazor.web.js` has fingerprint as well. We can use the assets collection to import the `blazor.web.js` file.

Relevant file in blazorweb template https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/App.razor#L45.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
