### PR TITLE
Improve cancellation handling and add certificate exception class

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -51,8 +51,13 @@ internal sealed class CertificateService(IInteractionService interactionService)
             if (trustExitCode != 0)
             {
                 interactionService.DisplayLines(ensureCertificateCollector.GetLines());
-                throw new InvalidOperationException($"Failed to trust certificates, trust command failed with exit code: {trustExitCode}");
+                throw new CertificateServiceException($"Failed to trust certificates, trust command failed with exit code: {trustExitCode}");
             }
         }
     }
+}
+
+public sealed class CertificateServiceException(string message) : Exception(message)
+{
+
 }

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -171,7 +171,7 @@ internal sealed class AddCommand : BaseCommand
         }
         catch (OperationCanceledException)
         {
-            _interactionService.DisplayMessage("stop_sign", "[yellow bold]Operation cancelled by user action.[/]");
+            _interactionService.DisplayCancellationMessage();
             return ExitCodeConstants.FailedToAddPackage;
         }
         catch (Exception ex)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -134,74 +134,79 @@ internal sealed class NewCommand : BaseCommand
     {
         using var activity = _activitySource.StartActivity();
 
-        var template = await GetProjectTemplateAsync(parseResult, cancellationToken);
-        var name = await GetProjectNameAsync(parseResult, cancellationToken);
-        var outputPath = await GetOutputPathAsync(parseResult, template.PathAppendage, cancellationToken);
-        var prerelease = parseResult.GetValue<bool>("--prerelease");
-        var source = parseResult.GetValue<string?>("--source");
-        var version = await GetProjectTemplatesVersionAsync(parseResult, prerelease, source, cancellationToken);
-
-        var templateInstallCollector = new OutputCollector();
-        var templateInstallResult = await _interactionService.ShowStatusAsync<(int ExitCode, string? TemplateVersion)>(
-            ":ice:  Getting latest templates...",
-            async () => {
-                var options = new DotNetCliRunnerInvocationOptions()
-                {
-                    StandardOutputCallback = templateInstallCollector.AppendOutput,
-                    StandardErrorCallback = templateInstallCollector.AppendOutput,
-                };
-
-                var result = await _runner.InstallTemplateAsync("Aspire.ProjectTemplates", version, source, true, options, cancellationToken);
-                return result;
-            });
-
-        if (templateInstallResult.ExitCode != 0)
-        {
-            _interactionService.DisplayLines(templateInstallCollector.GetLines());
-            _interactionService.DisplayError($"The template installation failed with exit code {templateInstallResult.ExitCode}. For more information run with --debug switch.");
-            return ExitCodeConstants.FailedToInstallTemplates;
-        }
-
-        _interactionService.DisplayMessage($"package", $"Using project templates version: {templateInstallResult.TemplateVersion}");
-
-        var newProjectCollector = new OutputCollector();
-        var newProjectExitCode = await _interactionService.ShowStatusAsync(
-            ":rocket:  Creating new Aspire project...",
-            async () => {
-                var options = new DotNetCliRunnerInvocationOptions()
-                {
-                    StandardOutputCallback = newProjectCollector.AppendOutput,
-                    StandardErrorCallback = newProjectCollector.AppendOutput,
-                };
-                var result = await _runner.NewProjectAsync(
-                            template.TemplateName,
-                            name,
-                            outputPath,
-                            options,
-                            cancellationToken);
-                return result;
-            });
-
-        if (newProjectExitCode != 0)
-        {
-            _interactionService.DisplayLines(newProjectCollector.GetLines());
-            _interactionService.DisplayError($"Project creation failed with exit code {newProjectExitCode}. For more information run with --debug switch.");
-            return ExitCodeConstants.FailedToCreateNewProject;
-        }
-
         try
         {
+            var template = await GetProjectTemplateAsync(parseResult, cancellationToken);
+            var name = await GetProjectNameAsync(parseResult, cancellationToken);
+            var outputPath = await GetOutputPathAsync(parseResult, template.PathAppendage, cancellationToken);
+            var prerelease = parseResult.GetValue<bool>("--prerelease");
+            var source = parseResult.GetValue<string?>("--source");
+            var version = await GetProjectTemplatesVersionAsync(parseResult, prerelease, source, cancellationToken);
+
+            var templateInstallCollector = new OutputCollector();
+            var templateInstallResult = await _interactionService.ShowStatusAsync<(int ExitCode, string? TemplateVersion)>(
+                ":ice:  Getting latest templates...",
+                async () => {
+                    var options = new DotNetCliRunnerInvocationOptions()
+                    {
+                        StandardOutputCallback = templateInstallCollector.AppendOutput,
+                        StandardErrorCallback = templateInstallCollector.AppendOutput,
+                    };
+
+                    var result = await _runner.InstallTemplateAsync("Aspire.ProjectTemplates", version, source, true, options, cancellationToken);
+                    return result;
+                });
+
+            if (templateInstallResult.ExitCode != 0)
+            {
+                _interactionService.DisplayLines(templateInstallCollector.GetLines());
+                _interactionService.DisplayError($"The template installation failed with exit code {templateInstallResult.ExitCode}. For more information run with --debug switch.");
+                return ExitCodeConstants.FailedToInstallTemplates;
+            }
+
+            _interactionService.DisplayMessage($"package", $"Using project templates version: {templateInstallResult.TemplateVersion}");
+
+            var newProjectCollector = new OutputCollector();
+            var newProjectExitCode = await _interactionService.ShowStatusAsync(
+                ":rocket:  Creating new Aspire project...",
+                async () => {
+                    var options = new DotNetCliRunnerInvocationOptions()
+                    {
+                        StandardOutputCallback = newProjectCollector.AppendOutput,
+                        StandardErrorCallback = newProjectCollector.AppendOutput,
+                    };
+                    var result = await _runner.NewProjectAsync(
+                                template.TemplateName,
+                                name,
+                                outputPath,
+                                options,
+                                cancellationToken);
+                    return result;
+                });
+
+            if (newProjectExitCode != 0)
+            {
+                _interactionService.DisplayLines(newProjectCollector.GetLines());
+                _interactionService.DisplayError($"Project creation failed with exit code {newProjectExitCode}. For more information run with --debug switch.");
+                return ExitCodeConstants.FailedToCreateNewProject;
+            }
+
             await _certificateService.EnsureCertificatesTrustedAsync(_runner, cancellationToken);
+
+            _interactionService.DisplaySuccess($"Project created successfully in {outputPath}.");
+
+            return ExitCodeConstants.Success;
         }
-        catch (Exception ex)
+        catch (OperationCanceledException)
+        {
+            _interactionService.DisplayCancellationMessage();
+            return ExitCodeConstants.FailedToCreateNewProject;
+        }
+        catch (CertificateServiceException ex)
         {
             _interactionService.DisplayError($"An error occurred while trusting the certificates: {ex.Message}");
             return ExitCodeConstants.FailedToTrustCertificates;
         }
-
-        _interactionService.DisplaySuccess($"Project created successfully in {outputPath}.");
-
-        return ExitCodeConstants.Success;
     }
 }
 

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -296,6 +296,16 @@ internal sealed class PublishCommand : BaseCommand
                 return ExitCodeConstants.Success;
             }
         }
+        catch (OperationCanceledException)
+        {
+            _interactionService.DisplayError("The operation was canceled.");
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+        catch (ProjectLocatorException ex) when (ex.Message == "Project file is not an Aspire app host project.")
+        {
+            _interactionService.DisplayError("The specified project file is not an Aspire app host project.");
+            return ExitCodeConstants.FailedToFindProject;
+        }
         catch (ProjectLocatorException ex) when (ex.Message == "Project file does not exist.")
         {
             _interactionService.DisplayError("The --project option specified a project that does not exist.");

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -18,4 +18,5 @@ internal interface IInteractionService
     void DisplaySuccess(string message);
     void DisplayDashboardUrls((string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken) dashboardUrls);
     void DisplayLines(IEnumerable<(string Stream, string Line)> lines);
+    void DisplayCancellationMessage();
 }

--- a/src/Aspire.Cli/Interaction/InteractionService.cs
+++ b/src/Aspire.Cli/Interaction/InteractionService.cs
@@ -127,4 +127,11 @@ internal class InteractionService : IInteractionService
             }
         }
     }
+
+    public void DisplayCancellationMessage()
+    {
+        _ansiConsole.WriteLine();
+        _ansiConsole.WriteLine();
+        DisplayMessage("stop_sign", "[yellow bold]Operation cancelled by user action.[/]");
+    }
 }


### PR DESCRIPTION
Fixes #8982

# aspire new

![image](https://github.com/user-attachments/assets/a9d8c886-30c6-4c33-9c1a-b3ba80736ae8)

# aspire add

![image](https://github.com/user-attachments/assets/adbffd50-3126-4556-a091-9577bd5e0629)

# aspire run

![image](https://github.com/user-attachments/assets/78df32f1-ba48-41ca-b3ef-e40dccbfd5f7)

# aspire publish

![image](https://github.com/user-attachments/assets/d59734b8-36af-4a82-9275-6ef5341f86d9)

Also in this PR I tweaked the exception handling around certificate failures. This was to reduce the level of nesting of code blocks. I did this by making the `ICertificateService` throw a `CertificateServiceException` and catching it globally. I added covering tests to make sure that failure to setup certificates returns the correct exit code.