### PR TITLE
Use normal WaitForResourceHealthyAsync in AppHostRpcTarget.

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -160,6 +160,9 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
             }
         }
 
+        var showDashboardResources = configuration.GetBool(KnownConfigNames.ShowDashboardResources, KnownConfigNames.Legacy.ShowDashboardResources);
+        var hideDashboard = !(showDashboardResources ?? false);
+
         var snapshot = new CustomResourceSnapshot
         {
             Properties = [],
@@ -170,11 +173,7 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
                 ContainerResource => KnownResourceTypes.Container,
                 _ => dashboardResource.GetType().Name
             },
-            State = configuration.GetBool(KnownConfigNames.ShowDashboardResources, KnownConfigNames.Legacy.ShowDashboardResources) is true
-                ? null
-#pragma warning disable CS0618 // Type or member is obsolete
-                : KnownResourceStates.Hidden
-#pragma warning restore CS0618 // Type or member is obsolete
+            IsHidden = hideDashboard
         };
 
         dashboardResource.Annotations.Add(new ResourceSnapshotAnnotation(snapshot));

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -39,10 +39,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                     }
                 }
 
-                // HACK: We are special casing the Aspire dashboard here until we address the issue of the Hidden state
-                //       making it impossible to determine whether a hidden resource is running or not. When that change
-                //       is made we can remove the special case logic here for the dashboard.
-                if (resourceEvent.Snapshot.State?.Text == KnownResourceStates.Running || resourceEvent.Resource.Name == KnownResourceNames.AspireDashboard)
+                if (resourceEvent.Snapshot.State?.Text == KnownResourceStates.Running)
                 {
                     if (state == null)
                     {

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 using HealthChecks.Uris;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -1281,12 +1282,8 @@ public static class ResourceBuilderExtensions
         });
 
         var healthCheckKey = $"{builder.Resource.Name}_{endpointName}_{path}_{statusCode}_check";
-        builder.ApplicationBuilder.Services.AddLogging(configure =>
-        {
-            // The AddUrlGroup health check makes use of http client factory.
-            configure.AddFilter($"System.Net.Http.HttpClient.{healthCheckKey}.LogicalHandler", LogLevel.None);
-            configure.AddFilter($"System.Net.Http.HttpClient.{healthCheckKey}.ClientHandler", LogLevel.None);
-        });
+
+        builder.ApplicationBuilder.Services.SuppressHealthCheckHttpClientLogging(healthCheckKey);
 
         builder.ApplicationBuilder.Services.AddHealthChecks().AddUrlGroup((UriHealthCheckOptions options) =>
         {

--- a/src/Aspire.Hosting/Utils/ContainerReferenceParser.cs
+++ b/src/Aspire.Hosting/Utils/ContainerReferenceParser.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Text.RegularExpressions;
 
 namespace Aspire.Hosting.Utils;

--- a/src/Aspire.Hosting/Utils/ContainerReferenceParser.cs
+++ b/src/Aspire.Hosting/Utils/ContainerReferenceParser.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
 using System.Text.RegularExpressions;
 
 namespace Aspire.Hosting.Utils;

--- a/src/Aspire.Hosting/Utils/LoggingUtils.cs
+++ b/src/Aspire.Hosting/Utils/LoggingUtils.cs
@@ -16,6 +16,5 @@ internal static class LoggingUtils
             configure.AddFilter($"System.Net.Http.HttpClient.{healthCheckName}.LogicalHandler", LogLevel.None);
             configure.AddFilter($"System.Net.Http.HttpClient.{healthCheckName}.ClientHandler", LogLevel.None);
         });
-
     }
 }

--- a/src/Aspire.Hosting/Utils/LoggingUtils.cs
+++ b/src/Aspire.Hosting/Utils/LoggingUtils.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Utils;
+
+internal static class LoggingUtils
+{
+    public static void SuppressHealthCheckHttpClientLogging(this IServiceCollection services, string healthCheckName)
+    {
+        services.AddLogging(configure =>
+        {
+            // The AddUrlGroup health check makes use of http client factory.
+            configure.AddFilter($"System.Net.Http.HttpClient.{healthCheckName}.LogicalHandler", LogLevel.None);
+            configure.AddFilter($"System.Net.Http.HttpClient.{healthCheckName}.ClientHandler", LogLevel.None);
+        });
+
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -52,7 +52,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(dashboard);
         Assert.Equal("aspire-dashboard", dashboard.Name);
         Assert.Equal(dashboardPath, dashboard.Command);
-        Assert.Equal("Hidden", initialSnapshot.InitialSnapshot.State);
+        Assert.True(initialSnapshot.InitialSnapshot.IsHidden);
     }
 
     [Fact]


### PR DESCRIPTION
Following on from the changes to split out hidden resource state into an IsHidden field, removing the hacks that I had in AppHostRpcTarget.

Also fixes: #9098