### PR TITLE
Fix resource actions not updating resource page state

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -12,7 +12,7 @@
         {
             var highlightedCommand = _highlightedCommands[i];
 
-            <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
+            <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
                 @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && IconResolver.ResolveIconName(highlightedCommand.IconName, IconSize.Size16, highlightedCommand.IconVariant) is { } icon)
                 {
                     <FluentIcon Value="@icon" Width="16px" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -30,13 +30,13 @@ public partial class ResourceActions : ComponentBase
     public required TelemetryRepository TelemetryRepository { get; set; }
 
     [Parameter]
-    public required Func<CommandViewModel, Task> CommandSelected { get; set; }
+    public required EventCallback<CommandViewModel> CommandSelected { get; set; }
 
     [Parameter]
     public required Func<ResourceViewModel, CommandViewModel, bool> IsCommandExecuting { get; set; }
 
     [Parameter]
-    public required Func<string?, Task> OnViewDetails { get; set; }
+    public required EventCallback<string?> OnViewDetails { get; set; }
 
     [Parameter]
     public required ResourceViewModel Resource { get; set; }
@@ -70,8 +70,8 @@ public partial class ResourceActions : ComponentBase
             GetResourceName,
             ControlLoc,
             Loc,
-            OnViewDetails,
-            CommandSelected,
+            OnViewDetails.InvokeAsync,
+            CommandSelected.InvokeAsync,
             IsCommandExecuting,
             showConsoleLogsItem: true,
             showUrls: false);

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -535,8 +535,16 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 GetResourceName,
                 ControlsStringsLoc,
                 Loc,
-                (buttonId) => ShowResourceDetailsAsync(resource, buttonId),
-                (command) => ExecuteResourceCommandAsync(resource, command),
+                async (buttonId) =>
+                {
+                    await ShowResourceDetailsAsync(resource, buttonId);
+                    StateHasChanged();
+                },
+                async (command) =>
+                {
+                    await ExecuteResourceCommandAsync(resource, command);
+                    StateHasChanged();
+                },
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
                 showConsoleLogsItem: true,
                 showUrls: true);

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -486,11 +486,6 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             if (_resourceByName.TryGetValue(ResourceName, out var selectedResource))
             {
                 await ShowResourceDetailsAsync(selectedResource, buttonId: null);
-
-                if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph)
-                {
-                    await UpdateResourceGraphSelectedAsync();
-                }
             }
 
             // Navigate to remove ?resource=xxx in the URL.
@@ -535,16 +530,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 GetResourceName,
                 ControlsStringsLoc,
                 Loc,
-                async (buttonId) =>
-                {
-                    await ShowResourceDetailsAsync(resource, buttonId);
-                    StateHasChanged();
-                },
-                async (command) =>
-                {
-                    await ExecuteResourceCommandAsync(resource, command);
-                    StateHasChanged();
-                },
+                (buttonId) => ShowResourceDetailsAsync(resource, buttonId),
+                (command) => ExecuteResourceCommandAsync(resource, command),
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
                 showConsoleLogsItem: true,
                 showUrls: true);
@@ -588,6 +575,11 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 }
 
                 break;
+            }
+
+            if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph)
+            {
+                await UpdateResourceGraphSelectedAsync();
             }
 
             await _dataGrid.SafeRefreshDataAsync();


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/8812

* Change back to EventCallback so state is automatically changed on resources page
* Also fix issue with `View details` not highlighting the node in the graph view

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
