### PR TITLE
[tests] Unquarantine some tests

### DIFF
--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -246,7 +246,6 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/5937")]
     public async Task VerifyWithInitBindMount()
     {
         // Creates a script that should be executed when the container is initialized.

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -343,7 +343,6 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4651")]
     public async Task TestServicesWithMultipleReplicas()
     {
         var replicaCount = 3;
@@ -571,7 +570,6 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8871")]
     public async Task SpecifyingEnvPortInEndpointFlowsToEnv()
     {
         const string testName = "ports-flow-to-env";
@@ -953,7 +951,6 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresSSLCertificate]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/4599")]
     public async Task ProxylessAndProxiedEndpointBothWorkOnSameResource()
     {
         const string testName = "proxyless-and-proxied-endpoints";


### PR DESCRIPTION
Based on the stats from https://github.com/dotnet/aspire/issues/8813.

Aspire.Hosting.Tests.DistributedApplicationTests.TestServicesWithMultipleReplicas - 0 / 100 failed
Aspire.Hosting.Tests.DistributedApplicationTests.SpecifyingEnvPortInEndpointFlowsToEnv - 0 / 100 failed
Aspire.Hosting.Tests.DistributedApplicationTests.ProxylessAndProxiedEndpointBothWorkOnSameResource - 0 / 100 failed
Aspire.Hosting.MongoDB.Tests.MongoDbFunctionalTests.VerifyWithInitBindMount - 0 / 100 failed

Fixes https://github.com/dotnet/aspire/issues/8721
Fixes https://github.com/dotnet/aspire/issues/5937
Fixes https://github.com/dotnet/aspire/issues/8871
Fixes https://github.com/dotnet/aspire/issues/4599
