### PR TITLE
[tests] Disable Aspire.Hosting.Azure.Tests.AzureCosmosDBEmulatorFunctionalTests.AddAzureCosmosDB_RunAsEmulator_CreatesDatabase

### DIFF
--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
@@ -267,7 +267,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
 
     [Fact]
     [RequiresDocker]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7178")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/7178")]
     public async Task AddAzureCosmosDB_RunAsEmulator_CreatesDatabase()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));


### PR DESCRIPTION
Changing from QuarantinedTest to ActiveIssue as this is not a flaky test
and fails on every run.

Issue: https://github.com/dotnet/aspire/issues/7178
