### PR TITLE
[CI] Run some Templates tests on the internal pipeline to support CG

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -59,7 +59,8 @@ steps:
               -projects $(Build.SourcesDirectory)\tests\Aspire.Templates.Tests\Aspire.Templates.Tests.csproj
       env:
         RunOnlyBasicBuildTemplateTests: true
-        TEST_ROOT_PATH: $(Build.SourcesDirectory)\..
+        # test root path for template test projects
+        DEV_TEMP: $(Build.SourcesDirectory)\..
         TEST_LOG_PATH: $(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Aspire.Templates.Tests
       displayName: Run Template tests
 

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -38,7 +38,30 @@ steps:
               /bl:${{ parameters.repoLogPath }}/build.binlog
               $(_OfficialBuildIdArgs)
               $(_InternalBuildArgs)
+              /p:SkipTestProjects=true
       displayName: Build
+
+    - script: ${{ parameters.dotnetScript }}
+              build
+              tests/workloads.proj
+              -p:SkipPackageCheckForTemplatesTesting=true
+      displayName: Prepare sdks for templates testing
+
+    - script: ${{ parameters.buildScript }}
+              -build
+              -restore
+              -test
+              -configuration ${{ parameters.buildConfig }}
+              /bl:${{ parameters.repoLogPath }}/BuildTemplatesTests.binlog
+              $(_OfficialBuildIdArgs)
+              $(_InternalBuildArgs)
+              /p:SkipTests=false
+              -projects $(Build.SourcesDirectory)\tests\Aspire.Templates.Tests\Aspire.Templates.Tests.csproj
+      env:
+        RunOnlyBasicBuildTemplateTests: true
+        TEST_ROOT_PATH: $(Build.SourcesDirectory)\..
+        TEST_LOG_PATH: $(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Aspire.Templates.Tests
+      displayName: Run Template tests
 
   # Public pipeline - helix tests
   - ${{ if eq(parameters.runAsPublic, 'true') }}:

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -44,7 +44,7 @@ steps:
     - script: ${{ parameters.dotnetScript }}
               build
               tests/workloads.proj
-              -p:SkipPackageCheckForTemplatesTesting=true
+              /p:SkipPackageCheckForTemplatesTesting=true
       displayName: Prepare sdks for templates testing
 
     - script: ${{ parameters.buildScript }}

--- a/tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
+++ b/tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
@@ -27,6 +27,7 @@
 
     <!-- FIXME: do not run Template tests in the outerloop until further notice -->
     <SkipTests Condition=" '$(RunQuarantinedTests)' == 'true' ">true</SkipTests>
+    <TestRunnerAdditionalArguments Condition="'$(RunOnlyBasicBuildTemplateTests)' == 'true'">$(TestRunnerAdditionalArguments) --filter-trait category=basic-build</TestRunnerAdditionalArguments>
   </PropertyGroup>
 
   <Import Project="..\Shared\TemplatesTesting\Aspire.Shared.TemplatesTesting.targets" />

--- a/tests/Aspire.Templates.Tests/BuildAndRunStarterTemplateBuiltInTest.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunStarterTemplateBuiltInTest.cs
@@ -29,6 +29,7 @@ public class BuildAndRunStarterTemplateBuiltInTest : TemplateTestsBase
     [Theory]
     [MemberData(nameof(TestFrameworkTypeWithConfig))]
     [RequiresSSLCertificate]
+    [Trait("category", "basic-build")]
     public async Task BuildAndRunStarterTemplateBuiltInTest_Test(string config, string testType)
     {
         string id = TemplateTestsBase.GetNewProjectId(prefix: $"starter test.{config}-{testType.Replace(".", "_")}");

--- a/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
@@ -29,6 +29,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
     [Theory]
     [MemberData(nameof(BuildConfigurationsForTestData))]
     [RequiresSSLCertificate]
+    [Trait("category", "basic-build")]
     public async Task BuildAndRunAspireTemplate(string config)
     {
         string id = GetNewProjectId(prefix: $"aspire_{config}");
@@ -97,6 +98,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
     [Theory]
     [MemberData(nameof(BuildConfigurationsForTestData))]
     [RequiresSSLCertificate]
+    [Trait("category", "basic-build")]
     public async Task StarterTemplateNewAndRunWithoutExplicitBuild(string config)
     {
         var id = GetNewProjectId(prefix: $"aspire_starter_run_{config}");
@@ -147,6 +149,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
     [Theory]
     [InlineData("9.*-*")]
     [InlineData("[9.0.0]")]
+    [Trait("category", "basic-build")]
     public async Task CreateAndModifyAspireAppHostTemplate(string version)
     {
         string id = GetNewProjectId(prefix: $"aspire_apphost_{version.Replace("*", "wildcard").Replace("[", "").Replace("]", "")}");

--- a/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
@@ -37,7 +37,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
         await project.BuildAsync(extraBuildArgs: [$"-c {config}"]);
         await project.StartAppHostAsync(extraArgs: [$"-c {config}"]);
 
-        if (PlaywrightProvider.HasPlaywrightSupport)
+        if (BuildEnvironment.ShouldRunPlaywrightTests)
         {
             await using var context = await CreateNewBrowserContextAsync();
             var page = await project.OpenDashboardPageAsync(context);
@@ -106,7 +106,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
             _testOutput,
             buildEnvironment: BuildEnvironment.ForDefaultFramework);
 
-        await using var context = PlaywrightProvider.HasPlaywrightSupport ? await CreateNewBrowserContextAsync() : null;
+        await using var context = BuildEnvironment.ShouldRunPlaywrightTests ? await CreateNewBrowserContextAsync() : null;
         await AssertStarterTemplateRunAsync(context, project, config, _testOutput);
     }
 
@@ -136,7 +136,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
         testSpecificBuildEnvironment.EnvVars[KnownConfigNames.AllowUnsecuredTransport] = "true";
         await project.StartAppHostAsync();
 
-        if (PlaywrightProvider.HasPlaywrightSupport)
+        if (BuildEnvironment.ShouldRunPlaywrightTests)
         {
             await using var context = await CreateNewBrowserContextAsync();
             var page = await project.OpenDashboardPageAsync(context);

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
@@ -10,6 +10,7 @@ public class NewUpAndBuildStandaloneTemplateTests(ITestOutputHelper testOutput) 
     [Theory]
     [MemberData(nameof(TestDataForNewAndBuildTemplateTests), arguments: ["aspire", ""])]
     [MemberData(nameof(TestDataForNewAndBuildTemplateTests), arguments: ["aspire-starter", ""])]
+    [Trait("category", "basic-build")]
     public async Task CanNewAndBuild(string templateName, string extraArgs, TestSdk sdk, TestTargetFramework tfm, string? error)
     {
         var id = GetNewProjectId(prefix: $"new_build_{templateName}_{tfm.ToTFMString()}");

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -16,6 +16,7 @@ public class NewUpAndBuildSupportProjectTemplates(ITestOutputHelper testOutput) 
     [MemberData(nameof(TestDataForNewAndBuildTemplateTests), arguments: ["aspire-xunit", "--xunit-version v2"])]
     [MemberData(nameof(TestDataForNewAndBuildTemplateTests), arguments: ["aspire-xunit", "--xunit-version v3"])]
     [MemberData(nameof(TestDataForNewAndBuildTemplateTests), arguments: ["aspire-xunit", "--xunit-version v3mtp"])]
+    [Trait("category", "basic-build")]
     public async Task CanNewAndBuild(string templateName, string extraTestCreationArgs, TestSdk sdk, TestTargetFramework tfm, string? error)
     {
         var id = GetNewProjectId(prefix: $"new_build_{FixupSymbolName(templateName)}");

--- a/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
@@ -20,6 +20,7 @@ public abstract partial class PerTestFrameworkTemplatesTests : TemplateTestsBase
 
     [Theory]
     [MemberData(nameof(ProjectNames_TestData))]
+    [Trait("category", "basic-build")]
     public async Task TemplatesForIndividualTestFrameworks(string prefix)
     {
         var id = $"{prefix}-{_testTemplateName}";

--- a/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
@@ -32,7 +32,7 @@ public abstract partial class PerTestFrameworkTemplatesTests : TemplateTestsBase
             buildEnvironment: BuildEnvironment.ForDefaultFramework);
 
         await project.BuildAsync(extraBuildArgs: [$"-c {config}"]);
-        if (PlaywrightProvider.HasPlaywrightSupport && RequiresSSLCertificateAttribute.IsSupported)
+        if (BuildEnvironment.ShouldRunPlaywrightTests && RequiresSSLCertificateAttribute.IsSupported)
         {
             await using (var context = await CreateNewBrowserContextAsync())
             {

--- a/tests/Aspire.Templates.Tests/StarterTemplateProjectNamesTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateProjectNamesTests.cs
@@ -33,7 +33,7 @@ public abstract class StarterTemplateProjectNamesTests : TemplateTestsBase
             BuildEnvironment.ForDefaultFramework,
             $"-t {_testType}");
 
-        await using var context = PlaywrightProvider.HasPlaywrightSupport ? await CreateNewBrowserContextAsync() : null;
+        await using var context = BuildEnvironment.ShouldRunPlaywrightTests ? await CreateNewBrowserContextAsync() : null;
         _testOutput.WriteLine($"Checking the starter template project");
         await AssertStarterTemplateRunAsync(context, project, config, _testOutput);
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateRunTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateRunTestsBase.cs
@@ -57,6 +57,7 @@ public abstract class StarterTemplateRunTestsBase<T> : TemplateTestsBase, IClass
     [InlineData("http://")]
     [InlineData("https://")]
     [RequiresPlaywright]
+    [Trait("category", "basic-build")]
     public async Task ApiServiceWorks(string urlPrefix)
     {
         await using var context = await CreateNewBrowserContextAsync();

--- a/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
@@ -266,7 +266,7 @@ public partial class TemplateTestsBase
 
     public static IEnumerable<string> GetProjectNamesForTest()
     {
-        if (!PlatformDetection.IsRunningPRValidation)
+        if (!PlatformDetection.IsRunningPRValidation && !EnvironmentVariables.RunOnlyBasicBuildTemplatesTests)
         {
             // Avoid running these cases on PR validation
 

--- a/tests/Shared/TemplatesTesting/BuildEnvironment.cs
+++ b/tests/Shared/TemplatesTesting/BuildEnvironment.cs
@@ -21,14 +21,11 @@ public class BuildEnvironment
     public DirectoryInfo?                   RepoRoot                      { get; init; }
     public TemplatesCustomHive?             TemplatesCustomHive           { get; init; }
 
-    public static readonly string TempDir =
-        string.IsNullOrEmpty(EnvironmentVariables.TestRootPath)
-            ? (IsRunningOnCI
-                ? Path.GetTempPath()
-                : Environment.GetEnvironmentVariable("DEV_TEMP") is { } devTemp && Path.Exists(devTemp)
-                    ? devTemp
-                    : Path.GetTempPath())
-            : EnvironmentVariables.TestRootPath;
+    public static readonly string TempDir = IsRunningOnCI
+        ? Path.GetTempPath()
+        : Environment.GetEnvironmentVariable("DEV_TEMP") is { } devTemp && Path.Exists(devTemp)
+            ? devTemp
+            : Path.GetTempPath();
 
     public static readonly TestTargetFramework DefaultTargetFramework = ComputeDefaultTargetFramework();
     public static readonly string           TestAssetsPath = Path.Combine(AppContext.BaseDirectory, "testassets");

--- a/tests/Shared/TemplatesTesting/BuildEnvironment.cs
+++ b/tests/Shared/TemplatesTesting/BuildEnvironment.cs
@@ -35,6 +35,7 @@ public class BuildEnvironment
     public static bool IsRunningOnCIBuildMachine => Environment.GetEnvironmentVariable("BUILD_BUILDID") is not null;
     public static bool IsRunningOnGithubActions => Environment.GetEnvironmentVariable("GITHUB_JOB") is not null;
     public static bool IsRunningOnCI => IsRunningOnHelix || IsRunningOnCIBuildMachine || IsRunningOnGithubActions;
+    public static bool ShouldRunPlaywrightTests => PlaywrightProvider.HasPlaywrightSupport && !EnvironmentVariables.RunOnlyBasicBuildTemplatesTests;
 
     private static readonly Lazy<BuildEnvironment> s_instance_80 = new(() =>
         new BuildEnvironment(sdkDirName: "dotnet-8"));

--- a/tests/Shared/TemplatesTesting/BuildEnvironment.cs
+++ b/tests/Shared/TemplatesTesting/BuildEnvironment.cs
@@ -21,11 +21,14 @@ public class BuildEnvironment
     public DirectoryInfo?                   RepoRoot                      { get; init; }
     public TemplatesCustomHive?             TemplatesCustomHive           { get; init; }
 
-    public static readonly string TempDir = IsRunningOnCI
-        ? Path.GetTempPath()
-        : Environment.GetEnvironmentVariable("DEV_TEMP") is { } devTemp && Path.Exists(devTemp)
-            ? devTemp
-            : Path.GetTempPath();
+    public static readonly string TempDir =
+        string.IsNullOrEmpty(EnvironmentVariables.TestRootPath)
+            ? (IsRunningOnCI
+                ? Path.GetTempPath()
+                : Environment.GetEnvironmentVariable("DEV_TEMP") is { } devTemp && Path.Exists(devTemp)
+                    ? devTemp
+                    : Path.GetTempPath())
+            : EnvironmentVariables.TestRootPath;
 
     public static readonly TestTargetFramework DefaultTargetFramework = ComputeDefaultTargetFramework();
     public static readonly string           TestAssetsPath = Path.Combine(AppContext.BaseDirectory, "testassets");

--- a/tests/Shared/TemplatesTesting/EnvironmentVariables.cs
+++ b/tests/Shared/TemplatesTesting/EnvironmentVariables.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.TestUtilities;
+
 namespace Aspire.Templates.Tests;
 
 public static class EnvironmentVariables
@@ -10,8 +12,10 @@ public static class EnvironmentVariables
     public static readonly string? SkipProjectCleanup        = Environment.GetEnvironmentVariable("SKIP_PROJECT_CLEANUP");
     public static readonly string? BuiltNuGetsPath           = Environment.GetEnvironmentVariable("BUILT_NUGETS_PATH");
     public static readonly bool    ShowBuildOutput           = Environment.GetEnvironmentVariable("SHOW_BUILD_OUTPUT") is "true";
-    public static readonly bool    IsRunningOnCI             = Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null;
+    public static readonly bool    IsRunningOnCI             = PlatformDetection.IsRunningOnCI;
     public static readonly bool    TestsRunningOutsideOfRepo = Environment.GetEnvironmentVariable("TestsRunningOutsideOfRepo") is "true";
     public static readonly string? TestScenario              = Environment.GetEnvironmentVariable("TEST_SCENARIO");
     public static readonly string? DefaultTFMForTesting      = Environment.GetEnvironmentVariable("DEFAULT_TFM_FOR_TESTING");
+    public static readonly string? TestRootPath              = Environment.GetEnvironmentVariable("TEST_ROOT_PATH");
+    public static readonly bool    RunOnlyBasicBuildTemplatesTests = Environment.GetEnvironmentVariable("RunOnlyBasicBuildTemplateTests") is "true";
 }

--- a/tests/Shared/TemplatesTesting/EnvironmentVariables.cs
+++ b/tests/Shared/TemplatesTesting/EnvironmentVariables.cs
@@ -7,15 +7,15 @@ namespace Aspire.Templates.Tests;
 
 public static class EnvironmentVariables
 {
-    public static readonly string? SdkForTemplateTestingPath = Environment.GetEnvironmentVariable("SDK_FOR_TEMPLATES_TESTING_PATH");
-    public static readonly string? TestLogPath               = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
-    public static readonly string? SkipProjectCleanup        = Environment.GetEnvironmentVariable("SKIP_PROJECT_CLEANUP");
-    public static readonly string? BuiltNuGetsPath           = Environment.GetEnvironmentVariable("BUILT_NUGETS_PATH");
-    public static readonly bool    ShowBuildOutput           = Environment.GetEnvironmentVariable("SHOW_BUILD_OUTPUT") is "true";
-    public static readonly bool    IsRunningOnCI             = PlatformDetection.IsRunningOnCI;
-    public static readonly bool    TestsRunningOutsideOfRepo = Environment.GetEnvironmentVariable("TestsRunningOutsideOfRepo") is "true";
-    public static readonly string? TestScenario              = Environment.GetEnvironmentVariable("TEST_SCENARIO");
-    public static readonly string? DefaultTFMForTesting      = Environment.GetEnvironmentVariable("DEFAULT_TFM_FOR_TESTING");
-    public static readonly string? TestRootPath              = Environment.GetEnvironmentVariable("TEST_ROOT_PATH");
+    public static readonly string? SdkForTemplateTestingPath       = Environment.GetEnvironmentVariable("SDK_FOR_TEMPLATES_TESTING_PATH");
+    public static readonly string? TestLogPath                     = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
+    public static readonly string? SkipProjectCleanup              = Environment.GetEnvironmentVariable("SKIP_PROJECT_CLEANUP");
+    public static readonly string? BuiltNuGetsPath                 = Environment.GetEnvironmentVariable("BUILT_NUGETS_PATH");
+    public static readonly bool    ShowBuildOutput                 = Environment.GetEnvironmentVariable("SHOW_BUILD_OUTPUT") is "true";
+    public static readonly bool    IsRunningOnCI                   = PlatformDetection.IsRunningOnCI;
+    public static readonly bool    TestsRunningOutsideOfRepo       = Environment.GetEnvironmentVariable("TestsRunningOutsideOfRepo") is "true";
+    public static readonly string? TestScenario                    = Environment.GetEnvironmentVariable("TEST_SCENARIO");
+    public static readonly string? DefaultTFMForTesting            = Environment.GetEnvironmentVariable("DEFAULT_TFM_FOR_TESTING");
+    public static readonly string? TestRootPath                    = Environment.GetEnvironmentVariable("DEV_TEMP");
     public static readonly bool    RunOnlyBasicBuildTemplatesTests = Environment.GetEnvironmentVariable("RunOnlyBasicBuildTemplateTests") is "true";
 }


### PR DESCRIPTION
A limited set of the template tests are run on the internal pipeline, on the build agent itself, to allow CG to scan for dependencies. The limited set of tests are marked with `Category=basic-build`, and Playwright parts of the tests are skipped. This is OK here because CG just needs the projects to be built, and we are not trying to actually test the templates here.

Fixes: https://github.com/dotnet/aspire/issues/8904