### PR TITLE
Change ReferenceExpression to properly escape unescaped braces and add tests for bracket handling and interpolation

### DIFF
--- a/tests/Aspire.Hosting.Tests/ReferenceExpressionTests.cs
+++ b/tests/Aspire.Hosting.Tests/ReferenceExpressionTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -14,7 +13,7 @@ public class ReferenceExpressionTests
     [InlineData("}", "Hello }}", "Hello }")]
     [InlineData("{1}", "Hello {{1}}", "Hello {1}")]
     [InlineData("{x}", "Hello {{x}}", "Hello {x}")]
-    [InlineData("{{x}}", "Hello {{{{x}}}}", "Hello {{x}}")]
+    [InlineData("{{x}}", "Hello {{x}}", "Hello {x}")]
     public void TestReferenceExpressionCreateInputStringTreatedAsLiteral(string input, string expectedFormat, string expectedExpression)
     {
         var refExpression = ReferenceExpression.Create($"Hello {input}");
@@ -68,5 +67,37 @@ public class ReferenceExpressionTests
         var s = "Test";
         var expr = ReferenceExpression.Create($"{s}").ValueExpression;
         Assert.Equal("Test", expr);
+    }
+
+    [Fact]
+    public async Task ReferenceExpressionWithBracketsAndInterpolation()
+    {
+        var v = new Value();
+
+        var expr = ReferenceExpression.Create($"[{{\"api_uri\":\"{v}\"}}]");
+
+        Assert.Equal("[{\"api_uri\":\"{value}\"}]", expr.ValueExpression);
+        Assert.Equal("[{\"api_uri\":\"Hello World\"}]", await expr.GetValueAsync(default));
+    }
+
+    [Fact]
+    public async Task ReferenceExpressionWithEscapedBracketsAndInterpolation()
+    {
+        var v = new Value();
+
+        var expr = ReferenceExpression.Create($"[{{{{\"api_uri\":\"{v}\"}}}}]");
+
+        Assert.Equal("[{\"api_uri\":\"{value}\"}]", expr.ValueExpression);
+        Assert.Equal("[{\"api_uri\":\"Hello World\"}]", await expr.GetValueAsync(default));
+    }
+
+    private sealed class Value : IValueProvider, IManifestExpressionProvider
+    {
+        public string ValueExpression => "{value}";
+
+        public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default)
+        {
+            return new("Hello World");
+        }
     }
 }


### PR DESCRIPTION
## Description

Change ReferenceExpression to properly escape unescaped braces and add tests for bracket handling and interpolation

Fixes #8974

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - TBD (once merged)
  - [ ] No
