### PR TITLE
[tests] MongoDbFunctionalTests.VerifyWithInitBindMount - create bindmount path before writing to it

### DIFF
--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -259,6 +259,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             .Build();
 
         var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(bindMountPath);
 
         try
         {


### PR DESCRIPTION
Issue: https://github.com/dotnet/aspire/issues/5937

```
System.IO.DirectoryNotFoundException : Could not find a part of the path '/tmp/p03cmxhk.ubl/mongo-init.js'.
  at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode, Boolean failForSymlink, Boolean&amp; wasSymlink, Func`4 createOpenException)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64&amp; fileLength, UnixFileMode&amp; filePermissions, Boolean failForSymlink, Boolean&amp; wasSymlink, Func`4 createOpenException)
   at System.IO.File.OpenHandle(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.File.WriteToFileAsync(String path, FileMode mode, String contents, Encoding encoding, CancellationToken cancellationToken)
   at Aspire.Hosting.MongoDB.Tests.MongoDbFunctionalTests.VerifyWithInitBindMount() in /_/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs:line 266
--- End of stack trace from previous location ---
```

This should fix the current test failure. We can then find out if the test is actually flaky.