### PR TITLE
[tests] Fix flaky DistributedApplicationTests.ProxylessAndProxiedEndpointBothWorkOnSameResource

### DIFF
--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -57,6 +57,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Trust HTTPS development certificate (Linux)
+        if: matrix.tests.os == 'ubuntu-latest'
+        run: ./dotnet.sh dev-certs https --trust
+
       - name: Test ${{ matrix.tests.project }}
         run: |
           ${{ matrix.tests.command }}

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -952,6 +952,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
+    [RequiresSSLCertificate]
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/4599")]
     public async Task ProxylessAndProxiedEndpointBothWorkOnSameResource()
     {
@@ -1016,6 +1017,7 @@ public class DistributedApplicationTests
             }
             catch (Exception ex) when (ex is not EqualException)
             {
+                _testOutputHelper.WriteLine($"Exception {ex} while trying to get https url");
                 await Task.Delay(100, token);
             }
         }


### PR DESCRIPTION
After https://github.com/dotnet/aspire/pull/8958 the test always failed
with `System.Security.Authentication.AuthenticationException: The remote
certificate is invalid because of errors in the certificate chain:
UntrustedRoot.`.

- Mark the test with `[RequiresSSLCertificate]` so it gets skipped on
  Windows where don't install the cert
- And install+trust the dev-certs on linux for the outerloop workflow.
