### PR TITLE
Only display trace menu option for uninstrumented peer resources

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
@@ -56,21 +56,26 @@ public static class ResourceMenuItems
         }
 
         // Show telemetry menu items if there is telemetry for the resource.
-        var hasTelemetryApplication = telemetryRepository.GetApplicationByCompositeName(resource.Name) != null;
-        if (hasTelemetryApplication)
+        var telemetryApplication = telemetryRepository.GetApplicationByCompositeName(resource.Name) ;
+        if (telemetryApplication != null)
         {
             menuItems.Add(new MenuButtonItem { IsDivider = true });
-            menuItems.Add(new MenuButtonItem
+
+            if (!telemetryApplication.UninstrumentedPeer)
             {
-                Text = loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
-                Tooltip = loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
-                Icon = s_structuredLogsIcon,
-                OnClick = () =>
+                menuItems.Add(new MenuButtonItem
                 {
-                    navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: getResourceName(resource)));
-                    return Task.CompletedTask;
-                }
-            });
+                    Text = loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
+                    Tooltip = loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
+                    Icon = s_structuredLogsIcon,
+                    OnClick = () =>
+                    {
+                        navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: getResourceName(resource)));
+                        return Task.CompletedTask;
+                    }
+                });
+            }
+
             menuItems.Add(new MenuButtonItem
             {
                 Text = loc[nameof(Resources.Resources.ResourceActionTracesText)],
@@ -82,17 +87,21 @@ public static class ResourceMenuItems
                     return Task.CompletedTask;
                 }
             });
-            menuItems.Add(new MenuButtonItem
+
+            if (!telemetryApplication.UninstrumentedPeer)
             {
-                Text = loc[nameof(Resources.Resources.ResourceActionMetricsText)],
-                Tooltip = loc[nameof(Resources.Resources.ResourceActionMetricsText)],
-                Icon = s_metricsIcon,
-                OnClick = () =>
+                menuItems.Add(new MenuButtonItem
                 {
-                    navigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: getResourceName(resource)));
-                    return Task.CompletedTask;
-                }
-            });
+                    Text = loc[nameof(Resources.Resources.ResourceActionMetricsText)],
+                    Tooltip = loc[nameof(Resources.Resources.ResourceActionMetricsText)],
+                    Icon = s_metricsIcon,
+                    OnClick = () =>
+                    {
+                        navigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: getResourceName(resource)));
+                        return Task.CompletedTask;
+                    }
+                });
+            }
         }
 
         var menuCommands = resource.Commands

--- a/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
@@ -56,7 +56,7 @@ public static class ResourceMenuItems
         }
 
         // Show telemetry menu items if there is telemetry for the resource.
-        var telemetryApplication = telemetryRepository.GetApplicationByCompositeName(resource.Name) ;
+        var telemetryApplication = telemetryRepository.GetApplicationByCompositeName(resource.Name);
         if (telemetryApplication != null)
         {
             menuItems.Add(new MenuButtonItem { IsDivider = true });

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceMenuItemsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceMenuItemsTests.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Tests.TelemetryRepositoryTests;
+using Aspire.Tests.Shared.DashboardModel;
+using Aspire.Tests.Shared.Telemetry;
+using Google.Protobuf.Collections;
+using Microsoft.AspNetCore.Components;
+using OpenTelemetry.Proto.Trace.V1;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class ResourceMenuItemsTests
+{
+    private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void AddMenuItems_NoTelemetry_NoTelemetryItems()
+    {
+        // Arrange
+        var resource = ModelTestHelpers.CreateResource();
+        var telemetryRespository = TelemetryTestHelpers.CreateRepository();
+
+        // Act
+        var menuItems = new List<MenuButtonItem>();
+        ResourceMenuItems.AddMenuItems(
+            menuItems,
+            openingMenuButtonId: null,
+            resource,
+            new TestNavigationManager(),
+            telemetryRespository,
+            r => r.Name,
+            new TestStringLocalizer<Resources.ControlsStrings>(),
+            new TestStringLocalizer<Resources.Resources>(),
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            (_, _) => false,
+            true,
+            true);
+
+        // Assert
+        Assert.Collection(menuItems,
+            e => Assert.Equal("Localized:ActionViewDetailsText", e.Text),
+            e => Assert.Equal("Localized:ResourceActionConsoleLogsText", e.Text));
+    }
+
+    [Fact]
+    public void AddMenuItems_UninstrumentedPeer_TraceItem()
+    {
+        // Arrange
+        var resource = ModelTestHelpers.CreateResource(appName: "test-abc");
+        var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: attributes => (resource.Name, resource));
+        var repository = TelemetryTestHelpers.CreateRepository(outgoingPeerResolvers: [outgoingPeerResolver]);
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = TelemetryTestHelpers.CreateResource(name: "source", instanceId: "abc"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = TelemetryTestHelpers.CreateScope(),
+                        Spans =
+                        {
+                            TelemetryTestHelpers.CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "value-1")], kind: Span.Types.SpanKind.Client),
+                            TelemetryTestHelpers.CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(5), endTime: s_testTime.AddMinutes(10), parentSpanId: "1-1", attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "value-2")], kind: Span.Types.SpanKind.Client)
+                        }
+                    }
+                }
+            }
+        });
+
+        // Act
+        var menuItems = new List<MenuButtonItem>();
+        ResourceMenuItems.AddMenuItems(
+            menuItems,
+            openingMenuButtonId: null,
+            resource,
+            new TestNavigationManager(),
+            repository,
+            r => r.Name,
+            new TestStringLocalizer<Resources.ControlsStrings>(),
+            new TestStringLocalizer<Resources.Resources>(),
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            (_, _) => false,
+            true,
+            true);
+
+        // Assert
+        Assert.Collection(menuItems,
+            e => Assert.Equal("Localized:ActionViewDetailsText", e.Text),
+            e => Assert.Equal("Localized:ResourceActionConsoleLogsText", e.Text),
+            e => Assert.True(e.IsDivider),
+            e => Assert.Equal("Localized:ResourceActionTracesText", e.Text));
+    }
+
+    [Fact]
+    public void AddMenuItems_HasTelemetry_TelemetryItems()
+    {
+        // Arrange
+        var resource = ModelTestHelpers.CreateResource(appName: "test-abc");
+        var repository = TelemetryTestHelpers.CreateRepository();
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = TelemetryTestHelpers.CreateResource(name: "test", instanceId: "abc"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = TelemetryTestHelpers.CreateScope(),
+                        Spans =
+                        {
+                            TelemetryTestHelpers.CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10))
+                        }
+                    }
+                }
+            }
+        });
+
+        // Act
+        var menuItems = new List<MenuButtonItem>();
+        ResourceMenuItems.AddMenuItems(
+            menuItems,
+            openingMenuButtonId: null,
+            resource,
+            new TestNavigationManager(),
+            repository,
+            r => r.Name,
+            new TestStringLocalizer<Resources.ControlsStrings>(),
+            new TestStringLocalizer<Resources.Resources>(),
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            (_, _) => false,
+            true,
+            true);
+
+        // Assert
+        Assert.Collection(menuItems,
+            e => Assert.Equal("Localized:ActionViewDetailsText", e.Text),
+            e => Assert.Equal("Localized:ResourceActionConsoleLogsText", e.Text),
+            e => Assert.True(e.IsDivider),
+            e => Assert.Equal("Localized:ResourceActionStructuredLogsText", e.Text),
+            e => Assert.Equal("Localized:ResourceActionTracesText", e.Text),
+            e => Assert.Equal("Localized:ResourceActionMetricsText", e.Text));
+    }
+
+    private sealed class TestNavigationManager : NavigationManager
+    {
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestOutgoingPeerResolver.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestOutgoingPeerResolver.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Tests.Shared.DashboardModel;
+
+namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
+
+public sealed class TestOutgoingPeerResolver : IOutgoingPeerResolver, IDisposable
+{
+    private readonly Func<KeyValuePair<string, string>[], (string? Name, ResourceViewModel? Resource)>? _onResolve;
+    private readonly List<Func<Task>> _callbacks;
+
+    public TestOutgoingPeerResolver(Func<KeyValuePair<string, string>[], (string? Name, ResourceViewModel? Resource)>? onResolve = null)
+    {
+        _onResolve = onResolve;
+        _callbacks = new();
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public IDisposable OnPeerChanges(Func<Task> callback)
+    {
+        _callbacks.Add(callback);
+        return this;
+    }
+
+    public async Task InvokePeerChanges()
+    {
+        foreach (var callback in _callbacks)
+        {
+            await callback();
+        }
+    }
+
+    public bool TryResolvePeer(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResourced)
+    {
+        if (_onResolve != null)
+        {
+            (name, matchedResourced) = _onResolve(attributes);
+            return (name != null);
+        }
+
+        name = "TestPeer";
+        matchedResourced = ModelTestHelpers.CreateResource(appName: "TestPeer");
+        return true;
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using System.Text;
-using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
@@ -1927,49 +1926,6 @@ public class TraceTests
             {
                 AssertId("3-2", s.SpanId);
             });
-    }
-
-    private sealed class TestOutgoingPeerResolver : IOutgoingPeerResolver, IDisposable
-    {
-        private readonly Func<KeyValuePair<string, string>[], (string? Name, ResourceViewModel? Resource)>? _onResolve;
-        private readonly List<Func<Task>> _callbacks;
-
-        public TestOutgoingPeerResolver(Func<KeyValuePair<string, string>[], (string? Name, ResourceViewModel? Resource)>? onResolve = null)
-        {
-            _onResolve = onResolve;
-            _callbacks = new();
-        }
-
-        public void Dispose()
-        {
-        }
-
-        public IDisposable OnPeerChanges(Func<Task> callback)
-        {
-            _callbacks.Add(callback);
-            return this;
-        }
-
-        public async Task InvokePeerChanges()
-        {
-            foreach (var callback in _callbacks)
-            {
-                await callback();
-            }
-        }
-
-        public bool TryResolvePeer(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResourced)
-        {
-            if (_onResolve != null)
-            {
-                (name, matchedResourced) = _onResolve(attributes);
-                return (name != null);
-            }
-
-            name = "TestPeer";
-            matchedResourced = ModelTestHelpers.CreateResource(appName: "TestPeer");
-            return true;
-        }
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/9015

Display only the trace option for uninstrumented peer resources:

![image](https://github.com/user-attachments/assets/b1b76e84-2292-48bf-9769-6160744e7511)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
