### PR TITLE
Use gRPC OTLP endpoint in TestShop

### DIFF
--- a/playground/TestShop/TestShop.AppHost/Properties/launchSettings.json
+++ b/playground/TestShop/TestShop.AppHost/Properties/launchSettings.json
@@ -8,8 +8,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        //"ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16037",
-        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:16038",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16037",
+        //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:16038",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
         "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
       }
@@ -22,8 +22,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        //"ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
-        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16032",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
+        //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16032",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17031",
         "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"


### PR DESCRIPTION
No longer need to test HTTP endpoints. They've been stable for a long time.