### PR TITLE
Disable launch profiles for publish mode and inspect mode runs.

### DIFF
--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -210,7 +210,7 @@ internal sealed class PublishCommand : BaseCommand
                     {
                         StandardOutputCallback = publishOutputCollector.AppendOutput,
                         StandardErrorCallback = publishOutputCollector.AppendError,
-                        NoLaunchProfile = true,
+                        NoLaunchProfile = true
                     };
 
                     var pendingRun = _runner.RunAsync(

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -104,7 +104,8 @@ internal sealed class PublishCommand : BaseCommand
             var buildOptions = new DotNetCliRunnerInvocationOptions
             {
                 StandardOutputCallback = outputCollector.AppendOutput,
-                StandardErrorCallback = outputCollector.AppendError
+                StandardErrorCallback = outputCollector.AppendError,
+                NoLaunchProfile = true,
             };
 
             var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, buildOptions, cancellationToken);
@@ -207,6 +208,7 @@ internal sealed class PublishCommand : BaseCommand
                     {
                         StandardOutputCallback = outputCollector.AppendOutput,
                         StandardErrorCallback = outputCollector.AppendError,
+                        NoLaunchProfile = true,
                     };
 
                     var pendingRun = _runner.RunAsync(

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -32,6 +32,8 @@ internal sealed class DotNetCliRunnerInvocationOptions
 {
     public Action<string>? StandardOutputCallback { get; set; }
     public Action<string>? StandardErrorCallback { get; set; }
+
+    public bool NoLaunchProfile { get; set; }
 }
 
 internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider serviceProvider) : IDotNetCliRunner
@@ -165,7 +167,10 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
 
         var watchOrRunCommand = watch ? "watch" : "run";
         var noBuildSwitch = noBuild ? "--no-build" : string.Empty;
-        string[] cliArgs = [watchOrRunCommand, noBuildSwitch, "--project", projectFile.FullName, "--", ..args];
+        var noProfileSwitch = options.NoLaunchProfile ? "--no-launch-profile" : string.Empty;
+
+        string[] cliArgs = [watchOrRunCommand, noBuildSwitch, noProfileSwitch, "--project", projectFile.FullName, "--", ..args];
+
         return await ExecuteAsync(
             args: cliArgs,
             env: env,

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -36,7 +36,7 @@ internal sealed class DotNetCliRunnerInvocationOptions
     public bool NoLaunchProfile { get; set; }
 }
 
-internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider serviceProvider) : IDotNetCliRunner
+internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider serviceProvider) : IDotNetCliRunner
 {
     private readonly ActivitySource _activitySource = new ActivitySource(nameof(DotNetCliRunner));
 
@@ -348,7 +348,7 @@ internal sealed class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceP
         return socketPath;
     }
 
-    public async Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+    public virtual async Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
@@ -180,6 +180,8 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
                 // Simulate apphost running successfully and establishing a backchannel
                 runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
                 {
+                    Assert.True(options.NoLaunchProfile);
+
                     if (args.Any(a => a == "inspect"))
                     {
                         var inspectModeCompleted = new TaskCompletionSource();

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Aspire.Cli.Tests.DotNet;
+
+public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task DotNetCliCorrectlyAppliesNoLaunchProfileArgumentWhenSpecifiedInOptions()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(outputHelper);
+        var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
+
+        var options = new DotNetCliRunnerInvocationOptions()
+        {
+            NoLaunchProfile = true
+        };
+
+        var runner = new AssertingDotNetCliRunner(
+            logger,
+            provider,
+            (args, _, _, _, _) => Assert.Contains(args, arg => arg == "--no-launch-profile"),
+            42
+            );
+
+        // This is what we are really testing here - that RunAsync reads
+        // the NoLaunchProfile property from the invocation options and
+        // correctly applies it to the command-line arguments for the
+        // dotnet run command.
+        var exitCode = await runner.RunAsync(
+            projectFile: projectFile,
+            watch: false,
+            noBuild: false,
+            args: ["--operation", "inspect"],
+            env: new Dictionary<string, string>(),
+            null,
+            options,
+            CancellationToken.None
+            );
+
+        Assert.Equal(42, exitCode);
+    }
+}
+
+internal sealed class AssertingDotNetCliRunner(
+    ILogger<DotNetCliRunner> logger,
+    IServiceProvider serviceProvider,
+    Action<string[], IDictionary<string, string>?, DirectoryInfo, TaskCompletionSource<IAppHostBackchannel>?, DotNetCliRunnerInvocationOptions> assertionCallback,
+    int exitCode
+    ) : DotNetCliRunner(logger, serviceProvider)
+{
+    public override Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+    {
+        assertionCallback(args, env, workingDirectory, backchannelCompletionSource, options);
+        return Task.FromResult(exitCode);
+    }
+}


### PR DESCRIPTION
Fixes: #8934

The `aspire publish` command will now pass `--no-launch-profile` to the inspect mode and publish mode invocations of the apphost.