### PR TITLE
Fix WithCommand ambiguous overload

### DIFF
--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
@@ -40,6 +40,7 @@
     <Compile Include="$(SharedDir)CommandLineArgsParser.cs" Link="Utils\CommandLineArgsParser.cs" />
     <Compile Include="$(SharedDir)LaunchProfiles\*.cs" />
     <Compile Include="$(SharedDir)PortAllocator.cs" Link="Publishing\PortAllocator.cs" />
+    <Compile Include="$(SharedDir)OverloadResolutionPriorityAttribute.cs" Link="Utils\OverloadResolutionPriorityAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
@@ -1359,6 +1360,7 @@ public static class ResourceBuilderExtensions
     /// and can be executed by a user using the dashboard UI.</para>
     /// <para>When a command is executed, the <paramref name="executeCommand"/> callback is called and is run inside the .NET Aspire host.</para>
     /// </remarks>
+    [OverloadResolutionPriority(1)]
     public static IResourceBuilder<T> WithCommand<T>(
         this IResourceBuilder<T> builder,
         string name,

--- a/src/Shared/OverloadResolutionPriorityAttribute.cs
+++ b/src/Shared/OverloadResolutionPriorityAttribute.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET9_0_OR_GREATER
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Specifies the priority of a member in overload resolution. When unspecified, the default priority is 0.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+internal sealed class OverloadResolutionPriorityAttribute(int priority) : Attribute
+{
+    public int Priority => priority;
+}
+#endif

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -208,6 +208,21 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         await CancelTokenAndAwaitTask(cts, task).DefaultTimeout();
     }
 
+    [Fact]
+    public void WithCommandOverloadNotAmbiguous()
+    {
+        var testResource = new TestResource("test-resource");
+        using var applicationBuilder = TestDistributedApplicationBuilder.Create(testOutputHelper: testOutputHelper);
+        var builder = applicationBuilder.AddResource(testResource);
+        builder.WithCommand(
+            name: "TestName",
+            displayName: "Display name!",
+            executeCommand: c => Task.FromResult(CommandResults.Success()));
+
+        // This test simply needs to compile.
+        Assert.True(true);
+    }
+
     private static DashboardServiceData CreateDashboardServiceData(
         ResourceLoggerService resourceLoggerService,
         ResourceNotificationService resourceNotificationService,


### PR DESCRIPTION
## Description

Uses [`OverloadResolutionPriority`](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-13.0/overload-resolution-priority) to fix ambiguous overload introduced by #8276. 

Pretty sure this only fixes it for callers using a C# compiler version from the .NET 9 SDK or higher. Folks using a C# compiler from .NET 8 would still see the issue. We could decide that's good enough and tell folks to use a newer SDK version or call the `WithCommand` overload explicitly passing null for the `CommandOptions` parameter.

Fixes #9046

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
