### PR TITLE
Change settable injection properties to init

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -18,16 +18,16 @@ public partial class ResourceActions : ComponentBase
     private AspireMenuButton? _menuButton;
 
     [Inject]
-    public required IStringLocalizer<Resources.Resources> Loc { get; set; }
+    public required IStringLocalizer<Resources.Resources> Loc { get; init; }
 
     [Inject]
-    public required IStringLocalizer<Resources.ControlsStrings> ControlLoc { get; set; }
+    public required IStringLocalizer<Resources.ControlsStrings> ControlLoc { get; init; }
 
     [Inject]
-    public required NavigationManager NavigationManager { get; set; }
+    public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; set; }
+    public required TelemetryRepository TelemetryRepository { get; init; }
 
     [Parameter]
     public required EventCallback<CommandViewModel> CommandSelected { get; set; }

--- a/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
@@ -19,10 +19,10 @@ public partial class SpanActions : ComponentBase
     private AspireMenuButton? _menuButton;
 
     [Inject]
-    public required IStringLocalizer<Resources.ControlsStrings> ControlsLoc { get; set; }
+    public required IStringLocalizer<Resources.ControlsStrings> ControlsLoc { get; init; }
 
     [Inject]
-    public required NavigationManager NavigationManager { get; set; }
+    public required NavigationManager NavigationManager { get; init; }
 
     [Parameter]
     public required EventCallback<string> OnViewDetails { get; set; }

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
@@ -19,16 +19,16 @@ public partial class StructuredLogActions : ComponentBase
     private AspireMenuButton? _menuButton;
 
     [Inject]
-    public required IStringLocalizer<Resources.StructuredLogs> Loc { get; set; }
+    public required IStringLocalizer<Resources.StructuredLogs> Loc { get; init; }
 
     [Inject]
-    public required IStringLocalizer<Resources.ControlsStrings> ControlsLoc { get; set; }
+    public required IStringLocalizer<Resources.ControlsStrings> ControlsLoc { get; init; }
 
     [Inject]
-    public required IStringLocalizer<Resources.Dialogs> DialogsLoc { get; set; }
+    public required IStringLocalizer<Resources.Dialogs> DialogsLoc { get; init; }
 
     [Inject]
-    public required IDialogService DialogService { get; set; }
+    public required IDialogService DialogService { get; init; }
 
     [Parameter]
     public required EventCallback<string> OnViewDetails { get; set; }

--- a/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
@@ -19,10 +19,10 @@ public partial class TraceActions : ComponentBase
     private AspireMenuButton? _menuButton;
 
     [Inject]
-    public required IStringLocalizer<Resources.ControlsStrings> ControlsLoc { get; set; }
+    public required IStringLocalizer<Resources.ControlsStrings> ControlsLoc { get; init; }
 
     [Inject]
-    public required NavigationManager NavigationManager { get; set; }
+    public required NavigationManager NavigationManager { get; init; }
 
     [Parameter]
     public required OtlpTrace Trace { get; set; }


### PR DESCRIPTION
There isn't any difference in runtime behavior. This just makes code more consistent by always using init properties for DI injection properties.