### PR TITLE
Wait for dashboard to be healthy before returning URL via RPC (revert-revert)

### DIFF
--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -21,6 +21,7 @@
     <Compile Include="$(SharedDir)Model\KnownRelationshipTypes.cs" Link="Dashboard\KnownRelationshipTypes.cs" />
     <Compile Include="$(SharedDir)IConfigurationExtensions.cs" Link="Utils\IConfigurationExtensions.cs" />
     <Compile Include="$(SharedDir)KnownFormats.cs" Link="Utils\KnownFormats.cs" />
+    <Compile Include="$(SharedDir)KnownHealthCheckNames.cs" Link="Utils\KnownHealthCheckNames.cs" />
     <Compile Include="$(SharedDir)KnownResourceNames.cs" Link="Utils\KnownResourceNames.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -117,7 +117,10 @@ internal class AppHostRpcTarget(
         // Wait for the dashboard to be healthy before returning the URL. This next statement has several
         // layers of hacks. Some to work around devcontainer/codespaces port forwarding behavior, and one to
         // temporarily work around the fact that resource events abuse the state to mark the resource as
-        // hidden instead of having another field.
+        // hidden instead of having another field. There is a corresponding modification in the ResourceHealthService
+        // which allows the dashboard resource to trigger health reports even though it never enters
+        // the Running state. This is a hack. The reason we can't just check HealthStatus is because
+        // the current implementation of HealthStatus depends on the state of the resource as well.
         await resourceNotificationService.WaitForResourceAsync(
             KnownResourceNames.AspireDashboard,
             re => re.Snapshot.HealthReports.All(h => h.Status == HealthStatus.Healthy),

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -21,7 +21,8 @@ internal class AppHostRpcTarget(
     IServiceProvider serviceProvider,
     IDistributedApplicationEventing eventing,
     PublishingActivityProgressReporter activityReporter,
-    IHostApplicationLifetime lifetime
+    IHostApplicationLifetime lifetime,
+    DistributedApplicationOptions options
     ) 
 {
     public async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
@@ -101,6 +102,25 @@ internal class AppHostRpcTarget(
 
     public Task<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)> GetDashboardUrlsAsync()
     {
+        return GetDashboardUrlsAsync(CancellationToken.None);
+    }
+
+    public async Task<(string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken)> GetDashboardUrlsAsync(CancellationToken cancellationToken)
+    {
+        if (!options.DashboardEnabled)
+        {
+            logger.LogError("Dashboard URL requested but dashboard is disabled.");
+            throw new InvalidOperationException("Dashboard URL requested but dashboard is disabled.");
+        }
+
+        // Wait for the dashboard to be healthy before we return the URL. This is to avoid
+        // a race condition when using Codespaces or devcontainers where the dashboard URL
+        // is displayed before the dashboard port forwarding is actually configured. It is
+        // also a point of friction to show the URL before the dashboard is ready to be used
+        // when using Devcontainers/Codespaces because people think that something isn't working
+        // when in fact they just need to refresh the page.
+        await resourceNotificationService.WaitForResourceHealthyAsync(KnownResourceNames.AspireDashboard, cancellationToken).ConfigureAwait(false);
+
         var dashboardOptions = serviceProvider.GetService<IOptions<DashboardOptions>>();
 
         if (dashboardOptions is null)
@@ -122,11 +142,11 @@ internal class AppHostRpcTarget(
 
         if (baseUrlWithLoginToken == codespacesUrlWithLoginToken)
         {
-            return Task.FromResult<(string, string?)>((baseUrlWithLoginToken, null));
+            return (baseUrlWithLoginToken, null);
         }
         else
         {
-            return Task.FromResult((baseUrlWithLoginToken, codespacesUrlWithLoginToken));
+            return (baseUrlWithLoginToken, codespacesUrlWithLoginToken);
         }
     }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -127,7 +127,6 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
         nameGenerator.EnsureDcpInstancesPopulated(dashboardResource);
 
         ConfigureAspireDashboardResource(dashboardResource);
-
         // Make the dashboard first in the list so it starts as fast as possible.
         model.Resources.Insert(0, dashboardResource);
     }
@@ -179,6 +178,7 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
         dashboardResource.Annotations.Add(new ResourceSnapshotAnnotation(snapshot));
 
         dashboardResource.Annotations.Add(new EnvironmentCallbackAnnotation(ConfigureEnvironmentVariables));
+        dashboardResource.Annotations.Add(new HealthCheckAnnotation(KnownHealthCheckNames.DasboardHealthCheck));
     }
 
     internal async Task ConfigureEnvironmentVariables(EnvironmentCallbackContext context)

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -19,6 +19,7 @@ using Aspire.Hosting.Health;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Orchestrator;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -331,6 +332,20 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                 _innerBuilder.Services.AddLifecycleHook<DashboardLifecycleHook>();
                 _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DashboardOptions>, ConfigureDefaultDashboardOptions>());
                 _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DashboardOptions>, ValidateDashboardOptions>());
+
+                // Dashboard health check.
+                _innerBuilder.Services.AddHealthChecks().AddUrlGroup(sp => {
+
+                    var dashboardOptions = sp.GetRequiredService<IOptions<DashboardOptions>>().Value;
+                    if (StringUtils.TryGetUriFromDelimitedString(dashboardOptions.DashboardUrl, ";", out var firstDashboardUrl))
+                    {
+                        return firstDashboardUrl;
+                    }
+                    else
+                    {
+                        throw new DistributedApplicationException($"The dashboard resource '{KnownResourceNames.AspireDashboard}' does not have endpoints.");
+                    }
+                }, KnownHealthCheckNames.DasboardHealthCheck);
             }
 
             if (options.EnableResourceLogging)

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -39,7 +39,10 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                     }
                 }
 
-                if (resourceEvent.Snapshot.State?.Text == KnownResourceStates.Running)
+                // HACK: We are special casing the Aspire dashboard here until we address this issue. This is so that
+                //       AppHostRpcTarget can hold until the resource is in a healthy state (due to health check) even
+                //       though it is a hidden resource.
+                if (resourceEvent.Snapshot.State?.Text == KnownResourceStates.Running || resourceEvent.Resource.Name == KnownResourceNames.AspireDashboard)
                 {
                     if (state == null)
                     {

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -39,9 +39,9 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                     }
                 }
 
-                // HACK: We are special casing the Aspire dashboard here until we address this issue. This is so that
-                //       AppHostRpcTarget can hold until the resource is in a healthy state (due to health check) even
-                //       though it is a hidden resource.
+                // HACK: We are special casing the Aspire dashboard here until we address the issue of the Hidden state
+                //       making it impossible to determine whether a hidden resource is running or not. When that change
+                //       is made we can remove the special case logic here for the dashboard.
                 if (resourceEvent.Snapshot.State?.Text == KnownResourceStates.Running || resourceEvent.Resource.Name == KnownResourceNames.AspireDashboard)
                 {
                     if (state == null)

--- a/src/Shared/KnownHealthCheckNames.cs
+++ b/src/Shared/KnownHealthCheckNames.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire;
+
+internal static class KnownHealthCheckNames
+{
+    /// <summary>
+    /// Common name for dashboard health check.
+    /// </summary>
+    public const string DasboardHealthCheck = "aspire_dashboard_check";
+}


### PR DESCRIPTION
Reverts dotnet/aspire#9038

This PR reverts an earlier revert (with some modifications). Previous we used WaitForResourceHealthyAsync(...) which worked in the repo but failed in the nightly builds. This is because in the repo we show the dashboard resource in the resources list (its not hidden) but in the release packages the dashboard has a hidden state.

This change introduces a temporary work around n the `ResourceHealthCheckService` which special cases the dashboard resource so that health checks will be run for the dashboard.

Then in the `AppHostRpcTarget` we special case a `WaitForResourceAsync` call so that we wait for all the dashboard resource health reports to be healthy.

This change will go in before #9063 - but once that change is fully tested and merged we can refine this code to be less hacky. I want to get this in before though because I think #9063 may take a little bit to thoroughly test.