### PR TITLE
Revert "#8488 Fixes Aspire.Dashboard.Tests (#8953)"

### DIFF
--- a/tests/Aspire.Dashboard.Tests/ChannelExtensionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ChannelExtensionsTests.cs
@@ -29,7 +29,7 @@ public class ChannelExtensionsTests
                 readBatch = batch;
                 cts.Cancel();
             }
-        }, TestContext.Current.CancellationToken);
+        });
 
         // Assert
         await TaskHelpers.WaitIgnoreCancelAsync(readTask).DefaultTimeout();
@@ -53,7 +53,7 @@ public class ChannelExtensionsTests
                 readBatch = batch;
                 cts.Cancel();
             }
-        }, TestContext.Current.CancellationToken);
+        });
 
         // Assert
         await TaskHelpers.WaitIgnoreCancelAsync(readTask).DefaultTimeout();
@@ -84,16 +84,16 @@ public class ChannelExtensionsTests
             {
                 resultChannel.Writer.Complete();
             }
-        }, TestContext.Current.CancellationToken);
+        });
 
         // Assert
         var stopwatch = Stopwatch.StartNew();
-        var read1 = await resultChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        var read1 = await resultChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(["a", "b", "c"], read1.Single());
 
         channel.Writer.TryWrite(["d", "e", "f"]);
 
-        var read2 = await resultChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        var read2 = await resultChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(["d", "e", "f"], read2.Single());
 
         var elapsed = stopwatch.Elapsed;
@@ -128,16 +128,16 @@ public class ChannelExtensionsTests
             {
                 resultChannel.Writer.Complete();
             }
-        }, TestContext.Current.CancellationToken);
+        });
 
         // Assert
         var stopwatch = Stopwatch.StartNew();
-        var read1 = await resultChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        var read1 = await resultChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(["a", "b", "c"], read1.Single());
 
         channel.Writer.TryWrite(["d", "e", "f"]);
 
-        var read2Task = resultChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        var read2Task = resultChannel.Reader.ReadAsync().DefaultTimeout();
         cts.Cancel();
 
         await TaskHelpers.WaitIgnoreCancelAsync(readTask).DefaultTimeout();

--- a/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
@@ -42,7 +42,7 @@ public sealed class DashboardClientAuthTests
         await using var server = await CreateResourceServiceServerAsync(loggerFactory, useHttps).DefaultTimeout();
         await using var client = await CreateDashboardClientAsync(loggerFactory, server.Url, authMode: ResourceClientAuthMode.Unsecured).DefaultTimeout();
 
-        var call = await server.Calls.ApplicationInformationCallsChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        var call = await server.Calls.ApplicationInformationCallsChannel.Reader.ReadAsync().DefaultTimeout();
 
         Assert.NotNull(call.Request);
         Assert.NotNull(call.RequestHeaders);
@@ -58,7 +58,7 @@ public sealed class DashboardClientAuthTests
         await using var server = await CreateResourceServiceServerAsync(loggerFactory, useHttps).DefaultTimeout();
         await using var client = await CreateDashboardClientAsync(loggerFactory, server.Url, authMode: ResourceClientAuthMode.ApiKey, configureOptions: options => options.ResourceServiceClient.ApiKey = "TestApiKey!").DefaultTimeout();
 
-        var call = await server.Calls.ApplicationInformationCallsChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        var call = await server.Calls.ApplicationInformationCallsChannel.Reader.ReadAsync().DefaultTimeout();
 
         Assert.NotNull(call.Request);
         Assert.NotNull(call.RequestHeaders);

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -34,12 +34,12 @@ public class FrontendBrowserTokenAuthTests
             config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
             config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
-        var response = await client.GetAsync("/", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await client.GetAsync("/").DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -56,19 +56,19 @@ public class FrontendBrowserTokenAuthTests
             config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
             config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act 1
-        var response1 = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey), TestContext.Current.CancellationToken).DefaultTimeout();
+        var response1 = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey)).DefaultTimeout();
 
         // Assert 1
         Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
         Assert.Equal(DashboardUrls.TracesUrl(), response1.RequestMessage!.RequestUri!.PathAndQuery);
 
         // Act 2
-        var response2 = await client.GetAsync(DashboardUrls.StructuredLogsUrl(), TestContext.Current.CancellationToken).DefaultTimeout();
+        var response2 = await client.GetAsync(DashboardUrls.StructuredLogsUrl()).DefaultTimeout();
 
         // Assert 2
         Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
@@ -87,12 +87,12 @@ public class FrontendBrowserTokenAuthTests
             config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
             config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
         }, testSink: testSink);
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var client = new HttpClient { BaseAddress = new Uri($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}") };
 
         // Act
-        var response = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey), TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey)).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -111,12 +111,12 @@ public class FrontendBrowserTokenAuthTests
             config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
             config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
-        var response = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: "Wrong!"), TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: "Wrong!")).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -136,19 +136,19 @@ public class FrontendBrowserTokenAuthTests
             config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = authMode.ToString();
             config[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
-        var response = await client.PostAsync("/api/validatetoken?token=" + requestToken, content: null, TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await client.PostAsync("/api/validatetoken?token=" + requestToken, content: null).DefaultTimeout();
 
         // Assert
         Assert.Equal(statusCode, response.StatusCode);
 
         if (result != null)
         {
-            var actualResult = await response.Content.ReadFromJsonAsync<bool>(TestContext.Current.CancellationToken);
+            var actualResult = await response.Content.ReadFromJsonAsync<bool>();
             Assert.Equal(result, actualResult);
         }
     }
@@ -164,7 +164,7 @@ public class FrontendBrowserTokenAuthTests
         }, testSink: testSink);
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         // Assert
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
@@ -225,7 +225,7 @@ public class FrontendBrowserTokenAuthTests
         }, testSink: testSink);
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         // Assert
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
@@ -252,7 +252,7 @@ public class FrontendBrowserTokenAuthTests
         }, testSink: testSink);
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         // Assert
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
@@ -25,7 +25,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
                 ConfigureOpenIdConnect(config, authority);
             });
 
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var handler = new HttpClientHandler()
         {
@@ -36,7 +36,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
         using var client = new HttpClient(handler) { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
-        var response = await client.GetAsync("/", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await client.GetAsync("/").DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
@@ -53,7 +53,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("code", query.Get("response_type"));
         Assert.Equal("openid profile", query.Get("scope"));
 
-        await app.StopAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
             },
             testSink: testSink);
 
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var handler = new HttpClientHandler()
         {
@@ -81,7 +81,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
         using var client = new HttpClient(handler) { BaseAddress = new Uri($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}") };
 
         // Act
-        var response = await client.GetAsync("/", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await client.GetAsync("/").DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -89,7 +89,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
         var log = testSink.Writes.Single(s => s.LoggerName == typeof(FrontendCompositeAuthenticationHandler).FullName && s.EventId.Name == "AuthenticationSchemeNotAuthenticatedWithFailure");
         Assert.Equal("FrontendComposite was not authenticated. Failure message: Connection type Frontend is not enabled on this connection.", log.Message);
 
-        await app.StopAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StopAsync().DefaultTimeout();
     }
 
     private static void ConfigureOpenIdConnect(Dictionary<string, string?> config, MockOpenIdAuthority.Authority authority)

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpCorsHttpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpCorsHttpServiceTests.cs
@@ -22,7 +22,7 @@ public class OtlpCorsHttpServiceTests
     {
         // Arrange
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper);
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
@@ -32,7 +32,7 @@ public class OtlpCorsHttpServiceTests
         preflightRequest.Headers.TryAddWithoutValidation("Origin", "http://localhost:8000");
 
         // Act
-        var responseMessage = await httpClient.SendAsync(preflightRequest, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await httpClient.SendAsync(preflightRequest).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, responseMessage.StatusCode);
@@ -46,7 +46,7 @@ public class OtlpCorsHttpServiceTests
         {
             config[DashboardConfigNames.DashboardOtlpCorsAllowedOriginsKeyName.ConfigKey] = "http://localhost:8000, http://localhost:8001";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
@@ -56,7 +56,7 @@ public class OtlpCorsHttpServiceTests
         preflightRequest1.Headers.TryAddWithoutValidation("Access-Control-Request-Headers", "x-requested-with,x-custom,Content-Type");
         preflightRequest1.Headers.TryAddWithoutValidation("Origin", "http://localhost:8000");
 
-        var responseMessage1 = await httpClient.SendAsync(preflightRequest1, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage1 = await httpClient.SendAsync(preflightRequest1).DefaultTimeout();
 
         // Assert 1
         Assert.Equal(HttpStatusCode.NoContent, responseMessage1.StatusCode);
@@ -70,7 +70,7 @@ public class OtlpCorsHttpServiceTests
         preflightRequest2.Headers.TryAddWithoutValidation("Access-Control-Request-Headers", "x-requested-with,x-custom,Content-Type");
         preflightRequest2.Headers.TryAddWithoutValidation("Origin", "http://localhost:8001");
 
-        var responseMessage2 = await httpClient.SendAsync(preflightRequest2, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage2 = await httpClient.SendAsync(preflightRequest2).DefaultTimeout();
 
         // Assert 2
         Assert.Equal(HttpStatusCode.NoContent, responseMessage2.StatusCode);
@@ -87,7 +87,7 @@ public class OtlpCorsHttpServiceTests
         {
             config[DashboardConfigNames.DashboardOtlpCorsAllowedOriginsKeyName.ConfigKey] = "http://localhost:8000";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
@@ -97,7 +97,7 @@ public class OtlpCorsHttpServiceTests
         preflightRequest.Headers.TryAddWithoutValidation("Origin", "http://localhost:8001");
 
         // Act
-        var responseMessage = await httpClient.SendAsync(preflightRequest, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await httpClient.SendAsync(preflightRequest).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.NoContent, responseMessage.StatusCode);
@@ -115,7 +115,7 @@ public class OtlpCorsHttpServiceTests
             config[DashboardConfigNames.DashboardOtlpCorsAllowedOriginsKeyName.ConfigKey] = "*";
             config[DashboardConfigNames.DashboardOtlpCorsAllowedHeadersKeyName.ConfigKey] = "*";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
@@ -125,7 +125,7 @@ public class OtlpCorsHttpServiceTests
         preflightRequest.Headers.TryAddWithoutValidation("Origin", "http://localhost:8000");
 
         // Act
-        var responseMessage = await httpClient.SendAsync(preflightRequest, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await httpClient.SendAsync(preflightRequest).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.NoContent, responseMessage.StatusCode);

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
@@ -29,13 +29,13 @@ public class OtlpGrpcServiceTests
     {
         // Arrange
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper);
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel($"http://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}", _testOutputHelper);
         var client = new LogsService.LogsServiceClient(channel);
 
         // Act
-        var response = client.ExportAsync(new ExportLogsServiceRequest(), cancellationToken: TestContext.Current.CancellationToken);
+        var response = client.ExportAsync(new ExportLogsServiceRequest());
         var message = await response.ResponseAsync.DefaultTimeout();
         var headers = await response.ResponseHeadersAsync.DefaultTimeout();
 
@@ -54,13 +54,13 @@ public class OtlpGrpcServiceTests
             config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
             config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel($"http://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}", _testOutputHelper);
         var client = new LogsService.LogsServiceClient(channel);
 
         // Act
-        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), cancellationToken: TestContext.Current.CancellationToken).ResponseAsync).DefaultTimeout();
+        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest()).ResponseAsync).DefaultTimeout();
 
         // Assert
         Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);
@@ -76,7 +76,7 @@ public class OtlpGrpcServiceTests
             config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
             config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel($"http://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}", _testOutputHelper);
         var client = new LogsService.LogsServiceClient(channel);
@@ -87,7 +87,7 @@ public class OtlpGrpcServiceTests
         };
 
         // Act
-        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), metadata, cancellationToken: TestContext.Current.CancellationToken).ResponseAsync).DefaultTimeout();
+        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), metadata).ResponseAsync).DefaultTimeout();
 
         // Assert
         Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);
@@ -103,7 +103,7 @@ public class OtlpGrpcServiceTests
             config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
             config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel($"http://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}", _testOutputHelper);
         var client = new LogsService.LogsServiceClient(channel);
@@ -114,7 +114,7 @@ public class OtlpGrpcServiceTests
         };
 
         // Act
-        var response = await client.ExportAsync(new ExportLogsServiceRequest(), metadata, cancellationToken: TestContext.Current.CancellationToken).ResponseAsync.DefaultTimeout();
+        var response = await client.ExportAsync(new ExportLogsServiceRequest(), metadata).ResponseAsync.DefaultTimeout();
 
         // Assert
         Assert.Equal(0, response.PartialSuccess.RejectedLogRecords);
@@ -132,7 +132,7 @@ public class OtlpGrpcServiceTests
             config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
             config[DashboardConfigNames.DashboardOtlpSecondaryApiKeyName.ConfigKey] = secondaryApiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel($"http://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}", _testOutputHelper);
         var client = new LogsService.LogsServiceClient(channel);
@@ -143,7 +143,7 @@ public class OtlpGrpcServiceTests
         };
 
         // Act
-        var response = await client.ExportAsync(new ExportLogsServiceRequest(), metadata, cancellationToken: TestContext.Current.CancellationToken).ResponseAsync.DefaultTimeout();
+        var response = await client.ExportAsync(new ExportLogsServiceRequest(), metadata).ResponseAsync.DefaultTimeout();
 
         // Assert
         Assert.Equal(0, response.PartialSuccess.RejectedLogRecords);
@@ -173,13 +173,13 @@ public class OtlpGrpcServiceTests
             }
         };
         logger.LogInformation("Writing original JSON file.");
-        await File.WriteAllTextAsync(configPath, configJson.ToString(), TestContext.Current.CancellationToken).DefaultTimeout();
+        await File.WriteAllTextAsync(configPath, configJson.ToString()).DefaultTimeout();
 
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(loggerFactory, config =>
         {
             config[dashboardConfigFilePathNameKey] = configPath;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel($"http://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}", loggerFactory);
         var client = new LogsService.LogsServiceClient(channel);
@@ -190,7 +190,7 @@ public class OtlpGrpcServiceTests
         };
 
         // Act 1
-        var response1 = await client.ExportAsync(new ExportLogsServiceRequest(), metadata, cancellationToken: TestContext.Current.CancellationToken).ResponseAsync.DefaultTimeout();
+        var response1 = await client.ExportAsync(new ExportLogsServiceRequest(), metadata).ResponseAsync.DefaultTimeout();
 
         // Assert 1
         Assert.Equal(0, response1.PartialSuccess.RejectedLogRecords);
@@ -216,7 +216,7 @@ public class OtlpGrpcServiceTests
         };
 
         logger.LogInformation("Writing new JSON file.");
-        await File.WriteAllTextAsync(configPath, configJson.ToString(), TestContext.Current.CancellationToken).DefaultTimeout();
+        await File.WriteAllTextAsync(configPath, configJson.ToString()).DefaultTimeout();
 
         logger.LogInformation("Waiting for options change.");
         var options = await tcs.Task;
@@ -226,7 +226,7 @@ public class OtlpGrpcServiceTests
 
         // Act 2
         logger.LogInformation("Client sends new request with old API key.");
-        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), metadata, cancellationToken: TestContext.Current.CancellationToken).ResponseAsync).DefaultTimeout();
+        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), metadata).ResponseAsync).DefaultTimeout();
 
         // Assert 2
         Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);
@@ -243,7 +243,7 @@ public class OtlpGrpcServiceTests
             // Change dashboard to HTTPS so the caller can negotiate a HTTP/2 connection.
             config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel(
             $"https://{app.FrontendSingleEndPointAccessor().EndPoint}",
@@ -255,7 +255,7 @@ public class OtlpGrpcServiceTests
         var client = new LogsService.LogsServiceClient(channel);
 
         // Act
-        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), cancellationToken: TestContext.Current.CancellationToken).ResponseAsync).DefaultTimeout();
+        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest()).ResponseAsync).DefaultTimeout();
 
         // Assert
         Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);
@@ -274,13 +274,13 @@ public class OtlpGrpcServiceTests
 
             config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ClientCertificate.ToString();
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel($"https://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}", _testOutputHelper);
         var client = new LogsService.LogsServiceClient(channel);
 
         // Act
-        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), cancellationToken: TestContext.Current.CancellationToken).ResponseAsync).DefaultTimeout();
+        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest()).ResponseAsync).DefaultTimeout();
 
         // Assert
         // StatusCode can change depending upon order of execution inside HttpClient.
@@ -308,7 +308,7 @@ public class OtlpGrpcServiceTests
             config["Dashboard:Otlp:CertificateAuthOptions:AllowedCertificateTypes"] = "SelfSigned";
             config["Dashboard:Otlp:CertificateAuthOptions:ValidateValidityPeriod"] = "false";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var clientCertificate = TestCertificateLoader.GetTestCertificate("eku.client.pfx");
         using var channel = IntegrationTestHelpers.CreateGrpcChannel(
@@ -319,7 +319,7 @@ public class OtlpGrpcServiceTests
         var client = new LogsService.LogsServiceClient(channel);
 
         // Act
-        var response = await client.ExportAsync(new ExportLogsServiceRequest(), cancellationToken: TestContext.Current.CancellationToken).ResponseAsync.DefaultTimeout();
+        var response = await client.ExportAsync(new ExportLogsServiceRequest()).ResponseAsync.DefaultTimeout();
 
         // Assert
         Assert.Equal(0, response.PartialSuccess.RejectedLogRecords);
@@ -345,7 +345,7 @@ public class OtlpGrpcServiceTests
             config["Dashboard:Otlp:CertificateAuthOptions:AllowedCertificateTypes"] = "SelfSigned";
             config["Dashboard:Otlp:CertificateAuthOptions:ValidateValidityPeriod"] = "false";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel(
             $"https://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}",
@@ -359,7 +359,7 @@ public class OtlpGrpcServiceTests
         var client = new LogsService.LogsServiceClient(channel);
 
         // Act
-        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), cancellationToken: TestContext.Current.CancellationToken).ResponseAsync).DefaultTimeout();
+        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest()).ResponseAsync).DefaultTimeout();
 
         // Assert
         Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);
@@ -383,7 +383,7 @@ public class OtlpGrpcServiceTests
             config["Authentication:Schemes:Certificate:AllowedCertificateTypes"] = "SelfSigned";
             config["Authentication:Schemes:Certificate:ValidateValidityPeriod"] = "false";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var clientCertificates = new X509CertificateCollection(new[] { TestCertificateLoader.GetTestCertificate("eku.client.pfx") });
         using var channel = IntegrationTestHelpers.CreateGrpcChannel(
@@ -398,7 +398,7 @@ public class OtlpGrpcServiceTests
         var client = new LogsService.LogsServiceClient(channel);
 
         // Act
-        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), cancellationToken: TestContext.Current.CancellationToken).ResponseAsync).DefaultTimeout();
+        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest()).ResponseAsync).DefaultTimeout();
 
         // Assert
         Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
@@ -33,7 +33,7 @@ public class OtlpHttpServiceTests
     {
         // Arrange
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper);
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
@@ -43,10 +43,10 @@ public class OtlpHttpServiceTests
         content.Headers.TryAddWithoutValidation("content-type", OtlpHttpEndpointsBuilder.ProtobufContentType);
 
         // Act
-        var responseMessage = await httpClient.PostAsync("/v1/logs", content, TestContext.Current.CancellationToken).DefaultTimeout(TestConstants.LongTimeoutDuration);
+        var responseMessage = await httpClient.PostAsync("/v1/logs", content).DefaultTimeout(TestConstants.LongTimeoutDuration);
         responseMessage.EnsureSuccessStatusCode();
 
-        var response = ExportLogsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken).DefaultTimeout());
+        var response = ExportLogsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync().DefaultTimeout());
 
         // Assert
         Assert.Equal(OtlpHttpEndpointsBuilder.ProtobufContentType, responseMessage.Content.Headers.GetValues("content-type").Single());
@@ -59,7 +59,7 @@ public class OtlpHttpServiceTests
     {
         // Arrange
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper);
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
@@ -69,7 +69,7 @@ public class OtlpHttpServiceTests
         content.Headers.TryAddWithoutValidation("content-type", OtlpHttpEndpointsBuilder.ProtobufContentType);
 
         // Act
-        var responseMessage = await httpClient.PostAsync("/v1/logs", content, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await httpClient.PostAsync("/v1/logs", content).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, responseMessage.StatusCode);
@@ -105,7 +105,7 @@ public class OtlpHttpServiceTests
             config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
             config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
@@ -113,7 +113,7 @@ public class OtlpHttpServiceTests
         content.Headers.TryAddWithoutValidation("content-type", OtlpHttpEndpointsBuilder.ProtobufContentType);
 
         // Act
-        var responseMessage = await httpClient.PostAsync("/v1/logs", content, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await httpClient.PostAsync("/v1/logs", content).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.Unauthorized, responseMessage.StatusCode);
@@ -129,7 +129,7 @@ public class OtlpHttpServiceTests
             config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
             config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
@@ -141,7 +141,7 @@ public class OtlpHttpServiceTests
         requestMessage.Headers.TryAddWithoutValidation(OtlpApiKeyAuthenticationHandler.ApiKeyHeaderName, "WRONG");
 
         // Act
-        var responseMessage = await httpClient.SendAsync(requestMessage, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await httpClient.SendAsync(requestMessage).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.Unauthorized, responseMessage.StatusCode);
@@ -157,7 +157,7 @@ public class OtlpHttpServiceTests
             config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
             config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
@@ -169,10 +169,10 @@ public class OtlpHttpServiceTests
         requestMessage.Headers.TryAddWithoutValidation(OtlpApiKeyAuthenticationHandler.ApiKeyHeaderName, apiKey);
 
         // Act
-        var responseMessage = await httpClient.SendAsync(requestMessage, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await httpClient.SendAsync(requestMessage).DefaultTimeout();
         responseMessage.EnsureSuccessStatusCode();
 
-        var response = ExportLogsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken).DefaultTimeout());
+        var response = ExportLogsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync().DefaultTimeout());
 
         // Assert
         Assert.Equal(OtlpHttpEndpointsBuilder.ProtobufContentType, responseMessage.Content.Headers.GetValues("content-type").Single());
@@ -191,7 +191,7 @@ public class OtlpHttpServiceTests
             // Change dashboard to HTTPS so the caller can negotiate a HTTP/2 connection.
             config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"https://{app.FrontendSingleEndPointAccessor().EndPoint}",
             validationCallback: cert =>
@@ -203,7 +203,7 @@ public class OtlpHttpServiceTests
         content.Headers.TryAddWithoutValidation("content-type", OtlpHttpEndpointsBuilder.ProtobufContentType);
 
         // Act
-        var responseMessage = await httpClient.PostAsync("/v1/logs", content, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await httpClient.PostAsync("/v1/logs", content).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.Unauthorized, responseMessage.StatusCode);
@@ -221,7 +221,7 @@ public class OtlpHttpServiceTests
         {
             dictionary[DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://127.0.0.1:0";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var endpoint = app.OtlpServiceHttpEndPointAccessor();
         using var client = new HttpClient { BaseAddress = new Uri($"http://{endpoint.EndPoint}") };
@@ -233,7 +233,7 @@ public class OtlpHttpServiceTests
         }
 
         // Act
-        var responseMessage = await client.PostAsync("/v1/logs", content, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await client.PostAsync("/v1/logs", content).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.UnsupportedMediaType, responseMessage.StatusCode);
@@ -249,7 +249,7 @@ public class OtlpHttpServiceTests
         {
             dictionary[DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://127.0.0.1:0";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var endpoint = app.OtlpServiceHttpEndPointAccessor();
         using var client = new HttpClient { BaseAddress = new Uri($"http://{endpoint.EndPoint}") };
@@ -260,7 +260,7 @@ public class OtlpHttpServiceTests
         requestMessage.Content = content;
 
         // Act
-        var responseMessage = await client.SendAsync(requestMessage, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await client.SendAsync(requestMessage).DefaultTimeout();
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, responseMessage.StatusCode);
@@ -274,7 +274,7 @@ public class OtlpHttpServiceTests
         {
             dictionary[DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://127.0.0.1:0";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var endpoint = app.OtlpServiceHttpEndPointAccessor();
         using var client = new HttpClient { BaseAddress = new Uri($"http://{endpoint.EndPoint}") };
@@ -283,11 +283,11 @@ public class OtlpHttpServiceTests
         using var content = new ByteArrayContent(request.ToByteArray());
         content.Headers.TryAddWithoutValidation("content-type", OtlpHttpEndpointsBuilder.ProtobufContentType);
 
-        var responseMessage = await client.PostAsync("/v1/logs", content, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await client.PostAsync("/v1/logs", content).DefaultTimeout();
         responseMessage.EnsureSuccessStatusCode();
 
         // Act
-        var response = ExportLogsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+        var response = ExportLogsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync());
 
         // Assert
         Assert.Equal(OtlpHttpEndpointsBuilder.ProtobufContentType, responseMessage.Content.Headers.GetValues("content-type").Single());
@@ -303,7 +303,7 @@ public class OtlpHttpServiceTests
         {
             dictionary[DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://127.0.0.1:0";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var endpoint = app.OtlpServiceHttpEndPointAccessor();
         using var client = new HttpClient { BaseAddress = new Uri($"http://{endpoint.EndPoint}") };
@@ -312,11 +312,11 @@ public class OtlpHttpServiceTests
         using var content = new ByteArrayContent(request.ToByteArray());
         content.Headers.TryAddWithoutValidation("content-type", OtlpHttpEndpointsBuilder.ProtobufContentType);
 
-        var responseMessage = await client.PostAsync("/v1/traces", content, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await client.PostAsync("/v1/traces", content).DefaultTimeout();
         responseMessage.EnsureSuccessStatusCode();
 
         // Act
-        var response = ExportTraceServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken).DefaultTimeout());
+        var response = ExportTraceServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync().DefaultTimeout());
 
         // Assert
         Assert.Equal(OtlpHttpEndpointsBuilder.ProtobufContentType, responseMessage.Content.Headers.GetValues("content-type").Single());
@@ -332,7 +332,7 @@ public class OtlpHttpServiceTests
         {
             dictionary[DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://127.0.0.1:0";
         });
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var endpoint = app.OtlpServiceHttpEndPointAccessor();
         using var client = new HttpClient { BaseAddress = new Uri($"http://{endpoint.EndPoint}") };
@@ -341,11 +341,11 @@ public class OtlpHttpServiceTests
         using var content = new ByteArrayContent(request.ToByteArray());
         content.Headers.TryAddWithoutValidation("content-type", OtlpHttpEndpointsBuilder.ProtobufContentType);
 
-        var responseMessage = await client.PostAsync("/v1/metrics", content, TestContext.Current.CancellationToken).DefaultTimeout();
+        var responseMessage = await client.PostAsync("/v1/metrics", content).DefaultTimeout();
         responseMessage.EnsureSuccessStatusCode();
 
         // Act
-        var response = ExportMetricsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken).DefaultTimeout());
+        var response = ExportMetricsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync().DefaultTimeout());
 
         // Assert
         Assert.Equal(OtlpHttpEndpointsBuilder.ProtobufContentType, responseMessage.Content.Headers.GetValues("content-type").Single());

--- a/tests/Aspire.Dashboard.Tests/Integration/ResponseCompressionTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ResponseCompressionTests.cs
@@ -16,7 +16,7 @@ public class ResponseCompressionTests(ITestOutputHelper testOutputHelper)
     {
         // Arrange
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper);
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClientHandler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.None };
         using var client = new HttpClient(httpClientHandler) { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
@@ -24,7 +24,7 @@ public class ResponseCompressionTests(ITestOutputHelper testOutputHelper)
         // Act 1
         var request = new HttpRequestMessage(HttpMethod.Get, DashboardUrls.StructuredLogsBasePath);
         request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("br"));
-        var response = await client.SendAsync(request, TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await client.SendAsync(request).DefaultTimeout();
 
         // Assert 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -38,7 +38,7 @@ public class ResponseCompressionTests(ITestOutputHelper testOutputHelper)
     {
         // Arrange
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper);
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var httpClientHandler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.None };
         using var client = new HttpClient(httpClientHandler) { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
@@ -46,7 +46,7 @@ public class ResponseCompressionTests(ITestOutputHelper testOutputHelper)
         // Act 1
         var request = new HttpRequestMessage(HttpMethod.Get, path);
         request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("br"));
-        var response = await client.SendAsync(request, TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await client.SendAsync(request).DefaultTimeout();
 
         // Assert 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -38,7 +38,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             });
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         // Assert
         Assert.Collection(app.FrontendEndPointsAccessor,
@@ -70,7 +70,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             });
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         // Assert,
         Assert.Collection(app.FrontendEndPointsAccessor,
@@ -208,7 +208,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             var initialBrowserTokenProvidedByConfiguration = localBuilder?.Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey];
 
             // update the browser token's config file and get the new value
-            await File.WriteAllTextAsync(browserTokenConfigFile, changedFrontendBrowserToken, TestContext.Current.CancellationToken).DefaultTimeout();
+            await File.WriteAllTextAsync(browserTokenConfigFile, changedFrontendBrowserToken).DefaultTimeout();
 
             // Assert
             Assert.Equal(initialFrontendBrowserToken, initialBrowserTokenProvidedByConfiguration);
@@ -257,7 +257,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             });
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(OtlpAuthMode.ApiKey, app.DashboardOptionsMonitor.CurrentValue.Otlp.AuthMode);
@@ -280,7 +280,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             });
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(8080, app.DashboardOptionsMonitor.CurrentValue.DebugSession.Port);
@@ -330,13 +330,13 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
                 BaseAddress = new Uri($"https://{app.FrontendSingleEndPointAccessor().EndPoint}")
             };
             var request = new HttpRequestMessage(HttpMethod.Get, "/");
-            var response = await httpClient.SendAsync(request, TestContext.Current.CancellationToken).DefaultTimeout();
+            var response = await httpClient.SendAsync(request).DefaultTimeout();
             response.EnsureSuccessStatusCode();
 
             // Check OTLP service
             using var channel = IntegrationTestHelpers.CreateGrpcChannel($"https://{app.FrontendSingleEndPointAccessor().EndPoint}", testOutputHelper);
             var client = new LogsService.LogsServiceClient(channel);
-            var serviceResponse = await client.ExportAsync(new ExportLogsServiceRequest(), cancellationToken: TestContext.Current.CancellationToken).ResponseAsync.DefaultTimeout();
+            var serviceResponse = await client.ExportAsync(new ExportLogsServiceRequest()).ResponseAsync.DefaultTimeout();
             Assert.Equal(0, serviceResponse.PartialSuccess.RejectedLogRecords);
         }
         finally
@@ -431,17 +431,17 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
                 BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}")
             };
             var request = new HttpRequestMessage(HttpMethod.Get, "/");
-            var responseMessage = await httpClient.SendAsync(request, TestContext.Current.CancellationToken).DefaultTimeout();
+            var responseMessage = await httpClient.SendAsync(request).DefaultTimeout();
             responseMessage.EnsureSuccessStatusCode();
 
             // Check OTLP service
             using var content = new ByteArrayContent(new ExportLogsServiceRequest().ToByteArray());
             content.Headers.TryAddWithoutValidation("content-type", OtlpHttpEndpointsBuilder.ProtobufContentType);
 
-            responseMessage = await httpClient.PostAsync("/v1/logs", content, TestContext.Current.CancellationToken);
+            responseMessage = await httpClient.PostAsync("/v1/logs", content);
             responseMessage.EnsureSuccessStatusCode();
 
-            var response = ExportLogsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken).DefaultTimeout());
+            var response = ExportLogsServiceResponse.Parser.ParseFrom(await responseMessage.Content.ReadAsByteArrayAsync().DefaultTimeout());
 
             Assert.Equal(OtlpHttpEndpointsBuilder.ProtobufContentType, responseMessage.Content.Headers.GetValues("content-type").Single());
             Assert.False(responseMessage.Headers.Contains("content-security-policy"));
@@ -485,7 +485,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             });
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(FrontendAuthMode.Unsecured, app.DashboardOptionsMonitor.CurrentValue.Frontend.AuthMode);
@@ -526,7 +526,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             clearLogFilterRules: false);
 
         // Assert
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         var options = app.Services.GetRequiredService<IOptions<LoggerFilterOptions>>();
 
@@ -554,7 +554,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
                 }
             }
         };
-        await File.WriteAllTextAsync(configFilePath, configJson.ToString(), TestContext.Current.CancellationToken).DefaultTimeout();
+        await File.WriteAllTextAsync(configFilePath, configJson.ToString()).DefaultTimeout();
 
         try
         {
@@ -567,7 +567,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
                 clearLogFilterRules: false);
 
             // Assert
-            await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+            await app.StartAsync().DefaultTimeout();
 
             var options = app.Services.GetRequiredService<IOptions<LoggerFilterOptions>>();
 
@@ -589,7 +589,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper, testSink: testSink);
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         // Assert
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
@@ -721,12 +721,12 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper);
 
         // Act
-        await app.StartAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        await app.StartAsync().DefaultTimeout();
 
         using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
-        var response = await client.GetAsync("/", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await client.GetAsync("/").DefaultTimeout();
 
         // Assert
         response.EnsureSuccessStatusCode();

--- a/tests/Aspire.Dashboard.Tests/Middleware/ValidateTokenMiddlewareTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Middleware/ValidateTokenMiddlewareTests.cs
@@ -19,7 +19,7 @@ public class ValidateTokenMiddlewareTests
     public async Task ValidateToken_NotBrowserTokenAuth_RedirectedToHomepage()
     {
         using var host = await SetUpHostAsync(FrontendAuthMode.Unsecured, string.Empty).DefaultTimeout();
-        var response = await host.GetTestClient().GetAsync("/login?t=test", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await host.GetTestClient().GetAsync("/login?t=test").DefaultTimeout();
         Assert.Equal("/", response.Headers.Location?.OriginalString);
     }
 
@@ -27,7 +27,7 @@ public class ValidateTokenMiddlewareTests
     public async Task ValidateToken_NotBrowserTokenAuth_RedirectedToReturnUrl()
     {
         using var host = await SetUpHostAsync(FrontendAuthMode.Unsecured, string.Empty).DefaultTimeout();
-        var response = await host.GetTestClient().GetAsync("/login?t=test&returnUrl=/test", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await host.GetTestClient().GetAsync("/login?t=test&returnUrl=/test").DefaultTimeout();
         Assert.Equal("/test", response.Headers.Location?.OriginalString);
     }
 
@@ -35,7 +35,7 @@ public class ValidateTokenMiddlewareTests
     public async Task ValidateToken_BrowserTokenAuth_WrongToken_RedirectsToLogin()
     {
         using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token").DefaultTimeout();
-        var response = await host.GetTestClient().GetAsync("/login?t=wrong", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await host.GetTestClient().GetAsync("/login?t=wrong").DefaultTimeout();
         Assert.Equal("/login", response.Headers.Location?.OriginalString);
     }
 
@@ -43,7 +43,7 @@ public class ValidateTokenMiddlewareTests
     public async Task ValidateToken_BrowserTokenAuth_WrongToken_RedirectsToLogin_WithReturnUrl()
     {
         using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token").DefaultTimeout();
-        var response = await host.GetTestClient().GetAsync("/login?t=wrong&returnUrl=/test", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await host.GetTestClient().GetAsync("/login?t=wrong&returnUrl=/test").DefaultTimeout();
         Assert.Equal("/login?returnUrl=%2ftest", response.Headers.Location?.OriginalString);
     }
 
@@ -51,7 +51,7 @@ public class ValidateTokenMiddlewareTests
     public async Task ValidateToken_BrowserTokenAuth_RightToken_RedirectsToHome()
     {
         using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token").DefaultTimeout();
-        var response = await host.GetTestClient().GetAsync("/login?t=token", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await host.GetTestClient().GetAsync("/login?t=token").DefaultTimeout();
         Assert.Equal("/", response.Headers.Location?.OriginalString);
     }
 
@@ -59,7 +59,7 @@ public class ValidateTokenMiddlewareTests
     public async Task ValidateToken_BrowserTokenAuth_RightToken_RedirectsToReturnUrl()
     {
         using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token").DefaultTimeout();
-        var response = await host.GetTestClient().GetAsync("/login?t=token&returnUrl=/test", TestContext.Current.CancellationToken).DefaultTimeout();
+        var response = await host.GetTestClient().GetAsync("/login?t=token&returnUrl=/test").DefaultTimeout();
         Assert.Equal("/test", response.Headers.Location?.OriginalString);
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -57,7 +57,7 @@ public sealed class DashboardClientTests
             await foreach (var item in subscription.WithCancellation(cts.Token))
             {
             }
-        }, TestContext.Current.CancellationToken);
+        });
 
         cts.Cancel();
 
@@ -85,7 +85,7 @@ public sealed class DashboardClientTests
             await foreach (var item in subscription)
             {
             }
-        }, TestContext.Current.CancellationToken);
+        });
 
         await instance.DisposeAsync().DefaultTimeout();
 

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -138,38 +138,38 @@ public class ResourceOutgoingPeerResolverTests
         // Initial resource causes change.
         tcs.SetResult(new ResourceViewModelSubscription(
             [CreateResource("test", serviceAddress: "localhost", servicePort: 8080)],
-            GetChanges(TestContext.Current.CancellationToken)));
+            GetChanges()));
 
         // Assert 1
-        readValue = await resultChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        readValue = await resultChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(1, readValue);
 
         // Act 2
         // New resource causes change.
-        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2", serviceAddress: "localhost", servicePort: 8080, state: KnownResourceState.Starting)), TestContext.Current.CancellationToken);
+        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2", serviceAddress: "localhost", servicePort: 8080, state: KnownResourceState.Starting)));
 
         // Assert 2
-        readValue = await resultChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        readValue = await resultChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(2, readValue);
 
         // Act 3
         // URL change causes change.
-        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2", serviceAddress: "localhost", servicePort: 8081, state: KnownResourceState.Starting)), TestContext.Current.CancellationToken);
+        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2", serviceAddress: "localhost", servicePort: 8081, state: KnownResourceState.Starting)));
 
         // Assert 3
-        readValue = await resultChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        readValue = await resultChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(3, readValue);
 
         // Act 4
         // Resource update doesn't cause change.
-        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2", serviceAddress: "localhost", servicePort: 8081, state: KnownResourceState.Running)), TestContext.Current.CancellationToken);
+        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2", serviceAddress: "localhost", servicePort: 8081, state: KnownResourceState.Running)));
 
         // Dispose so that we know that all changes are processed.
         await resolver.DisposeAsync().DefaultTimeout();
         resultChannel.Writer.Complete();
 
         // Assert 4
-        Assert.False(await resultChannel.Reader.WaitToReadAsync(TestContext.Current.CancellationToken).DefaultTimeout());
+        Assert.False(await resultChannel.Reader.WaitToReadAsync().DefaultTimeout());
         Assert.Equal(3, changeCount);
 
         async IAsyncEnumerable<IReadOnlyList<ResourceViewModelChange>> GetChanges([EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/tests/Aspire.Dashboard.Tests/Telemetry/DashboardTelemetryServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Telemetry/DashboardTelemetryServiceTests.cs
@@ -65,7 +65,7 @@ public class DashboardTelemetryServiceTests(ITestOutputHelper output)
         await sender.DisposeAsync();
 
         var count = 0;
-        await foreach (var item in sender.ContextChannel.Reader.ReadAllAsync(TestContext.Current.CancellationToken))
+        await foreach (var item in sender.ContextChannel.Reader.ReadAllAsync())
         {
             count++;
         }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -601,7 +601,7 @@ public class LogTests
                         }
                     }
                 });
-            }, TestContext.Current.CancellationToken);
+            });
         }
 
         await task.DefaultTimeout();
@@ -745,7 +745,7 @@ public class LogTests
         });
 
         // Assert
-        var read1 = await resultChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        var read1 = await resultChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(1, read1);
         logger.LogInformation("Received log 1 callback");
 
@@ -766,7 +766,7 @@ public class LogTests
             }
         });
 
-        var read2 = await resultChannel.Reader.ReadAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+        var read2 = await resultChannel.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(2, read2);
         logger.LogInformation("Received log 2 callback");
 


### PR DESCRIPTION
This reverts commit ad2c8b3e912bc9df3152dad984c9eca2929b1c14.

Revert https://github.com/dotnet/aspire/pull/8953

Appreciate @illay1994 work, but it's not clear this is a net improvement over disabling the warnings. We need to think about this holistically. We should only take a change like this if it helps the tests functionally so much that it's worth the code ugliness. Which is unlikely.
