### PR TITLE
xunit1051 Part 1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,11 +34,6 @@
     <DashboardPublishedArtifactsOutputDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'DashboardArtifacts', '$(Configuration)'))</DashboardPublishedArtifactsOutputDir>
     <WorkloadsPackageSource>$(ArtifactsShippingPackagesDir)</WorkloadsPackageSource>
 
-    <!-- Issue: https://github.com/dotnet/aspire/issues/8488 -->
-    <!-- xUnit2031: Do not use Where clause with Assert.Single -->
-    <!-- xUnit1051: Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken to allow test cancellation to be more responsive. -->
-    <!-- TODO: Re-enable and remove this. -->
-    <NoWarn>$(NoWarn);xUnit2031;xUnit1051</NoWarn>
   </PropertyGroup>
 
   <!-- OS/Architecture properties for local development resources -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,6 +34,10 @@
     <DashboardPublishedArtifactsOutputDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'DashboardArtifacts', '$(Configuration)'))</DashboardPublishedArtifactsOutputDir>
     <WorkloadsPackageSource>$(ArtifactsShippingPackagesDir)</WorkloadsPackageSource>
 
+    <!-- Issue: https://github.com/dotnet/aspire/issues/8488 -->
+    <!-- xUnit2031: Do not use Where clause with Assert.Single -->
+    <!-- TODO: Re-enable and remove this. -->
+    <NoWarn>$(NoWarn);xUnit2031;</NoWarn>
   </PropertyGroup>
 
   <!-- OS/Architecture properties for local development resources -->

--- a/tests/Aspire.Azure.AI.OpenAI.Tests/AspireAzureOpenAIClientBuilderChatClientExtensionsTests.cs
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/AspireAzureOpenAIClientBuilderChatClientExtensionsTests.cs
@@ -214,7 +214,7 @@ public class AspireAzureOpenAIClientBuilderChatClientExtensionsTests
             host.Services.GetRequiredKeyedService<IChatClient>("openai_chatclient") :
             host.Services.GetRequiredService<IChatClient>();
 
-        var completion = await client.GetResponseAsync("Whatever");
+        var completion = await client.GetResponseAsync("Whatever", cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("Hello from middleware", completion.Text);
 
         static Task<ChatResponse> TestMiddleware(IEnumerable<ChatMessage> list, ChatOptions? options, IChatClient client, CancellationToken token)

--- a/tests/Aspire.Azure.AI.OpenAI.Tests/AspireAzureOpenAIClientBuilderEmbeddingGeneratorExtensionsTests.cs
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/AspireAzureOpenAIClientBuilderEmbeddingGeneratorExtensionsTests.cs
@@ -214,7 +214,7 @@ public class AspireAzureOpenAIClientBuilderEmbeddingGeneratorExtensionsTests
             host.Services.GetRequiredKeyedService<IEmbeddingGenerator<string, Embedding<float>>>("openai_embeddinggenerator") :
             host.Services.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
 
-        var vector = await generator.GenerateEmbeddingVectorAsync("Hello");
+        var vector = await generator.GenerateEmbeddingVectorAsync("Hello", cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(1.23f, vector.ToArray().Single());
     }
 

--- a/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
+++ b/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
@@ -9,6 +9,7 @@
     <!-- Do not run tests in Helix at all -->
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>
     <RunOnAzdoHelixLinux>false</RunOnAzdoHelixLinux>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
@@ -135,7 +135,8 @@ public abstract class ConformanceTests<TService, TOptions>
         {
             registeredNames.Add(healthCheckRegistration.Name);
             return false;
-        }).ConfigureAwait(false);
+        },
+        TestContext.Current.CancellationToken).ConfigureAwait(false);
 #pragma warning restore xUnit1030 // Do not call ConfigureAwait(false) in test method
 
         Assert.Equal(2, registeredNames.Count);
@@ -320,7 +321,7 @@ public abstract class ConformanceTests<TService, TOptions>
         HealthCheckService healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
 #pragma warning disable xUnit1030 // Do not call ConfigureAwait(false) in test method
-        HealthReport healthReport = await healthCheckService.CheckHealthAsync().ConfigureAwait(false);
+        HealthReport healthReport = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
 #pragma warning restore xUnit1030 // Do not call ConfigureAwait(false) in test method
 
         HealthStatus expected = CanConnectToServer ? HealthStatus.Healthy : HealthStatus.Unhealthy;

--- a/tests/Aspire.Confluent.Kafka.Tests/Aspire8MetricsTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/Aspire8MetricsTests.cs
@@ -38,7 +38,7 @@ public class Aspire8MetricsTests
         }
 
         using var host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         var metricsChannel = host.Services.GetRequiredService(ReflectionHelpers.MetricsChannelType.Value);
         var writer = GetMetricsChannelWriter(metricsChannel)!;
@@ -61,14 +61,14 @@ public class Aspire8MetricsTests
         }
 
         await Task.WhenAll(
-            collectorNetworkTx.WaitForMeasurementsAsync(statistics.Count),
-            collectorNetworkTransmitted.WaitForMeasurementsAsync(statistics.Count),
-            collectorNetworkRx.WaitForMeasurementsAsync(statistics.Count),
-            collectorNetworkReceived.WaitForMeasurementsAsync(statistics.Count),
-            collectorMessageTx.WaitForMeasurementsAsync(statistics.Count),
-            collectorMessageTransmitted.WaitForMeasurementsAsync(statistics.Count),
-            collectorMessageRx.WaitForMeasurementsAsync(statistics.Count),
-            collectorMessageReceived.WaitForMeasurementsAsync(statistics.Count)
+            collectorNetworkTx.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorNetworkTransmitted.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorNetworkRx.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorNetworkReceived.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorMessageTx.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorMessageTransmitted.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorMessageRx.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorMessageReceived.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken)
         );
 
         collectorConsumerQueueMessageCount.RecordObservableInstruments();
@@ -153,7 +153,7 @@ public class Aspire8MetricsTests
         }
 
         using var host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         var metricsChannel = host.Services.GetRequiredService(ReflectionHelpers.MetricsChannelType.Value);
         var writer = GetMetricsChannelWriter(metricsChannel)!;
@@ -176,14 +176,14 @@ public class Aspire8MetricsTests
         }
 
         await Task.WhenAll(
-            collectorNetworkTx.WaitForMeasurementsAsync(statistics.Count),
-            collectorNetworkTransmitted.WaitForMeasurementsAsync(statistics.Count),
-            collectorNetworkRx.WaitForMeasurementsAsync(statistics.Count),
-            collectorNetworkReceived.WaitForMeasurementsAsync(statistics.Count),
-            collectorMessageTx.WaitForMeasurementsAsync(statistics.Count),
-            collectorMessageTransmitted.WaitForMeasurementsAsync(statistics.Count),
-            collectorMessageRx.WaitForMeasurementsAsync(statistics.Count),
-            collectorMessageReceived.WaitForMeasurementsAsync(statistics.Count)
+            collectorNetworkTx.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorNetworkTransmitted.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorNetworkRx.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorNetworkReceived.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorMessageTx.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorMessageTransmitted.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorMessageRx.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken),
+            collectorMessageReceived.WaitForMeasurementsAsync(statistics.Count, TestContext.Current.CancellationToken)
         );
 
         collectorConsumerQueueMessageCount.RecordObservableInstruments();

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
@@ -60,7 +60,7 @@ public class OtelMetricsTests
         builder.Services.AddOpenTelemetry().WithMetrics(meterProvider => meterProvider.AddInMemoryExporter(metrics));
 
         using var host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
         IGrouping<string, Metric>[] groups;
 
         string topic = $"otel-topic-{Guid.NewGuid()}";
@@ -90,7 +90,7 @@ public class OtelMetricsTests
             int j = 0;
             while (true)
             {
-                var consumerResult = consumer.Consume();
+                var consumerResult = consumer.Consume(TestContext.Current.CancellationToken);
                 if (consumerResult == null)
                 {
                     continue;
@@ -108,7 +108,7 @@ public class OtelMetricsTests
 
         host.Services.GetRequiredService<MeterProvider>().EnsureMetricsAreFlushed();
 
-        await host.StopAsync();
+        await host.StopAsync(TestContext.Current.CancellationToken);
 
         groups = metrics.Where(x => x.MeterName == "OpenTelemetry.Instrumentation.ConfluentKafka")
             .GroupBy(x => x.Name).ToArray();

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
@@ -62,7 +62,7 @@ public class OtelTracesTests
         builder.Services.AddOpenTelemetry().WithTracing(traceProviderBuilder => traceProviderBuilder.AddInMemoryExporter(activities));
 
         using var host = builder.Build();
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         string topic = $"otel-topic-{Guid.NewGuid()}";
         using (var producer = useKeyed
@@ -95,7 +95,7 @@ public class OtelTracesTests
             int j = 0;
             while (true)
             {
-                var consumerResult = consumer.Consume();
+                var consumerResult = consumer.Consume(TestContext.Current.CancellationToken);
                 if (consumerResult == null)
                 {
                     continue;
@@ -113,6 +113,6 @@ public class OtelTracesTests
 
         Assert.Equal(5, activities.Where(x => x.OperationName == $"{topic} receive").Count());
 
-        await host.StopAsync();
+        await host.StopAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -16,7 +16,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
 using Xunit;
-
+using TestContext = Xunit.TestContext;
+        
 namespace Aspire.Dashboard.Components.Tests.Layout;
 
 [UseCulture("en-US")]
@@ -72,13 +73,13 @@ public partial class MainLayoutTests : DashboardTestContext
         });
 
         // Assert
-        await messageShownTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await messageShownTcs.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.NotNull(message);
 
         message.Close();
 
-        Assert.True(await dismissedSettingSetTcs.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(await dismissedSettingSetTcs.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -116,8 +117,8 @@ public partial class MainLayoutTests : DashboardTestContext
         });
 
         // Assert
-        var timeoutTask = Task.Delay(100);
-        var completedTask = await Task.WhenAny(messageShownTcs.Task, timeoutTask).WaitAsync(TimeSpan.FromSeconds(5));
+        var timeoutTask = Task.Delay(100, TestContext.Current.CancellationToken);
+        var completedTask = await Task.WhenAny(messageShownTcs.Task, timeoutTask).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // It's hard to test something not happening.
         // In this case of checking for a message, apply a small display and then double check that no message was displayed.

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -25,6 +25,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
+using TestContext = Xunit.TestContext;
 
 namespace Aspire.Dashboard.Components.Tests.Pages;
 
@@ -91,7 +92,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         logger.LogInformation("Waiting for finish message.");
         cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs)]);
 
-        var subscribedResourceName1 = await subscribedResourceNamesChannel.Reader.ReadAsync().DefaultTimeout();
+        var subscribedResourceName1 = await subscribedResourceNamesChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
         Assert.Equal("test-resource", subscribedResourceName1);
 
         navigationManager.LocationChanged += (sender, e) =>
@@ -117,11 +118,11 @@ public partial class ConsoleLogsTests : DashboardTestContext
         cut.WaitForState(() => instance.PageViewModel.SelectedResource == testResource2);
         cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsWatchingLogs)]);
 
-        var subscribedResourceName2 = await subscribedResourceNamesChannel.Reader.ReadAsync().DefaultTimeout();
+        var subscribedResourceName2 = await subscribedResourceNamesChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
         Assert.Equal("test-resource2", subscribedResourceName2);
 
         subscribedResourceNamesChannel.Writer.Complete();
-        Assert.False(await subscribedResourceNamesChannel.Reader.WaitToReadAsync().DefaultTimeout());
+        Assert.False(await subscribedResourceNamesChannel.Reader.WaitToReadAsync(TestContext.Current.CancellationToken).DefaultTimeout());
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -5,7 +5,14 @@
     <!--
       CS8002: Referenced assembly does not have a strong name
     -->
-    <NoWarn>$(NoWarn);CS8002</NoWarn>
+    <!--
+      FIXME: https://github.com/dotnet/aspire/issues/8488
+      xUnit1051: Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken  to allow test cancellation to be more responsive
+
+      This is being disabled here in addition to any central location, because this project
+      gets built independently on helix.
+    -->
+    <NoWarn>$(NoWarn);CS8002;xUnit1051</NoWarn>
 
     <InstallBrowsersForPlaywright Condition="'$(InstallBrowsersForPlaywright)' == '' and '$(CODESPACES)' == 'true'">true</InstallBrowsersForPlaywright>
     <InstallBrowsersForPlaywright Condition="'$(InstallBrowsersForPlaywright)' == '' and '$(ContinuousIntegrationBuild)' == 'true'">true</InstallBrowsersForPlaywright>

--- a/tests/Aspire.Elastic.Clients.Elasticsearch.Tests/AspireElasticClientExtensionsTest.cs
+++ b/tests/Aspire.Elastic.Clients.Elasticsearch.Tests/AspireElasticClientExtensionsTest.cs
@@ -57,7 +57,7 @@ public class AspireElasticClientExtensionsTest : IClassFixture<ElasticsearchCont
 
         var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
-        var healthCheckReport = await healthCheckService.CheckHealthAsync();
+        var healthCheckReport = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         var healthCheckName = useKeyed ? $"Elastic.Clients.Elasticsearch_{key}" : "Elastic.Clients.Elasticsearch";
 

--- a/tests/Aspire.Hosting.Analyzers.Tests/CombinationsAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/CombinationsAnalyzerTests.cs
@@ -41,7 +41,7 @@ public class CombinationsAnalyzerTests
                 CompilerError(diagnostic.Id).WithLocation(8, 5).WithMessage(message2)
             ]);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -74,6 +74,6 @@ public class CombinationsAnalyzerTests
                 CompilerError(diagnostic.Id).WithLocation(6, 21).WithMessage(message2)
             ]);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Aspire.Hosting.Analyzers.Tests/EndpointNameAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/EndpointNameAnalyzerTests.cs
@@ -27,7 +27,7 @@ public class EndpointNameAnalyzerTests
             """,
             [CompilerError(diagnostic.Id).WithLocation(6, 37).WithMessage(message)]);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -66,7 +66,7 @@ public class EndpointNameAnalyzerTests
                 CompilerError(diagnostic.Id).WithLocation(9, 9).WithMessage(message2)
             ]);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -82,7 +82,7 @@ public class EndpointNameAnalyzerTests
                 .WithEndpoint(port: 1234, name: "{{endpointName}}");
             """, []);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -112,6 +112,6 @@ public class EndpointNameAnalyzerTests
             }
             """, []);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Aspire.Hosting.Analyzers.Tests/ResourceNameAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/ResourceNameAnalyzerTests.cs
@@ -26,7 +26,7 @@ public class ResourceNameAnalyzerTests
             """,
             [CompilerError(diagnostic.Id).WithLocation(5, 22).WithMessage(message)]);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -61,7 +61,7 @@ public class ResourceNameAnalyzerTests
                 CompilerError(diagnostic.Id).WithLocation(8, 5).WithMessage(message2)
             ]);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -76,7 +76,7 @@ public class ResourceNameAnalyzerTests
             builder.AddParameter("{{resourceName}}");
             """, []);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -102,6 +102,6 @@ public class ResourceNameAnalyzerTests
             }
             """, []);
 
-        await test.RunAsync();
+        await test.RunAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Containers.Tests/Aspire.Hosting.Containers.Tests.csproj
+++ b/tests/Aspire.Hosting.Containers.Tests/Aspire.Hosting.Containers.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
+++ b/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
-    <NoWarn>$(NoWarn);ASPIREHOSTINGPYTHON001;</NoWarn>
+    <NoWarn>$(NoWarn);ASPIREHOSTINGPYTHON001;xUnit1051</NoWarn>
 
     <!--
       Do not run tests in Helix at all

--- a/tests/Aspire.Hosting.Elasticsearch.Tests/Aspire.Hosting.Elasticsearch.Tests.csproj
+++ b/tests/Aspire.Hosting.Elasticsearch.Tests/Aspire.Hosting.Elasticsearch.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Garnet.Tests/Aspire.Hosting.Garnet.Tests.csproj
+++ b/tests/Aspire.Hosting.Garnet.Tests/Aspire.Hosting.Garnet.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Kafka.Tests/Aspire.Hosting.Kafka.Tests.csproj
+++ b/tests/Aspire.Hosting.Kafka.Tests/Aspire.Hosting.Kafka.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -71,7 +71,7 @@ public class KubernetesPublisherTests(KubernetesPublisherFixture fixture)
 
             var app = builder.Build();
 
-            await ExecuteBeforeStartHooksAsync(app, default);
+            await ExecuteBeforeStartHooksAsync(app, TestContext.Current.CancellationToken);
 
             var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
@@ -90,7 +90,7 @@ public class KubernetesPublisherTests(KubernetesPublisherFixture fixture)
         // Assert
         var file = Path.Combine(fixture.TempDirectoryInstance.Path, expectedFile);
         Assert.True(File.Exists(file), $"File not found: {file}");
-        var outputContent = await File.ReadAllTextAsync(file);
+        var outputContent = await File.ReadAllTextAsync(file, TestContext.Current.CancellationToken);
         Assert.Equal(s_expectedFilesCache[expectedFile], outputContent, ignoreAllWhiteSpace: true, ignoreLineEndingDifferences: true);
     }
 
@@ -119,7 +119,7 @@ public class KubernetesPublisherTests(KubernetesPublisherFixture fixture)
 
         var app = builder.Build();
 
-        await ExecuteBeforeStartHooksAsync(app, default);
+        await ExecuteBeforeStartHooksAsync(app, TestContext.Current.CancellationToken);
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
@@ -135,7 +135,7 @@ public class KubernetesPublisherTests(KubernetesPublisherFixture fixture)
         var deploymentPath = Path.Combine(tempDir.Path, "templates/service/deployment.yaml");
         Assert.True(File.Exists(deploymentPath));
 
-        var content = await File.ReadAllTextAsync(deploymentPath);
+        var content = await File.ReadAllTextAsync(deploymentPath, TestContext.Current.CancellationToken);
 
         Assert.Equal(
             """

--- a/tests/Aspire.Hosting.Milvus.Tests/Aspire.Hosting.Milvus.Tests.csproj
+++ b/tests/Aspire.Hosting.Milvus.Tests/Aspire.Hosting.Milvus.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
-    <NoWarn>$(NoWarn);CS8002</NoWarn> <!-- Milvus.Client packages are not signed -->
+    <NoWarn>$(NoWarn);CS8002;xUnit1051</NoWarn> <!-- Milvus.Client packages are not signed -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.MongoDB.Tests/Aspire.Hosting.MongoDB.Tests.csproj
+++ b/tests/Aspire.Hosting.MongoDB.Tests/Aspire.Hosting.MongoDB.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.MySql.Tests/Aspire.Hosting.MySql.Tests.csproj
+++ b/tests/Aspire.Hosting.MySql.Tests/Aspire.Hosting.MySql.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Nats.Tests/Aspire.Hosting.Nats.Tests.csproj
+++ b/tests/Aspire.Hosting.Nats.Tests/Aspire.Hosting.Nats.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Oracle.Tests/Aspire.Hosting.Oracle.Tests.csproj
+++ b/tests/Aspire.Hosting.Oracle.Tests/Aspire.Hosting.Oracle.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/Aspire.Hosting.PostgreSQL.Tests.csproj
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/Aspire.Hosting.PostgreSQL.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
@@ -99,11 +99,11 @@ public class AddPythonAppTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
-        await app.ResourceNotifications.WaitForResourceAsync("pyproj", "Finished").WaitAsync(TimeSpan.FromSeconds(30));
+        await app.ResourceNotifications.WaitForResourceAsync("pyproj", "Finished", TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
-        await app.StopAsync();
+        await app.StopAsync(TestContext.Current.CancellationToken);
 
         // If we don't throw, clean up the directories.
         Directory.Delete(projectDirectory, true);

--- a/tests/Aspire.Hosting.Qdrant.Tests/Aspire.Hosting.Qdrant.Tests.csproj
+++ b/tests/Aspire.Hosting.Qdrant.Tests/Aspire.Hosting.Qdrant.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/Aspire.Hosting.RabbitMQ.Tests.csproj
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/Aspire.Hosting.RabbitMQ.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
@@ -122,7 +122,7 @@ public class AddRedisTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={myRedis-password.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith("localhost:2000", connectionString);
     }
@@ -266,7 +266,7 @@ public class AddRedisTests
         redis1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
         redis2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5002));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()), TestContext.Current.CancellationToken);
 
         var redisInsight = Assert.Single(builder.Resources.OfType<RedisInsightResource>());
         var envs = await redisInsight.GetEnvironmentVariableValuesAsync();
@@ -408,7 +408,7 @@ public class AddRedisTests
         var containerResource = Assert.Single(appModel.Resources.OfType<RedisResource>());
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith($"localhost:5001,password={password}", connectionString);
     }
@@ -423,7 +423,7 @@ public class AddRedisTests
         // Add fake allocated endpoints.
         redis.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()), TestContext.Current.CancellationToken);
 
         var commander = builder.Resources.Single(r => r.Name.EndsWith("-commander"));
 
@@ -447,7 +447,7 @@ public class AddRedisTests
         // Add fake allocated endpoints.
         redis.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()), TestContext.Current.CancellationToken);
 
         var commander = builder.Resources.Single(r => r.Name.EndsWith("-commander"));
 
@@ -468,7 +468,7 @@ public class AddRedisTests
         redis1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
         redis2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5002, "host2"));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()), TestContext.Current.CancellationToken);
 
         var commander = builder.Resources.Single(r => r.Name.EndsWith("-commander"));
 
@@ -625,7 +625,7 @@ public class AddRedisTests
         var containerResource = Assert.Single(appModel.Resources.OfType<RedisResource>());
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith($"localhost:5001,password={password}", connectionString);
     }

--- a/tests/Aspire.Hosting.Seq.Tests/AddSeqTests.cs
+++ b/tests/Aspire.Hosting.Seq.Tests/AddSeqTests.cs
@@ -79,7 +79,7 @@ public class AddSeqTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("{mySeq.bindings.http.url}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith("http://localhost:2000", connectionString);
     }

--- a/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
@@ -22,17 +22,17 @@ public class SeqFunctionalTests(ITestOutputHelper testOutputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
-        await app.WaitForTextAsync("Seq listening on", seq.Resource.Name);
+        await app.WaitForTextAsync("Seq listening on", seq.Resource.Name, TestContext.Current.CancellationToken);
 
-        var seqUrl = await seq.Resource.ConnectionStringExpression.GetValueAsync(default);
+        var seqUrl = await seq.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(seqUrl);
 
         var client = CreateClient(seqUrl);
 
-        await CreateTestDataAsync(client, default);
+        await CreateTestDataAsync(client, TestContext.Current.CancellationToken);
     }
 
     private static HttpClient CreateClient(string url)
@@ -97,24 +97,24 @@ public class SeqFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using (var app = builder1.Build())
             {
-                await app.StartAsync();
+                await app.StartAsync(TestContext.Current.CancellationToken);
 
-                await app.WaitForTextAsync("Seq listening on", seq1.Resource.Name);
+                await app.WaitForTextAsync("Seq listening on", seq1.Resource.Name, TestContext.Current.CancellationToken);
 
                 try
                 {
-                    var seqUrl = await seq1.Resource.ConnectionStringExpression.GetValueAsync(default);
+                    var seqUrl = await seq1.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken);
 
                     Assert.NotNull(seqUrl);
 
                     var client = CreateClient(seqUrl);
 
-                    await CreateTestDataAsync(client, default);
+                    await CreateTestDataAsync(client, TestContext.Current.CancellationToken);
                 }
                 finally
                 {
                     // Stops the container, or the Volume would still be in use
-                    await app.StopAsync();
+                    await app.StopAsync(TestContext.Current.CancellationToken);
                 }
             }
 
@@ -133,24 +133,24 @@ public class SeqFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using (var app = builder2.Build())
             {
-                await app.StartAsync();
+                await app.StartAsync(TestContext.Current.CancellationToken);
 
-                await app.WaitForTextAsync("Seq listening on", seq2.Resource.Name);
+                await app.WaitForTextAsync("Seq listening on", seq2.Resource.Name, TestContext.Current.CancellationToken);
 
                 try
                 {
-                    var seqUrl = await seq2.Resource.ConnectionStringExpression.GetValueAsync(default);
+                    var seqUrl = await seq2.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken);
 
                     Assert.NotNull(seqUrl);
 
                     var client = CreateClient(seqUrl);
 
-                    await CreateTestDataAsync(client, default);
+                    await CreateTestDataAsync(client, TestContext.Current.CancellationToken);
                 }
                 finally
                 {
                     // Stops the container, or the Volume would still be in use
-                    await app.StopAsync();
+                    await app.StopAsync(TestContext.Current.CancellationToken);
                 }
 
             }

--- a/tests/Aspire.Hosting.SqlServer.Tests/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/AddSqlServerTests.cs
@@ -91,7 +91,7 @@ public class AddSqlServerTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<SqlServerServerResource>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal("Server=127.0.0.1,1433;User ID=sa;Password=p@ssw0rd1;TrustServerCertificate=true", connectionString);
         Assert.Equal("Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true", connectionStringResource.ConnectionStringExpression.ValueExpression);
@@ -114,7 +114,7 @@ public class AddSqlServerTests
 
         var sqlResource = Assert.Single(appModel.Resources.OfType<SqlServerDatabaseResource>());
         var connectionStringResource = (IResourceWithConnectionString)sqlResource;
-        var connectionString = await connectionStringResource.GetConnectionStringAsync();
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal("Server=127.0.0.1,1433;User ID=sa;Password=p@ssw0rd1;TrustServerCertificate=true;Initial Catalog=mydb", connectionString);
         Assert.Equal("{sqlserver.connectionString};Initial Catalog=mydb", connectionStringResource.ConnectionStringExpression.ValueExpression);
@@ -277,7 +277,7 @@ public class AddSqlServerTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<SqlServerServerResource>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("Server=127.0.0.1,1433;User ID=sa;Password=p@ssw0rd1;TrustServerCertificate=true", connectionString);
         Assert.Equal("Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -53,7 +53,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
         await pendingStart;
 
-        await app.StopAsync();
+        await app.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -78,14 +78,14 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var hb = Host.CreateApplicationBuilder();
 
-        hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
+        hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken);
 
         hb.AddSqlServerDbContext<TestDbContext>(newDb.Resource.Name);
         hb.AddSqlServerClient(newDb.Resource.Name);
 
         using var host = hb.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         // Test SqlConnection
         await pipeline.ExecuteAsync(async token =>
@@ -174,7 +174,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using var app1 = builder1.Build();
 
-            await app1.StartAsync();
+            await app1.StartAsync(TestContext.Current.CancellationToken);
 
             await app1.ResourceNotifications.WaitForResourceHealthyAsync(db1.Resource.Name, cts.Token);
 
@@ -184,14 +184,14 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
                 hb1.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                 {
-                    [$"ConnectionStrings:{db1.Resource.Name}"] = await db1.Resource.ConnectionStringExpression.GetValueAsync(default),
+                    [$"ConnectionStrings:{db1.Resource.Name}"] = await db1.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken),
                 });
 
                 hb1.AddSqlServerClient(db1.Resource.Name);
 
                 using var host1 = hb1.Build();
 
-                await host1.StartAsync();
+                await host1.StartAsync(TestContext.Current.CancellationToken);
 
                 await pipeline.ExecuteAsync(async token =>
                 {
@@ -216,7 +216,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                     Assert.True(results.HasRows);
                 }, cts.Token);
 
-                await app1.StopAsync();
+                await app1.StopAsync(TestContext.Current.CancellationToken);
 
                 await pipeline.ExecuteAsync(async token =>
                 {
@@ -239,7 +239,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
             finally
             {
                 // Stops the container, or the Volume/mount would still be in use
-                await app1.StopAsync();
+                await app1.StopAsync(TestContext.Current.CancellationToken);
             }
 
             using var builder2 = TestDistributedApplicationBuilder.Create(o => { }, testOutputHelper);
@@ -259,7 +259,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using (var app2 = builder2.Build())
             {
-                await app2.StartAsync();
+                await app2.StartAsync(TestContext.Current.CancellationToken);
 
                 await app2.ResourceNotifications.WaitForResourceHealthyAsync(db2.Resource.Name, cts.Token);
 
@@ -269,14 +269,14 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
                     hb2.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {
-                        [$"ConnectionStrings:{db2.Resource.Name}"] = await db2.Resource.ConnectionStringExpression.GetValueAsync(default),
+                        [$"ConnectionStrings:{db2.Resource.Name}"] = await db2.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken),
                     });
 
                     hb2.AddSqlServerClient(db2.Resource.Name);
 
                     using (var host2 = hb2.Build())
                     {
-                        await host2.StartAsync();
+                        await host2.StartAsync(TestContext.Current.CancellationToken);
 
                         await pipeline.ExecuteAsync(async token =>
                         {
@@ -303,7 +303,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                 finally
                 {
                     // Stops the container, or the Volume/mount would still be in use
-                    await app2.StopAsync();
+                    await app2.StopAsync(TestContext.Current.CancellationToken);
                 }
             }
 
@@ -365,13 +365,13 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var hb = Host.CreateApplicationBuilder();
 
-        hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
+        hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken);
 
         hb.AddSqlServerClient(newDb.Resource.Name);
 
         using var host = hb.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         await app.ResourceNotifications.WaitForResourceHealthyAsync(newDb.Resource.Name, cts.Token);
 
@@ -418,7 +418,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var hb = Host.CreateApplicationBuilder();
 
-        hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
+        hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken);
 
         hb.AddSqlServerClient(newDb.Resource.Name);
 
@@ -490,13 +490,13 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
                 var hb = Host.CreateApplicationBuilder();
 
-                hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
+                hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken);
 
                 hb.AddSqlServerClient(newDb.Resource.Name);
 
                 using var host = hb.Build();
 
-                await host.StartAsync();
+                await host.StartAsync(TestContext.Current.CancellationToken);
 
                 await app.ResourceNotifications.WaitForResourceHealthyAsync(sqlserver.Resource.Name, cts.Token);
 
@@ -550,13 +550,13 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 
         foreach (var db in dbs)
         {
-            hb.Configuration[$"ConnectionStrings:{db.Resource.Name}"] = await db.Resource.ConnectionStringExpression.GetValueAsync(default);
+            hb.Configuration[$"ConnectionStrings:{db.Resource.Name}"] = await db.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken);
             hb.AddKeyedSqlServerClient(db.Resource.Name);
         }
 
         using var host = hb.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
         foreach (var db in dbs)
         {

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
@@ -24,12 +24,12 @@ public class TestingFactoryCrashTests
 
         if (crashArg is "before-build" or "after-build")
         {
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => factory.StartAsync().WaitAsync(cts.Token));
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => factory.StartAsync(TestContext.Current.CancellationToken).WaitAsync(cts.Token));
             Assert.Contains(crashArg, exception.Message);
         }
         else
         {
-            await factory.StartAsync().WaitAsync(cts.Token);
+            await factory.StartAsync(TestContext.Current.CancellationToken).WaitAsync(cts.Token);
         }
 
         await factory.DisposeAsync().AsTask().WaitAsync(cts.Token);

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -30,8 +30,8 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     public async Task CanGetConnectionStringFromAddConnectionString()
     {
         // Get a connection string from a resource
-        var connectionString = await _app.GetConnectionStringAsync("cs");
-        var connectionString2 = await _app.GetConnectionStringAsync("cs2");
+        var connectionString = await _app.GetConnectionStringAsync("cs", TestContext.Current.CancellationToken);
+        var connectionString2 = await _app.GetConnectionStringAsync("cs2", TestContext.Current.CancellationToken);
         Assert.Equal("testconnection", connectionString);
         Assert.Equal("Value=this is a value", connectionString2);
     }
@@ -49,11 +49,11 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     public async Task HttpClientGetTest()
     {
         // Wait for the application to be ready
-        await _app.WaitForTextAsync("Application started.", "mywebapp1").WaitAsync(TimeSpan.FromMinutes(1));
+        await _app.WaitForTextAsync("Application started.", "mywebapp1", TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromMinutes(1), TestContext.Current.CancellationToken);
 
         var httpClient = _app.CreateHttpClientWithResilience("mywebapp1");
 
-        var result1 = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast");
+        var result1 = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast", TestContext.Current.CancellationToken);
         Assert.NotNull(result1);
         Assert.True(result1.Length > 0);
     }
@@ -76,11 +76,11 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
         Assert.Equal("https", profileName);
 
         // Wait for resource to start.
-        await _app.ResourceNotifications.WaitForResourceAsync("mywebapp1").WaitAsync(TimeSpan.FromSeconds(60));
+        await _app.ResourceNotifications.WaitForResourceAsync("mywebapp1", cancellationToken: TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromSeconds(60), TestContext.Current.CancellationToken);
 
         // Explicitly get the HTTPS endpoint - this is only available on the "https" launch profile.
         var httpClient = _app.CreateHttpClientWithResilience("mywebapp1", "https");
-        var result = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast");
+        var result = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast", TestContext.Current.CancellationToken);
         Assert.NotNull(result);
         Assert.True(result.Length > 0);
     }

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <!--
       CS8002: Referenced assembly does not have a strong name. KubernetesClient package is unsigned, we ignore that warning on purpose
     -->
-    <NoWarn>$(NoWarn);CS8002</NoWarn>
+    <NoWarn>$(NoWarn);CS8002;xUnit1051</NoWarn>
 
     <!-- Do not run tests in Helix at all -->
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>

--- a/tests/Aspire.Hosting.Valkey.Tests/AddValkeyTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/AddValkeyTests.cs
@@ -80,7 +80,7 @@ public class AddValkeyTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("{myValkey.bindings.tcp.host}:{myValkey.bindings.tcp.port},password={myValkey-password.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith("localhost:2000", connectionString);
     }
@@ -336,7 +336,7 @@ public class AddValkeyTests
         var containerResource = Assert.Single(appModel.Resources.OfType<ValkeyResource>());
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(TestContext.Current.CancellationToken);
         Assert.Equal("{myValkey.bindings.tcp.host}:{myValkey.bindings.tcp.port},password={pass.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith($"localhost:5001,password={password}", connectionString);
     }

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -27,22 +27,22 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync();
+        await app.StartAsync(TestContext.Current.CancellationToken);
 
         var hb = Host.CreateApplicationBuilder();
 
         hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [$"ConnectionStrings:{valkey.Resource.Name}"] = await valkey.Resource.ConnectionStringExpression.GetValueAsync(default)
+            [$"ConnectionStrings:{valkey.Resource.Name}"] = await valkey.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken)
         });
 
         hb.AddRedisClient(valkey.Resource.Name);
 
         using var host = hb.Build();
 
-        await host.StartAsync();
+        await host.StartAsync(TestContext.Current.CancellationToken);
 
-        await app.WaitForHealthyAsync(valkey).WaitAsync(TestConstants.LongTimeoutTimeSpan);
+        await app.WaitForHealthyAsync(valkey, TestContext.Current.CancellationToken).WaitAsync(TestConstants.LongTimeoutTimeSpan, TestContext.Current.CancellationToken);
 
         var redisClient = host.Services.GetRequiredService<IConnectionMultiplexer>();
 
@@ -87,7 +87,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using (var app = builder1.Build())
             {
-                await app.StartAsync();
+                await app.StartAsync(TestContext.Current.CancellationToken);
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
@@ -95,16 +95,16 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
                     // BGSAVE is only available in admin mode, enable it for this instance
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {
-                        [$"ConnectionStrings:{valkey1.Resource.Name}"] = $"{await valkey1.Resource.ConnectionStringExpression.GetValueAsync(default)},allowAdmin=true"
+                        [$"ConnectionStrings:{valkey1.Resource.Name}"] = $"{await valkey1.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken)},allowAdmin=true"
                     });
 
                     hb.AddRedisClient(valkey1.Resource.Name);
 
                     using (var host = hb.Build())
                     {
-                        await host.StartAsync();
+                        await host.StartAsync(TestContext.Current.CancellationToken);
 
-                        await app.WaitForHealthyAsync(valkey1).WaitAsync(TestConstants.LongTimeoutTimeSpan);
+                        await app.WaitForHealthyAsync(valkey1, TestContext.Current.CancellationToken).WaitAsync(TestConstants.LongTimeoutTimeSpan, TestContext.Current.CancellationToken);
 
                         var redisClient = host.Services.GetRequiredService<IConnectionMultiplexer>();
 
@@ -121,7 +121,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
                 finally
                 {
                     // Stops the container, or the Volume/mount would still be in use
-                    await app.StopAsync();
+                    await app.StopAsync(TestContext.Current.CancellationToken);
                 }
             }
 
@@ -139,23 +139,23 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
 
             using (var app = builder2.Build())
             {
-                await app.StartAsync();
+                await app.StartAsync(TestContext.Current.CancellationToken);
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
 
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {
-                        [$"ConnectionStrings:{valkey2.Resource.Name}"] = await valkey2.Resource.ConnectionStringExpression.GetValueAsync(default)
+                        [$"ConnectionStrings:{valkey2.Resource.Name}"] = await valkey2.Resource.ConnectionStringExpression.GetValueAsync(TestContext.Current.CancellationToken)
                     });
 
                     hb.AddRedisClient(valkey2.Resource.Name);
 
                     using (var host = hb.Build())
                     {
-                        await host.StartAsync();
+                        await host.StartAsync(TestContext.Current.CancellationToken);
 
-                        await app.WaitForHealthyAsync(valkey2).WaitAsync(TestConstants.LongTimeoutTimeSpan);
+                        await app.WaitForHealthyAsync(valkey2, TestContext.Current.CancellationToken).WaitAsync(TestConstants.LongTimeoutTimeSpan, TestContext.Current.CancellationToken);
 
                         var redisClient = host.Services.GetRequiredService<IConnectionMultiplexer>();
 
@@ -169,7 +169,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
                 finally
                 {
                     // Stops the container, or the Volume/mount would still be in use
-                    await app.StopAsync();
+                    await app.StopAsync(TestContext.Current.CancellationToken);
                 }
             }
         }
@@ -229,6 +229,6 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
 
         await pendingStart;
 
-        await app.StopAsync();
+        await app.StopAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Aspire.Milvus.Client.Tests/AspireMilvusExtensionTests.cs
+++ b/tests/Aspire.Milvus.Client.Tests/AspireMilvusExtensionTests.cs
@@ -134,7 +134,7 @@ public class AspireMilvusExtensionTests : IClassFixture<MilvusContainerFixture>
 
         var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
-        var healthCheckReport = await healthCheckService.CheckHealthAsync();
+        var healthCheckReport = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         var healthCheckName = useKeyed ? $"Milvus_{DefaultKeyName}" : "Milvus";
 

--- a/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
@@ -131,7 +131,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
 
         var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
-        var healthCheckReport = await healthCheckService.CheckHealthAsync();
+        var healthCheckReport = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         var healthCheckName = "MongoDB.Driver";
 
@@ -175,7 +175,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
 
         var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
-        var healthCheckReport = await healthCheckService.CheckHealthAsync();
+        var healthCheckReport = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         var healthCheckName = $"MongoDB.Driver_{key}";
 

--- a/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
@@ -169,7 +169,7 @@ public class AspireNatsClientExtensionsTests : IClassFixture<NatsContainerFixtur
 
         var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
-        var healthCheckReport = await healthCheckService.CheckHealthAsync();
+        var healthCheckReport = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         var healthCheckName = useKeyed ? $"NATS_{key}" : "NATS";
 

--- a/tests/Aspire.OpenAI.Tests/AspireOpenAIClientBuilderChatClientExtensionsTests.cs
+++ b/tests/Aspire.OpenAI.Tests/AspireOpenAIClientBuilderChatClientExtensionsTests.cs
@@ -217,7 +217,7 @@ public class AspireOpenAIClientBuilderChatClientExtensionsTests
             host.Services.GetRequiredKeyedService<IChatClient>("openai_chatclient") :
             host.Services.GetRequiredService<IChatClient>();
 
-        var completion = await client.GetResponseAsync("Whatever");
+        var completion = await client.GetResponseAsync("Whatever", cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("Hello from middleware", completion.Text);
     }
 
@@ -251,7 +251,7 @@ public class AspireOpenAIClientBuilderChatClientExtensionsTests
             host.Services.GetRequiredService<IChatClient>();
         var loggerFactory = (TestLoggerFactory)host.Services.GetRequiredService<ILoggerFactory>();
 
-        var completion = await client.GetResponseAsync("Whatever");
+        var completion = await client.GetResponseAsync("Whatever", cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("Hello from middleware", completion.Text);
 
         const string category = "Microsoft.Extensions.AI.OpenTelemetryChatClient";

--- a/tests/Aspire.OpenAI.Tests/AspireOpenAIClientBuilderEmbeddingGeneratorExtensionsTests.cs
+++ b/tests/Aspire.OpenAI.Tests/AspireOpenAIClientBuilderEmbeddingGeneratorExtensionsTests.cs
@@ -217,7 +217,7 @@ public class AspireOpenAIClientBuilderEmbeddingGeneratorExtensionsTests
             host.Services.GetRequiredKeyedService<IEmbeddingGenerator<string, Embedding<float>>>("openai_embeddinggenerator") :
             host.Services.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
 
-        var vector = await generator.GenerateEmbeddingVectorAsync("Hello");
+        var vector = await generator.GenerateEmbeddingVectorAsync("Hello", cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(1.23f, vector.ToArray().Single());
     }
 
@@ -251,7 +251,7 @@ public class AspireOpenAIClientBuilderEmbeddingGeneratorExtensionsTests
             host.Services.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
         var loggerFactory = (TestLoggerFactory)host.Services.GetRequiredService<ILoggerFactory>();
 
-        var vector = await generator.GenerateEmbeddingVectorAsync("Hello");
+        var vector = await generator.GenerateEmbeddingVectorAsync("Hello", cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(1.23f, vector.ToArray().Single());
 
         const string category = "Microsoft.Extensions.AI.OpenTelemetryEmbeddingGenerator";

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -22,15 +22,6 @@
 
     <!-- on helix this will be available in the source dir -->
     <XunitRunnerJson Condition="'$(RepoRoot)' == ''">xunit.runner.json</XunitRunnerJson>
-
-    <!--
-      FIXME: https://github.com/dotnet/aspire/issues/8488
-      xUnit1051: Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken  to allow test cancellation to be more responsive
-
-      This is being disabled here in addition to any central location, because this project
-      gets built independently on helix.
-    -->
-    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SkipUnstableEmulators)' == 'true'">

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -17,16 +17,16 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     public async Task WithDockerfileTest()
     {
         var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.WithDockerfile_AppHost), _testOutput);
-        await using var app = await appHost.BuildAsync();
+        await using var app = await appHost.BuildAsync(TestContext.Current.CancellationToken);
 
-        await app.StartAsync();
-        await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(2));
+        await app.StartAsync(TestContext.Current.CancellationToken);
+        await app.WaitForResources(cancellationToken: TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromMinutes(2), TestContext.Current.CancellationToken);
 
-        await app.WaitForTextAsync($"I'm Batman. - Batman")
-                .WaitAsync(TimeSpan.FromMinutes(3));
+        await app.WaitForTextAsync($"I'm Batman. - Batman", cancellationToken: TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromMinutes(3), TestContext.Current.CancellationToken);
 
         app.EnsureNoErrorsLogged();
-        await app.StopAsync();
+        await app.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -34,13 +34,13 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     public async Task KafkaTest()
     {
         var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.KafkaBasic_AppHost), _testOutput);
-        await using var app = await appHost.BuildAsync();
+        await using var app = await appHost.BuildAsync(TestContext.Current.CancellationToken);
 
-        await app.StartAsync();
-        await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(2));
+        await app.StartAsync(TestContext.Current.CancellationToken);
+        await app.WaitForResources(cancellationToken: TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromMinutes(2), TestContext.Current.CancellationToken);
 
         // Wait for the producer to start sending messages
-        await app.WaitForTextAsync("Hello, World!").WaitAsync(TimeSpan.FromMinutes(5));
+        await app.WaitForTextAsync("Hello, World!", cancellationToken: TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
 
         // Wait for the consumer to receive some messages
         await WaitForAllTextAsync(app,
@@ -51,7 +51,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
             timeoutSecs: 120);
 
         app.EnsureNoErrorsLogged();
-        await app.StopAsync();
+        await app.StopAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -60,10 +60,10 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     public async Task AzureFunctionsTest()
     {
         var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.AzureFunctionsEndToEnd_AppHost), _testOutput);
-        await using var app = await appHost.BuildAsync();
+        await using var app = await appHost.BuildAsync(TestContext.Current.CancellationToken);
 
-        await app.StartAsync();
-        await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(2));
+        await app.StartAsync(TestContext.Current.CancellationToken);
+        await app.WaitForResources(cancellationToken: TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromMinutes(2), TestContext.Current.CancellationToken);
 
         // Wait for the 'Job host started' message as an indication
         // that the Functions host has initialized correctly
@@ -75,7 +75,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
             timeoutSecs: 160);
 
         // Assert that HTTP triggers work correctly
-        await AppHostTests.CreateHttpClientWithResilience(app, "funcapp").GetAsync("/api/injected-resources");
+        await AppHostTests.CreateHttpClientWithResilience(app, "funcapp").GetAsync("/api/injected-resources", TestContext.Current.CancellationToken);
         await WaitForAllTextAsync(app,
             [
                 "Executed 'Functions.injected-resources'"
@@ -85,7 +85,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
 
         using var apiServiceClient = AppHostTests.CreateHttpClientWithResilience(app, "apiservice");
         // Assert that Azure Storage Queue triggers work correctly
-        await apiServiceClient.GetAsync("/publish/asq");
+        await apiServiceClient.GetAsync("/publish/asq", TestContext.Current.CancellationToken);
         await WaitForAllTextAsync(app,
             [
                 "Executed 'Functions.MyAzureQueueTrigger'"
@@ -94,7 +94,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
             timeoutSecs: 160);
 
         // Assert that Azure Storage Blob triggers work correctly
-        await apiServiceClient.GetAsync("/publish/blob");
+        await apiServiceClient.GetAsync("/publish/blob", TestContext.Current.CancellationToken);
         await WaitForAllTextAsync(app,
             [
                 "Executed 'Functions.MyAzureBlobTrigger'"
@@ -103,7 +103,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
             timeoutSecs: 160);
 
         // Assert that EventHubs triggers work correctly
-        await apiServiceClient.GetAsync("/publish/eventhubs");
+        await apiServiceClient.GetAsync("/publish/eventhubs", TestContext.Current.CancellationToken);
         await WaitForAllTextAsync(app,
             [
                 "Executed 'Functions.MyEventHubTrigger'"
@@ -113,7 +113,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
 
 #if !SKIP_UNSTABLE_EMULATORS // https://github.com/dotnet/aspire/issues/7066
         // Assert that ServiceBus triggers work correctly
-        await apiServiceClient.GetAsync("/publish/asb");
+        await apiServiceClient.GetAsync("/publish/asb", TestContext.Current.CancellationToken);
         await WaitForAllTextAsync(app,
             [
                 "Executed 'Functions.MyServiceBusTrigger'"
@@ -126,7 +126,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
         // resource that happens after the Functions host has been built. The error log shows up after the Functions
         // worker extension has been built and before the host has launched.
         // app.EnsureNoErrorsLogged();
-        await app.StopAsync();
+        await app.StopAsync(TestContext.Current.CancellationToken);
     }
 
     internal static Task WaitForAllTextAsync(DistributedApplication app, IEnumerable<string> logTexts, string? resourceName = null, int timeoutSecs = -1)

--- a/tests/Aspire.Qdrant.Client.Tests/AspireQdrantClientExtensionsTest.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/AspireQdrantClientExtensionsTest.cs
@@ -48,7 +48,7 @@ public class AspireQdrantClientExtensionsTest : IClassFixture<QdrantContainerFix
 
         var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
-        var healthCheckReport = await healthCheckService.CheckHealthAsync();
+        var healthCheckReport = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         var healthCheckName = useKeyed ? $"Qdrant.Client_{key}" : "Qdrant.Client";
 

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -37,7 +37,7 @@ public class AspireRabbitMQLoggingTests
         await using var rabbitMqContainer = new RabbitMqBuilder()
             .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{RabbitMQContainerImageTags.Image}:{RabbitMQContainerImageTags.Tag}")
             .Build();
-        await rabbitMqContainer.StartAsync();
+        await rabbitMqContainer.StartAsync(TestContext.Current.CancellationToken);
 
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
@@ -62,10 +62,10 @@ public class AspireRabbitMQLoggingTests
         using var host = builder.Build();
         using var connection = host.Services.GetRequiredService<IConnection>();
 
-        await rabbitMqContainer.StopAsync();
+        await rabbitMqContainer.StopAsync(TestContext.Current.CancellationToken);
         await rabbitMqContainer.DisposeAsync();
 
-        await tsc.Task.WaitAsync(TimeSpan.FromMinutes(1));
+        await tsc.Task.WaitAsync(TimeSpan.FromMinutes(1), TestContext.Current.CancellationToken);
 
         var logs = logger.Logs.ToArray();
         Assert.True(logs.Length >= 2, "Should be at least 2 logs written.");

--- a/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
@@ -376,7 +376,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
         Assert.Empty(connection3.GetServers().Single().Keys());
 
         // set a value in the output cache and ensure it was added to the redis3 server
-        await outputCache.SetAsync("outputKey", [1, 2, 3, 4], tags: null, validFor: TimeSpan.MaxValue, cancellationToken: default);
+        await outputCache.SetAsync("outputKey", [1, 2, 3, 4], tags: null, validFor: TimeSpan.MaxValue, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Empty(connection1.GetServers().Single().Keys());
         Assert.Single(connection2.GetServers().Single().Keys());

--- a/tests/Aspire.Templates.Tests/AppHostTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/AppHostTemplateTests.cs
@@ -32,7 +32,7 @@ public partial class AppHostTemplateTests : TemplateTestsBase
         File.WriteAllText(projectPath, newContents);
 
         // Ensure project builds successfully
-        await project.BuildAsync(workingDirectory: project.RootDir);
+        await project.BuildAsync(workingDirectory: project.RootDir, token: TestContext.Current.CancellationToken);
     }
 
     [GeneratedRegex(@"(PackageReference\s.*""Aspire\.Hosting\.AppHost.*Version=)""[^""]+""")]

--- a/tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
+++ b/tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
@@ -16,15 +16,6 @@
     <ExtractTestClassNamesForHelix Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(PrepareForHelix)' == 'true'">true</ExtractTestClassNamesForHelix>
     <ExtractTestClassNamesPrefix>Aspire.Templates.Tests</ExtractTestClassNamesPrefix>
 
-    <!--
-      FIXME: https://github.com/dotnet/aspire/issues/8488
-      xUnit1051: Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken  to allow test cancellation to be more responsive
-
-      This is being disabled here in addition to any central location, because this project
-      gets built independently on helix.
-    -->
-    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
-
     <!-- FIXME: do not run Template tests in the outerloop until further notice -->
     <SkipTests Condition=" '$(RunQuarantinedTests)' == 'true' ">true</SkipTests>
   </PropertyGroup>

--- a/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
@@ -34,8 +34,8 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
         string id = GetNewProjectId(prefix: $"aspire_{config}");
         await using var project = await AspireProject.CreateNewTemplateProjectAsync(id, "aspire", _testOutput, buildEnvironment: BuildEnvironment.ForDefaultFramework);
 
-        await project.BuildAsync(extraBuildArgs: [$"-c {config}"]);
-        await project.StartAppHostAsync(extraArgs: [$"-c {config}"]);
+        await project.BuildAsync(extraBuildArgs: [$"-c {config}"], TestContext.Current.CancellationToken);
+        await project.StartAppHostAsync(extraArgs: [$"-c {config}"], token: TestContext.Current.CancellationToken);
 
         if (PlaywrightProvider.HasPlaywrightSupport)
         {
@@ -55,9 +55,9 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
 
         CreateCPMFile(project, version);
 
-        await project.BuildAsync();
-        await project.StartAppHostAsync();
-        await project.StopAppHostAsync();
+        await project.BuildAsync(token: TestContext.Current.CancellationToken);
+        await project.StartAppHostAsync(token: TestContext.Current.CancellationToken);
+        await project.StopAppHostAsync(TestContext.Current.CancellationToken);
 
         static string ExtractAndRemoveVersionFromPackageReference(AspireProject project)
         {
@@ -124,7 +124,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
             buildEnvironment: testSpecificBuildEnvironment,
             extraArgs: "--no-https");
 
-        await project.BuildAsync();
+        await project.BuildAsync(token: TestContext.Current.CancellationToken);
         using var buildCmd = new DotNetCommand(_testOutput, buildEnv: testSpecificBuildEnvironment, label: "first-run")
                                     .WithWorkingDirectory(project.AppHostProjectDirectory);
 
@@ -134,7 +134,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
 
         // Run with the environment variable set
         testSpecificBuildEnvironment.EnvVars[KnownConfigNames.AllowUnsecuredTransport] = "true";
-        await project.StartAppHostAsync();
+        await project.StartAppHostAsync(token: TestContext.Current.CancellationToken);
 
         if (PlaywrightProvider.HasPlaywrightSupport)
         {
@@ -154,7 +154,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
 
         ModifyProjectFile(project, version);
 
-        await project.BuildAsync(workingDirectory: project.RootDir);
+        await project.BuildAsync(workingDirectory: project.RootDir, token: TestContext.Current.CancellationToken);
 
         static void ModifyProjectFile(AspireProject project, string version)
         {

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
@@ -34,7 +34,7 @@ public class NewUpAndBuildStandaloneTemplateTests(ITestOutputHelper testOutput) 
 
             Assert.True(error is null, $"Expected to throw an exception with message: {error}");
 
-            await project.BuildAsync(extraBuildArgs: [$"-c Debug"]);
+            await project.BuildAsync(extraBuildArgs: [$"-c Debug"], token: TestContext.Current.CancellationToken);
         }
         catch (ToolCommandException tce) when (error is not null)
         {

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -57,7 +57,7 @@ public class NewUpAndBuildSupportProjectTemplates(ITestOutputHelper testOutput) 
                                         extraArgs: extraTestCreationArgs,
                                         overrideRootDir: topLevelDir);
 
-            await project.BuildAsync(extraBuildArgs: [$"-c {config}"], workingDirectory: testProjectDir);
+            await project.BuildAsync(extraBuildArgs: [$"-c {config}"], workingDirectory: testProjectDir, token: TestContext.Current.CancellationToken);
         }
         catch (ToolCommandException tce) when (error is not null)
         {

--- a/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
@@ -31,7 +31,7 @@ public abstract partial class PerTestFrameworkTemplatesTests : TemplateTestsBase
             _testOutput,
             buildEnvironment: BuildEnvironment.ForDefaultFramework);
 
-        await project.BuildAsync(extraBuildArgs: [$"-c {config}"]);
+        await project.BuildAsync(extraBuildArgs: [$"-c {config}"], token: TestContext.Current.CancellationToken);
         if (PlaywrightProvider.HasPlaywrightSupport && RequiresSSLCertificateAttribute.IsSupported)
         {
             await using (var context = await CreateNewBrowserContextAsync())

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -33,11 +33,7 @@
       CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
       CS1712: Type parameter 'type_parameter' has no matching typeparam tag in the XML comment on 'type_or_member' (but other type parameters do)
     -->
-    <!-- Issue: https://github.com/dotnet/aspire/issues/8488 -->
-    <!-- xUnit2031: Do not use Where clause with Assert.Single -->
-    <!-- xUnit1051: Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken to allow test cancellation to be more responsive. -->
-    <!-- TODO: Re-enable and remove this. -->
-    <NoWarn>$(NoWarn);1573;1591;1712;xUnit2031</NoWarn>
+    <NoWarn>$(NoWarn);1573;1591;1712;</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -33,7 +33,11 @@
       CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
       CS1712: Type parameter 'type_parameter' has no matching typeparam tag in the XML comment on 'type_or_member' (but other type parameters do)
     -->
-    <NoWarn>$(NoWarn);1573;1591;1712</NoWarn>
+    <!-- Issue: https://github.com/dotnet/aspire/issues/8488 -->
+    <!-- xUnit2031: Do not use Where clause with Assert.Single -->
+    <!-- xUnit1051: Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken to allow test cancellation to be more responsive. -->
+    <!-- TODO: Re-enable and remove this. -->
+    <NoWarn>$(NoWarn);1573;1591;1712;xUnit2031</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/PassThroughServiceEndpointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/PassThroughServiceEndpointResolverTests.cs
@@ -124,7 +124,7 @@ public class PassThroughServiceEndpointResolverTests
             .BuildServiceProvider();
 
         var resolver = services.GetRequiredService<ServiceEndpointResolver>();
-        var result = await resolver.GetEndpointsAsync("catalog", default);
+        var result = await resolver.GetEndpointsAsync("catalog", TestContext.Current.CancellationToken);
         Assert.Equal(new DnsEndPoint("catalog", 0), result.Endpoints[0].EndPoint);
     }
 }

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndpointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndpointResolverTests.cs
@@ -39,7 +39,7 @@ public class ServiceEndpointResolverTests
         var watcher = new ServiceEndpointWatcher([], NullLogger.Instance, "foo", TimeProvider.System, Options.Options.Create(new ServiceDiscoveryOptions()));
         var exception = Assert.Throws<InvalidOperationException>(watcher.Start);
         Assert.Equal("No service endpoint providers are configured.", exception.Message);
-        exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await watcher.GetEndpointsAsync());
+        exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await watcher.GetEndpointsAsync(TestContext.Current.CancellationToken));
         Assert.Equal("No service endpoint providers are configured.", exception.Message);
     }
 
@@ -60,7 +60,7 @@ public class ServiceEndpointResolverTests
         serviceCollection.AddHttpClient("foo", c => c.BaseAddress = new("http://foo")).AddServiceDiscovery();
         var services = serviceCollection.BuildServiceProvider();
         var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("foo");
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await client.GetStringAsync("/"));
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await client.GetStringAsync("/", TestContext.Current.CancellationToken));
         Assert.Equal("No provider which supports the provided service name, 'http://foo', has been configured.", exception.Message);
     }
 


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #8488

Fixed xunit1051 warning in following projects:

tests\Aspire.Azure.AI.OpenAI.Tests
tests\Aspire.Components.Common.Tests
tests\Aspire.Confluent.Kafka.Tests
tests\Aspire.Dashboard.Components.Tests
tests\Aspire.Elastic.Clients.Elasticsearch.Tests
tests\Aspire.Hosting.Analyzers.Tests
tests\Aspire.Hosting.Kubernetes.Tests
tests\Aspire.Hosting.Python.Tests
tests\Aspire.Hosting.Redis.Tests
tests\Aspire.Hosting.Seq.Tests
tests\Aspire.Hosting.SqlServer.Tests
tests\Aspire.Hosting.Testing.Tests
tests\Aspire.Hosting.Valkey.Tests
tests\Aspire.Milvus.Client.Tests
tests\Aspire.MongoDB.Driver.Tests
tests\Aspire.NATS.Net.Tests
tests\Aspire.OpenAI.Tests
tests\Aspire.Playground.Tests
tests\Aspire.Qdrant.Client.Tests
tests\Aspire.RabbitMQ.Client.Tests
tests\Aspire.StackExchange.Redis.Tests
tests\Aspire.Templates.Tests
tests\Microsoft.Extensions.ServiceDiscovery.Tests

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
