### PR TITLE
Increase page size for NuGet package search

### DIFF
--- a/src/Aspire.Cli/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGetPackageCache.cs
@@ -16,7 +16,7 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, IDotN
 {
     private readonly ActivitySource _activitySource = new(nameof(NuGetPackageCache));
 
-    private const int SearchPageSize = 100;
+    private const int SearchPageSize = 1000;
 
     public async Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, string? source, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Adjust the page size for NuGet package search results from 100 to 1000 to improve the efficiency of package retrieval. Current implementation had us launching dotnet package search multiple times. This reduces the chances we'll have to execute more than once in the medium term. Eventually we may need a more efficient mechanism here.

Actual package installation time is still ultimately constrained by NuGet package install time.

Related: #8370