### PR TITLE
Refactor connection string expressions to use Interpolate method

### DIFF
--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
@@ -21,7 +21,7 @@ var db = builder.AddSqlServer("sql")
 
 var insertionrows = builder.AddParameter("insertionrows");
 
-var cs = builder.AddConnectionString("cs", ReferenceExpression.Create($"sql={db};rows={insertionrows}"));
+var cs = builder.AddConnectionString("cs", ReferenceExpression.Interpolate($"sql={db};rows={insertionrows}"));
 
 builder.AddProject<Projects.ParameterEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationResource.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationResource.cs
@@ -27,7 +27,7 @@ public class AzureAppConfigurationResource(string name, Action<AzureResourceInfr
     /// Gets the connection string template for the manifest for the Azure App Configuration resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create($"{Endpoint}");
+       ReferenceExpression.Create(Endpoint);
 
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -81,11 +81,11 @@ public class AzureContainerAppEnvironmentResource(string name, Action<AzureResou
     IManifestExpressionProvider IAzureContainerAppEnvironment.ContainerAppEnvironmentName => ContainerAppEnvironmentName;
 
     // Implement IAzureContainerRegistry interface
-    ReferenceExpression IContainerRegistry.Name => ReferenceExpression.Create($"{ContainerRegistryName}");
+    ReferenceExpression IContainerRegistry.Name => ReferenceExpression.Create(ContainerRegistryName);
 
-    ReferenceExpression IContainerRegistry.Endpoint => ReferenceExpression.Create($"{ContainerRegistryUrl}");
+    ReferenceExpression IContainerRegistry.Endpoint => ReferenceExpression.Create(ContainerRegistryUrl);
 
-    ReferenceExpression IAzureContainerRegistry.ManagedIdentityId => ReferenceExpression.Create($"{ContainerRegistryManagedIdentityId}");
+    ReferenceExpression IAzureContainerRegistry.ManagedIdentityId => ReferenceExpression.Create(ContainerRegistryManagedIdentityId);
 
     IManifestExpressionProvider IAzureContainerAppEnvironment.GetSecretOutputKeyVault(AzureBicepResource resource)
     {

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsResource.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsResource.cs
@@ -23,7 +23,7 @@ public class AzureApplicationInsightsResource(string name, Action<AzureResourceI
     /// Gets the connection string template for the manifest for the Azure Application Insights resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{ConnectionString}");
+        ReferenceExpression.Create(ConnectionString);
 
     // UseAzureMonitor is looks for this specific environment variable name.
     string IResourceWithConnectionString.ConnectionStringEnvironmentVariable => "APPLICATIONINSIGHTS_CONNECTION_STRING";

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIResource.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIResource.cs
@@ -30,10 +30,10 @@ public class AzureOpenAIResource(string name, Action<AzureResourceInfrastructure
     /// Gets the connection string template for the manifest for the resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{ConnectionString}");
+        ReferenceExpression.Create(ConnectionString);
 
     internal ReferenceExpression GetConnectionString(string deploymentName) =>
-        ReferenceExpression.Create($"{ConnectionString};Deployment={deploymentName}");
+        ReferenceExpression.Interpolate($"{ConnectionString};Deployment={deploymentName}");
 
     /// <summary>
     /// Gets the list of deployments of the Azure OpenAI resource.

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBEmulatorConnectionString.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBEmulatorConnectionString.cs
@@ -10,6 +10,6 @@ internal static class AzureCosmosDBEmulatorConnectionString
 {
     public static ReferenceExpression Create(EndpointReference endpoint, bool isPreviewEmulator) =>
         isPreviewEmulator
-            ? ReferenceExpression.Create($"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint={endpoint.Property(EndpointProperty.Url)}")
-            : ReferenceExpression.Create($"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint=https://{endpoint.Property(EndpointProperty.IPV4Host)}:{endpoint.Property(EndpointProperty.Port)};DisableServerCertificateValidation=True;");
+            ? ReferenceExpression.Interpolate($"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint={endpoint.Property(EndpointProperty.Url)}")
+            : ReferenceExpression.Interpolate($"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint=https://{endpoint.Property(EndpointProperty.IPV4Host)}:{endpoint.Property(EndpointProperty.Port)};DisableServerCertificateValidation=True;");
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -67,8 +67,8 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
         IsEmulator
         ? AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint, IsPreviewEmulator)
         : UseAccessKeyAuthentication ?
-            ReferenceExpression.Create($"{ConnectionStringSecretOutput}") :
-            ReferenceExpression.Create($"{ConnectionStringOutput}");
+            ReferenceExpression.Create(ConnectionStringSecretOutput) :
+            ReferenceExpression.Create(ConnectionStringOutput);
 
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
     {

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -100,7 +100,7 @@ public static class AzureFunctionsProjectResourceExtensions
                 if (context.ExecutionContext.IsPublishMode)
                 {
                     var endpoint = resource.GetEndpoint("http");
-                    context.EnvironmentVariables["ASPNETCORE_URLS"] = ReferenceExpression.Create($"http://+:{endpoint.Property(EndpointProperty.TargetPort)}");
+                    context.EnvironmentVariables["ASPNETCORE_URLS"] = ReferenceExpression.Interpolate($"http://+:{endpoint.Property(EndpointProperty.TargetPort)}");
                 }
 
                 // Set the storage connection string.

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -29,7 +29,7 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     /// Gets the connection string template for the manifest for the Azure Key Vault resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{VaultUri}");
+        ReferenceExpression.Create(VaultUri);
 
     BicepOutputReference IAzureKeyVaultResource.VaultUriOutputReference => VaultUri;
 

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -69,8 +69,8 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
     public ReferenceExpression ConnectionStringExpression =>
         InnerResource?.ConnectionStringExpression ??
             (UsePasswordAuthentication ?
-                ReferenceExpression.Create($"{ConnectionStringSecretOutput}") :
-                ReferenceExpression.Create($"{ConnectionStringOutput}"));
+                ReferenceExpression.Create(ConnectionStringSecretOutput) :
+                ReferenceExpression.Create(ConnectionStringOutput));
 
     /// <summary>
     /// A dictionary where the key is the resource name and the value is the database name.
@@ -99,10 +99,10 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
         // Note that the bicep template puts each database's connection string in a KeyVault secret.
         if (InnerResource is null && ConnectionStringSecretOutput is not null)
         {
-            return ReferenceExpression.Create($"{ConnectionStringSecretOutput.Resource.GetSecret(GetDatabaseKeyVaultSecretName(databaseResourceName))}");
+            return ReferenceExpression.Interpolate($"{ConnectionStringSecretOutput.Resource.GetSecret(GetDatabaseKeyVaultSecretName(databaseResourceName))}");
         }
 
-        return ReferenceExpression.Create($"{this};Database={databaseName}");
+        return ReferenceExpression.Interpolate($"{this};Database={databaseName}");
     }
 
     internal static string GetDatabaseKeyVaultSecretName(string databaseResourceName) => $"connectionstrings--{databaseResourceName}";

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresResource.cs
@@ -25,7 +25,7 @@ public class AzurePostgresResource(PostgresServerResource innerResource, Action<
     /// Gets the connection template for the manifest for the Azure Postgres Flexible Server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{ConnectionString}");
+        ReferenceExpression.Create(ConnectionString);
 
     /// <inheritdoc/>
     public override string Name => _innerResource.Name;

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
@@ -55,8 +55,8 @@ public class AzureRedisCacheResource(string name, Action<AzureResourceInfrastruc
     public ReferenceExpression ConnectionStringExpression =>
         InnerResource?.ConnectionStringExpression ??
             (UseAccessKeyAuthentication ?
-                ReferenceExpression.Create($"{ConnectionStringSecretOutput}") :
-                ReferenceExpression.Create($"{ConnectionStringOutput}"));
+                ReferenceExpression.Create(ConnectionStringSecretOutput) :
+                ReferenceExpression.Create(ConnectionStringOutput));
 
     internal void SetInnerResource(RedisResource innerResource)
     {

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisResource.cs
@@ -25,7 +25,7 @@ public class AzureRedisResource(RedisResource innerResource, Action<AzureResourc
     /// Gets the connection string template for the manifest for the Azure Redis resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{ConnectionString}");
+        ReferenceExpression.Create(ConnectionString);
 
     /// <inheritdoc/>
     public override string Name => _innerResource.Name;

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchResource.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchResource.cs
@@ -29,7 +29,7 @@ public class AzureSearchResource(string name, Action<AzureResourceInfrastructure
     /// Gets the connection string template for the manifest for the resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{ConnectionString}");
+        ReferenceExpression.Create(ConnectionString);
 
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
@@ -37,8 +37,8 @@ public class AzureServiceBusResource(string name, Action<AzureResourceInfrastruc
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         IsEmulator
-        ? ReferenceExpression.Create($"Endpoint=sb://{EmulatorEndpoint.Property(EndpointProperty.HostAndPort)};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")
-        : ReferenceExpression.Create($"{ServiceBusEndpoint}");
+        ? ReferenceExpression.Interpolate($"Endpoint=sb://{EmulatorEndpoint.Property(EndpointProperty.HostAndPort)};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;")
+        : ReferenceExpression.Create(ServiceBusEndpoint);
 
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
         => ApplyAzureFunctionsConfiguration(target, connectionName);

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRResource.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRResource.cs
@@ -34,8 +34,8 @@ public class AzureSignalRResource(string name, Action<AzureResourceInfrastructur
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         IsEmulator
-        ? ReferenceExpression.Create($"Endpoint={EmulatorEndpoint.Property(EndpointProperty.Url)};AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH;Version=1.0;")
-        : ReferenceExpression.Create($"Endpoint=https://{HostName};AuthType=azure");
+        ? ReferenceExpression.Interpolate($"Endpoint={EmulatorEndpoint.Property(EndpointProperty.Url)};AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH;Version=1.0;")
+        : ReferenceExpression.Interpolate($"Endpoint=https://{HostName};AuthType=azure");
 
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
@@ -25,7 +25,7 @@ public class AzureSqlDatabaseResource(string name, string databaseName, AzureSql
     /// Gets the connection string expression for the Azure SQL database.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
+        ReferenceExpression.Interpolate($"{Parent};Database={DatabaseName}");
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlServerResource.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlServerResource.cs
@@ -60,7 +60,7 @@ public class AzureSqlServerResource : AzureProvisioningResource, IResourceWithCo
             }
 
             return result ??
-                ReferenceExpression.Create($"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
+                ReferenceExpression.Interpolate($"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
         }
     }
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
@@ -55,15 +55,15 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
 
     internal ReferenceExpression GetTableConnectionString() => IsEmulator
         ? AzureStorageEmulatorConnectionString.Create(tableEndpoint: EmulatorTableEndpoint)
-        : ReferenceExpression.Create($"{TableEndpoint}");
+        : ReferenceExpression.Create(TableEndpoint);
 
     internal ReferenceExpression GetQueueConnectionString() => IsEmulator
         ? AzureStorageEmulatorConnectionString.Create(queueEndpoint: EmulatorQueueEndpoint)
-        : ReferenceExpression.Create($"{QueueEndpoint}");
+        : ReferenceExpression.Create(QueueEndpoint);
 
     internal ReferenceExpression GetBlobConnectionString() => IsEmulator
         ? AzureStorageEmulatorConnectionString.Create(blobEndpoint: EmulatorBlobEndpoint)
-        : ReferenceExpression.Create($"{BlobEndpoint}");
+        : ReferenceExpression.Create(BlobEndpoint);
 
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
     {

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -188,7 +188,7 @@ public static class AzureWebPubSubExtensions
     {
         ArgumentException.ThrowIfNullOrEmpty(userEventPattern);
 
-        var urlExpression = ReferenceExpression.Create(urlTemplateExpression);
+        var urlExpression = ReferenceExpression.Interpolate(urlTemplateExpression);
 
         return AddEventHandler(builder, urlExpression, userEventPattern, systemEvents, authSettings);
     }

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubHubResource.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubHubResource.cs
@@ -38,7 +38,7 @@ public class AzureWebPubSubHubResource(string name, AzureWebPubSubResource webpu
     /// <summary>
     /// Gets the connection string template for the manifest for Azure Web PubSub.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"Endpoint={Parent.Endpoint};Hub={HubName}");
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Interpolate($"Endpoint={Parent.Endpoint};Hub={HubName}");
 
     internal List<(ReferenceExpression url, string userEvents, string[]? systemEvents, UpstreamAuthSettings? auth)> EventHandlers { get; } = new();
 }

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubResource.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubResource.cs
@@ -27,7 +27,7 @@ public class AzureWebPubSubResource(string name, Action<AzureResourceInfrastruct
     /// <summary>
     /// Gets the connection string template for the manifest for Azure Web PubSub.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Endpoint}");
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create(Endpoint);
 
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)

--- a/src/Aspire.Hosting.Elasticsearch/ElasticsearchResource.cs
+++ b/src/Aspire.Hosting.Elasticsearch/ElasticsearchResource.cs
@@ -46,6 +46,6 @@ public class ElasticsearchResource(string name, ParameterResource password) : Co
     /// Gets the connection string expression for the Elasticsearch
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"http://{UserName}:{PasswordParameter}@{PrimaryEndpoint.Property(EndpointProperty.HostAndPort)}");
+        ReferenceExpression.Interpolate($"http://{UserName}:{PasswordParameter}@{PrimaryEndpoint.Property(EndpointProperty.HostAndPort)}");
 }
 

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -139,8 +139,8 @@ public static class KafkaBuilderExtensions
             var bootstrapServers = context.ExecutionContext.IsRunMode
                 // In run mode, Kafka UI assumes Kafka is being accessed over a default Aspire container network and hardcodes the host as the Kafka resource name
                 // This will need to be refactored once updated service discovery APIs are available
-                ? ReferenceExpression.Create($"{endpoint.Resource.Name}:{endpoint.Property(EndpointProperty.TargetPort)}")
-                : ReferenceExpression.Create($"{endpoint.Property(EndpointProperty.HostAndPort)}");
+                ? ReferenceExpression.Interpolate($"{endpoint.Resource.Name}:{endpoint.Property(EndpointProperty.TargetPort)}")
+                : ReferenceExpression.Create(endpoint.Property(EndpointProperty.HostAndPort));
 
             context.EnvironmentVariables.Add($"KAFKA_CLUSTERS_{index}_NAME", endpoint.Resource.Name);
             context.EnvironmentVariables.Add($"KAFKA_CLUSTERS_{index}_BOOTSTRAPSERVERS", bootstrapServers);
@@ -217,8 +217,8 @@ public static class KafkaBuilderExtensions
         var advertisedListeners = context.ExecutionContext.IsRunMode
             // In run mode, PLAINTEXT_INTERNAL assumes kafka is being accessed over a default Aspire container network and hardcodes the resource address
             // This will need to be refactored once updated service discovery APIs are available
-            ? ReferenceExpression.Create($"PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:{primaryEndpoint.Property(EndpointProperty.Port)},PLAINTEXT_INTERNAL://{resource.Name}:{internalEndpoint.Property(EndpointProperty.TargetPort)}")
-            : ReferenceExpression.Create($"PLAINTEXT://{primaryEndpoint.Property(EndpointProperty.Host)}:29092,PLAINTEXT_HOST://{primaryEndpoint.Property(EndpointProperty.HostAndPort)},PLAINTEXT_INTERNAL://{internalEndpoint.Property(EndpointProperty.HostAndPort)}");
+            ? ReferenceExpression.Interpolate($"PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:{primaryEndpoint.Property(EndpointProperty.Port)},PLAINTEXT_INTERNAL://{resource.Name}:{internalEndpoint.Property(EndpointProperty.TargetPort)}")
+            : ReferenceExpression.Interpolate($"PLAINTEXT://{primaryEndpoint.Property(EndpointProperty.Host)}:29092,PLAINTEXT_HOST://{primaryEndpoint.Property(EndpointProperty.HostAndPort)},PLAINTEXT_INTERNAL://{internalEndpoint.Property(EndpointProperty.HostAndPort)}");
 
         context.EnvironmentVariables["KAFKA_ADVERTISED_LISTENERS"] = advertisedListeners;
     }

--- a/src/Aspire.Hosting.Kafka/KafkaServerResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaServerResource.cs
@@ -35,5 +35,5 @@ public class KafkaServerResource(string name) : ContainerResource(name), IResour
     /// Gets the connection string expression for the Kafka broker.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create($"{PrimaryEndpoint.Property(EndpointProperty.HostAndPort)}");
+       ReferenceExpression.Create(PrimaryEndpoint.Property(EndpointProperty.HostAndPort));
 }

--- a/src/Aspire.Hosting.Keycloak/KeycloakResource.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResource.cs
@@ -22,8 +22,8 @@ public sealed class KeycloakResource(string name, ParameterResource? admin, Para
 
     internal ReferenceExpression AdminReference =>
         AdminUserNameParameter is not null ?
-            ReferenceExpression.Create($"{AdminUserNameParameter}") :
-            ReferenceExpression.Create($"{DefaultAdmin}");
+            ReferenceExpression.Create(AdminUserNameParameter) :
+            ReferenceExpression.Create(DefaultAdmin);
 
     /// <summary>
     /// Gets the parameter that contains the Keycloak admin password.

--- a/src/Aspire.Hosting.Milvus/MilvusDatabaseResource.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusDatabaseResource.cs
@@ -24,7 +24,7 @@ public class MilvusDatabaseResource(string name, string databaseName, MilvusServ
     /// Gets the connection string expression for the Milvus database.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
+       ReferenceExpression.Interpolate($"{Parent};Database={DatabaseName}");
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting.Milvus/MilvusServerResource.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusServerResource.cs
@@ -39,7 +39,7 @@ public class MilvusServerResource : ContainerResource, IResourceWithConnectionSt
     /// Gets the connection string expression for the Milvus gRPC endpoint.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create(
+       ReferenceExpression.Interpolate(
             $"Endpoint={PrimaryEndpoint.Property(EndpointProperty.Url)};Key=root:{ApiKeyParameter}");
 
     private readonly Dictionary<string, string> _databases = new Dictionary<string, string>(StringComparers.ResourceName);

--- a/src/Aspire.Hosting.MongoDB/MongoDBServerResource.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBServerResource.cs
@@ -45,7 +45,7 @@ public class MongoDBServerResource(string name) : ContainerResource(name), IReso
 
     internal ReferenceExpression UserNameReference =>
         UserNameParameter is not null ?
-            ReferenceExpression.Create($"{UserNameParameter}") :
+            ReferenceExpression.Create(UserNameParameter) :
             ReferenceExpression.Create($"{DefaultUserName}");
 
     /// <summary>

--- a/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
@@ -24,7 +24,7 @@ public class MySqlDatabaseResource(string name, string databaseName, MySqlServer
     /// Gets the connection string expression for the MySQL database.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
+       ReferenceExpression.Interpolate($"{Parent};Database={DatabaseName}");
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting.MySql/MySqlServerResource.cs
+++ b/src/Aspire.Hosting.MySql/MySqlServerResource.cs
@@ -37,7 +37,7 @@ public class MySqlServerResource : ContainerResource, IResourceWithConnectionStr
     /// Gets the connection string expression for the MySQL server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create(
+        ReferenceExpression.Interpolate(
             $"Server={PrimaryEndpoint.Property(EndpointProperty.Host)};Port={PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=root;Password={PasswordParameter}");
 
     private readonly Dictionary<string, string> _databases = new Dictionary<string, string>(StringComparers.ResourceName);

--- a/src/Aspire.Hosting.Nats/NatsServerResource.cs
+++ b/src/Aspire.Hosting.Nats/NatsServerResource.cs
@@ -39,8 +39,8 @@ public class NatsServerResource(string name) : ContainerResource(name), IResourc
 
     internal ReferenceExpression UserNameReference =>
         UserNameParameter is not null ?
-            ReferenceExpression.Create($"{UserNameParameter}") :
-            ReferenceExpression.Create($"{DefaultUserName}");
+            ReferenceExpression.Create(UserNameParameter) :
+            ReferenceExpression.Create(DefaultUserName);
 
     /// <summary>
     /// Gets or sets the password for the NATS server.

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
@@ -24,7 +24,7 @@ public class OracleDatabaseResource(string name, string databaseName, OracleData
     /// Gets the connection string expression for the Oracle Database.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create($"{Parent}/{DatabaseName}");
+       ReferenceExpression.Interpolate($"{Parent}/{DatabaseName}");
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseServerResource.cs
@@ -37,7 +37,7 @@ public class OracleDatabaseServerResource : ContainerResource, IResourceWithConn
     /// Gets the connection string expression for the Oracle Database server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create(
+        ReferenceExpression.Interpolate(
             $"user id=system;password={PasswordParameter};data source={PrimaryEndpoint.Property(EndpointProperty.HostAndPort)}");
 
     private readonly Dictionary<string, string> _databases = new(StringComparers.ResourceName);

--- a/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
@@ -33,7 +33,7 @@ public class PostgresDatabaseResource(string name, string databaseName, Postgres
                 ["Database"] = DatabaseName
             };
 
-            return ReferenceExpression.Create($"{Parent};{connectionStringBuilder.ToString()}");
+            return ReferenceExpression.Interpolate($"{Parent};{connectionStringBuilder.ToString()}");
         }
     }
     /// <summary>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresServerResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresServerResource.cs
@@ -38,8 +38,8 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
 
     internal ReferenceExpression UserNameReference =>
         UserNameParameter is not null ?
-            ReferenceExpression.Create($"{UserNameParameter}") :
-            ReferenceExpression.Create($"{DefaultUserName}");
+            ReferenceExpression.Create(UserNameParameter) :
+            ReferenceExpression.Create(DefaultUserName);
 
     /// <summary>
     /// Gets or sets the parameter that contains the PostgreSQL server password.
@@ -47,7 +47,7 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
     public ParameterResource PasswordParameter { get; set; }
 
     private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
+        ReferenceExpression.Interpolate(
             $"Host={PrimaryEndpoint.Property(EndpointProperty.Host)};Port={PrimaryEndpoint.Property(EndpointProperty.Port)};Username={UserNameReference};Password={PasswordParameter}");
 
     /// <summary>

--- a/src/Aspire.Hosting.Qdrant/QdrantServerResource.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantServerResource.cs
@@ -44,13 +44,13 @@ public class QdrantServerResource : ContainerResource, IResourceWithConnectionSt
     /// Gets the connection string expression for the Qdrant gRPC endpoint.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create(
+       ReferenceExpression.Interpolate(
             $"Endpoint={PrimaryEndpoint.Property(EndpointProperty.Url)};Key={ApiKeyParameter}");
 
     /// <summary>
     /// Gets the connection string expression for the Qdrant HTTP endpoint.
     /// </summary>
     public ReferenceExpression HttpConnectionStringExpression =>
-        ReferenceExpression.Create(
+        ReferenceExpression.Interpolate(
             $"Endpoint={HttpEndpoint.Property(EndpointProperty.Url)};Key={ApiKeyParameter}");
 }

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
@@ -39,8 +39,8 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
 
     internal ReferenceExpression UserNameReference =>
         UserNameParameter is not null ?
-            ReferenceExpression.Create($"{UserNameParameter}") :
-            ReferenceExpression.Create($"{DefaultUserName}");
+            ReferenceExpression.Create(UserNameParameter) :
+            ReferenceExpression.Create(DefaultUserName);
 
     /// <summary>
     /// Gets the parameter that contains the RabbitMQ server password.
@@ -51,6 +51,6 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
     /// Gets the connection string expression for the RabbitMQ server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create(
+        ReferenceExpression.Interpolate(
             $"amqp://{UserNameReference}:{PasswordParameter}@{PrimaryEndpoint.Property(EndpointProperty.HostAndPort)}");
 }

--- a/src/Aspire.Hosting.Seq/SeqResource.cs
+++ b/src/Aspire.Hosting.Seq/SeqResource.cs
@@ -22,5 +22,5 @@ public class SeqResource(string name) : ContainerResource(name), IResourceWithCo
     /// Gets the connection string expression for the Seq server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{PrimaryEndpoint.Property(EndpointProperty.Url)}");
+        ReferenceExpression.Create(PrimaryEndpoint.Property(EndpointProperty.Url));
 }

--- a/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
@@ -33,7 +33,7 @@ public class SqlServerDatabaseResource(string name, string databaseName, SqlServ
                 ["Database"] = DatabaseName
             };
 
-            return ReferenceExpression.Create($"{Parent};{connectionStringBuilder.ToString()}");
+            return ReferenceExpression.Interpolate($"{Parent};{connectionStringBuilder.ToString()}");
         }
     }
 

--- a/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
@@ -34,7 +34,7 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
     public ParameterResource PasswordParameter { get; private set; }
 
     private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
+        ReferenceExpression.Interpolate(
             $"Server={PrimaryEndpoint.Property(EndpointProperty.IPV4Host)},{PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=sa;Password={PasswordParameter};TrustServerCertificate=true");
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -86,6 +86,37 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
     }
 
     /// <summary>
+    /// Creates a new instance of <see cref="ReferenceExpression"/> with the specified format and value providers.
+    /// </summary>
+    /// <param name="handler">The handler that contains the format and value providers.</param>
+    /// <returns>A new instance of <see cref="ReferenceExpression"/> with the specified format and value providers.</returns>
+    public static ReferenceExpression Interpolate(in ExpressionInterpolatedStringHandler handler)
+    {
+        return handler.GetExpression();
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ReferenceExpression"/> for a single value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <param name="value">An instance of an object which implements <see cref="IValueProvider"/> and <see cref="IManifestExpressionProvider"/>.</param>
+    /// <returns></returns>
+    public static ReferenceExpression Create<T>(T value) where T : IValueProvider, IManifestExpressionProvider
+    {
+        return new("{0}", [value], [value.ValueExpression]);
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ReferenceExpression"/> for a string.
+    /// </summary>
+    /// <param name="value">The string value.</param>
+    /// <returns></returns>
+    public static ReferenceExpression Create(string? value)
+    {
+        return new(value?.Replace("{", "{{").Replace("}", "}}") ?? string.Empty, [], []);
+    }
+
+    /// <summary>
     /// Represents a handler for interpolated strings that contain expressions. Those expressions will either be literal strings or
     /// instances of types that implement both <see cref="IValueProvider"/> and <see cref="IManifestExpressionProvider"/>.
     /// </summary>

--- a/src/Aspire.Hosting/ConnectionStringParameterResource.cs
+++ b/src/Aspire.Hosting/ConnectionStringParameterResource.cs
@@ -21,5 +21,5 @@ internal sealed class ConnectionStringParameterResource : ParameterResource, IRe
     public string? ConnectionStringEnvironmentVariable => _environmentVariableName;
 
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{this}");
+        ReferenceExpression.Create(this);
 }

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -839,7 +839,7 @@ public static class ProjectResourceBuilderExtensions
                     var host = builder.ApplicationBuilder.ExecutionContext.IsRunMode &&
                         builder.Resource.KestrelEndpointAnnotationHosts.TryGetValue(e.EndpointAnnotation, out var kestrelHost) ? kestrelHost : "*";
 
-                    var url = ReferenceExpression.Create($"{e.EndpointAnnotation.UriScheme}://{host}:{e.Property(EndpointProperty.TargetPort)}");
+                    var url = ReferenceExpression.Interpolate($"{e.EndpointAnnotation.UriScheme}://{host}:{e.Property(EndpointProperty.TargetPort)}");
 
                     // We use special config system environment variables to perform the override.
                     context.EnvironmentVariables[$"Kestrel__Endpoints__{e.EndpointAnnotation.Name}__Url"] = url;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -55,7 +55,7 @@ public class AzureBicepProvisionerTests
                .WithParameter("conn", connectionStringResource)
                .WithParameter("jsonObj", new JsonObject { ["key"] = "value" })
                .WithParameter("param", param)
-               .WithParameter("expr", ReferenceExpression.Create($"{param.Resource}/1"))
+               .WithParameter("expr", ReferenceExpression.Interpolate($"{param.Resource}/1"))
                .WithParameter("endpoint", container.GetEndpoint("http"));
 
         var parameters = new JsonObject();
@@ -298,6 +298,6 @@ public class AzureBicepProvisionerTests
         IResourceWithConnectionString
     {
         public ReferenceExpression ConnectionStringExpression =>
-           ReferenceExpression.Create($"{connectionString}");
+           ReferenceExpression.Create(connectionString);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1735,8 +1735,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                 // Any value that resolves to the secret output can be a direct keyvault reference.
                 // This includes nested expressions.
                 var connectionString = db.GetSecretOutput("connectionString");
-                var secret0 = ReferenceExpression.Create($"{connectionString}");
-                var secret1 = ReferenceExpression.Create($"{secret0}");
+                var secret0 = ReferenceExpression.Create(connectionString);
+                var secret1 = ReferenceExpression.Create(secret0);
 
                 context.EnvironmentVariables["connectionString"] = connectionString;
                 context.EnvironmentVariables["secret0"] = secret0;
@@ -1744,7 +1744,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
 
                 var connectionString1 = db.GetSecretOutput("connectionString1");
                 // Complex expressions that contain a secret output
-                var complex = ReferenceExpression.Create($"a/{connectionString}/{secret0}/{connectionString1}");
+                var complex = ReferenceExpression.Interpolate($"a/{connectionString}/{secret0}/{connectionString1}");
                 context.EnvironmentVariables["complex"] = complex;
             });
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.cs
@@ -19,7 +19,7 @@ public class AzureProvisioningResourceExtensionsTests(ITestOutputHelper output)
             .WithHttpsEndpoint();
 
         var endpointReference = apiProject.GetEndpoint("https");
-        var referenceExpression = ReferenceExpression.Create($"prefix:{endpointReference.Property(EndpointProperty.HostAndPort)}");
+        var referenceExpression = ReferenceExpression.Interpolate($"prefix:{endpointReference.Property(EndpointProperty.HostAndPort)}");
 
         var resource1 = builder.AddAzureInfrastructure("resource1", infrastructure =>
         {

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePublisherTests.cs
@@ -36,7 +36,7 @@ public class AzurePublisherTests(ITestOutputHelper output)
 
         var storageSku = builder.AddParameter("storageSku", "Standard_LRS", publishValueAsDefault: true);
         var description = builder.AddParameter("skuDescription", "The sku is ", publishValueAsDefault: true);
-        var skuDescriptionExpr = ReferenceExpression.Create($"{description} {storageSku}");
+        var skuDescriptionExpr = ReferenceExpression.Interpolate($"{description} {storageSku}");
 
         var kvName = builder.AddParameter("kvName");
         var kvRg = builder.AddParameter("kvRg", "rg-shared");

--- a/tests/Aspire.Hosting.Containers.Tests/ContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ContainerResourceTests.cs
@@ -322,6 +322,6 @@ public class ContainerResourceTests
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
         public ReferenceExpression ConnectionStringExpression =>
-            ReferenceExpression.Create($"{connectionString}");
+            ReferenceExpression.Create(connectionString);
     }
 }

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -30,7 +30,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         var param0 = builder.AddParameter("param0");
         var param1 = builder.AddParameter("param1", secret: true);
         var param2 = builder.AddParameter("param2", "default", publishValueAsDefault: true);
-        var cs = builder.AddConnectionString("cs", ReferenceExpression.Create($"Url={param0}, Secret={param1}"));
+        var cs = builder.AddConnectionString("cs", ReferenceExpression.Interpolate($"Url={param0}, Secret={param1}"));
 
         // Add a container to the application
         var redis = builder.AddContainer("cache", "redis")

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -52,7 +52,7 @@ public class KubernetesPublisherTests(KubernetesPublisherFixture fixture)
             var param1 = builder.AddParameter("param1", secret: true);
             var param2 = builder.AddParameter("param2", "default", publishValueAsDefault: true);
             var param3 = builder.AddResource(ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, "param3"));
-            var cs = builder.AddConnectionString("cs", ReferenceExpression.Create($"Url={param0}, Secret={param1}"));
+            var cs = builder.AddConnectionString("cs", ReferenceExpression.Interpolate($"Url={param0}, Secret={param1}"));
 
             // Add a container to the application
             var api = builder.AddContainer("myapp", "mcr.microsoft.com/dotnet/aspnet:8.0")

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -329,7 +329,7 @@ public class AddParameterTests
         var key = appBuilder.AddParameter("key", "secretKey", secret: true);
 
         // Get the service provider.
-        appBuilder.AddConnectionString("mycs", ReferenceExpression.Create($"Endpoint={endpoint};Key={key}"));
+        appBuilder.AddConnectionString("mycs", ReferenceExpression.Interpolate($"Endpoint={endpoint};Key={key}"));
 
         using var app = appBuilder.Build();
 

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -104,6 +104,6 @@ public class ExecutableResourceTests
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
         public ReferenceExpression ConnectionStringExpression =>
-            ReferenceExpression.Create($"{connectionString}");
+            ReferenceExpression.Create(connectionString);
     }
 }

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -197,7 +197,7 @@ sealed class MyContainerResource : ContainerResource, IResourceWithConnectionStr
     public EndpointReference PrimaryEndpoint { get; }
 
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create($"{PrimaryEndpoint.Property(EndpointProperty.Url)}");
+       ReferenceExpression.Create(PrimaryEndpoint.Property(EndpointProperty.Url));
 }
 
 sealed class TestValueProviderResource(string name) : Resource(name), IValueProvider
@@ -220,16 +220,16 @@ sealed class TestExpressionResolverResource : ContainerResource, IResourceWithEn
 
         Expressions = new()
         {
-            { "TwoFullEndpoints", ReferenceExpression.Create($"Test1={Endpoint1.Property(EndpointProperty.Scheme)}://{Endpoint1.Property(EndpointProperty.IPV4Host)}:{Endpoint1.Property(EndpointProperty.Port)}/;Test2={Endpoint2.Property(EndpointProperty.Scheme)}://{Endpoint2.Property(EndpointProperty.Host)}:{Endpoint2.Property(EndpointProperty.Port)}/;") },
-            { "Url", ReferenceExpression.Create($"Url={Endpoint1.Property(EndpointProperty.Url)};") },
-            { "Url2", ReferenceExpression.Create($"Url={Endpoint1};") },
-            { "OnlyHost", ReferenceExpression.Create($"Host={Endpoint1.Property(EndpointProperty.Host)};") },
-            { "OnlyPort", ReferenceExpression.Create($"Port={Endpoint1.Property(EndpointProperty.Port)};") },
-            { "HostAndPort", ReferenceExpression.Create($"HostPort={Endpoint1.Property(EndpointProperty.HostAndPort)}") },
-            { "PortBeforeHost", ReferenceExpression.Create($"Port={Endpoint1.Property(EndpointProperty.Port)};Host={Endpoint1.Property(EndpointProperty.Host)};") },
-            { "FullAndPartial", ReferenceExpression.Create($"Test1={Endpoint1.Property(EndpointProperty.Scheme)}://{Endpoint1.Property(EndpointProperty.IPV4Host)}:{Endpoint1.Property(EndpointProperty.Port)}/;Test2={Endpoint2.Property(EndpointProperty.Scheme)}://localhost:{Endpoint2.Property(EndpointProperty.Port)}/;") },
-            { "Empty", ReferenceExpression.Create($"") },
-            { "String", ReferenceExpression.Create($"String") },
+            { "TwoFullEndpoints", ReferenceExpression.Interpolate($"Test1={Endpoint1.Property(EndpointProperty.Scheme)}://{Endpoint1.Property(EndpointProperty.IPV4Host)}:{Endpoint1.Property(EndpointProperty.Port)}/;Test2={Endpoint2.Property(EndpointProperty.Scheme)}://{Endpoint2.Property(EndpointProperty.Host)}:{Endpoint2.Property(EndpointProperty.Port)}/;") },
+            { "Url", ReferenceExpression.Interpolate($"Url={Endpoint1.Property(EndpointProperty.Url)};") },
+            { "Url2", ReferenceExpression.Interpolate($"Url={Endpoint1};") },
+            { "OnlyHost", ReferenceExpression.Interpolate($"Host={Endpoint1.Property(EndpointProperty.Host)};") },
+            { "OnlyPort", ReferenceExpression.Interpolate($"Port={Endpoint1.Property(EndpointProperty.Port)};") },
+            { "HostAndPort", ReferenceExpression.Interpolate($"HostPort={Endpoint1.Property(EndpointProperty.HostAndPort)}") },
+            { "PortBeforeHost", ReferenceExpression.Interpolate($"Port={Endpoint1.Property(EndpointProperty.Port)};Host={Endpoint1.Property(EndpointProperty.Host)};") },
+            { "FullAndPartial", ReferenceExpression.Interpolate($"Test1={Endpoint1.Property(EndpointProperty.Scheme)}://{Endpoint1.Property(EndpointProperty.IPV4Host)}:{Endpoint1.Property(EndpointProperty.Port)}/;Test2={Endpoint2.Property(EndpointProperty.Scheme)}://localhost:{Endpoint2.Property(EndpointProperty.Port)}/;") },
+            { "Empty", ReferenceExpression.Create("") },
+            { "String", ReferenceExpression.Create("String") },
             { "SecretParameter", ReferenceExpression.Create("SecretParameter", [new ParameterResource("SecretParameter", _ => "SecretParameter", secret: true)], []) },
             { "NonSecretParameter", ReferenceExpression.Create("NonSecretParameter", [new ParameterResource("NonSecretParameter", _ => "NonSecretParameter", secret: false)], []) }
         };

--- a/tests/Aspire.Hosting.Tests/ReferenceExpressionTests.cs
+++ b/tests/Aspire.Hosting.Tests/ReferenceExpressionTests.cs
@@ -17,7 +17,7 @@ public class ReferenceExpressionTests
     [InlineData("{{x}}", "Hello {{{{x}}}}", "Hello {{x}}")]
     public void TestReferenceExpressionCreateInputStringTreatedAsLiteral(string input, string expectedFormat, string expectedExpression)
     {
-        var refExpression = ReferenceExpression.Create($"Hello {input}");
+        var refExpression = ReferenceExpression.Interpolate($"Hello {input}");
         Assert.Equal(expectedFormat, refExpression.Format);
 
         // Generally, the input string should end up unchanged in the expression, since it's a literal
@@ -35,7 +35,7 @@ public class ReferenceExpressionTests
     [InlineData("{myVar1}", "{myVar1}")]
     public void ReferenceExpressionHandlesValueWithNonParameterBrackets(string input, string expected)
     {
-        var expr = ReferenceExpression.Create($"{input}").ValueExpression;
+        var expr = ReferenceExpression.Create(input).ValueExpression;
         Assert.Equal(expected, expr);
     }
 
@@ -66,7 +66,7 @@ public class ReferenceExpressionTests
     public void ReferenceExpressionHandlesValueWithoutBrackets()
     {
         var s = "Test";
-        var expr = ReferenceExpression.Create($"{s}").ValueExpression;
+        var expr = ReferenceExpression.Create(s).ValueExpression;
         Assert.Equal("Test", expr);
     }
 }

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -124,7 +124,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
         var dependency = builder.AddResource(new CustomResource("test"));
-        var cs = builder.AddConnectionString("cs", ReferenceExpression.Create($"{dependency};Timeout=100"));
+        var cs = builder.AddConnectionString("cs", ReferenceExpression.Interpolate($"{dependency};Timeout=100"));
 
         var nginx = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
                            .WaitFor(cs);

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -84,7 +84,7 @@ public class WithEnvironmentTests
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var childExpression = ReferenceExpression.Create($"value");
-        var parameterExpression = ReferenceExpression.Create($"{childExpression}");
+        var parameterExpression = ReferenceExpression.Create(childExpression);
 
         var project = builder.AddProject<ProjectA>("projectA")
             .WithEnvironment("myName", parameterExpression);
@@ -357,7 +357,7 @@ public class WithEnvironmentTests
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
         public ReferenceExpression ConnectionStringExpression =>
-            ReferenceExpression.Create($"{connectionString}");
+            ReferenceExpression.Create(connectionString);
     }
 
     private sealed class ProjectA : IProjectMetadata

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -278,7 +278,7 @@ public class WithReferenceTests
         var endpoint = builder.AddParameter("endpoint", "http://localhost:3452");
         var key = builder.AddParameter("key", "secretKey", secret: true);
 
-        var cs = ReferenceExpression.Create($"Endpoint={endpoint};Key={key}");
+        var cs = ReferenceExpression.Interpolate($"Endpoint={endpoint};Key={key}");
 
         // Get the service provider.
         var resource = builder.AddConnectionString("cs", cs);
@@ -399,7 +399,7 @@ public class WithReferenceTests
         public string? ConnectionString { get; set; }
 
         public ReferenceExpression ConnectionStringExpression =>
-            ReferenceExpression.Create($"{ConnectionString}");
+            ReferenceExpression.Create(ConnectionString);
     }
 
     private sealed class ProjectA : IProjectMetadata

--- a/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
+++ b/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
@@ -11,7 +11,7 @@ builder.Configuration["ConnectionStrings:cs"] = "testconnection";
 
 builder.AddConnectionString("cs");
 
-builder.AddConnectionString("cs2", ReferenceExpression.Create($"Value={builder.AddParameter("p", "this is a value")}"));
+builder.AddConnectionString("cs2", ReferenceExpression.Interpolate($"Value={builder.AddParameter("p", "this is a value")}"));
 
 if (args.Contains("--add-redis"))
 {


### PR DESCRIPTION
## Description

- Refactor connection string expressions to use Interpolate method
- Adjusted tests to reflect changes in connection string expression handling, ensuring consistency across the codebase.

Fixes #8979

TODO?: Codefixer to nudge people to use these new methods. Obsolete in the next release? Or do it in this one?

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
