### PR TITLE
Add possibility to create Blob, Queue, and Table in emulator

### DIFF
--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -15,6 +15,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" />
+    <PackageReference Include="Azure.Data.Tables" />
+    <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.Storage" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
@@ -98,4 +98,39 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
         infra.Add(account);
         return account;
     }
+
+    private readonly List<AzureTableStorageResource> _azureTableStorageResources = [];
+
+    /// <inheritdoc/>
+    internal AzureTableStorageResource AddTableStorage(string name)
+    {
+        var resource = new AzureTableStorageResource(name, this);
+        _azureTableStorageResources.Add(resource);
+        return resource;
+    }
+
+    internal IReadOnlyList<AzureTableStorageResource> TableStorageResource => _azureTableStorageResources;
+
+    private readonly List<AzureBlobStorageResource> _azureBlobStorageResources = [];
+
+    internal AzureBlobStorageResource AddBlobStorage(string name)
+    {
+        var resource = new AzureBlobStorageResource(name, this);
+        _azureBlobStorageResources.Add(resource);
+        return resource;
+    }
+
+    internal IReadOnlyList<AzureBlobStorageResource> BlobStorageResources => _azureBlobStorageResources;
+
+    private readonly List<AzureQueueStorageResource> _azureQueueStorageResources = [];
+
+    /// <inheritdoc/>
+    internal AzureQueueStorageResource AddQueueStorage(string name)
+    {
+        var resource = new AzureQueueStorageResource(name, this);
+        _azureQueueStorageResources.Add(resource);
+        return resource;
+    }
+
+    internal IReadOnlyList<AzureQueueStorageResource> QueueStorageResource => _azureQueueStorageResources;
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
@@ -24,9 +24,11 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.OperationalInsights\Aspire.Hosting.Azure.OperationalInsights.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ApplicationInsights\Aspire.Hosting.Azure.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppConfiguration\Aspire.Hosting.Azure.AppConfiguration.csproj" />
+    <ProjectReference Include="..\..\src\Components\Aspire.Azure.Data.Tables\Aspire.Azure.Data.Tables.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Messaging.EventHubs\Aspire.Azure.Messaging.EventHubs.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Messaging.ServiceBus\Aspire.Azure.Messaging.ServiceBus.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Storage.Blobs\Aspire.Azure.Storage.Blobs.csproj" />
+    <ProjectReference Include="..\..\src\Components\Aspire.Azure.Storage.Queues\Aspire.Azure.Storage.Queues.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Microsoft.Azure.Cosmos\Aspire.Microsoft.Azure.Cosmos.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Microsoft.EntityFrameworkCore.Cosmos\Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />


### PR DESCRIPTION
## Description

Support Blob, Queue and Table creation for azure storage container resource.

Fixes #5167 #8295

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
