### PR TITLE
Add hidden to protocol, support in dashboard

### DIFF
--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -26,6 +26,8 @@ for (var i = 0; i < 5; i++)
     }
 }
 
+builder.AddParameter("testParameterResource", () => "value", secret: true);
+
 // TODO: OTEL env var can be removed when OTEL libraries are updated to 1.9.0
 // See https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/RELEASENOTES.md#1100
 var serviceBuilder = builder.AddProject<Projects.Stress_ApiService>("stress-apiservice", launchProfileName: null)

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -393,7 +393,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         var builder = ImmutableList.CreateBuilder<SelectViewModel<ResourceTypeDetails>>();
 
         foreach (var grouping in resourcesByName
-            .Where(r => !r.Value.IsHidden())
+            .Where(r => !r.Value.IsResourceHidden())
             .OrderBy(c => c.Value, ResourceViewModelNameComparer.Instance)
             .GroupBy(r => r.Value.DisplayName, StringComparers.ResourceName))
         {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -393,7 +393,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         var builder = ImmutableList.CreateBuilder<SelectViewModel<ResourceTypeDetails>>();
 
         foreach (var grouping in resourcesByName
-            .Where(r => !r.Value.IsHiddenState())
+            .Where(r => !r.Value.IsHidden())
             .OrderBy(c => c.Value, ResourceViewModelNameComparer.Instance)
             .GroupBy(r => r.Value.DisplayName, StringComparers.ResourceName))
         {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -118,7 +118,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                && IsKeyValueTrue(resource.State ?? string.Empty, PageViewModel.ResourceStatesToVisibility)
                && IsKeyValueTrue(resource.HealthStatus?.Humanize() ?? string.Empty, PageViewModel.ResourceHealthStatusesToVisibility)
                && (_filter.Length == 0 || resource.MatchesFilter(_filter))
-               && !resource.IsHiddenState();
+               && !resource.IsHidden();
 
         static bool IsKeyValueTrue(string key, IDictionary<string, bool> dictionary) => dictionary.TryGetValue(key, out var value) && value;
     }
@@ -451,7 +451,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private bool HasCollapsedResources()
     {
-        return _resourceByName.Any(r => !r.Value.IsHiddenState() && _collapsedResourceNames.Contains(r.Key));
+        return _resourceByName.Any(r => !r.Value.IsHidden() && _collapsedResourceNames.Contains(r.Key));
     }
 
     private void UpdateMaxHighlightedCount()
@@ -619,7 +619,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         var count = 0;
         foreach (var (_, item) in _resourceByName)
         {
-            if (item.IsHiddenState())
+            if (item.IsHidden())
             {
                 continue;
             }
@@ -693,7 +693,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private async Task OnToggleCollapseAll()
     {
         var resourcesWithChildren = _resourceByName.Values
-            .Where(r => !r.IsHiddenState())
+            .Where(r => !r.IsHidden())
             .Where(r => _resourceByName.Values.Any(nested => nested.GetResourcePropertyValue(KnownProperties.Resource.ParentName) == r.Name))
             .ToList();
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -118,7 +118,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                && IsKeyValueTrue(resource.State ?? string.Empty, PageViewModel.ResourceStatesToVisibility)
                && IsKeyValueTrue(resource.HealthStatus?.Humanize() ?? string.Empty, PageViewModel.ResourceHealthStatusesToVisibility)
                && (_filter.Length == 0 || resource.MatchesFilter(_filter))
-               && !resource.IsHidden();
+               && !resource.IsResourceHidden();
 
         static bool IsKeyValueTrue(string key, IDictionary<string, bool> dictionary) => dictionary.TryGetValue(key, out var value) && value;
     }
@@ -451,7 +451,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private bool HasCollapsedResources()
     {
-        return _resourceByName.Any(r => !r.Value.IsHidden() && _collapsedResourceNames.Contains(r.Key));
+        return _resourceByName.Any(r => !r.Value.IsResourceHidden() && _collapsedResourceNames.Contains(r.Key));
     }
 
     private void UpdateMaxHighlightedCount()
@@ -619,7 +619,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         var count = 0;
         foreach (var (_, item) in _resourceByName)
         {
-            if (item.IsHidden())
+            if (item.IsResourceHidden())
             {
                 continue;
             }
@@ -693,7 +693,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private async Task OnToggleCollapseAll()
     {
         var resourcesWithChildren = _resourceByName.Values
-            .Where(r => !r.IsHidden())
+            .Where(r => !r.IsResourceHidden())
             .Where(r => _resourceByName.Values.Any(nested => nested.GetResourcePropertyValue(KnownProperties.Resource.ParentName) == r.Name))
             .ToList();
 

--- a/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
@@ -7,11 +7,6 @@ namespace Aspire.Dashboard.Extensions;
 
 internal static class ResourceViewModelExtensions
 {
-    public static bool IsHiddenState(this ResourceViewModel resource)
-    {
-        return resource.KnownState is KnownResourceState.Hidden;
-    }
-
     public static bool IsRunningState(this ResourceViewModel resource)
     {
         return resource.KnownState is KnownResourceState.Running;

--- a/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
@@ -24,7 +24,7 @@ public static class ResourceGraphMapper
         {
             var matches = resourcesByName.Values
                 .Where(r => string.Equals(r.DisplayName, resourceRelationships.Key, StringComparisons.ResourceName))
-                .Where(r => !r.IsHidden())
+                .Where(r => !r.IsResourceHidden())
                 .ToList();
 
             foreach (var match in matches)

--- a/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
@@ -24,7 +24,7 @@ public static class ResourceGraphMapper
         {
             var matches = resourcesByName.Values
                 .Where(r => string.Equals(r.DisplayName, resourceRelationships.Key, StringComparisons.ResourceName))
-                .Where(r => r.KnownState != KnownResourceState.Hidden)
+                .Where(r => !r.IsHidden())
                 .ToList();
 
             foreach (var match in matches)

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Aspire.Dashboard.Components.Controls;
-using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Utils;
 using Google.Protobuf.WellKnownTypes;
 using Humanizer;
@@ -39,6 +38,7 @@ public sealed class ResourceViewModel
     public required ImmutableArray<CommandViewModel> Commands { get; init; }
     /// <summary>The health status of the resource. <see langword="null"/> indicates that health status is expected but not yet available.</summary>
     public HealthStatus? HealthStatus { get; private set; }
+    public bool Hidden { private get; init; }
 
     public required ImmutableArray<HealthReportViewModel> HealthReports
     {
@@ -79,6 +79,11 @@ public sealed class ResourceViewModel
         return null;
     }
 
+    public bool IsHidden()
+    {
+        return Hidden || KnownState is KnownResourceState.Hidden;
+    }
+
     internal static HealthStatus? ComputeHealthStatus(ImmutableArray<HealthReportViewModel> healthReports, KnownResourceState? state)
     {
         if (state != KnownResourceState.Running)
@@ -100,7 +105,7 @@ public sealed class ResourceViewModel
         var count = 0;
         foreach (var (_, item) in allResources)
         {
-            if (item.IsHiddenState())
+            if (item.IsHidden())
             {
                 continue;
             }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -38,7 +38,7 @@ public sealed class ResourceViewModel
     public required ImmutableArray<CommandViewModel> Commands { get; init; }
     /// <summary>The health status of the resource. <see langword="null"/> indicates that health status is expected but not yet available.</summary>
     public HealthStatus? HealthStatus { get; private set; }
-    public bool Hidden { private get; init; }
+    public bool IsHidden { private get; init; }
 
     public required ImmutableArray<HealthReportViewModel> HealthReports
     {
@@ -79,9 +79,9 @@ public sealed class ResourceViewModel
         return null;
     }
 
-    public bool IsHidden()
+    public bool IsResourceHidden()
     {
-        return Hidden || KnownState is KnownResourceState.Hidden;
+        return IsHidden || KnownState is KnownResourceState.Hidden;
     }
 
     internal static HealthStatus? ComputeHealthStatus(ImmutableArray<HealthReportViewModel> healthReports, KnownResourceState? state)
@@ -105,7 +105,7 @@ public sealed class ResourceViewModel
         var count = 0;
         foreach (var (_, item) in allResources)
         {
-            if (item.IsHidden())
+            if (item.IsResourceHidden())
             {
                 continue;
             }

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -41,7 +41,7 @@ partial class Resource
                 StateStyle = HasStateStyle ? StateStyle : null,
                 Commands = GetCommands(),
                 HealthReports = HealthReports.Select(ToHealthReportViewModel).OrderBy(vm => vm.Name).ToImmutableArray(),
-                Hidden = Hidden
+                IsHidden = IsHidden
             };
         }
         catch (Exception ex)

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -41,6 +41,7 @@ partial class Resource
                 StateStyle = HasStateStyle ? StateStyle : null,
                 Commands = GetCommands(),
                 HealthReports = HealthReports.Select(ToHealthReportViewModel).OrderBy(vm => vm.Name).ToImmutableArray(),
+                Hidden = Hidden
             };
         }
         catch (Exception ex)

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -123,6 +123,11 @@ public sealed record CustomResourceSnapshot
     /// </summary>
     public ImmutableArray<RelationshipSnapshot> Relationships { get; init; } = [];
 
+    /// <summary>
+    /// Whether this resource should be hidden in UI.
+    /// </summary>
+    public bool Hidden { get; init; }
+
     internal static HealthStatus? ComputeHealthStatus(ImmutableArray<HealthReportSnapshot> healthReports, string? state)
     {
         if (state != KnownResourceStates.Running)
@@ -337,6 +342,7 @@ public static class KnownResourceStates
     /// <summary>
     /// The hidden state. Useful for hiding the resource.
     /// </summary>
+    /// <remarks>This member is obsolete. Please set <see cref="CustomResourceSnapshot.Hidden"/> instead.</remarks>
     public static readonly string Hidden = nameof(Hidden);
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -126,7 +126,7 @@ public sealed record CustomResourceSnapshot
     /// <summary>
     /// Whether this resource should be hidden in UI.
     /// </summary>
-    public bool Hidden { get; init; }
+    public bool IsHidden { get; init; }
 
     internal static HealthStatus? ComputeHealthStatus(ImmutableArray<HealthReportSnapshot> healthReports, string? state)
     {
@@ -342,7 +342,7 @@ public static class KnownResourceStates
     /// <summary>
     /// The hidden state. Useful for hiding the resource.
     /// </summary>
-    /// <remarks>This member is obsolete. Please set <see cref="CustomResourceSnapshot.Hidden"/> instead.</remarks>
+    [Obsolete("Use CustomResourceSnapshot.Hidden instead.")]
     public static readonly string Hidden = nameof(Hidden);
 
     /// <summary>

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -44,7 +44,9 @@ public static class ConnectionStringBuilderExtensions
                       {
                           ResourceType = "ConnectionString",
                           // TODO: We'll hide this until we come up with a sane representation of these in the dashboard
+#pragma warning disable CS0618 // Type or member is obsolete
                           State = KnownResourceStates.Hidden,
+#pragma warning restore CS0618 // Type or member is obsolete
                           Properties = []
                       });
     }

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -173,7 +173,9 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
             },
             State = configuration.GetBool(KnownConfigNames.ShowDashboardResources, KnownConfigNames.Legacy.ShowDashboardResources) is true
                 ? null
+#pragma warning disable CS0618 // Type or member is obsolete
                 : KnownResourceStates.Hidden
+#pragma warning restore CS0618 // Type or member is obsolete
         };
 
         dashboardResource.Annotations.Add(new ResourceSnapshotAnnotation(snapshot));

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -49,7 +49,8 @@ internal sealed class DashboardServiceData : IDisposable
                     State = snapshot.State?.Text,
                     StateStyle = snapshot.State?.Style,
                     HealthReports = snapshot.HealthReports,
-                    Commands = snapshot.Commands
+                    Commands = snapshot.Commands,
+                    Hidden = snapshot.Hidden,
                 };
             }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -50,7 +50,7 @@ internal sealed class DashboardServiceData : IDisposable
                     StateStyle = snapshot.State?.Style,
                     HealthReports = snapshot.HealthReports,
                     Commands = snapshot.Commands,
-                    Hidden = snapshot.Hidden,
+                    IsHidden = snapshot.IsHidden,
                 };
             }
 

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -28,7 +28,7 @@ internal abstract class ResourceSnapshot
     public required ImmutableArray<RelationshipSnapshot> Relationships { get; init; }
     public required ImmutableArray<HealthReportSnapshot> HealthReports { get; init; }
     public required ImmutableArray<ResourceCommandSnapshot> Commands { get; init; }
-    public required bool Hidden { get; init; }
+    public required bool IsHidden { get; init; }
 
     protected abstract IEnumerable<(string Key, Value Value, bool IsSensitive)> GetProperties();
 

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -28,6 +28,7 @@ internal abstract class ResourceSnapshot
     public required ImmutableArray<RelationshipSnapshot> Relationships { get; init; }
     public required ImmutableArray<HealthReportSnapshot> HealthReports { get; init; }
     public required ImmutableArray<ResourceCommandSnapshot> Commands { get; init; }
+    public required bool Hidden { get; init; }
 
     protected abstract IEnumerable<(string Key, Value Value, bool IsSensitive)> GetProperties();
 

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -18,7 +18,7 @@ partial class Resource
             Uid = snapshot.Uid,
             State = snapshot.State ?? "",
             StateStyle = snapshot.StateStyle ?? "",
-            Hidden = snapshot.Hidden
+            IsHidden = snapshot.IsHidden
         };
 
         if (snapshot.CreationTimeStamp.HasValue)

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -18,6 +18,7 @@ partial class Resource
             Uid = snapshot.Uid,
             State = snapshot.State ?? "",
             StateStyle = snapshot.StateStyle ?? "",
+            Hidden = snapshot.Hidden
         };
 
         if (snapshot.CreationTimeStamp.HasValue)

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -239,7 +239,7 @@ message Resource {
     repeated ResourceRelationship relationships = 20;
 
     // Whether the resource should be visually hidden in the dashboard.
-    bool hidden = 21;
+    bool is_hidden = 21;
 }
 
 ////////////////////////////////////////////

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -237,6 +237,9 @@ message Resource {
 
     // The list of relationships for this resource.
     repeated ResourceRelationship relationships = 20;
+
+    // Whether the resource should be visually hidden in the dashboard.
+    bool hidden = 21;
 }
 
 ////////////////////////////////////////////

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -24,7 +24,9 @@ internal class ResourceSnapshotBuilder
         var volumes = GetVolumes(container);
 
         var environment = GetEnvironmentVariables(container.Status?.EffectiveEnv ?? container.Spec.Env, container.Spec.Env);
+#pragma warning disable CS0618 // Type or member is obsolete
         var state = container.AppModelInitialState == KnownResourceStates.Hidden ? KnownResourceStates.Hidden : container.Status?.State;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var relationships = ImmutableArray<RelationshipSnapshot>.Empty;
 

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -152,17 +152,19 @@ public static class ParameterResourceBuilderExtensions
         configurationKey ??= $"Parameters:{name}";
         return configuration[configurationKey]
             ?? parameterDefault?.GetDefaultValue()
-            ?? throw new DistributedApplicationException($"Parameter resource could not be used because configuration key '{configurationKey}' is missing and the Parameter has no default value."); ;
+            ?? throw new DistributedApplicationException($"Parameter resource could not be used because configuration key '{configurationKey}' is missing and the Parameter has no default value.");
     }
 
     internal static IResourceBuilder<T> AddParameter<T>(this IDistributedApplicationBuilder builder, T resource)
         where T : ParameterResource
     {
-        var state = new CustomResourceSnapshot()
+        var state = new CustomResourceSnapshot
         {
             ResourceType = "Parameter",
             // hide parameters by default
+#pragma warning disable CS0618 // Type or member is obsolete
             State = KnownResourceStates.Hidden,
+#pragma warning restore CS0618 // Type or member is obsolete
             Properties = [
                 new("parameter.secret", resource.Secret.ToString()),
                 new(CustomResourceKnownProperties.Source, resource.ConfigurationKey)

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -328,7 +328,7 @@ public partial class ResourcesTests : DashboardTestContext
             Relationships = default,
             Properties = ImmutableDictionary<string, ResourcePropertyViewModel>.Empty,
             Commands = [],
-            Hidden = false,
+            IsHidden = false,
         };
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -328,6 +328,7 @@ public partial class ResourcesTests : DashboardTestContext
             Relationships = default,
             Properties = ImmutableDictionary<string, ResourcePropertyViewModel>.Empty,
             Commands = [],
+            Hidden = false,
         };
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -203,7 +203,7 @@ public class ResourcePublisherTests
             HealthReports = [],
             Commands = [],
             Relationships = [],
-            Hidden = false
+            IsHidden = false
         };
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -202,7 +202,8 @@ public class ResourcePublisherTests
             Environment = [],
             HealthReports = [],
             Commands = [],
-            Relationships = []
+            Relationships = [],
+            Hidden = false
         };
     }
 

--- a/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationExtensions.cs
+++ b/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationExtensions.cs
@@ -89,6 +89,7 @@ public static partial class DistributedApplicationExtensions
         return app.ResourceNotifications.WaitForResourceAsync(resourceName, targetState, cancellationToken);
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     /// <summary>
     /// Waits for all resources in the application to reach one of the specified states.
     /// </summary>
@@ -102,6 +103,7 @@ public static partial class DistributedApplicationExtensions
 
         return Task.WhenAll(applicationModel.Resources.Select(r => app.ResourceNotifications.WaitForResourceAsync(r.Name, targetStates, cancellationToken)));
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     /// Gets the app host and resource logs from the application.

--- a/tests/Shared/DashboardModel/ModelTestHelpers.cs
+++ b/tests/Shared/DashboardModel/ModelTestHelpers.cs
@@ -21,7 +21,8 @@ public static class ModelTestHelpers
         HealthStatus? reportHealthStatus = null,
         bool createNullHealthReport = false,
         ImmutableArray<CommandViewModel>? commands = null,
-        ImmutableArray<RelationshipViewModel>? relationships = null)
+        ImmutableArray<RelationshipViewModel>? relationships = null,
+        bool hidden = false)
     {
         return new ResourceViewModel
         {
@@ -42,6 +43,7 @@ public static class ModelTestHelpers
             HealthReports = reportHealthStatus is null && !createNullHealthReport ? [] : [new HealthReportViewModel("healthcheck", reportHealthStatus, null, null)],
             Commands = commands ?? [],
             Relationships = relationships ?? [],
+            Hidden = hidden
         };
     }
 }

--- a/tests/Shared/DashboardModel/ModelTestHelpers.cs
+++ b/tests/Shared/DashboardModel/ModelTestHelpers.cs
@@ -43,7 +43,7 @@ public static class ModelTestHelpers
             HealthReports = reportHealthStatus is null && !createNullHealthReport ? [] : [new HealthReportViewModel("healthcheck", reportHealthStatus, null, null)],
             Commands = commands ?? [],
             Relationships = relationships ?? [],
-            Hidden = hidden
+            IsHidden = hidden
         };
     }
 }


### PR DESCRIPTION
## Description

First part of #9063, adds the `hidden` attribute and consumes it in the dashboard. @mitchdenny 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes (added one small mapping test)
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
