### PR TITLE
Bubble exceptions out of publishers.

### DIFF
--- a/src/Aspire.Hosting/AppHostExitCodes.cs
+++ b/src/Aspire.Hosting/AppHostExitCodes.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+internal static class AppHostExitCodes
+{
+    public const int PublishFailure = 2;
+}

--- a/src/Aspire.Hosting/AppHostExitCodes.cs
+++ b/src/Aspire.Hosting/AppHostExitCodes.cs
@@ -1,9 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace Aspire.Hosting;
-
-internal static class AppHostExitCodes
-{
-    public const int PublishFailure = 2;
-}

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -72,6 +72,8 @@ internal sealed class DistributedApplicationRunner(ILogger<DistributedApplicatio
                     (status) => status with { IsError = true },
                     stoppingToken).ConfigureAwait(false);
 
+                Environment.ExitCode = AppHostExitCodes.PublishFailure;
+
                 if (!backchannelService.IsBackchannelExpected)
                 {
                      lifetime.StopApplication();

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -72,11 +72,9 @@ internal sealed class DistributedApplicationRunner(ILogger<DistributedApplicatio
                     (status) => status with { IsError = true },
                     stoppingToken).ConfigureAwait(false);
 
-                Environment.ExitCode = AppHostExitCodes.PublishFailure;
-
                 if (!backchannelService.IsBackchannelExpected)
                 {
-                     lifetime.StopApplication();
+                     throw new DistributedApplicationException($"Publishing failed exception message: {ex.Message}", ex);
                 }
             }
         }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationRunnerTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationRunnerTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class DistributedApplicationRunnerTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void EnsureFailingPublishResultsInNonZeroExitCode()
+    {
+        var args = new[] { "--publisher", "explodingpublisher" };
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper, args);
+        using var app = builder.Build();
+
+        Assert.Equal(0, Environment.ExitCode);
+
+        app.Run();
+
+        Assert.Equal(AppHostExitCodes.PublishFailure, Environment.ExitCode);
+    }
+}
+
+internal sealed class ExplodingPublisher : IDistributedApplicationPublisher
+{
+    public Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException("Boom!");
+    }
+}


### PR DESCRIPTION
Fixes: #8852

Modifies the behavior of `DistributedApplicationRunner` so that it throws an exception. When used via the Aspire CLI this results in the exception being printed (and the progress indicator showing that it blew up).

![image](https://github.com/user-attachments/assets/ebb42880-5a48-4585-9be4-3d5cffbc547d)

When the publisher is executed via `dotnet` the exit code is set (default .NET behavior when an exception bubbles out):

```
@mitchdenny ➜ .../aspire/playground/publishers/Publishers.AppHost (mitchdenny/make-failing-publisher-exit-non-zero) $ dotnet run -- --publisher explodingpublisher --output-path foo
Using launch settings from /workspaces/aspire/playground/publishers/Publishers.AppHost/Properties/launchSettings.json...
Building...
info: Aspire.Hosting.DistributedApplication[0]
      Aspire version: 9.3.0-dev
fail: Aspire.Hosting.DistributedApplicationRunner[0]
      Failed to publish the distributed application.
      System.NotImplementedException: Boom!
         at ExplodingPublisher.PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken) in /workspaces/aspire/playground/publishers/Publishers.AppHost/Program.cs:line 83
         at Aspire.Hosting.DistributedApplicationRunner.ExecuteAsync(CancellationToken stoppingToken) in /workspaces/aspire/src/Aspire.Hosting/DistributedApplicationRunner.cs:line 46
fail: Microsoft.Extensions.Hosting.Internal.Host[11]
      Hosting failed to start
      Aspire.Hosting.DistributedApplicationException: Publishing failed exception message: Boom!
       ---> System.NotImplementedException: Boom!
         at ExplodingPublisher.PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken) in /workspaces/aspire/playground/publishers/Publishers.AppHost/Program.cs:line 83
         at Aspire.Hosting.DistributedApplicationRunner.ExecuteAsync(CancellationToken stoppingToken) in /workspaces/aspire/src/Aspire.Hosting/DistributedApplicationRunner.cs:line 46
         --- End of inner exception stack trace ---
         at Aspire.Hosting.DistributedApplicationRunner.ExecuteAsync(CancellationToken stoppingToken) in /workspaces/aspire/src/Aspire.Hosting/DistributedApplicationRunner.cs:line 77
         at Microsoft.Extensions.Hosting.Internal.Host.<StartAsync>b__15_1(IHostedService service, CancellationToken token)
         at Microsoft.Extensions.Hosting.Internal.Host.ForeachService[T](IEnumerable`1 services, CancellationToken token, Boolean concurrent, Boolean abortOnFirstException, List`1 exceptions, Func`3 operation)
Unhandled exception. System.AggregateException: One or more errors occurred. (Publishing failed exception message: Boom!)
 ---> Aspire.Hosting.DistributedApplicationException: Publishing failed exception message: Boom!
 ---> System.NotImplementedException: Boom!
   at ExplodingPublisher.PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken) in /workspaces/aspire/playground/publishers/Publishers.AppHost/Program.cs:line 83
   at Aspire.Hosting.DistributedApplicationRunner.ExecuteAsync(CancellationToken stoppingToken) in /workspaces/aspire/src/Aspire.Hosting/DistributedApplicationRunner.cs:line 46
   --- End of inner exception stack trace ---
   at Aspire.Hosting.DistributedApplicationRunner.ExecuteAsync(CancellationToken stoppingToken) in /workspaces/aspire/src/Aspire.Hosting/DistributedApplicationRunner.cs:line 77
   at Microsoft.Extensions.Hosting.Internal.Host.<StartAsync>b__15_1(IHostedService service, CancellationToken token)
   at Microsoft.Extensions.Hosting.Internal.Host.ForeachService[T](IEnumerable`1 services, CancellationToken token, Boolean concurrent, Boolean abortOnFirstException, List`1 exceptions, Func`3 operation)
   at Microsoft.Extensions.Hosting.Internal.Host.StartAsync(CancellationToken cancellationToken)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
   at Aspire.Hosting.DistributedApplication.RunAsync(CancellationToken cancellationToken) in /workspaces/aspire/src/Aspire.Hosting/DistributedApplication.cs:line 415
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Aspire.Hosting.DistributedApplication.Run() in /workspaces/aspire/src/Aspire.Hosting/DistributedApplication.cs:line 443
   at Program.<Main>$(String[] args) in /workspaces/aspire/playground/publishers/Publishers.AppHost/Program.cs:line 77
```

This means the exit code is correctly set for folks that are scripting things this way vs. aspire CLI.