### PR TITLE
Prevent forked repo failing OuterLoop Tests every 2 hours

### DIFF
--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -89,7 +89,7 @@ jobs:
           path: ${{ github.workspace }}/artifacts/all-logs
 
       - name: Process logs and post results
-        if: ${{ github.repository_owner == 'dotnet' }}
+        if: ${{ always() && github.repository_owner == 'dotnet' }}
         shell: pwsh
         run: |
           $logDirectory = "${{ github.workspace }}/artifacts/all-logs"

--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -89,7 +89,7 @@ jobs:
           path: ${{ github.workspace }}/artifacts/all-logs
 
       - name: Process logs and post results
-        if: always()
+        if: ${{ github.repository_owner == 'dotnet' }}
         shell: pwsh
         run: |
           $logDirectory = "${{ github.workspace }}/artifacts/all-logs"


### PR DESCRIPTION
## Description

[Forks of Aspire have failing OuterLoop Tests workflow runs every 2 hours](https://github.com/james-gould/aspire/actions), which is also causing an email 12 times a day about a failed run, with the previous 2 steps in the action skipped.

This PR also skips the 3rd step, preventing the fail/alert.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
