### PR TITLE
Put examples docs in remark to be visible in Visual Studio  (XML doc comments)

### DIFF
--- a/playground/AspireEventHub/EventHubsConsumer/Processor.cs
+++ b/playground/AspireEventHub/EventHubsConsumer/Processor.cs
@@ -17,10 +17,10 @@ namespace EventHubsConsumer;
 ///   Use <see cref="EventProcessorClientOptions"/> to specify options such as the maximum wait time and prefetch count.
 ///   Proper configuration and usage of the EventProcessorClient can significantly improve the efficiency and performance of your Azure Event Hubs
 ///   applications. Remember to handle exceptions and monitor the health of your nodes to ensure smooth operation.
-/// </remarks>
 /// <example>
 ///   See samples at https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples
 /// </example>
+/// </remarks>
 internal sealed class Processor(EventProcessorClient client, ILogger<Processor> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -69,6 +69,7 @@ public static class AzureAppConfigurationExtensions
     /// <param name="target">The target Azure App Configuration resource.</param>
     /// <param name="roles">The built-in App Configuration roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks>
     /// <example>
     /// Assigns the AppConfigurationDataReader role to the 'Projects.Api' project.
     /// <code lang="csharp">
@@ -81,6 +82,7 @@ public static class AzureAppConfigurationExtensions
     ///   .WithReference(appStore);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureAppConfigurationResource> target,

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppContainerExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppContainerExtensions.cs
@@ -22,7 +22,6 @@ public static class AzureContainerAppContainerExtensions
     /// <remarks>
     /// This method checks if the application is in publish mode. If it is, it adds the necessary infrastructure
     /// for container apps and applies the provided configuration action to the container app.
-    /// </remarks>
     /// <example>
     /// <code>
     /// builder.AddContainer("name", "image").PublishAsAzureContainerApp((infrastructure, app) =>
@@ -31,6 +30,7 @@ public static class AzureContainerAppContainerExtensions
     /// });
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> PublishAsAzureContainerApp<T>(this IResourceBuilder<T> container, Action<AzureResourceInfrastructure, ContainerApp> configure)
         where T : ContainerResource
     {

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExecutableExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExecutableExtensions.cs
@@ -22,7 +22,6 @@ public static class AzureContainerAppExecutableExtensions
     /// <remarks>
     /// This method checks if the application is in publish mode. If it is, it adds the necessary infrastructure
     /// for container apps and applies the provided configuration action to the container app.
-    /// </remarks>
     /// <example>
     /// <code>
     /// builder.AddNpmApp("name", "image").PublishAsAzureContainerApp((infrastructure, app) =>
@@ -31,6 +30,7 @@ public static class AzureContainerAppExecutableExtensions
     /// });
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> PublishAsAzureContainerApp<T>(this IResourceBuilder<T> executable, Action<AzureResourceInfrastructure, ContainerApp> configure)
         where T : ExecutableResource
     {

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppProjectExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppProjectExtensions.cs
@@ -22,7 +22,6 @@ public static class AzureContainerAppProjectExtensions
     /// <remarks>
     /// This method adds the necessary infrastructure for container apps to the application builder
     /// and applies the specified configuration to the container app.
-    /// </remarks>
     /// <example>
     /// <code>
     /// builder.AddProject&lt;Projects.Api&gt;.PublishAsAzureContainerApp((infrastructure, app) =>
@@ -31,6 +30,7 @@ public static class AzureContainerAppProjectExtensions
     /// });
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> PublishAsAzureContainerApp<T>(this IResourceBuilder<T> project, Action<AzureResourceInfrastructure, ContainerApp> configure)
         where T : ProjectResource
     {

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
@@ -37,7 +37,6 @@ public static class ContainerAppExtensions
     /// <paramref name="certificateName"/> is prompted.</para>
     /// <para>For deployments triggered locally by the Azure Developer CLI the <c>config.json</c> file in the <c>.azure/{environment name}</c> path
     /// can by modified with the certificate name since Azure Developer CLI will not prompt again for the value.</para>
-    /// </remarks>
     /// <example>
     /// This example shows declaring two parameters to capture the custom domain and certificate name and
     /// passing them to the <see cref="ConfigureCustomDomain(ContainerApp, IResourceBuilder{ParameterResource}, IResourceBuilder{ParameterResource})"/>
@@ -54,6 +53,7 @@ public static class ContainerAppExtensions
     ///        });
     /// </code>
     /// </example>
+    /// </remarks>
     [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static void ConfigureCustomDomain(this ContainerApp app, IResourceBuilder<ParameterResource> customDomain, IResourceBuilder<ParameterResource> certificateName)
     {

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -199,6 +199,7 @@ public static class AzureOpenAIExtensions
     /// <param name="target">The target Azure OpenAI resource.</param>
     /// <param name="roles">The built-in Cognitive Services roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks>
     /// <example>
     /// Assigns the CognitiveServicesOpenAIUser role to the 'Projects.Api' project.
     /// <code lang="csharp">
@@ -211,6 +212,7 @@ public static class AzureOpenAIExtensions
     ///   .WithReference(openai);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureOpenAIResource> target,

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -323,6 +323,7 @@ public static class AzureCosmosExtensions
     /// </summary>
     /// <param name="builder">The Azure Cosmos DB resource builder.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> builder.</returns>
+    /// <remarks>
     /// <example>
     /// The following example creates an Azure Cosmos DB resource that uses access key authentication.
     /// <code lang="csharp">
@@ -337,6 +338,7 @@ public static class AzureCosmosExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzureCosmosDBResource> WithAccessKeyAuthentication(this IResourceBuilder<AzureCosmosDBResource> builder)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -81,6 +81,7 @@ public static class AzureKeyVaultResourceExtensions
     /// <param name="target">The target Azure Key Vault resource.</param>
     /// <param name="roles">The built-in Key Vault roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks>
     /// <example>
     /// Assigns the KeyVaultReader role to the 'Projects.Api' project.
     /// <code lang="csharp">
@@ -93,6 +94,7 @@ public static class AzureKeyVaultResourceExtensions
     ///   .WithReference(vault);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureKeyVaultResource> target,

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -119,7 +119,6 @@ public static class AzurePostgresExtensions
     /// https://learn.microsoft.com/azure/postgresql/flexible-server/how-to-connect-with-managed-identity#connect-using-managed-identity-in-c for more information.
     ///
     /// You can use the <see cref="WithPasswordAuthentication(IResourceBuilder{AzurePostgresFlexibleServerResource}, IResourceBuilder{IAzureKeyVaultResource}, IResourceBuilder{ParameterResource}?, IResourceBuilder{ParameterResource}?)"/> method to configure the resource to use password authentication.
-    /// </remarks>
     /// <example>
     /// The following example creates an Azure PostgreSQL Flexible Server resource and referencing that resource in a .NET project.
     /// <code lang="csharp">
@@ -133,6 +132,7 @@ public static class AzurePostgresExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzurePostgresFlexibleServerResource> AddAzurePostgresFlexibleServer(this IDistributedApplicationBuilder builder, [ResourceName] string name)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -187,6 +187,7 @@ public static class AzurePostgresExtensions
     /// <param name="builder">The Azure PostgreSQL server resource builder.</param>
     /// <param name="configureContainer">Callback that exposes underlying container to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{AzurePostgresFlexibleServerResource}"/> builder.</returns>
+    /// <remarks>
     /// <example>
     /// The following example creates an Azure PostgreSQL Flexible Server resource that runs locally in a
     /// PostgreSQL container and referencing that resource in a .NET project.
@@ -202,6 +203,7 @@ public static class AzurePostgresExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzurePostgresFlexibleServerResource> RunAsContainer(this IResourceBuilder<AzurePostgresFlexibleServerResource> builder, Action<IResourceBuilder<PostgresServerResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -265,6 +267,7 @@ public static class AzurePostgresExtensions
     /// <param name="userName">The parameter used to provide the user name for the PostgreSQL resource. If <see langword="null"/> a default value will be used.</param>
     /// <param name="password">The parameter used to provide the administrator password for the PostgreSQL resource. If <see langword="null"/> a random password will be generated.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{AzurePostgresFlexibleServerResource}"/> builder.</returns>
+    /// <remarks>
     /// <example>
     /// The following example creates an Azure PostgreSQL Flexible Server resource that uses password authentication.
     /// <code lang="csharp">
@@ -279,6 +282,7 @@ public static class AzurePostgresExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzurePostgresFlexibleServerResource> WithPasswordAuthentication(
         this IResourceBuilder<AzurePostgresFlexibleServerResource> builder,
         IResourceBuilder<ParameterResource>? userName = null,

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -97,7 +97,6 @@ public static class AzureRedisExtensions
     /// https://github.com/Azure/Microsoft.Azure.StackExchangeRedis for more information.
     ///
     /// You can use the <see cref="WithAccessKeyAuthentication(IResourceBuilder{AzureRedisCacheResource}, IResourceBuilder{IAzureKeyVaultResource})"/> method to configure the resource to use access key authentication.
-    /// </remarks>
     /// <example>
     /// The following example creates an Azure Cache for Redis resource and referencing that resource in a .NET project.
     /// <code lang="csharp">
@@ -111,6 +110,7 @@ public static class AzureRedisExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzureRedisCacheResource> AddAzureRedis(
         this IDistributedApplicationBuilder builder,
         [ResourceName] string name)
@@ -131,6 +131,7 @@ public static class AzureRedisExtensions
     /// <param name="builder">The Azure Cache for Redis resource builder.</param>
     /// <param name="configureContainer">Callback that exposes underlying container to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{AzureRedisCacheResource}"/> builder.</returns>
+    /// <remarks>
     /// <example>
     /// The following example creates an Azure Cache for Redis resource that runs locally in a
     /// Redis container and referencing that resource in a .NET project.
@@ -146,6 +147,7 @@ public static class AzureRedisExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzureRedisCacheResource> RunAsContainer(
         this IResourceBuilder<AzureRedisCacheResource> builder,
         Action<IResourceBuilder<RedisResource>>? configureContainer = null)
@@ -174,6 +176,7 @@ public static class AzureRedisExtensions
     /// </summary>
     /// <param name="builder">The Azure Cache for Redis resource builder.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{AzureRedisCacheResource}"/> builder.</returns>
+    /// <remarks>
     /// <example>
     /// The following example creates an Azure Cache for Redis resource that uses access key authentication.
     /// <code lang="csharp">
@@ -188,6 +191,7 @@ public static class AzureRedisExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzureRedisCacheResource> WithAccessKeyAuthentication(this IResourceBuilder<AzureRedisCacheResource> builder)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -81,6 +81,7 @@ public static class AzureSearchExtensions
     /// <param name="target">The target Azure AI Search service resource.</param>
     /// <param name="roles">The built-in AI Search roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks
     /// <example>
     /// Assigns the SearchIndexDataReader role to the 'Projects.Api' project.
     /// <code lang="csharp">
@@ -93,6 +94,7 @@ public static class AzureSearchExtensions
     ///   .WithReference(search);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureSearchResource> target,

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -81,7 +81,7 @@ public static class AzureSearchExtensions
     /// <param name="target">The target Azure AI Search service resource.</param>
     /// <param name="roles">The built-in AI Search roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
-    /// <remarks
+    /// <remarks>
     /// <example>
     /// Assigns the SearchIndexDataReader role to the 'Projects.Api' project.
     /// <code lang="csharp">

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -315,7 +315,6 @@ public static class AzureServiceBusExtensions
     /// </summary>
     /// <remarks>
     /// This version of the package defaults to the <inheritdoc cref="ServiceBusEmulatorContainerImageTags.Tag"/> tag of the <inheritdoc cref="ServiceBusEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="ServiceBusEmulatorContainerImageTags.Image"/> container image.
-    /// </remarks>
     /// <param name="builder">The Azure Service Bus resource builder.</param>
     /// <param name="configureContainer">Callback that exposes underlying container used for emulation to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
@@ -335,6 +334,7 @@ public static class AzureServiceBusExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzureServiceBusResource> RunAsEmulator(this IResourceBuilder<AzureServiceBusResource> builder, Action<IResourceBuilder<AzureServiceBusEmulatorResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -509,6 +509,7 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The builder for the <see cref="AzureServiceBusEmulatorResource"/>.</param>
     /// <param name="configJson">A callback to update the JSON object representation of the configuration.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks
     /// <example>
     /// Here is an example of how to configure the emulator to use a different logging mechanism:
     /// <code language="csharp">
@@ -523,6 +524,7 @@ public static class AzureServiceBusExtensions
     ///        );
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzureServiceBusEmulatorResource> WithConfiguration(this IResourceBuilder<AzureServiceBusEmulatorResource> builder, Action<JsonNode> configJson)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -624,6 +626,7 @@ public static class AzureServiceBusExtensions
     /// <param name="target">The target Azure Service Bus namespace.</param>
     /// <param name="roles">The built-in Service Bus roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks
     /// <example>
     /// Assigns the AzureServiceBusDataSender role to the 'Projects.Api' project.
     /// <code lang="csharp">
@@ -636,6 +639,7 @@ public static class AzureServiceBusExtensions
     ///   .WithReference(sb);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureServiceBusResource> target,

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -509,7 +509,7 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The builder for the <see cref="AzureServiceBusEmulatorResource"/>.</param>
     /// <param name="configJson">A callback to update the JSON object representation of the configuration.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <remarks
+    /// <remarks>
     /// <example>
     /// Here is an example of how to configure the emulator to use a different logging mechanism:
     /// <code language="csharp">
@@ -626,7 +626,7 @@ public static class AzureServiceBusExtensions
     /// <param name="target">The target Azure Service Bus namespace.</param>
     /// <param name="roles">The built-in Service Bus roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
-    /// <remarks
+    /// <remarks>
     /// <example>
     /// Assigns the AzureServiceBusDataSender role to the 'Projects.Api' project.
     /// <code lang="csharp">

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -146,6 +146,7 @@ public static class AzureSignalRExtensions
     /// <param name="target">The target Azure SignalR resource.</param>
     /// <param name="roles">The built-in SignalR roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks>
     /// <example>
     /// Assigns the SignalRContributor role to the 'Projects.Api' project.
     /// <code lang="csharp">
@@ -158,6 +159,7 @@ public static class AzureSignalRExtensions
     ///   .WithReference(signalr);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureSignalRResource> target,

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -133,6 +133,7 @@ public static class AzureSqlExtensions
     /// <param name="builder">The builder for the Azure SQL resource.</param>
     /// <param name="configureContainer">Callback that exposes underlying container to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{AzureSqlServerResource}"/> builder.</returns>
+    /// <remarks>
     /// <example>
     /// The following example creates an Azure SQL Database (server) resource that runs locally in a
     /// SQL Server container and referencing that resource in a .NET project.
@@ -148,6 +149,7 @@ public static class AzureSqlExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<AzureSqlServerResource> RunAsContainer(this IResourceBuilder<AzureSqlServerResource> builder, Action<IResourceBuilder<SqlServerServerResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -322,6 +322,7 @@ public static class AzureStorageExtensions
     /// <param name="target">The target Azure Storage account.</param>
     /// <param name="roles">The built-in storage roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks>
     /// <example>
     /// Assigns the StorageBlobDataContributor role to the 'Projects.Api' project.
     /// <code lang="csharp">
@@ -335,6 +336,7 @@ public static class AzureStorageExtensions
     ///   .WithReference(blobs);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureStorageResource> target,

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -247,6 +247,7 @@ public static class AzureWebPubSubExtensions
     /// <param name="target">The target Azure Web PubSub resource.</param>
     /// <param name="roles">The built-in Web PubSub roles to be assigned.</param>
     /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks>
     /// <example>
     /// Assigns the WebPubSubServiceReader role to the 'Projects.Api' project.
     /// <code lang="csharp">
@@ -259,6 +260,7 @@ public static class AzureWebPubSubExtensions
     ///   .WithReference(webPubSub);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureWebPubSubResource> target,

--- a/src/Aspire.Hosting.Docker/DockerComposeServiceExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeServiceExtensions.cs
@@ -33,7 +33,6 @@ public static class DockerComposeServiceExtensions
     /// </code>
     /// </example>
     /// </remarks>
-
     public static IResourceBuilder<T> PublishAsDockerComposeService<T>(this IResourceBuilder<T> builder, Action<DockerComposeServiceResource, Service> configure)
         where T : IComputeResource
     {

--- a/src/Aspire.Hosting.Docker/DockerComposeServiceExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeServiceExtensions.cs
@@ -24,7 +24,6 @@ public static class DockerComposeServiceExtensions
     /// <remarks>
     /// This method checks if the application is in publish mode. If it is, it adds a customization annotation
     /// that will be applied by the DockerComposeInfrastructure when generating the Docker Compose service.
-    /// </remarks>
     /// <example>
     /// <code>
     /// builder.AddContainer("redis", "redis:alpine").PublishAsDockerComposeService((resource, service) =>
@@ -33,6 +32,8 @@ public static class DockerComposeServiceExtensions
     /// });
     /// </code>
     /// </example>
+    /// </remarks>
+
     public static IResourceBuilder<T> PublishAsDockerComposeService<T>(this IResourceBuilder<T> builder, Action<DockerComposeServiceResource, Service> configure)
         where T : IComputeResource
     {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesServiceExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesServiceExtensions.cs
@@ -23,7 +23,6 @@ public static class KubernetesServiceExtensions
     /// <remarks>
     /// This method checks if the application is in publish mode. If it is, it adds a customization annotation
     /// that will be applied by the infrastructure when generating the Kubernetes service.
-    /// </remarks>
     /// <example>
     /// <code>
     /// builder.AddContainer("redis", "redis:alpine").PublishAsKubernetesService((service) =>
@@ -32,6 +31,7 @@ public static class KubernetesServiceExtensions
     /// });
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> PublishAsKubernetesService<T>(this IResourceBuilder<T> builder, Action<KubernetesResource> configure)
         where T : IComputeResource
     {

--- a/src/Aspire.Hosting.Python/PythonProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonProjectResourceBuilderExtensions.cs
@@ -58,7 +58,6 @@ public static class PythonProjectResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-
     [Obsolete("AddPythonProject is deprecated. Please use AddPythonApp instead.")]
     public static IResourceBuilder<PythonProjectResource> AddPythonProject(
         this IDistributedApplicationBuilder builder, [ResourceName] string name, string projectDirectory, string scriptPath, params string[] scriptArgs)

--- a/src/Aspire.Hosting.Python/PythonProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonProjectResourceBuilderExtensions.cs
@@ -43,7 +43,6 @@ public static class PythonProjectResourceBuilderExtensions
     /// You can instrument your project by adding the <c>opentelemetry-distro</c>, and <c>opentelemetry-exporter-otlp</c> to
     /// your Python project.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Add a python project to the application model. In this example the project is located in the <c>PythonProject</c> directory
     /// if this path is relative then it is assumed to be relative to the AppHost directory, and the virtual environment path if relative
@@ -58,6 +57,8 @@ public static class PythonProjectResourceBuilderExtensions
     /// builder.Build().Run(); 
     /// </code>
     /// </example>
+    /// </remarks>
+
     [Obsolete("AddPythonProject is deprecated. Please use AddPythonApp instead.")]
     public static IResourceBuilder<PythonProjectResource> AddPythonProject(
         this IDistributedApplicationBuilder builder, [ResourceName] string name, string projectDirectory, string scriptPath, params string[] scriptArgs)
@@ -89,7 +90,6 @@ public static class PythonProjectResourceBuilderExtensions
     /// You can instrument your project by adding the <c>opentelemetry-distro</c>, and <c>opentelemetry-exporter-otlp</c> to
     /// your Python project.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Add a python project to the application model. In this example the project is located in the <c>PythonProject</c> directory
     /// if this path is relative then it is assumed to be relative to the AppHost directory, and the virtual environment path if relative
@@ -104,6 +104,7 @@ public static class PythonProjectResourceBuilderExtensions
     /// builder.Build().Run(); 
     /// </code>
     /// </example>
+    /// </remarks>
     [Obsolete("AddPythonProject is deprecated. Please use AddPythonApp instead.")]
     public static IResourceBuilder<PythonProjectResource> AddPythonProject(
         this IDistributedApplicationBuilder builder, [ResourceName] string name, string projectDirectory, string scriptPath,

--- a/src/Aspire.Hosting.Valkey/ValkeyBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Valkey/ValkeyBuilderExtensions.cs
@@ -53,6 +53,7 @@ public static class ValkeyBuilderExtensions
     /// </example>
     /// </remarks>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// check this
     public static IResourceBuilder<ValkeyResource> AddValkey(
         this IDistributedApplicationBuilder builder,
         [ResourceName] string name,

--- a/src/Aspire.Hosting/ApplicationModel/AfterEndpointsAllocatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AfterEndpointsAllocatedEvent.cs
@@ -15,7 +15,6 @@ namespace Aspire.Hosting.ApplicationModel;
 /// method. This event provides access to the <see cref="IServiceProvider"/> interface to resolve dependencies including
 /// <see cref="DistributedApplicationModel"/> service which is passed in as an argument
 /// in <see cref="Aspire.Hosting.Lifecycle.IDistributedApplicationLifecycleHook.AfterEndpointsAllocatedAsync(Aspire.Hosting.ApplicationModel.DistributedApplicationModel, CancellationToken)"/>.
-/// </remarks>
 /// <example>
 /// Subscribe to the <see cref="AfterEndpointsAllocatedEvent"/> event and resolve the distributed application model.
 /// <code lang="C#">
@@ -26,6 +25,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// });
 /// </code>
 /// </example>
+/// </remarks>
 public class AfterEndpointsAllocatedEvent(IServiceProvider services, DistributedApplicationModel model) : IDistributedApplicationEvent
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -152,14 +152,13 @@ public static class ResourceExtensions
     /// <summary>
     /// Get the environment variables from the given resource.
     /// </summary>
+    /// <param name="resource">The resource to get the environment variables from.</param>
+    /// <param name="applicationOperation">The context in which the AppHost is being executed.</param>
+    /// <returns>The environment variables retrieved from the resource.</returns>
     /// <remarks>
     /// This method is useful when you want to make sure the environment variables are added properly to resources, mostly in test situations.
     /// This method has asynchronous behavior when <paramref name = "applicationOperation" /> is <see cref="DistributedApplicationOperation.Run"/>
     /// and environment variables were provided from <see cref="IValueProvider"/> otherwise it will be synchronous.
-    /// </remarks>
-    /// <param name="resource">The resource to get the environment variables from.</param>
-    /// <param name="applicationOperation">The context in which the AppHost is being executed.</param>
-    /// <returns>The environment variables retrieved from the resource.</returns>
     /// <example>
     /// Using <see cref="GetEnvironmentVariableValuesAsync(IResourceWithEnvironment, DistributedApplicationOperation)"/> inside
     /// a unit test to validate environment variable values.
@@ -184,6 +183,7 @@ public static class ResourceExtensions
     ///         });
     /// </code>
     /// </example>
+    /// </remarks>
     public static async ValueTask<Dictionary<string, string>> GetEnvironmentVariableValuesAsync(this IResourceWithEnvironment resource,
             DistributedApplicationOperation applicationOperation = DistributedApplicationOperation.Run)
     {
@@ -206,14 +206,13 @@ public static class ResourceExtensions
     /// <summary>
     /// Get the arguments from the given resource.
     /// </summary>
+    /// <param name="resource">The resource to get the arguments from.</param>
+    /// <param name="applicationOperation">The context in which the AppHost is being executed.</param>
+    /// <returns>The arguments retrieved from the resource.</returns>
     /// <remarks>
     /// This method is useful when you want to make sure the arguments are added properly to resources, mostly in test situations.
     /// This method has asynchronous behavior when <paramref name = "applicationOperation" /> is <see cref="DistributedApplicationOperation.Run"/>
     /// and arguments were provided from <see cref="IValueProvider"/> otherwise it will be synchronous.
-    /// </remarks>
-    /// <param name="resource">The resource to get the arguments from.</param>
-    /// <param name="applicationOperation">The context in which the AppHost is being executed.</param>
-    /// <returns>The arguments retrieved from the resource.</returns>
     /// <example>
     /// Using <see cref="GetArgumentValuesAsync(IResourceWithArgs, DistributedApplicationOperation)"/> inside
     /// a unit test to validate argument values.
@@ -236,6 +235,7 @@ public static class ResourceExtensions
     ///         });
     /// </code>
     /// </example>
+    /// </remarks>
     public static async ValueTask<string[]> GetArgumentValuesAsync(this IResourceWithArgs resource,
         DistributedApplicationOperation applicationOperation = DistributedApplicationOperation.Run)
     {

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -12,13 +12,12 @@ public static class ConnectionStringBuilderExtensions
     /// <summary>
     /// Adds a connection string resource to the distributed application with the specified expression.
     /// </summary>
-    /// <remarks>
-    /// This method also enables appending custom data to the connection string based on other resources that expose connection strings.
-    /// </remarks>
     /// <param name="builder">Distributed application builder</param>
     /// <param name="name">The name of the resource.</param>
     /// <param name="connectionStringExpression">The connection string expression.</param>
     /// <returns>An <see cref="IResourceBuilder{ConnectionStringResource}"/> instance.</returns>
+    /// <remarks>
+    /// This method also enables appending custom data to the connection string based on other resources that expose connection strings.
     /// <example>
     /// <code language="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
@@ -35,6 +34,7 @@ public static class ConnectionStringBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ConnectionStringResource> AddConnectionString(this IDistributedApplicationBuilder builder, [ResourceName] string name, ReferenceExpression connectionStringExpression)
     {
         var cs = new ConnectionStringResource(name, connectionStringExpression);
@@ -54,7 +54,6 @@ public static class ConnectionStringBuilderExtensions
     /// </summary>
     /// <remarks>
     /// This method also enables appending custom data to the connection string based on other resources that expose connection strings.
-    /// </remarks>
     /// <param name="builder">Distributed application builder</param>
     /// <param name="name">The name of the resource.</param>
     /// <param name="connectionStringBuilder">The callback to configure the connection string expression.</param>
@@ -75,6 +74,7 @@ public static class ConnectionStringBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ConnectionStringResource> AddConnectionString(this IDistributedApplicationBuilder builder, [ResourceName] string name, Action<ReferenceExpressionBuilder> connectionStringBuilder)
     {
         var rb = new ReferenceExpressionBuilder();

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -65,7 +65,6 @@ public static class ContainerResourceBuilderExtensions
     /// <para>
     /// The <paramref name="target"/> path specifies the path the volume will be mounted inside the container's file system.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Adds a volume named <c>data</c> that will be mounted in the container's file system at the path <c>/usr/data</c>:
     /// <code language="csharp">
@@ -77,6 +76,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithVolume<T>(this IResourceBuilder<T> builder, string? name, string target, bool isReadOnly = false) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -105,7 +105,6 @@ public static class ContainerResourceBuilderExtensions
     /// <para>
     /// The <paramref name="target"/> path specifies the path the volume will be mounted inside the container's file system.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Adds an anonymous volume that will be mounted in the container's file system at the path <c>/usr/data</c>:
     /// <code language="csharp">
@@ -117,6 +116,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithVolume<T>(this IResourceBuilder<T> builder, string target) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -147,7 +147,6 @@ public static class ContainerResourceBuilderExtensions
     /// <para>
     /// The <paramref name="target"/> path specifies the path the file or directory will be mounted inside the container's file system.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Adds a bind mount that will mount the <c>config</c> directory in the app host project directory, to the container's file system at the path <c>/database/config</c>,
     /// and mark it read-only so that the container cannot modify it:
@@ -172,6 +171,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithBindMount<T>(this IResourceBuilder<T> builder, string source, string target, bool isReadOnly = false) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -384,6 +384,7 @@ public static class ContainerResourceBuilderExtensions
     /// <param name="builder">Builder for the container resource.</param>
     /// <param name="lifetime">The lifetime behavior of the container resource. The defaults behavior is <see cref="ContainerLifetime.Session"/>.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
     /// <example>
     /// Marking a container resource to have a <see cref="ContainerLifetime.Persistent"/> lifetime.
     /// <code language="csharp">
@@ -395,6 +396,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithLifetime<T>(this IResourceBuilder<T> builder, ContainerLifetime lifetime) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -458,7 +460,6 @@ public static class ContainerResourceBuilderExtensions
     /// method results in an additional attribute being added to the `container.v0` resource type which contains the configuration
     /// necessary to allow the deployment tool to build the container image prior to deployment.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Creates a container called <c>mycontainer</c> with an image called <c>myimage</c>.
     /// <code language="csharp">
@@ -470,6 +471,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithDockerfile<T>(this IResourceBuilder<T> builder, string contextPath, string? dockerfilePath = null, string? stage = null) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -511,7 +513,6 @@ public static class ContainerResourceBuilderExtensions
     /// method results in an additional attribute being added to the `container.v1` resource type which contains the configuration
     /// necessary to allow the deployment tool to build the container image prior to deployment.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Creates a container called <c>mycontainer</c> based on a Dockerfile in the context path <c>path/to/context</c>.
     /// <code language="csharp">
@@ -522,6 +523,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ContainerResource> AddDockerfile(this IDistributedApplicationBuilder builder, [ResourceName] string name, string contextPath, string? dockerfilePath = null, string? stage = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -571,7 +573,6 @@ public static class ContainerResourceBuilderExtensions
     /// adds an additional build argument the container resource to be used when the image is built. This method must be called after
     /// <see cref="ContainerResourceBuilderExtensions.WithDockerfile{T}(IResourceBuilder{T}, string, string?, string?)"/>.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Adding a static build argument.
     /// <code language="csharp">
@@ -584,6 +585,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithBuildArg<T>(this IResourceBuilder<T> builder, string name, object? value) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -619,7 +621,6 @@ public static class ContainerResourceBuilderExtensions
     /// adds an additional build argument the container resource to be used when the image is built. This method must be called after
     /// <see cref="ContainerResourceBuilderExtensions.WithDockerfile{T}(IResourceBuilder{T}, string, string?, string?)"/>.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Adding a build argument based on a parameter..
     /// <code language="csharp">
@@ -634,6 +635,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithBuildArg<T>(this IResourceBuilder<T> builder, string name, IResourceBuilder<ParameterResource> value) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -666,7 +668,6 @@ public static class ContainerResourceBuilderExtensions
     /// results in a <c>--secret</c> argument being appended to the <c>docker build</c> or <c>podman build</c> command. This overload results in an environment
     /// variable-based secret being passed to the build process. The value of the environment variable is the value of the secret referenced by the <see cref="ParameterResource"/>.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Adding a build secret based on a parameter.
     /// <code language="csharp">
@@ -681,6 +682,7 @@ public static class ContainerResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithBuildSecret<T>(this IResourceBuilder<T> builder, string name, IResourceBuilder<ParameterResource> value) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -716,7 +718,6 @@ public static class ContainerResourceBuilderExtensions
     /// Make sure any data being written to containers is idempotent for a given app model configuration. Specifically, be careful not to include any data that will be
     /// unique on a per-run basis.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Create a directory called <c>custom-entry</c> in the container's file system at the path <c>/usr/data</c> and create a file called <c>entrypoint.sh</c> inside it with the content <c>echo hello world</c>.
     /// The default permissions for these files will be for the user or group to be able to read and write to the files, but not execute them. entrypoint.sh will be created with execution permissions for the owner.
@@ -741,6 +742,7 @@ public static class ContainerResourceBuilderExtensions
     ///     defaultOwner: 1000);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, IEnumerable<ContainerFileSystemItem> entries, int? defaultOwner = null, int? defaultGroup = null, UnixFileMode? umask = null) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -779,7 +781,6 @@ public static class ContainerResourceBuilderExtensions
     /// Make sure any data being written to containers is idempotent for a given app model configuration. Specifically, be careful not to include any data that will be
     /// unique on a per-run basis.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Create a configuration file for every Postgres instance in the application model.
     /// <code language="csharp">
@@ -814,6 +815,7 @@ public static class ContainerResourceBuilderExtensions
     /// });
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithContainerFiles<T>(this IResourceBuilder<T> builder, string destinationPath, Func<ContainerFileSystemCallbackContext, CancellationToken, Task<IEnumerable<ContainerFileSystemItem>>> callback, int? defaultOwner = null, int? defaultGroup = null, UnixFileMode? umask = null) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -32,7 +32,6 @@ namespace Aspire.Hosting;
 /// constructing the <see cref="IDistributedApplicationBuilder"/> including disabling the .NET Aspire dashboard (see <see cref="DistributedApplicationOptions.DisableDashboard"/>) or
 /// allowing unsecured communication between the browser and dashboard, and dashboard and app host (see <see cref="DistributedApplicationOptions.AllowUnsecuredTransport"/>.
 /// </para>
-/// </remarks>
 /// <example>
 /// The following example shows creating a PostgreSQL server resource with a database and referencing that
 /// database in a .NET project.
@@ -45,6 +44,7 @@ namespace Aspire.Hosting;
 /// builder.Build().Run();
 /// </code>
 /// </example>
+/// </remarks>
 [DebuggerDisplay("{_host}")]
 public class DistributedApplication : IHost, IAsyncDisposable
 {
@@ -72,7 +72,6 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// passed to the <see cref="CreateBuilder()"/> method the app host has no
     /// way to be put into publish mode. Refer to <see cref="CreateBuilder(string[])"/> or <see cref="CreateBuilder(DistributedApplicationOptions)"/>
     /// when more control is needed over the behavior of the distributed application at runtime.
-    /// </remarks>
     /// <example>
     /// The following example is creating a Postgres server resource with a database and referencing that
     /// database in a .NET project.
@@ -85,6 +84,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IDistributedApplicationBuilder CreateBuilder() => CreateBuilder([]);
 
     /// <summary>
@@ -165,7 +165,6 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// <see cref="DistributedApplicationOptions.Args"/> property to ensure that the app host continues to function
     /// correctly when used with deployment tools that need to enable publish mode.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Override the container registry used by the distributed application.
     /// <code lang="csharp">
@@ -182,6 +181,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IDistributedApplicationBuilder CreateBuilder(DistributedApplicationOptions options)
     {
         WaitForDebugger();
@@ -247,7 +247,6 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// <item>Database seeding.</item>
     /// <item>Integration test readiness checks.</item>
     /// </list>
-    /// </remarks>
     /// <example>
     /// Wait for resource readiness:
     /// <code>
@@ -288,6 +287,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// }
     /// </code>
     /// </example>
+    /// </remarks>
     public ResourceNotificationService ResourceNotifications => _resourceNotifications ??= _host.Services.GetRequiredService<ResourceNotificationService>();
 
     /// <summary>
@@ -411,7 +411,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
         {
             await ExecuteBeforeStartHooksAsync(cancellationToken).ConfigureAwait(false);
         }
-        
+
         await _host.RunAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
@@ -28,7 +28,6 @@ public static class DistributedApplicationBuilderExtensions
     /// referenced directly. Using the <see cref="CreateResourceBuilder{T}(IDistributedApplicationBuilder, string)"/> method allows for easier mutation
     /// of resources within the test scenario.
     /// </para>
-    /// </remarks>
     /// <example>
     /// In this example, the MyAspireApp.AppHost project has previously added a Redis resource named "cache" to the application host. The test project,
     /// MyAspireApp.AppHost.Tests, modifies that resource so that it sleeps instead of starting the Redis container. This allows the test case to verify
@@ -57,6 +56,7 @@ public static class DistributedApplicationBuilderExtensions
     /// }
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> CreateResourceBuilder<T>(this IDistributedApplicationBuilder builder, string name) where T : IResource
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));

--- a/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
@@ -26,7 +26,6 @@ namespace Aspire.Hosting;
 /// method. Once the builder is created extension methods which target the <see cref="IDistributedApplicationBuilder"/>
 /// interface can be used to add resources to the distributed application.
 /// </para>
-/// </remarks>
 /// <example>
 /// <para>
 /// This example shows a distributed application that contains a .NET project (InventoryService) that uses
@@ -50,6 +49,7 @@ namespace Aspire.Hosting;
 /// builder.Build().Run();
 /// </code>
 /// </example>
+/// </remarks>
 public interface IDistributedApplicationBuilder
 {
     /// <inheritdoc cref="HostApplicationBuilder.Configuration" />
@@ -88,7 +88,6 @@ public interface IDistributedApplicationBuilder
     /// properties. Developers building .NET Aspire based applications may whish to change the application
     /// model depending on whether they are running locally, or whether they are publishing to the cloud.
     /// </para>
-    /// </remarks>
     /// <example>
     /// <para>
     /// An example of using the <see cref="DistributedApplicationExecutionContext.IsRunMode"/> property on the <see cref="IDistributedApplicationBuilder"/> via
@@ -112,6 +111,7 @@ public interface IDistributedApplicationBuilder
     /// }
     /// </code>
     /// </example>
+    /// </remarks>
     public DistributedApplicationExecutionContext ExecutionContext { get; }
 
     /// <summary>
@@ -135,7 +135,6 @@ public interface IDistributedApplicationBuilder
     /// Aspire-based applications. It is typically used by developers building extensions to Aspire and is
     /// called from within an extension method to add a custom resource to the application model.
     /// </para>
-    /// </remarks>
     /// <example>
     /// This example shows the implementation of the <see cref="ContainerResourceBuilderExtensions.AddContainer(IDistributedApplicationBuilder, string, string)"/>
     /// method which makes use of the <see cref="AddResource{T}(T)"/> method to add a container resource to the application. In .NET Aspire
@@ -152,6 +151,7 @@ public interface IDistributedApplicationBuilder
     /// }
     /// </code>
     /// </example>
+    /// </remarks>
     IResourceBuilder<T> AddResource<T>(T resource) where T : IResource;
 
     /// <summary>
@@ -176,7 +176,6 @@ public interface IDistributedApplicationBuilder
     /// collection. Not all changes to annotations will be effective depending on what stage of the lifecycle the app host is in. See <see cref="IDistributedApplicationLifecycleHook"/>
     /// for more details.
     /// </para>
-    /// </remarks>
     /// <example>
     /// <para>
     /// The following example shows the implementation of the <see cref="ParameterResourceBuilderExtensions.AddConnectionString(IDistributedApplicationBuilder, string, string?)"/>
@@ -208,6 +207,7 @@ public interface IDistributedApplicationBuilder
     /// }
     /// </code>
     /// </example>
+    /// </remarks>
     IResourceBuilder<T> CreateResourceBuilder<T>(T resource) where T : IResource;
 
     /// <summary>

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -91,7 +91,6 @@ public static class ProjectResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-
     public static IResourceBuilder<ProjectResource> AddProject(this IDistributedApplicationBuilder builder, [ResourceName] string name, string projectPath)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -47,7 +47,6 @@ public static class ProjectResourceBuilderExtensions
     /// Note that endpoints coming from the Kestrel configuration are automatically added to the project. The Kestrel Url and Protocols are used
     /// to build the equivalent <see cref="EndpointAnnotation"/>.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Example of adding a project to the application model.
     /// <code lang="csharp">
@@ -58,6 +57,7 @@ public static class ProjectResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ProjectResource> AddProject<TProject>(this IDistributedApplicationBuilder builder, [ResourceName] string name) where TProject : IProjectMetadata, new()
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -80,7 +80,6 @@ public static class ProjectResourceBuilderExtensions
     /// path is not an absolute path then it will be computed relative to the app host directory.
     /// </para>
     /// <inheritdoc cref="AddProject(IDistributedApplicationBuilder, string)" path="/remarks/para[@name='kestrel']" />
-    /// </remarks>
     /// <example>
     /// Add a project to the app model via a project path.
     /// <code lang="csharp">
@@ -91,6 +90,8 @@ public static class ProjectResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
+
     public static IResourceBuilder<ProjectResource> AddProject(this IDistributedApplicationBuilder builder, [ResourceName] string name, string projectPath)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -127,7 +128,6 @@ public static class ProjectResourceBuilderExtensions
     /// that references the project can have a <c>AspireProjectMetadataTypeName="..."</c> attribute added to override the name.
     /// </para>
     /// <inheritdoc cref="AddProject(IDistributedApplicationBuilder, string)" path="/remarks/para[@name='kestrel']" />
-    /// </remarks>
     /// <example>
     /// Example of adding a project to the application model.
     /// <code lang="csharp">
@@ -138,6 +138,7 @@ public static class ProjectResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ProjectResource> AddProject<TProject>(this IDistributedApplicationBuilder builder, [ResourceName] string name, string? launchProfileName) where TProject : IProjectMetadata, new()
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -165,7 +166,6 @@ public static class ProjectResourceBuilderExtensions
     /// path is not an absolute path then it will be computed relative to the app host directory.
     /// </para>
     /// <inheritdoc cref="AddProject(IDistributedApplicationBuilder, string)" path="/remarks/para[@name='kestrel']" />
-    /// </remarks>
     /// <example>
     /// Add a project to the app model via a project path.
     /// <code lang="csharp">
@@ -176,6 +176,7 @@ public static class ProjectResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ProjectResource> AddProject(this IDistributedApplicationBuilder builder, [ResourceName] string name, string projectPath, string? launchProfileName)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -214,7 +215,6 @@ public static class ProjectResourceBuilderExtensions
     /// spaces in project names are converted to underscores. This normalization may lead to naming conflicts. If a conflict occurs the <c>&lt;ProjectReference /&gt;</c>
     /// that references the project can have a <c>AspireProjectMetadataTypeName="..."</c> attribute added to override the name.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Example of adding a project to the application model.
     /// <code lang="csharp">
@@ -225,6 +225,7 @@ public static class ProjectResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ProjectResource> AddProject<TProject>(this IDistributedApplicationBuilder builder, [ResourceName] string name, Action<ProjectResourceOptions> configure) where TProject : IProjectMetadata, new()
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -254,7 +255,6 @@ public static class ProjectResourceBuilderExtensions
     /// model using a path to the project file. This allows for projects to be referenced that may not be part of the same solution. If the project
     /// path is not an absolute path then it will be computed relative to the app host directory.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Add a project to the app model via a project path.
     /// <code lang="csharp">
@@ -265,6 +265,7 @@ public static class ProjectResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ProjectResource> AddProject(this IDistributedApplicationBuilder builder, [ResourceName] string name, string projectPath, Action<ProjectResourceOptions> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -583,7 +584,6 @@ public static class ProjectResourceBuilderExtensions
     /// This capability can be useful when debugging scale out scenarios to ensure state is appropriately managed
     /// within a cluster of instances.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Start multiple instances of the same service.
     /// <code lang="csharp">
@@ -593,6 +593,7 @@ public static class ProjectResourceBuilderExtensions
     ///        .WithReplicas(3);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ProjectResource> WithReplicas(this IResourceBuilder<ProjectResource> builder, int replicas)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -617,7 +618,6 @@ public static class ProjectResourceBuilderExtensions
     /// into the project and set to true. If the <see cref="DisableForwardedHeaders(IResourceBuilder{ProjectResource})"/>
     /// extension is used this environment variable will not be set.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Disable forwarded headers for a project.
     /// <code lang="csharp">
@@ -627,6 +627,7 @@ public static class ProjectResourceBuilderExtensions
     ///        .DisableForwardedHeaders();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<ProjectResource> DisableForwardedHeaders(this IResourceBuilder<ProjectResource> builder)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -489,7 +489,6 @@ public static class ResourceBuilderExtensions
     /// of the endpoint annotation in the callback will not automatically change the <see cref="EndpointAnnotation.UriScheme"/>.
     /// All values should be set in the callback if the defaults are not acceptable.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Configure an endpoint to use UDP.
     /// <code lang="C#">
@@ -503,6 +502,7 @@ public static class ResourceBuilderExtensions
     ///                        });
     /// </code>
     /// </example>
+    /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "<Pending>")]
     public static IResourceBuilder<T> WithEndpoint<T>(this IResourceBuilder<T> builder, [EndpointName] string endpointName, Action<EndpointAnnotation> callback, bool createIfNotExists = true) where T : IResourceWithEndpoints
     {
@@ -712,7 +712,6 @@ public static class ResourceBuilderExtensions
     /// This allows you to modify any URLs for the resource, including adding, modifying, or even deletion.<br/>
     /// Note that any endpoints on the resource will automatically get a corresponding URL added for them.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Update all displayed URLs to have display text:
     /// <code lang="C#">
@@ -746,6 +745,7 @@ public static class ResourceBuilderExtensions
     ///                       });
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithUrls<T>(this IResourceBuilder<T> builder, Action<ResourceUrlsCallbackContext> callback)
         where T : IResource
     {
@@ -873,7 +873,6 @@ public static class ResourceBuilderExtensions
     /// <para>
     /// If the endpoint with the specified name does not exist, the callback will not be executed and a warning will be logged.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Customize the URL for the "https" endpoint to use the link text "Home":
     /// <code lang="C#">
@@ -888,6 +887,7 @@ public static class ResourceBuilderExtensions
     ///                       .WithUrlForEndpoint("https", url => url.Url = "/home");
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithUrlForEndpoint<T>(this IResourceBuilder<T> builder, string endpointName, Action<ResourceUrlAnnotation> callback)
         where T : IResource
     {
@@ -926,7 +926,6 @@ public static class ResourceBuilderExtensions
     /// <para>
     /// If the endpoint with the specified name does not exist, the callback will not be executed and a warning will be logged.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Add a URL for the "https" endpoint that deep-links to an admin page with the text "Admin":
     /// <code lang="C#">
@@ -934,6 +933,7 @@ public static class ResourceBuilderExtensions
     ///                       .WithUrlForEndpoint("https", ep => new() { Url = "/admin", DisplayText = "Admin" });
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithUrlForEndpoint<T>(this IResourceBuilder<T> builder, string endpointName, Func<EndpointReference, ResourceUrlAnnotation> callback)
         where T : IResourceWithEndpoints
     {
@@ -983,7 +983,6 @@ public static class ResourceBuilderExtensions
     /// return <see cref="HealthStatus.Healthy"/>.</para>
     /// <para>The <see cref="WithHealthCheck{T}(IResourceBuilder{T}, string)"/> method can be used to associate
     /// additional health checks with a resource.</para>
-    /// </remarks>
     /// <example>
     /// Start message queue before starting the worker service.
     /// <code lang="C#">
@@ -994,6 +993,7 @@ public static class ResourceBuilderExtensions
     ///        .WaitFor(messaging);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WaitFor<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency) where T : IResourceWithWaitSupport
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1025,7 +1025,6 @@ public static class ResourceBuilderExtensions
     /// behavior with the <see cref="WaitFor{T}(IResourceBuilder{T}, IResourceBuilder{IResource})"/> overload.</para>
     /// <para>When <see cref="WaitBehavior.StopOnResourceUnavailable"/> is specified, the wait operation
     /// will throw a <see cref="DistributedApplicationException"/> if the resource enters an unavailable state.</para>
-    /// </remarks>
     /// <example>
     /// Start message queue before starting the worker service.
     /// <code lang="C#">
@@ -1036,6 +1035,7 @@ public static class ResourceBuilderExtensions
     ///        .WaitFor(messaging, WaitBehavior.StopOnResourceUnavailable);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WaitFor<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency, WaitBehavior waitBehavior) where T : IResourceWithWaitSupport
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1094,7 +1094,6 @@ public static class ResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
     /// <para>This method is useful when a resource shouldn't automatically start when the app host starts.</para>
-    /// </remarks>
     /// <example>
     /// The database clean up tool project isn't started with the app host.
     /// The resource start command can be used to run it ondemand later.
@@ -1106,6 +1105,7 @@ public static class ResourceBuilderExtensions
     ///        .WithExplicitStart();
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithExplicitStart<T>(this IResourceBuilder<T> builder) where T : IResource
     {
         return builder.WithAnnotation(new ExplicitStartupAnnotation());
@@ -1124,7 +1124,6 @@ public static class ResourceBuilderExtensions
     /// would be to include a console application that initializes the database schema or performs other one off
     /// initialization tasks.</para>
     /// <para>Note that this method has no impact at deployment time and only works for local development.</para>
-    /// </remarks>
     /// <example>
     /// Wait for database initialization app to complete running.
     /// <code lang="C#">
@@ -1137,6 +1136,7 @@ public static class ResourceBuilderExtensions
     ///        .WaitForCompletion(dbprep);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WaitForCompletion<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency, int exitCode = 0) where T : IResourceWithWaitSupport
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1171,7 +1171,6 @@ public static class ResourceBuilderExtensions
     /// registered in the application hosts dependency injection container. The <see cref="WithHealthCheck{T}(IResourceBuilder{T}, string)"/>
     /// method does not inject the health check itself it is purely an association mechanism.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Define a custom health check and associate it with a resource.
     /// <code lang="C#">
@@ -1193,6 +1192,7 @@ public static class ResourceBuilderExtensions
     ///                      // custom check defined in the code.
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithHealthCheck<T>(this IResourceBuilder<T> builder, string key) where T : IResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1223,7 +1223,6 @@ public static class ResourceBuilderExtensions
     /// on a periodic basis. The base address is dynamically determined based on the endpoint that was selected. By
     /// default the path is set to "/" and the status code is set to 200.
     /// </para>
-    /// </remarks>
     /// <example>
     /// This example shows adding an HTTP health check to a backend project.
     /// The health check makes sure that the front end does not start until the backend is
@@ -1237,6 +1236,7 @@ public static class ResourceBuilderExtensions
     ///        .WithReference(backend).WaitFor(backend);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithHttpHealthCheck<T>(this IResourceBuilder<T> builder, string? path = null, int? statusCode = null, string? endpointName = null) where T : IResourceWithEndpoints
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1318,7 +1318,6 @@ public static class ResourceBuilderExtensions
     /// on a periodic basis. The base address is dynamically determined based on the endpoint that was selected. By
     /// default the path is set to "/" and the status code is set to 200.
     /// </para>
-    /// </remarks>
     /// <example>
     /// This example shows adding an HTTPS health check to a backend project.
     /// The health check makes sure that the front end does not start until the backend is
@@ -1332,6 +1331,7 @@ public static class ResourceBuilderExtensions
     ///        .WithReference(backend).WaitFor(backend);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithHttpsHealthCheck<T>(this IResourceBuilder<T> builder, string? path = null, int? statusCode = null, string? endpointName = null) where T : IResourceWithEndpoints
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1494,7 +1494,6 @@ public static class ResourceBuilderExtensions
     /// The <see cref="HttpCommandOptions.GetCommandResult"/> callback will be invoked after the response is received to determine the result of the command invocation. If this callback
     /// is not specified, the command will be considered succesful if the response status code is in the 2xx range.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Adds a command to the project resource that when invoked sends an HTTP POST request to the path <c>/clear-cache</c>.
     /// <code lang="csharp">
@@ -1524,6 +1523,7 @@ public static class ResourceBuilderExtensions
     ///                      });
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<TResource> WithHttpCommand<TResource>(
         this IResourceBuilder<TResource> builder,
         string path,
@@ -1584,7 +1584,6 @@ public static class ResourceBuilderExtensions
     /// The <see cref="HttpCommandOptions.GetCommandResult"/> callback will be invoked after the response is received to determine the result of the command invocation. If this callback
     /// is not specified, the command will be considered succesful if the response status code is in the 2xx range.
     /// </para>
-    /// </remarks>
     /// <example>
     /// Adds commands to a project resource that when invoked sends an HTTP POST request to an endpoint on a separate load generator resource, to generate load against the
     /// resource the command was executed against.
@@ -1597,6 +1596,7 @@ public static class ResourceBuilderExtensions
     /// loadGenerator.WithReference(customerService);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<TResource> WithHttpCommand<TResource>(
         this IResourceBuilder<TResource> builder,
         string path,
@@ -1760,7 +1760,6 @@ public static class ResourceBuilderExtensions
     /// The <c>WithRelationship</c> method is used to add relationships to the resource. Relationships are used to link
     /// resources together in UI. The <paramref name="type"/> indicates information about the relationship type.
     /// </para>
-    /// </remarks>
     /// <example>
     /// This example shows adding a relationship between two resources.
     /// <code lang="C#">
@@ -1770,6 +1769,7 @@ public static class ResourceBuilderExtensions
     ///                      .WithRelationship(backend.Resource, "Manager");
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithRelationship<T>(
         this IResourceBuilder<T> builder,
         IResource resource,
@@ -1887,7 +1887,6 @@ public static class ResourceBuilderExtensions
     /// The <c>WithParentRelationship</c> method is used to add parent relationships to the resource. Relationships are used to link
     /// resources together in UI.
     /// </para>
-    /// </remarks>
     /// <example>
     /// This example shows adding a relationship between two resources.
     /// <code lang="C#">
@@ -1898,6 +1897,7 @@ public static class ResourceBuilderExtensions
     ///                      .WithParentRelationship(backend);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithParentRelationship<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<IResource> parent) where T : IResource
@@ -1917,7 +1917,6 @@ public static class ResourceBuilderExtensions
     /// The <c>WithParentRelationship</c> method is used to add parent relationships to the resource. Relationships are used to link
     /// resources together in UI.
     /// </para>
-    /// </remarks>
     /// <example>
     /// This example shows adding a relationship between two resources.
     /// <code lang="C#">
@@ -1928,6 +1927,7 @@ public static class ResourceBuilderExtensions
     ///                      .WithParentRelationship(backend.Resource);
     /// </code>
     /// </example>
+    /// </remarks>
     public static IResourceBuilder<T> WithParentRelationship<T>(
         this IResourceBuilder<T> builder,
         IResource parent) where T : IResource

--- a/tests/Aspire.TestUtilities/QuarantinedTestAttribute.cs
+++ b/tests/Aspire.TestUtilities/QuarantinedTestAttribute.cs
@@ -11,7 +11,6 @@ namespace Aspire.TestUtilities;
 /// This attribute works by applying xUnit.net "Traits" based on the criteria specified in the attribute
 /// properties. Once these traits are applied, build scripts can include/exclude tests based on them.
 /// </para>
-/// </remarks>
 /// <example>
 /// <code>
 /// [Fact]
@@ -32,6 +31,7 @@ namespace Aspire.TestUtilities;
 /// </item>
 /// </list>
 /// </example>
+/// </remarks>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
 public sealed class QuarantinedTestAttribute : Attribute, ITraitAttribute
 {


### PR DESCRIPTION
## Description

PR involves including examples inside remarks tags of the XML documentation comments in all places in the repo where applicable.

Fixes #8841

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
