### PR TITLE
Don't log the token credential until it's used.

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -219,7 +219,7 @@ internal sealed class AzureProvisioner(
         var userSecretsLazy = new Lazy<Task<JsonObject>>(() => GetUserSecretsAsync(userSecretsPath, cancellationToken));
 
         // Make resources wait on the same provisioning context
-        var provisioningContextLazy = new Lazy<Task<ProvisioningContext>>(() => GetProvisioningContextAsync(tokenCredentialHolder.Credential, userSecretsLazy, cancellationToken));
+        var provisioningContextLazy = new Lazy<Task<ProvisioningContext>>(() => GetProvisioningContextAsync(tokenCredentialHolder, userSecretsLazy, cancellationToken));
 
         var tasks = new List<Task>();
 
@@ -366,9 +366,13 @@ internal sealed class AzureProvisioner(
         }
     }
 
-    private async Task<ProvisioningContext> GetProvisioningContextAsync(TokenCredential credential, Lazy<Task<JsonObject>> userSecretsLazy, CancellationToken cancellationToken)
+    private async Task<ProvisioningContext> GetProvisioningContextAsync(TokenCredentialHolder holder, Lazy<Task<JsonObject>> userSecretsLazy, CancellationToken cancellationToken)
     {
         var subscriptionId = _options.SubscriptionId ?? throw new MissingConfigurationException("An Azure subscription id is required. Set the Azure:SubscriptionId configuration value.");
+
+        var credential = holder.Credential;
+
+        holder.LogCredentialType();
 
         var armClient = new ArmClient(credential, subscriptionId);
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/TokenCredentialHolder.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/TokenCredentialHolder.cs
@@ -10,8 +10,12 @@ namespace Aspire.Hosting.Azure.Provisioning;
 
 internal class TokenCredentialHolder
 {
+    private readonly ILogger<TokenCredentialHolder> _logger;
+
     public TokenCredentialHolder(ILogger<TokenCredentialHolder> logger, IOptions<AzureProvisionerOptions> options)
     {
+        _logger = logger;
+
         // Optionally configured in AppHost appSettings under "Azure" : { "CredentialSource": "AzureCli" }
         var credentialSetting = options.Value.CredentialSource;
 
@@ -32,19 +36,22 @@ internal class TokenCredentialHolder
             })
         };
 
-        if (credential.GetType() == typeof(DefaultAzureCredential))
+        Credential = credential;
+    }
+
+    public TokenCredential Credential { get; }
+
+    internal void LogCredentialType()
+    {
+        if (Credential.GetType() == typeof(DefaultAzureCredential))
         {
-            logger.LogInformation(
+            _logger.LogInformation(
                 "Using DefaultAzureCredential for provisioning. This may not work in all environments. " +
                 "See https://aka.ms/azsdk/net/identity/credential-chains#defaultazurecredential-overview for more information.");
         }
         else
         {
-            logger.LogInformation("Using {credentialType} for provisioning.", credential.GetType().Name);
+            _logger.LogInformation("Using {credentialType} for provisioning.", Credential.GetType().Name);
         }
-
-        Credential = credential;
     }
-
-    public TokenCredential Credential { get; }
 }


### PR DESCRIPTION
## Description

[This change](https://github.com/dotnet/aspire/pull/8751) introduced some excess logging every time an azure resource is used. Only log when actually using the credential (as it was before).

Fixes #8905

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
