### PR TITLE
[tests] Fix flaky test Aspire.Hosting.Tests.DistributedApplicationTests.ProxylessAndProxiedEndpointBothWorkOnSameResource

### DIFF
--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -980,6 +980,9 @@ public class DistributedApplicationTests
         using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
         var token = cts.Token;
 
+        // Wait for servicea to be ready
+        await app.WaitForTextAsync("Content root path:", resourceName: testProgram.ServiceABuilder.Resource.Name).DefaultTimeout(TestConstants.LongTimeoutDuration);
+
         var urls = string.Empty;
         var httpEndPoint = app.GetEndpoint(testProgram.ServiceABuilder.Resource.Name, endpointName: "http");
         while (true)


### PR DESCRIPTION
Wait for the `servicea` to completely be ready.

Issue: https://github.com/dotnet/aspire/issues/4599

This is a quarantined test.
