### PR TITLE
regularize and increase some timeouts

### DIFF
--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\QuarantinedTestAttribute.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\Requires*.cs" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" />
+    <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.TestUtilities;
+using Microsoft.AspNetCore.InternalTesting;
 using SamplesIntegrationTests;
 using SamplesIntegrationTests.Infrastructure;
 using Xunit;
@@ -20,10 +21,10 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
         await using var app = await appHost.BuildAsync();
 
         await app.StartAsync();
-        await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(2));
+        await app.WaitForResources().WaitAsync(TestConstants.ExtraLongTimeoutTimeSpan);
 
         await app.WaitForTextAsync($"I'm Batman. - Batman")
-                .WaitAsync(TimeSpan.FromMinutes(3));
+                .WaitAsync(TestConstants.ExtraLongTimeoutTimeSpan);
 
         app.EnsureNoErrorsLogged();
         await app.StopAsync();
@@ -37,10 +38,10 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
         await using var app = await appHost.BuildAsync();
 
         await app.StartAsync();
-        await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(2));
+        await app.WaitForResources().WaitAsync(TestConstants.ExtraLongTimeoutTimeSpan);
 
         // Wait for the producer to start sending messages
-        await app.WaitForTextAsync("Hello, World!").WaitAsync(TimeSpan.FromMinutes(5));
+        await app.WaitForTextAsync("Hello, World!").WaitAsync(TestConstants.ExtraLongTimeoutTimeSpan);
 
         // Wait for the consumer to receive some messages
         await WaitForAllTextAsync(app,
@@ -63,7 +64,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
         await using var app = await appHost.BuildAsync();
 
         await app.StartAsync();
-        await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(2));
+        await app.WaitForResources().WaitAsync(TestConstants.ExtraLongTimeoutTimeSpan);
 
         // Wait for the 'Job host started' message as an indication
         // that the Functions host has initialized correctly


### PR DESCRIPTION
In https://github.com/dotnet/aspire/pull/9053 one of these tests hit a 2 min timeout when it was still pulling a docker image. Change to standard 3 or 6 min timeout.

We may want to do a pass across all our tests to remove these randomly picked minute numbers.