### PR TITLE
Improve header button style

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -19,16 +19,19 @@
                 <ApplicationName/>
             </FluentAnchor>
             <div class="flex-filler"></div>
-            <FluentAnchor Appearance="Appearance.Stealth"
+            <FluentAnchor Class="header-button"
+                          Appearance="Appearance.Stealth"
                           Href="https://aka.ms/dotnet/aspire/repo" Target="_blank" Rel="noreferrer noopener"
                           Title="@Loc[nameof(Layout.MainLayoutAspireRepoLink)]" aria-label="@Loc[nameof(Layout.MainLayoutAspireRepoLink)]">
                 <FluentIcon Value="@(new AspireIcons.Size24.GitHub())" Color="Color.Neutral"/>
             </FluentAnchor>
-            <FluentButton Appearance="Appearance.Stealth" OnClick="@LaunchHelpAsync" Target="_blank" Rel="noreferrer noopener"
+            <FluentButton Class="header-button"
+                          Appearance="Appearance.Stealth" OnClick="@LaunchHelpAsync" Target="_blank" Rel="noreferrer noopener"
                           Title="@Loc[nameof(Layout.MainLayoutAspireDashboardHelpLink)]" aria-label="@Loc[nameof(Layout.MainLayoutAspireDashboardHelpLink)]">
                 <FluentIcon Value="@(new Icons.Regular.Size24.QuestionCircle())" Color="Color.Neutral"/>
             </FluentButton>
-            <FluentButton Appearance="Appearance.Stealth" OnClick="@LaunchSettingsAsync"
+            <FluentButton Class="header-button"
+                          Appearance="Appearance.Stealth" OnClick="@LaunchSettingsAsync"
                           Title="@Loc[nameof(Layout.MainLayoutLaunchSettings)]" aria-label="@Loc[nameof(Layout.MainLayoutLaunchSettings)]">
                 <FluentIcon Value="@(new Icons.Regular.Size24.Settings())" Color="Color.Neutral"/>
             </FluentButton>

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -34,9 +34,9 @@
         grid-template-columns: auto 1fr;
         grid-template-rows: auto auto 1fr;
         grid-template-areas:
-        "icon head"
-        "nav messagebar"
-        "nav main";
+            "icon head"
+            "nav messagebar"
+            "nav main";
         background-color: var(--fill-color);
         color: var(--neutral-foreground-rest);
     }
@@ -76,13 +76,6 @@
         margin-left: auto;
     }
 
-    ::deep.layout > header > .header-gutters > fluent-button[appearance=stealth]:not(:hover)::part(control),
-    ::deep.layout > header > .header-gutters > fluent-anchor[appearance=stealth]:not(:hover)::part(control),
-    ::deep.layout > header > .header-gutters > fluent-anchor[appearance=stealth].logo::part(control),
-    ::deep.layout > .aspire-icon fluent-anchor[appearance=stealth].logo::part(control) {
-        background-color: var(--neutral-layer-4);
-    }
-
     ::deep.layout > header {
         background-color: var(--neutral-layer-4);
         margin-bottom: 0;
@@ -105,7 +98,7 @@
     }
 
     ::deep.layout > header > .header-gutters {
-        margin-left: 0;
+        margin: 0;
     }
 }
 
@@ -145,10 +138,10 @@
         grid-template-columns: auto 1fr;
         grid-template-rows: auto auto auto 1fr;
         grid-template-areas:
-        "icon head"
-        "nav-menu nav-menu"
-        "messagebar messagebar"
-        "main main";
+            "icon head"
+            "nav-menu nav-menu"
+            "messagebar messagebar"
+            "main main";
         background-color: var(--fill-color);
         color: var(--neutral-foreground-rest);
     }
@@ -186,13 +179,6 @@
 
     ::deep .header-right {
         margin-left: auto;
-    }
-
-    ::deep.layout > header > .header-gutters > fluent-button[appearance=stealth]:not(:hover)::part(control),
-    ::deep.layout > header > .header-gutters > fluent-anchor[appearance=stealth]:not(:hover)::part(control),
-    ::deep.layout > header > .header-gutters > fluent-anchor[appearance=stealth].logo::part(control),
-    ::deep.layout > .aspire-icon fluent-anchor[appearance=stealth].logo::part(control) {
-        background-color: var(--neutral-layer-4);
     }
 
     ::deep.layout > .aspire-icon {
@@ -240,4 +226,27 @@
        Remove the default horizontal padding to allow for more text  */
     padding-left: 0;
     padding-right: 0;
+}
+
+::deep.layout > header > .header-gutters > fluent-button[appearance=stealth]:not(:hover)::part(control),
+::deep.layout > header > .header-gutters > fluent-anchor[appearance=stealth]:not(:hover)::part(control),
+::deep.layout > header > .header-gutters > fluent-anchor[appearance=stealth].logo::part(control),
+::deep.layout > .aspire-icon fluent-anchor[appearance=stealth].logo::part(control) {
+    background-color: var(--neutral-layer-4);
+}
+
+::deep .header-gutters .header-button {
+    height: 100%;
+    display: block;
+}
+
+::deep .header-gutters .header-button::part(control) {
+    width: 50px;
+    height: 100%;
+    border-radius: 0;
+    background-color: var(--neutral-fill-secondary-rest);
+}
+
+::deep.layout > header > .header-gutters > .header-button-selected:not(:hover)::part(control) {
+    background-color: var(--neutral-layer-floating) !important;
 }


### PR DESCRIPTION
Improve header button style. They're now block buttons with background hover color. Makes the button more consistent with other fluent designs, e.g. Outlook web, Teams, etc

After:
![image](https://github.com/user-attachments/assets/b936d5a0-5e4c-4eb6-9924-015c97e607aa)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
