### PR TITLE
Wait for debugger when app host runs.

### DIFF
--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -127,12 +127,10 @@ internal sealed class PublishCommand : BaseCommand
                         $"{nameof(ExecuteAsync)}-Action-GetPublishers",
                         ActivityKind.Client);
 
-                    var getPublishesProcessIdCompletionSource = new TaskCompletionSource();
                     var getPublishersRunOptions = new DotNetCliRunnerInvocationOptions
                     {
                         StandardOutputCallback = outputCollector.AppendOutput,
                         StandardErrorCallback = outputCollector.AppendError,
-                        ProcessIdCallback = getPublishesProcessIdCompletionSource.SetResult,
                     };
 
                     var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
@@ -148,7 +146,6 @@ internal sealed class PublishCommand : BaseCommand
 
                     if (waitForDebugger)
                     {
-                        await getPublishesProcessIdCompletionSource.Task.WaitAsync(cancellationToken);
                         _interactionService.DisplayMessage("bug", $"Waiting for debugger to attach to app host process.");
                     }
 
@@ -206,12 +203,10 @@ internal sealed class PublishCommand : BaseCommand
                     launchingAppHostTask.IsIndeterminate();
                     launchingAppHostTask.StartTask();
 
-                    var publishProcessIdCompletionSource = new TaskCompletionSource();
                     var publishRunOptions = new DotNetCliRunnerInvocationOptions
                     {
                         StandardOutputCallback = outputCollector.AppendOutput,
                         StandardErrorCallback = outputCollector.AppendError,
-                        ProcessIdCallback = publishProcessIdCompletionSource.SetResult,
                     };
 
                     var pendingRun = _runner.RunAsync(
@@ -227,7 +222,6 @@ internal sealed class PublishCommand : BaseCommand
                     ProgressTask? attachDebuggerTask = null;
                     if (waitForDebugger)
                     {
-                        await publishProcessIdCompletionSource.Task.WaitAsync(cancellationToken);
                         attachDebuggerTask = context.AddTask($":bug:  Waiting for debugger to attach to app host process");
                         attachDebuggerTask.IsIndeterminate();
                         attachDebuggerTask.StartTask();

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -38,15 +38,21 @@ internal sealed class RootCommand : BaseRootCommand
         waitForDebuggerOption.Recursive = true;
         waitForDebuggerOption.DefaultValueFactory = (result) => false;
 
+        var cliWaitForDebuggerOption = new Option<bool>("--cli-wait-for-debugger");
+        cliWaitForDebuggerOption.Description = "Wait for a debugger to attach before executing the command.";
+        cliWaitForDebuggerOption.Recursive = true;
+        cliWaitForDebuggerOption.Hidden = true;
+        cliWaitForDebuggerOption.DefaultValueFactory = (result) => false;
+
         #if DEBUG
-        waitForDebuggerOption.Validators.Add((result) => {
+        cliWaitForDebuggerOption.Validators.Add((result) => {
 
             var waitForDebugger = result.GetValueOrDefault<bool>();
 
             if (waitForDebugger)
             {
                 _interactionService.ShowStatus(
-                    $":bug:  Waiting for debugger to attach to process ID: {Environment.ProcessId}",
+                    $":bug:  Waiting for debugger to attach to CLI process ID: {Environment.ProcessId}",
                     () => {
                         while (!Debugger.IsAttached)
                         {
@@ -58,6 +64,7 @@ internal sealed class RootCommand : BaseRootCommand
         #endif
 
         Options.Add(waitForDebuggerOption);
+        Options.Add(cliWaitForDebuggerOption);
 
         Subcommands.Add(newCommand);
         Subcommands.Add(runCommand);

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -112,12 +112,10 @@ internal sealed class RunCommand : BaseCommand
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
 
-            var processLaunchedCompletionSource = new TaskCompletionSource();
             var runOptions = new DotNetCliRunnerInvocationOptions
             {
                 StandardOutputCallback = outputCollector.AppendOutput,
                 StandardErrorCallback = outputCollector.AppendError,
-                ProcessIdCallback = processLaunchedCompletionSource.SetResult
             };
 
             var backchannelCompletitionSource = new TaskCompletionSource<IAppHostBackchannel>();
@@ -146,7 +144,6 @@ internal sealed class RunCommand : BaseCommand
                         // the completion source to be set.
                         if (waitForDebugger)
                         {
-                            await processLaunchedCompletionSource.Task.WaitAsync(cancellationToken);
                             _interactionService.DisplayMessage("bug", $"Waiting for debugger to attach to app host process");
                         }
 

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -32,8 +32,6 @@ internal sealed class DotNetCliRunnerInvocationOptions
 {
     public Action<string>? StandardOutputCallback { get; set; }
     public Action<string>? StandardErrorCallback { get; set; }
-
-    public Action? ProcessIdCallback { get; set; }
 }
 
 internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider serviceProvider) : IDotNetCliRunner
@@ -389,8 +387,6 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         logger.LogDebug("Running dotnet with args: {Args}", string.Join(" ", args));
 
         var started = process.Start();
-
-        options.ProcessIdCallback?.Invoke();
 
         if (backchannelCompletionSource is not null)
         {

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -32,6 +32,8 @@ internal sealed class DotNetCliRunnerInvocationOptions
 {
     public Action<string>? StandardOutputCallback { get; set; }
     public Action<string>? StandardErrorCallback { get; set; }
+
+    public Action? ProcessIdCallback { get; set; }
 }
 
 internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider serviceProvider) : IDotNetCliRunner
@@ -387,6 +389,8 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         logger.LogDebug("Running dotnet with args: {Args}", string.Join(" ", args));
 
         var started = process.Start();
+
+        options.ProcessIdCallback?.Invoke();
 
         if (backchannelCompletionSource is not null)
         {


### PR DESCRIPTION
Fixes: #9095

This PR splits out the concept of waiting for the debugger to the CLI itself, and attaching the debugger to the app host instances that are launched. Here is a summary of the changes:

1. We now have two switches: `--wait-for-debugger` and `--cli-wait-for-debugger` (hidden)
2. Introduced a new callback on the invocation options which is called when the process is launched but before the backchannel is established.
3. We then print a message to connect the debugger, and then await the back channel connection.

Once the debugger is attached the app host will drop through `CreateBuilder(...)` and the back channel will come online.

Note that we are not able to tell the user the process ID to connect to. This is because the process ID that we see is the `dotnet run` process, not the process that `dotnet run` launches.

The `--cli-wait-for-debugger` (now hidden) will also result in a message being displayed to attach to the CLI process, but this will mostly be used by just out team, hence the reason it is hidden (to avoid confusion).

In the case of `aspire run` we prompt to attach the debugger before we display the resource list.

In the case of `aspire publish`, there are two different app host processes. One when we launch in inspect mode, and one for when we actually do the publish. The one in inspect mode is similar to the `aspire run` scenario. But once we launch the app host in publish mode the prompt to attach the debugger is shown inside the progress task list. This is because the `AnsiConsole.Progress()` call takes over rendering and if we printed out a message it would be wiped away immediately (progress is not threadsafe either).

# `aspire run --wait-for-debugger`

https://github.com/user-attachments/assets/8bb16fea-bddf-4e0d-9085-8b7da9fae4b8

# `aspire publish --wait-for-debugger`

https://github.com/user-attachments/assets/036409b7-3675-4ff9-a9fb-4b35dfa4361a

