### PR TITLE
Fix prompting when invalid template specified on command-line.

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -78,7 +78,8 @@ internal sealed class NewCommand : BaseCommand
             ("aspire-xunit", "Aspire Test Project (xUnit)", "./")
             ];
 
-        if (parseResult.GetValue<string?>("template") is { } templateName && validTemplates.SingleOrDefault(t => t.TemplateName == templateName) is { } template)
+        if (parseResult.GetValue<string?>("template") is { } templateName &&
+            validTemplates.SingleOrDefault(t => t.TemplateName == templateName) is { TemplateName: not null } template)
         {
             return template;
         }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -68,24 +68,23 @@ internal sealed class NewCommand : BaseCommand
         //       Once we integrate with template engine we will also be able to
         //       interrogate the various options and add them. For now we will 
         //       keep it simple.
-        (string TemplateName, string TemplateDescription, string? PathAppendage)[] validTemplates = [
-            ("aspire-starter", "Aspire Starter App", "./src") ,
-            ("aspire", "Aspire Empty App", "./src"),
-            ("aspire-apphost", "Aspire App Host", "./"),
-            ("aspire-servicedefaults", "Aspire Service Defaults", "./"),
-            ("aspire-mstest", "Aspire Test Project (MSTest)", "./"),
-            ("aspire-nunit", "Aspire Test Project (NUnit)", "./"),
-            ("aspire-xunit", "Aspire Test Project (xUnit)", "./")
-            ];
+        Dictionary<string, (string TemplateName, string TemplateDescription, string? PathAppendage)> validTemplates = new() {
+            { "aspire-starter", ("aspire-starter", "Aspire Starter App", "./src")},
+            { "aspire", ("aspire", "Aspire Empty App", "./src") },
+            { "aspire-apphost", ("aspire-apphost", "Aspire App Host", "./") },
+            { "aspire-servicedefaults", ("aspire-servicedefaults", "Aspire Service Defaults", "./") },
+            { "aspire-mstest", ("aspire-mstest", "Aspire Test Project (MSTest)", "./") },
+            { "aspire-nunit", ("aspire-nunit", "Aspire Test Project (NUnit)", "./") },
+            { "aspire-xunit", ("aspire-xunit", "Aspire Test Project (xUnit)", "./")}
+        };
 
-        if (parseResult.GetValue<string?>("template") is { } templateName &&
-            validTemplates.SingleOrDefault(t => t.TemplateName == templateName) is { TemplateName: not null } template)
+        if (parseResult.GetValue<string?>("template") is { } templateName && validTemplates.TryGetValue(templateName.ToLowerInvariant(), out var template))
         {
             return template;
         }
         else
         {
-            return await _prompter.PromptForTemplateAsync(validTemplates, cancellationToken);
+            return await _prompter.PromptForTemplateAsync(validTemplates.Values.ToArray(), cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -68,7 +68,7 @@ internal sealed class NewCommand : BaseCommand
         //       Once we integrate with template engine we will also be able to
         //       interrogate the various options and add them. For now we will 
         //       keep it simple.
-        Dictionary<string, (string TemplateName, string TemplateDescription, string? PathAppendage)> validTemplates = new() {
+        Dictionary<string, (string TemplateName, string TemplateDescription, string? PathAppendage)> validTemplates = new(StringComparer.OrdinalIgnoreCase) {
             { "aspire-starter", ("aspire-starter", "Aspire Starter App", "./src")},
             { "aspire", ("aspire", "Aspire Empty App", "./src") },
             { "aspire-apphost", ("aspire-apphost", "Aspire App Host", "./") },
@@ -78,7 +78,7 @@ internal sealed class NewCommand : BaseCommand
             { "aspire-xunit", ("aspire-xunit", "Aspire Test Project (xUnit)", "./")}
         };
 
-        if (parseResult.GetValue<string?>("template") is { } templateName && validTemplates.TryGetValue(templateName.ToLowerInvariant(), out var template))
+        if (parseResult.GetValue<string?>("template") is { } templateName && validTemplates.TryGetValue(templateName, out var template))
         {
             return template;
         }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -69,6 +69,67 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandPromptsForProjectTemplateIfInvalidTemplateSpecified()
+    {
+        var tcs = new TaskCompletionSource();
+
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options => {
+
+            // Set of options that we'll give when prompted.
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+                prompter.PromptForTemplateCallback = (templates) => {
+                    tcs.SetResult();
+                    return templates[0];
+                };
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, options, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (
+                        0, // Exit code.
+                        new NuGetPackage[] { package } // Single package.
+                        );
+                };
+
+                return runner;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new notavalidtemplate");
+
+        var pendingNewCommand = result.InvokeAsync();
+
+        // This basically waits for the prompt to select the project
+        // template to be shown. If it isn't shown then this test will
+        // fail witha timeout.
+        await tcs.Task.WaitAsync(CliTestConstants.DefaultTimeout);
+        var exitCode = await pendingNewCommand;
+
+        // Success because the default behavior of the prompter will
+        // result in the new command completing and the stub
+        // for the DotNetCliRunner will return success for all the
+        // commands.
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
     public async Task NewCommandOrdersTemplatePackageVersionsCorrectly()
     {
         IEnumerable<NuGetPackage>? promptedPackages = null;


### PR DESCRIPTION
Fixes #8966

The issue was a bad pattern match when detecting whether the user had specified a valid template. Because this method returns a tuple a tuple was being interpreted as non-null value and dropping through.

Added a test case to cover this situation as well.