### PR TITLE
Split out collectors and handle process crash before backchannel connection.

### DIFF
--- a/src/Aspire.Cli/Backchannel/FailedToConnectBackchannelConnection.cs
+++ b/src/Aspire.Cli/Backchannel/FailedToConnectBackchannelConnection.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Cli.Backchannel;
+
+internal sealed class FailedToConnectBackchannelConnection(string message, Process process, Exception innerException) : Exception(message, innerException)
+{
+    public Process Process => process;
+}

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -353,7 +353,7 @@ internal sealed class PublishCommand : BaseCommand
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
-            _interactionService.DisplayError($"An error occurred while connecting to the AppHost backchannel, app host possibly crashed before it was available: {ex.Message}");
+            _interactionService.DisplayError($"An error occurred while connecting to the app host backchannel. The app host possibly crashed before it was available: {ex.Message}");
 
             var operationArgumentIndex = ex.Process.StartInfo.ArgumentList.IndexOf("--operation");
             var operation = ex.Process.StartInfo.ArgumentList[operationArgumentIndex + 1];

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -353,7 +353,7 @@ internal sealed class PublishCommand : BaseCommand
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
-            _interactionService.DisplayError($"An error occurred while connecting to the app host backchannel. The app host possibly crashed before it was available: {ex.Message}");
+            _interactionService.DisplayError($"An error occurred while connecting to the app host. The app host possibly crashed before it was available: {ex.Message}");
 
             var operationArgumentIndex = ex.Process.StartInfo.ArgumentList.IndexOf("--operation");
             var operation = ex.Process.StartInfo.ArgumentList[operationArgumentIndex + 1];

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -67,7 +67,9 @@ internal sealed class PublishCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var outputCollector = new OutputCollector();
+        var buildOutputCollector = new OutputCollector();
+        var inspectOutputCollector = new OutputCollector();
+        var publishOutputCollector = new OutputCollector();
 
         (bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
 
@@ -103,15 +105,15 @@ internal sealed class PublishCommand : BaseCommand
 
             var buildOptions = new DotNetCliRunnerInvocationOptions
             {
-                StandardOutputCallback = outputCollector.AppendOutput,
-                StandardErrorCallback = outputCollector.AppendError
+                StandardOutputCallback = buildOutputCollector.AppendOutput,
+                StandardErrorCallback = buildOutputCollector.AppendError
             };
 
             var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, buildOptions, cancellationToken);
 
             if (buildExitCode != 0)
             {
-                _interactionService.DisplayLines(outputCollector.GetLines());
+                _interactionService.DisplayLines(buildOutputCollector.GetLines());
                 _interactionService.DisplayError("The project could not be built. For more information run with --debug switch.");
                 return ExitCodeConstants.FailedToBuildArtifacts;
             }
@@ -129,8 +131,8 @@ internal sealed class PublishCommand : BaseCommand
 
                     var getPublishersRunOptions = new DotNetCliRunnerInvocationOptions
                     {
-                        StandardOutputCallback = outputCollector.AppendOutput,
-                        StandardErrorCallback = outputCollector.AppendError,
+                        StandardOutputCallback = inspectOutputCollector.AppendOutput,
+                        StandardErrorCallback = inspectOutputCollector.AppendError,
                     };
 
                     var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
@@ -161,7 +163,7 @@ internal sealed class PublishCommand : BaseCommand
 
             if (publishersResult.ExitCode != 0)
             {
-                _interactionService.DisplayLines(outputCollector.GetLines());
+                _interactionService.DisplayLines(inspectOutputCollector.GetLines());
                 _interactionService.DisplayError($"The publisher inspection failed with exit code {publishersResult.ExitCode}. For more information run with --debug switch.");
                 return ExitCodeConstants.FailedToBuildArtifacts;
             }
@@ -205,15 +207,15 @@ internal sealed class PublishCommand : BaseCommand
 
                     var publishRunOptions = new DotNetCliRunnerInvocationOptions
                     {
-                        StandardOutputCallback = outputCollector.AppendOutput,
-                        StandardErrorCallback = outputCollector.AppendError,
+                        StandardOutputCallback = publishOutputCollector.AppendOutput,
+                        StandardErrorCallback = publishOutputCollector.AppendError,
                     };
 
                     var pendingRun = _runner.RunAsync(
                         effectiveAppHostProjectFile,
                         false,
                         true,
-                        ["--publisher", publisher ?? "manifest", "--output-path", fullyQualifiedOutputPath],
+                        ["--operation", "publish", "--publisher", publisher ?? "manifest", "--output-path", fullyQualifiedOutputPath],
                         env,
                         backchannelCompletionSource,
                         publishRunOptions,
@@ -307,7 +309,7 @@ internal sealed class PublishCommand : BaseCommand
 
             if (exitCode != 0)
             {
-                _interactionService.DisplayLines(outputCollector.GetLines());
+                _interactionService.DisplayLines(publishOutputCollector.GetLines());
                 _interactionService.DisplayError($"Publishing artifacts failed with exit code {exitCode}. For more information run with --debug switch.");
                 return ExitCodeConstants.FailedToBuildArtifacts;
             }
@@ -348,6 +350,27 @@ internal sealed class PublishCommand : BaseCommand
                 ex,
                 appHostCompatibilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
                 );
+        }
+        catch (FailedToConnectBackchannelConnection ex)
+        {
+            _interactionService.DisplayError($"An error occurred while connecting to the AppHost backchannel, app host possibly crashed before it was available: {ex.Message}");
+
+            var operationArgumentIndex = ex.Process.StartInfo.ArgumentList.IndexOf("--operation");
+            var operation = ex.Process.StartInfo.ArgumentList[operationArgumentIndex + 1];
+
+            // This particular error can occur both when we are in inspect mode or in publish mode
+            // depending on where the code is that is causing the apphost process to crash
+            // before the backchannel is avaialble. When we remove publisher selection from the
+            // CLI this code can be simplified again.
+            Func<IEnumerable<(string Stream, string Line)>> linesCallback = operation switch {
+                "inspect" => inspectOutputCollector.GetLines,
+                "publish" => publishOutputCollector.GetLines,
+                _ => throw new InvalidOperationException($"Unknown operation: {operation}")
+            };
+
+            _interactionService.DisplayLines(linesCallback());
+
+            return ExitCodeConstants.FailedToBuildArtifacts;
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -283,7 +283,7 @@ internal sealed class RunCommand : BaseCommand
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
-            _interactionService.DisplayError($"An error occurred while connecting to the AppHost backchannel, app host possibly crashed before it was available: {ex.Message}");
+            _interactionService.DisplayError($"An error occurred while connecting to the app host backchannel. The app host possibly crashed before it was available: {ex.Message}");
             _interactionService.DisplayLines(runOutputCollector.GetLines());
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -50,7 +50,8 @@ internal sealed class RunCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var outputCollector = new OutputCollector();
+        var buildOutputCollector = new OutputCollector();
+        var runOutputCollector = new OutputCollector();
 
         (bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
         try
@@ -91,15 +92,15 @@ internal sealed class RunCommand : BaseCommand
             {
                 var buildOptions = new DotNetCliRunnerInvocationOptions
                 {
-                    StandardOutputCallback = outputCollector.AppendOutput,
-                    StandardErrorCallback = outputCollector.AppendError,
+                    StandardOutputCallback = buildOutputCollector.AppendOutput,
+                    StandardErrorCallback = buildOutputCollector.AppendError,
                 };
 
                 var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, buildOptions, cancellationToken);
 
                 if (buildExitCode != 0)
                 {
-                    _interactionService.DisplayLines(outputCollector.GetLines());
+                    _interactionService.DisplayLines(buildOutputCollector.GetLines());
                     _interactionService.DisplayError($"The project could not be built. For more information run with --debug switch.");
                     return ExitCodeConstants.FailedToBuildArtifacts;
                 }
@@ -114,8 +115,8 @@ internal sealed class RunCommand : BaseCommand
 
             var runOptions = new DotNetCliRunnerInvocationOptions
             {
-                StandardOutputCallback = outputCollector.AppendOutput,
-                StandardErrorCallback = outputCollector.AppendError,
+                StandardOutputCallback = runOutputCollector.AppendOutput,
+                StandardErrorCallback = runOutputCollector.AppendError,
             };
 
             var backchannelCompletitionSource = new TaskCompletionSource<IAppHostBackchannel>();
@@ -234,7 +235,7 @@ internal sealed class RunCommand : BaseCommand
                 var result =  await pendingRun;
                 if (result != 0)
                 {
-                    _interactionService.DisplayLines(outputCollector.GetLines());
+                    _interactionService.DisplayLines(runOutputCollector.GetLines());
                     _interactionService.DisplayError($"The project could not be run. For more information run with --debug switch.");
                     return result;
                 }
@@ -280,10 +281,16 @@ internal sealed class RunCommand : BaseCommand
             _interactionService.DisplayError($"An error occurred while trusting the certificates: {ex.Message}");
             return ExitCodeConstants.FailedToTrustCertificates;
         }
+        catch (FailedToConnectBackchannelConnection ex)
+        {
+            _interactionService.DisplayError($"An error occurred while connecting to the AppHost backchannel, app host possibly crashed before it was available: {ex.Message}");
+            _interactionService.DisplayLines(runOutputCollector.GetLines());
+            return ExitCodeConstants.FailedToDotnetRunAppHost;
+        }
         catch (Exception ex)
         {
             _interactionService.DisplayError($"An unexpected error occurred: {ex.Message}");
-            _interactionService.DisplayLines(outputCollector.GetLines());
+            _interactionService.DisplayLines(runOutputCollector.GetLines());
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
     }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -283,7 +283,7 @@ internal sealed class RunCommand : BaseCommand
         }
         catch (FailedToConnectBackchannelConnection ex)
         {
-            _interactionService.DisplayError($"An error occurred while connecting to the app host backchannel. The app host possibly crashed before it was available: {ex.Message}");
+            _interactionService.DisplayError($"An error occurred while connecting to the app host. The app host possibly crashed before it was available: {ex.Message}");
             _interactionService.DisplayLines(runOutputCollector.GetLines());
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -488,7 +488,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
             catch (SocketException ex) when (process.HasExited && process.ExitCode != 0)
             {
                 logger.LogError(ex, "AppHost process has exited. Unable to connect to backchannel at {SocketPath}", socketPath);
-                var backchannelException = new InvalidOperationException($"AppHost process has exited unexpectedly. Use --debug to see more details.");
+                var backchannelException = new FailedToConnectBackchannelConnection($"AppHost process has exited unexpectedly. Use --debug to see more details.", process, ex);
                 backchannelCompletionSource.SetException(backchannelException);
                 return;
             }


### PR DESCRIPTION
Fixes: #9051

This PR does two things. First it introduces error handling so that if the apphost process crashes before a backchannel is established that we detect that and display log outputs instead of just the generic error message. The other thing it does is that in the case of the `aspire run` and `aspire publish` command its splits out the build and run output collectors (build inspect and publish in the case of the publish command) so that we are only showing the most relevant logs.


https://github.com/user-attachments/assets/3c4b802b-a0ac-4e53-9555-b345b530565b

