### PR TITLE
Make WithHttpHealthCheck work like WithHttpCommand

### DIFF
--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -71,9 +71,8 @@ var frontend = builder.AddProject<Projects.MyFrontend>("frontend")
        // Don't show the non-HTTPS link on the resources page (details only)
        .WithUrlForEndpoint("http", url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)
        // Add health relative URL (show in details only)
-       .WithUrlForEndpoint("https", ep => new() { Url = "/health", DisplayText = "Health", DisplayLocation = UrlDisplayLocation.DetailsOnly });
-
-var _ = frontend.GetEndpoint("https").Exists ? frontend.WithHttpsHealthCheck("/health") : frontend.WithHttpHealthCheck("/health");
+       .WithUrlForEndpoint("https", ep => new() { Url = "/health", DisplayText = "Health", DisplayLocation = UrlDisplayLocation.DetailsOnly })
+       .WithHttpHealthCheck("/health");
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor", launchProfileName: "OrderProcessor")
         .WithReference(messaging).WaitFor(messaging);

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -8,7 +8,6 @@ using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
-using HealthChecks.Uris;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -1259,32 +1258,64 @@ public static class ResourceBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        endpointName = endpointName ?? "http";
-        return builder.WithHttpHealthCheckInternal(
-            path: path,
-            desiredScheme: "http",
-            endpointName: endpointName,
-            statusCode: statusCode
-            );
+        var endpointSelector = endpointName is not null
+            ? NamedEndpointSelector(builder, [endpointName], "HTTP health check")
+            : NamedEndpointSelector(builder, s_httpSchemes, "HTTP health check");
+
+        return WithHttpHealthCheck(builder, endpointSelector, path, statusCode);
     }
 
-    internal static IResourceBuilder<T> WithHttpHealthCheckInternal<T>(this IResourceBuilder<T> builder, string desiredScheme, string endpointName, string? path = null, int? statusCode = null) where T : IResourceWithEndpoints
+    /// <summary>
+    /// Adds a health check to the resource which is mapped to a specific endpoint.
+    /// </summary>
+    /// <typeparam name="T">A resource type that implements <see cref="IResourceWithEndpoints" />.</typeparam>
+    /// <param name="builder">A resource builder.</param>
+    /// <param name="endpointSelector"></param>
+    /// <param name="path">The relative path to test.</param>
+    /// <param name="statusCode">The result code to interpret as healthy.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method adds a health check to the health check service which polls the specified endpoint on a periodic basis.
+    /// The base address is dynamically determined based on the endpoint that was selected. By default the path is set to "/"
+    /// and the status code is set to 200.
+    /// </para>
+    /// <example>
+    /// This example shows adding an HTTP health check to a backend project.
+    /// The health check makes sure that the front end does not start until the backend is
+    /// reporting a healthy status based on the return code returned from the
+    /// "/health" path on the backend server.
+    /// <code lang="C#">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var backend = builder.AddProject&lt;Projects.Backend&gt;("backend");
+    /// backend.WithHttpHealthCheck(() => backend.GetEndpoint("https"), path: "/health")
+    /// builder.AddProject&lt;Projects.Frontend&gt;("frontend")
+    ///        .WithReference(backend).WaitFor(backend);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    public static IResourceBuilder<T> WithHttpHealthCheck<T>(this IResourceBuilder<T> builder, Func<EndpointReference>? endpointSelector, string? path = null, int? statusCode = null) where T : IResourceWithEndpoints
     {
-        path = path ?? "/";
-        statusCode = statusCode ?? 200;
+        endpointSelector ??= DefaultEndpointSelector(builder);
 
-        var endpoint = builder.Resource.GetEndpoint(endpointName);
+        var endpoint = endpointSelector()
+            ?? throw new DistributedApplicationException($"Could not create HTTP health check for resource '{builder.Resource.Name}' as the endpoint selector returned null.");
+
+        if (endpoint.Scheme != "http" && endpoint.Scheme != "https")
+        {
+            throw new DistributedApplicationException($"Could not create HTTP health check for resource '{builder.Resource.Name}' as the endpoint with name '{endpoint.EndpointName}' and scheme '{endpoint.Scheme}' is not an HTTP endpoint.");
+        }
+
+        path ??= "/";
+        statusCode ??= 200;
+
+        var endpointName = endpoint.EndpointName;
 
         builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((@event, ct) =>
         {
             if (!endpoint.Exists)
             {
                 throw new DistributedApplicationException($"The endpoint '{endpointName}' does not exist on the resource '{builder.Resource.Name}'.");
-            }
-
-            if (endpoint.Scheme != desiredScheme)
-            {
-                throw new DistributedApplicationException($"The endpoint '{endpointName}' on resource '{builder.Resource.Name}' was not using the '{desiredScheme}' scheme.");
             }
 
             return Task.CompletedTask;
@@ -1302,7 +1333,7 @@ public static class ResourceBuilderExtensions
 
         builder.ApplicationBuilder.Services.SuppressHealthCheckHttpClientLogging(healthCheckKey);
 
-        builder.ApplicationBuilder.Services.AddHealthChecks().AddUrlGroup((UriHealthCheckOptions options) =>
+        builder.ApplicationBuilder.Services.AddHealthChecks().AddUrlGroup(options =>
         {
             if (uri is null)
             {
@@ -1346,16 +1377,12 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
+    [Obsolete("This method is obsolete and will be removed in a future version. Use the WithHttpHealthCheck method instead.")]
     public static IResourceBuilder<T> WithHttpsHealthCheck<T>(this IResourceBuilder<T> builder, string? path = null, int? statusCode = null, string? endpointName = null) where T : IResourceWithEndpoints
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        endpointName = endpointName ?? "https";
-        return builder.WithHttpHealthCheckInternal(
-            path: path,
-            desiredScheme: "https",
-            endpointName: endpointName,
-            statusCode: statusCode);
+        return builder.WithHttpHealthCheck(path, statusCode, endpointName ?? "https");
     }
 
     /// <summary>
@@ -1551,8 +1578,8 @@ public static class ResourceBuilderExtensions
             path: path,
             displayName: displayName,
             endpointSelector: endpointName is not null
-                ? NamedEndpointSelector(builder, [endpointName])
-                : NamedEndpointSelector(builder, s_httpSchemes),
+                ? NamedEndpointSelector(builder, [endpointName], "HTTP command")
+                : NamedEndpointSelector(builder, s_httpSchemes, "HTTP command"),
             commandName: commandName,
             commandOptions: commandOptions);
 
@@ -1625,6 +1652,11 @@ public static class ResourceBuilderExtensions
 
         var endpoint = endpointSelector()
             ?? throw new DistributedApplicationException($"Could not create HTTP command for resource '{builder.Resource.Name}' as the endpoint selector returned null.");
+
+        if (endpoint.Scheme != "http" && endpoint.Scheme != "https")
+        {
+            throw new DistributedApplicationException($"Could not create HTTP command for resource '{builder.Resource.Name}' as the endpoint with name '{endpoint.EndpointName}' and scheme '{endpoint.Scheme}' is not an HTTP endpoint.");
+        }
 
         builder.ApplicationBuilder.Services.AddHttpClient();
 
@@ -1716,7 +1748,7 @@ public static class ResourceBuilderExtensions
     // if found.
     private static readonly string[] s_httpSchemes = ["https", "http"];
 
-    private static Func<EndpointReference> NamedEndpointSelector<TResource>(IResourceBuilder<TResource> builder, string[] endpointNames)
+    private static Func<EndpointReference> NamedEndpointSelector<TResource>(IResourceBuilder<TResource> builder, string[] endpointNames, string errorDisplayNoun)
         where TResource : IResourceWithEndpoints
         => () =>
         {
@@ -1731,7 +1763,7 @@ public static class ResourceBuilderExtensions
                 {
                     if (!s_httpSchemes.Contains(matchingEndpoint.Scheme, StringComparers.EndpointAnnotationUriScheme))
                     {
-                        throw new DistributedApplicationException($"Could not create HTTP command for resource '{builder.Resource.Name}' as the endpoint with name '{matchingEndpoint.EndpointName}' and scheme '{matchingEndpoint.Scheme}' is not an HTTP endpoint.");
+                        throw new DistributedApplicationException($"Could not create {errorDisplayNoun} for resource '{builder.Resource.Name}' as the endpoint with name '{matchingEndpoint.EndpointName}' and scheme '{matchingEndpoint.Scheme}' is not an HTTP endpoint.");
                     }
                     return matchingEndpoint;
                 }
@@ -1739,7 +1771,7 @@ public static class ResourceBuilderExtensions
 
             // No endpoint found with the specified names
             var endpointNamesString = string.Join(", ", endpointNames);
-            throw new DistributedApplicationException($"Could not create HTTP command for resource '{builder.Resource.Name}' as no endpoint was found matching one of the specified names: {endpointNamesString}");
+            throw new DistributedApplicationException($"Could not create {errorDisplayNoun} for resource '{builder.Resource.Name}' as no endpoint was found matching one of the specified names: {endpointNamesString}");
         };
 
     private static Func<EndpointReference> DefaultEndpointSelector<TResource>(IResourceBuilder<TResource> builder)

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.3/Aspire-StarterApplication.1.AppHost/AppHost.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.3/Aspire-StarterApplication.1.AppHost/AppHost.cs
@@ -5,19 +5,11 @@ var cache = builder.AddRedis("cache");
 
 #endif
 var apiService = builder.AddProject<Projects.GeneratedClassNamePrefix_ApiService>("apiservice")
-#if HasHttpsProfile
-    .WithHttpsHealthCheck("/health");
-#else
     .WithHttpHealthCheck("/health");
-#endif
 
 builder.AddProject<Projects.GeneratedClassNamePrefix_Web>("webfrontend")
     .WithExternalHttpEndpoints()
-#if HasHttpsProfile
-    .WithHttpsHealthCheck("/health")
-#else
     .WithHttpHealthCheck("/health")
-#endif
 #if UseRedisCache
     .WithReference(cache)
     .WaitFor(cache)

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -33,6 +33,50 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void WithHttpCommand_Throws_WhenEndpointByNameIsNotHttp()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var container = builder.AddContainer("name", "image")
+                .WithEndpoint(targetPort: 9999, scheme: "tcp", name: "nonhttp");
+
+        // Act
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+        {
+            container.WithHttpCommand("/some-path", "Do The Thing", endpointName: "nonhttp");
+        });
+
+        // Assert
+        Assert.Equal(
+            "Could not create HTTP command for resource 'name' as the endpoint with name 'nonhttp' and scheme 'tcp' is not an HTTP endpoint.",
+            ex.Message
+        );
+    }
+
+    [Fact]
+    public void WithHttpCommand_Throws_WhenEndpointIsNotHttp()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var container = builder.AddContainer("name", "image")
+                .WithEndpoint(targetPort: 9999, scheme: "tcp", name: "nonhttp");
+
+        // Act
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+        {
+            container.WithHttpCommand("/some-path", "Do The Thing", () => container.GetEndpoint("nonhttp"));
+        });
+
+        // Assert
+        Assert.Equal(
+            "Could not create HTTP command for resource 'name' as the endpoint with name 'nonhttp' and scheme 'tcp' is not an HTTP endpoint.",
+            ex.Message
+        );
+    }
+
+    [Fact]
     public void WithHttpCommand_AddsResourceCommandAnnotation_WithDefaultValues()
     {
         // Arrange


### PR DESCRIPTION
## Description

Obsoletes `WithHttpsHealthCheck` and changes `WithHttpHealthCheck` to work like `WithHttpCommand` WRT endpoint selection (i.e. it defaults to using the first endpoint with an `https` scheme, then falls back to the first endpoint with an `http` scheme, unless a specific endpoint name or selector function is passed in).

Fixes #8765

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: dotnet/aspire-docs#3326
