### PR TITLE
Add an option to set DCP log file name suffix based on test name

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -141,6 +141,10 @@ internal sealed class DcpHost
                 loggingSocket.Listen(LoggingSocketConnectionBacklog);
 
                 dcpProcessSpec.EnvironmentVariables.Add("DCP_LOG_SOCKET", _locations.DcpLogSocket);
+                if (!string.IsNullOrWhiteSpace(_dcpOptions.LogFileNameSuffix))
+                {
+                    dcpProcessSpec.EnvironmentVariables.Add("DCP_LOG_FILE_NAME_SUFFIX", _dcpOptions.LogFileNameSuffix);
+                }
 
                 _logProcessorTask = Task.Run(() => StartLoggingSocketAsync(loggingSocket));
             }

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -88,6 +88,12 @@ internal sealed class DcpOptions
     /// before DcpExecutor.StopAsync() returns. Default is false (resources are cleaned up asynchronously).
     /// </summary>
     public bool WaitForResourceCleanup { get; set; }
+
+    /// <summary>
+    /// Gets or sets the suffix to use for DCP log file names (applicable when verbose DCP logging is enabled).
+    /// By default log file name suffix defaults to the current process ID.
+    /// </summary>
+    public string? LogFileNameSuffix { get; set; }
 }
 
 internal class ValidateDcpOptions : IValidateOptions<DcpOptions>
@@ -190,6 +196,7 @@ internal class ConfigureDefaultDcpOptions(
         options.WaitForResourceCleanup = dcpPublisherConfiguration.GetValue(nameof(options.WaitForResourceCleanup), options.WaitForResourceCleanup);
         options.ServiceStartupWatchTimeout = configuration.GetValue(KnownConfigNames.ServiceStartupWatchTimeout, KnownConfigNames.Legacy.ServiceStartupWatchTimeout, options.ServiceStartupWatchTimeout);
         options.ContainerRuntimeInitializationTimeout = dcpPublisherConfiguration.GetValue(nameof(options.ContainerRuntimeInitializationTimeout), options.ContainerRuntimeInitializationTimeout);
+        options.LogFileNameSuffix = dcpPublisherConfiguration[nameof(options.LogFileNameSuffix)];
     }
 
     private static string? GetMetadataValue(IEnumerable<AssemblyMetadataAttribute>? assemblyMetadata, string key)

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -54,6 +54,7 @@ public class TestProgram : IDisposable
         builder.Configuration["DcpPublisher:ResourceNameSuffix"] = $"{Random.Shared.Next():x}";
         builder.Configuration["DcpPublisher:RandomizePorts"] = randomizePorts.ToString(CultureInfo.InvariantCulture);
         builder.Configuration["DcpPublisher:WaitForResourceCleanup"] = "true";
+        builder.Configuration["DcpPublisher:LogFileNameSuffix"] = testName;
 
         AppBuilder = builder;
 


### PR DESCRIPTION
## Description

Adds a DCP option that allows DCP log names to reflect the test that launched the specific DCP instance (and leverages it for `DistributedApplicationTests`). With this change DCP log names follow the following format

    `<"dcp" or "dcpctrl">-<unique instance id>-<test name>.log`

for example `dcp-12345678-proxyless-endpoint-works.log` (for `proxyless-endpoint-works` test), making it very easy to correlate between test under investigation and corresponding DCP log file.

The environment variable that this change is using is not effective yet with the DCP version that is integrated into Aspire, but it will become effective with the next DCP insertion.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
