### PR TITLE
[tests] Fix flaky tests `NodeFunctionalTests.VerifyNodeAppWorks` and ``NodeFunctionalTests.VerifyNpmApp`

### DIFF
--- a/tests/Aspire.Hosting.NodeJs.Tests/AddNodeAppTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/AddNodeAppTests.cs
@@ -11,7 +11,7 @@ public class AddNodeAppTests
     [Fact]
     public async Task VerifyManifest()
     {
-        using var builder = TestDistributedApplicationBuilder.Create();
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var workingDirectory = AppContext.BaseDirectory;
         var nodeApp = builder.AddNodeApp("nodeapp", "..\\foo\\app.js", workingDirectory)
@@ -45,6 +45,7 @@ public class AddNodeAppTests
 
         var npmApp = builder.AddNpmApp("npmapp", workingDirectory)
             .WithHttpEndpoint(port: 5032, env: "PORT");
+
         manifest = await ManifestUtils.GetManifest(npmApp.Resource);
 
         expectedManifest = $$"""

--- a/tests/Aspire.Hosting.NodeJs.Tests/Aspire.Hosting.NodeJs.Tests.csproj
+++ b/tests/Aspire.Hosting.NodeJs.Tests/Aspire.Hosting.NodeJs.Tests.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
+
     <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.NodeJs\Aspire.Hosting.NodeJs.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />

--- a/tests/Aspire.Hosting.NodeJs.Tests/NodeFunctionalTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/NodeFunctionalTests.cs
@@ -4,6 +4,7 @@
 using Aspire.TestUtilities;
 using Aspire.Hosting.Testing;
 using Xunit;
+using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Hosting.NodeJs.Tests;
 
@@ -22,7 +23,7 @@ public class NodeFunctionalTests : IClassFixture<NodeAppFixture>
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/8920")]
     public async Task VerifyNodeAppWorks()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        using var cts = new CancellationTokenSource(TestConstants.LongTimeoutDuration);
         using var nodeClient = _nodeJsFixture.App.CreateHttpClient(_nodeJsFixture.NodeAppBuilder!.Resource.Name, "http");
         var response = await nodeClient.GetStringAsync("/", cts.Token);
 
@@ -35,7 +36,7 @@ public class NodeFunctionalTests : IClassFixture<NodeAppFixture>
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/8870")]
     public async Task VerifyNpmAppWorks()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        using var cts = new CancellationTokenSource(TestConstants.LongTimeoutDuration);
         using var npmClient = _nodeJsFixture.App.CreateHttpClient(_nodeJsFixture.NpmAppBuilder!.Resource.Name, "http");
         var response = await npmClient.GetStringAsync("/", cts.Token);
 


### PR DESCRIPTION
- **AddNodeAppTests: Ensure the app builder cleans up after itself**

    The app here uses port 5031, and 5032, if this isn't cleaned up before
    subsequent tests that need the same ports would fail. Tests like
    `NodeFunctionalTests.VerifyNodeAppWorks` fail with `Watching for service
    port allocation ended with an error after 10009.0979` and eventually
    timing out.
- **NodeFunctionalTests: Use LongDurationTimeout which scales up on CI**

Issue: https://github.com/dotnet/aspire/issues/8870