### PR TITLE
Update Baseline package validation to 9.2.0

### DIFF
--- a/src/Aspire.Hosting.Azure/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting.Azure/CompatibilitySuppressions.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- This API shipped as experimental in 9.2 so it is okay to remove. -->
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.AzurePublisherExtensions.AddAzurePublisher(Aspire.Hosting.IDistributedApplicationBuilder,System.String,System.Action{Aspire.Hosting.Azure.AzurePublisherOptions})</Target>
+    <Left>lib/net8.0/Aspire.Hosting.Azure.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.Azure.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- Enabling this rule will cause build failures on undocumented public APIs. -->
     <SkipArcadeNoWarnCS1591>true</SkipArcadeNoWarnCS1591>
     <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>
-    <PackageValidationBaselineVersion Condition="'$(EnablePackageValidation)' == 'true' and '$(PackageValidationBaselineVersion)' == ''">9.1.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion Condition="'$(EnablePackageValidation)' == 'true' and '$(PackageValidationBaselineVersion)' == ''">9.2.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates the `PackageValidationBaselineVersion` in the `src/Directory.Build.props` file to align with the latest shipped version.

cc: @radical @eerhardt 
