### PR TITLE
AzureStorage auto create queues

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <AzureProvisiongVersion>1.0.0</AzureProvisiongVersion>
+    <AzureProvisiongStorageVersion>1.0.1</AzureProvisiongStorageVersion>
     <!-- The Npgsql version used when using Npgsql EF Core on net8. The major versions need to match between Npgsql and EF Core. -->
     <Npgsql8Version>8.0.6</Npgsql8Version>
   </PropertyGroup>
@@ -49,7 +50,7 @@
     <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.SignalR" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Sql" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="$(AzureProvisiongVersion)" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="$(AzureProvisiongStorageVersion)" />
     <PackageVersion Include="Azure.Provisioning.WebPubSub" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.4" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.2" />
@@ -146,7 +147,6 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
-    <PackageVersion Include="Azure.Core" Version="1.46.0" />
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
@@ -14,8 +14,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
-builder.AddAzureQueueClient("queue");
-builder.AddAzureBlobClient("blob");
+builder.AddAzureQueueClient("queues");
+builder.AddAzureBlobClient("blobs");
 builder.AddAzureEventHubProducerClient("myhub");
 #if !SKIP_UNSTABLE_EMULATORS
 builder.AddAzureServiceBusClient("messaging");
@@ -24,10 +24,16 @@ builder.AddAzureCosmosClient("cosmosdb");
 
 var app = builder.Build();
 
+app.MapGet("/", async (HttpClient client) =>
+{
+    var stream = await client.GetStreamAsync("http://funcapp/api/injected-resources");
+    return Results.Stream(stream, "application/json");
+});
+
 app.MapGet("/publish/asq", async (QueueServiceClient client, CancellationToken cancellationToken) =>
 {
-    var queue = client.GetQueueClient("queue");
-    await queue.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+    var queue = client.GetQueueClient("myqueue1");
+
     var data = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello, World!"));
     await queue.SendMessageAsync(data, cancellationToken: cancellationToken);
     return Results.Ok("Message sent to Azure Storage Queue.");
@@ -41,15 +47,14 @@ static string RandomString(int length)
 
 app.MapGet("/publish/blob", async (BlobServiceClient client, CancellationToken cancellationToken, int length = 20) =>
 {
-    var container = client.GetBlobContainerClient("blobs");
-    await container.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+    var container = client.GetBlobContainerClient("myblobcontainer");
 
     var entry = new { Id = Guid.NewGuid(), Text = RandomString(length) };
     var blob = container.GetBlobClient(entry.Id.ToString());
 
     await blob.UploadAsync(new BinaryData(entry));
 
-    return Results.Ok("String uploaded to Azure Storage Blobs.");
+    return Results.Ok($"String uploaded to Azure Storage Blobs {container.Uri}.");
 });
 
 app.MapGet("/publish/eventhubs", async (EventHubProducerClient client, CancellationToken cancellationToken, int length = 20) =>
@@ -79,12 +84,6 @@ app.MapGet("/publish/cosmosdb", async (CosmosClient cosmosClient) =>
     return Results.Ok("Document created in Azure Cosmos DB.");
 });
 #endif
-
-app.MapGet("/", async (HttpClient client) =>
-{
-    var stream = await client.GetStreamAsync("http://funcapp/api/injected-resources");
-    return Results.Stream(stream, "application/json");
-});
 
 app.MapDefaultEndpoints();
 

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyAzureBlobTrigger.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyAzureBlobTrigger.cs
@@ -4,16 +4,16 @@ using Microsoft.Extensions.Logging;
 
 namespace AzureFunctionsEndToEnd.Functions;
 
-public class MyAzureBlobTrigger(ILogger<MyAzureBlobTrigger> logger, BlobContainerClient containerClient)
+public class MyAzureBlobTrigger(BlobContainerClient containerClient, ILogger<MyAzureBlobTrigger> logger)
 {
     [Function(nameof(MyAzureBlobTrigger))]
-    [BlobOutput("test-files/{name}.txt", Connection = "blob")]
-    public async Task<string> RunAsync([BlobTrigger("blobs/{name}", Connection = "blob")] string triggerString, FunctionContext context)
+    [BlobOutput("test-files/{name}.txt", Connection = "blobs")]
+    public async Task<string> RunAsync([BlobTrigger("myblobcontainer/{name}", Connection = "blobs")] string triggerString, FunctionContext context)
     {
         var blobName = (string)context.BindingContext.BindingData["name"]!;
-        await containerClient.UploadBlobAsync(blobName, new BinaryData(triggerString));
+        _ = await containerClient.GetAccountInfoAsync();
 
-        logger.LogInformation("C# blob trigger function invoked for 'blobs/{source}' with {message}...", blobName, triggerString);
+        logger.LogInformation("C# blob trigger function invoked for 'myblobcontainer/{source}' with {message}...", blobName, triggerString);
         return triggerString.ToUpper();
     }
 }

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyAzureQueueTrigger.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyAzureQueueTrigger.cs
@@ -1,14 +1,17 @@
+using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace AzureFunctionsEndToEnd.Functions;
 
-public class MyAzureQueueTrigger(ILogger<MyAzureQueueTrigger> logger)
+public class MyAzureQueueTrigger(QueueClient queueClient, ILogger<MyAzureQueueTrigger> logger)
 {
     [Function(nameof(MyAzureQueueTrigger))]
-    public void Run([QueueTrigger("queue", Connection = "queue")] QueueMessage message)
+    public void Run([QueueTrigger("myqueue1", Connection = "queues")] QueueMessage message)
     {
+        _ = queueClient.GetProperties();
+
         logger.LogInformation("C# Queue trigger function processed: {Text}", message.MessageText);
     }
 }

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyHttpTrigger.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyHttpTrigger.cs
@@ -22,6 +22,7 @@ public class MyHttpTrigger(
 #endif
     EventHubProducerClient eventHubProducerClient,
     QueueServiceClient queueServiceClient,
+    QueueClient queueClient,
     BlobServiceClient blobServiceClient,
     BlobContainerClient blobContainerClient)
 {
@@ -35,6 +36,7 @@ public class MyHttpTrigger(
 #endif
         stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"Aspire-injected EventHubProducerClient namespace: {eventHubProducerClient.FullyQualifiedNamespace}");
         stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"Aspire-injected QueueServiceClient URI: {queueServiceClient.Uri}");
+        stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"Aspire-injected QueueClient URI: {queueClient.Uri}");
         stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"Aspire-injected BlobServiceClient URI: {blobServiceClient.Uri}");
         stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"Aspire-injected BlobContainerClient URI: {blobContainerClient.Uri}");
         return Results.Text(stringBuilder.ToString());

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/Program.cs
@@ -4,9 +4,13 @@ using Microsoft.Extensions.Hosting;
 var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
-builder.AddAzureQueueClient("queue");
-builder.AddAzureBlobClient("blob");
+
+builder.AddAzureQueueClient("queues");
+builder.AddAzureQueue("myqueue1");
+
+builder.AddAzureBlobClient("blobs");
 builder.AddAzureBlobContainerClient("myblobcontainer");
+
 builder.AddAzureEventHubProducerClient("myhub");
 #if !SKIP_UNSTABLE_EMULATORS
 builder.AddAzureServiceBusClient("messaging");

--- a/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.ApiService/Program.cs
+++ b/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.ApiService/Program.cs
@@ -12,29 +12,59 @@ builder.AddAzureBlobClient("blobs");
 builder.AddKeyedAzureBlobContainerClient("foocontainer");
 
 builder.AddAzureQueueClient("queues");
+builder.AddKeyedAzureQueue("myqueue");
 
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
 
-app.MapGet("/", async (BlobServiceClient bsc, QueueServiceClient qsc, [FromKeyedServices("foocontainer")] BlobContainerClient keyedContainerClient1) =>
+app.MapGet("/", (HttpContext context) =>
+{
+    var request = context.Request;
+    var scheme = request.Scheme;
+    var host = request.Host;
+
+    var endpointDataSource = context.RequestServices.GetRequiredService<EndpointDataSource>();
+    var urls = endpointDataSource.Endpoints
+        .OfType<RouteEndpoint>()
+        .Select(e => $"{scheme}://{host}{e.RoutePattern.RawText}");
+
+    var html = "<html><body><ul>" +
+               string.Join("", urls.Select(url => $"<li><a href=\"{url}\">{url}</a></li>")) +
+               "</ul></body></html>";
+
+    context.Response.ContentType = "text/html";
+    return context.Response.WriteAsync(html);
+});
+
+app.MapGet("/blobs", async (BlobServiceClient bsc, [FromKeyedServices("foocontainer")] BlobContainerClient bcc) =>
 {
     var blobNames = new List<string>();
     var blobNameAndContent = Guid.NewGuid().ToString();
 
-    await keyedContainerClient1.UploadBlobAsync(blobNameAndContent, new BinaryData(blobNameAndContent));
+    await bcc.UploadBlobAsync(blobNameAndContent, new BinaryData(blobNameAndContent));
 
     var directContainerClient = bsc.GetBlobContainerClient(blobContainerName: "test-container-1");
     await directContainerClient.UploadBlobAsync(blobNameAndContent, new BinaryData(blobNameAndContent));
 
     await ReadBlobsAsync(directContainerClient, blobNames);
-    await ReadBlobsAsync(keyedContainerClient1, blobNames);
-
-    var queue = qsc.GetQueueClient("myqueue");
-    await queue.CreateIfNotExistsAsync();
-    await queue.SendMessageAsync("Hello, world!");
+    await ReadBlobsAsync(bcc, blobNames);
 
     return blobNames;
+});
+
+app.MapGet("/queues", async (QueueServiceClient qsc, [FromKeyedServices("myqueue")] QueueClient qc) =>
+{
+    const string text = "Hello, World!";
+    List<string> messages = [$"Sent: {text}"];
+
+    var queue = qsc.GetQueueClient("my-queue");
+    await queue.SendMessageAsync(text);
+
+    var msg = await qc.ReceiveMessageAsync();
+    messages.Add($"Received: {msg.Value.Body}");
+
+    return messages;
 });
 
 app.Run();

--- a/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Program.cs
+++ b/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Program.cs
@@ -13,6 +13,7 @@ blobs.AddBlobContainer("mycontainer1", blobContainerName: "test-container-1");
 blobs.AddBlobContainer("mycontainer2", blobContainerName: "test-container-2");
 
 var queues = storage.AddQueues("queues");
+var myqueue = queues.AddQueue("myqueue", queueName: "my-queue");
 
 var storage2 = builder.AddAzureStorage("storage2").RunAsEmulator(container =>
 {
@@ -25,7 +26,8 @@ builder.AddProject<Projects.AzureStorageEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()
        .WithReference(blobs).WaitFor(blobs)
        .WithReference(blobContainer2).WaitFor(blobContainer2)
-       .WithReference(queues).WaitFor(queues);
+       .WithReference(queues).WaitFor(queues)
+       .WithReference(myqueue).WaitFor(myqueue);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -14,7 +14,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" />
+    <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Queues" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.Storage" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageQueueResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageQueueResource.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
+using Azure.Provisioning;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// A resource that represents an Azure Storage queue.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="queueName">The name of the queue.</param>
+/// <param name="parent">The <see cref="AzureQueueStorageResource"/> that the resource is stored in.</param>
+public class AzureQueueStorageQueueResource(string name, string queueName, AzureQueueStorageResource parent) : Resource(name),
+    IResourceWithConnectionString,
+    IResourceWithParent<AzureQueueStorageResource>
+{
+    /// <summary>
+    /// Gets the queue name.
+    /// </summary>
+    public string QueueName { get; } = ThrowIfNullOrEmpty(queueName);
+
+    /// <summary>
+    /// Gets the connection string template for the manifest for the Azure Storage queue resource.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => Parent.GetConnectionString(QueueName);
+
+    /// <summary>
+    /// Gets the parent <see cref="AzureQueueStorageResource"/> of this <see cref="AzureQueueStorageQueueResource"/>.
+    /// </summary>
+    public AzureQueueStorageResource Parent => parent ?? throw new ArgumentNullException(nameof(parent));
+
+    /// <summary>
+    /// Converts the current instance to a provisioning entity.
+    /// </summary>
+    /// <returns>A <see cref="global::Azure.Provisioning.Storage.StorageQueue"/> instance.</returns>
+    internal global::Azure.Provisioning.Storage.StorageQueue ToProvisioningEntity()
+    {
+        global::Azure.Provisioning.Storage.StorageQueue queue = new(Infrastructure.NormalizeBicepIdentifier(Name))
+        {
+            Name = QueueName
+        };
+
+        return queue;
+    }
+
+    private static string ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(argument, paramName);
+        return argument;
+    }
+}

--- a/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageResource.cs
@@ -16,10 +16,6 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
     IResourceWithParent<AzureStorageResource>,
     IResourceWithAzureFunctionsConfig
 {
-    // NOTE: if ever these contants are changed, the AzureStorageQueueSettings in Aspire.Azure.Storage.Queues class should be updated as well.
-    private const string Endpoint = nameof(Endpoint);
-    private const string QueueName = nameof(QueueName);
-
     /// <summary>
     /// Gets the parent AzureStorageResource of this AzureQueueStorageResource.
     /// </summary>
@@ -39,7 +35,18 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
         }
 
         ReferenceExpressionBuilder builder = new();
-        builder.Append($"{Endpoint}=\"{ConnectionStringExpression}\";{QueueName}={queueName};");
+
+        if (Parent.IsEmulator)
+        {
+            builder.AppendFormatted(ConnectionStringExpression);
+        }
+        else
+        {
+            builder.Append($"Endpoint={ConnectionStringExpression}");
+        }
+
+        builder.Append($";QueueName={queueName}");
+
         return builder.Build();
     }
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageResource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Azure.Provisioning;
 
 namespace Aspire.Hosting.Azure;
 
@@ -15,6 +16,10 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
     IResourceWithParent<AzureStorageResource>,
     IResourceWithAzureFunctionsConfig
 {
+    // NOTE: if ever these contants are changed, the AzureStorageQueueSettings in Aspire.Azure.Storage.Queues class should be updated as well.
+    private const string Endpoint = nameof(Endpoint);
+    private const string QueueName = nameof(QueueName);
+
     /// <summary>
     /// Gets the parent AzureStorageResource of this AzureQueueStorageResource.
     /// </summary>
@@ -25,6 +30,18 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         Parent.GetQueueConnectionString();
+
+    internal ReferenceExpression GetConnectionString(string? queueName)
+    {
+        if (string.IsNullOrEmpty(queueName))
+        {
+            return ConnectionStringExpression;
+        }
+
+        ReferenceExpressionBuilder builder = new();
+        builder.Append($"{Endpoint}=\"{ConnectionStringExpression}\";{QueueName}={queueName};");
+        return builder.Build();
+    }
 
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
     {
@@ -41,5 +58,15 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
             // Injected to support Aspire client integration for Azure Storage Queues.
             target[$"{AzureStorageResource.QueuesConnectionKeyPrefix}__{connectionName}__ServiceUri"] = Parent.QueueEndpoint;
         }
+    }
+
+    /// <summary>
+    /// Converts the current instance to a provisioning entity.
+    /// </summary>
+    /// <returns>A <see cref="global::Azure.Provisioning.Storage.QueueService"/> instance.</returns>
+    internal global::Azure.Provisioning.Storage.QueueService ToProvisioningEntity()
+    {
+        global::Azure.Provisioning.Storage.QueueService service = new(Infrastructure.NormalizeBicepIdentifier(Name));
+        return service;
     }
 }

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
@@ -24,6 +24,7 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
     private EndpointReference EmulatorTableEndpoint => new(this, "table");
 
     internal List<AzureBlobStorageContainerResource> BlobContainers { get; } = [];
+    internal List<AzureQueueStorageQueueResource> Queues { get; } = [];
 
     /// <summary>
     /// Gets the "blobEndpoint" output reference from the bicep template for the Azure Storage resource.

--- a/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
@@ -67,10 +67,6 @@
                           },
                           "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
                         },
-                        "EnableDistributedTracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
-                        },
                         "NetworkTimeout": {
                           "type": "string",
                           "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",

--- a/src/Components/Aspire.Azure.Storage.Blobs/AzureBlobStorageContainerSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AzureBlobStorageContainerSettings.cs
@@ -40,7 +40,7 @@ public sealed partial class AzureBlobStorageContainerSettings : AzureStorageBlob
             // when the connection string is built and BlobServiceClient doesn't support escape sequences. 
         }
 
-        // Connection string built from a URI? e.g., Endpoint=https://{account_name}.blob.core.windows.net;ContainerName=...;
+        // Connection string built from a URI? E.g., Endpoint=https://{account_name}.blob.core.windows.net;ContainerName=...;
         if (builder.TryGetValue("Endpoint", out var endpoint) && endpoint is string)
         {
             if (Uri.TryCreate(endpoint.ToString(), UriKind.Absolute, out var uri))

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.StorageQueueComponent.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.StorageQueueComponent.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Azure.Common;
+using Aspire.Azure.Storage.Queues;
+using Azure.Core;
+using Azure.Core.Extensions;
+using Azure.Storage.Queues;
+using HealthChecks.Azure.Storage.Queues;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Extensions.Hosting;
+
+public static partial class AspireQueueStorageExtensions
+{
+    private sealed class StorageQueueComponent : AzureComponent<AzureStorageQueuesSettings, QueueServiceClient, QueueClientOptions>
+    {
+        protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings, string connectionName,
+            string configurationSectionName)
+        {
+            return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<QueueServiceClient, QueueClientOptions>((options, cred) =>
+            {
+                var connectionString = settings.ConnectionString;
+                if (string.IsNullOrEmpty(connectionString) && settings.ServiceUri is null)
+                {
+                    throw new InvalidOperationException($"A QueueServiceClient could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{connectionName}' or specify a 'ConnectionString' or 'ServiceUri' in the '{configurationSectionName}' configuration section.");
+                }
+
+                return !string.IsNullOrEmpty(connectionString)
+                    ? new QueueServiceClient(connectionString, options)
+                    : cred is not null
+                        ? new QueueServiceClient(settings.ServiceUri, cred, options)
+                        : new QueueServiceClient(settings.ServiceUri, options);
+            }, requiresCredential: false);
+        }
+
+        protected override void BindClientOptionsToConfiguration(IAzureClientBuilder<QueueServiceClient, QueueClientOptions> clientBuilder, IConfiguration configuration)
+        {
+#pragma warning disable IDE0200 // Remove unnecessary lambda expression - needed so the ConfigBinder Source Generator works
+            clientBuilder.ConfigureOptions(options => configuration.Bind(options));
+#pragma warning restore IDE0200
+        }
+
+        protected override void BindSettingsToConfiguration(AzureStorageQueuesSettings settings, IConfiguration configuration)
+        {
+            configuration.Bind(settings);
+        }
+
+        protected override IHealthCheck CreateHealthCheck(QueueServiceClient client, AzureStorageQueuesSettings settings)
+            => new AzureQueueStorageHealthCheck(client, new AzureQueueStorageHealthCheckOptions());
+
+        protected override bool GetHealthCheckEnabled(AzureStorageQueuesSettings settings)
+            => !settings.DisableHealthChecks;
+
+        protected override TokenCredential? GetTokenCredential(AzureStorageQueuesSettings settings)
+            => settings.Credential;
+
+        protected override bool GetMetricsEnabled(AzureStorageQueuesSettings settings)
+            => false;
+
+        protected override bool GetTracingEnabled(AzureStorageQueuesSettings settings)
+            => !settings.DisableTracing;
+    }
+}

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.StorageQueueComponent.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.StorageQueueComponent.cs
@@ -6,6 +6,7 @@ using Aspire.Azure.Storage.Queues;
 using Azure.Core;
 using Azure.Core.Extensions;
 using Azure.Storage.Queues;
+using Azure.Storage.Queues.Specialized;
 using HealthChecks.Azure.Storage.Queues;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
@@ -16,53 +17,58 @@ namespace Microsoft.Extensions.Hosting;
 
 public static partial class AspireQueueStorageExtensions
 {
-    private sealed class StorageQueueComponent : AzureComponent<AzureStorageQueuesSettings, QueueServiceClient, QueueClientOptions>
+    private sealed partial class StorageQueueComponent : AzureComponent<AzureStorageQueueSettings, QueueClient, QueueClientOptions>
     {
-        protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient(
-            AzureClientFactoryBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings, string connectionName,
-            string configurationSectionName)
+        protected override IAzureClientBuilder<QueueClient, QueueClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureStorageQueueSettings settings, string connectionName, string configurationSectionName)
         {
-            return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<QueueServiceClient, QueueClientOptions>((options, cred) =>
+            return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<QueueClient, QueueClientOptions>((options, cred) =>
             {
+                if (string.IsNullOrEmpty(settings.QueueName))
+                {
+                    throw new InvalidOperationException($"The connection string '{connectionName}' does not exist or is missing the queue name.");
+                }
+
                 var connectionString = settings.ConnectionString;
                 if (string.IsNullOrEmpty(connectionString) && settings.ServiceUri is null)
                 {
                     throw new InvalidOperationException($"A QueueServiceClient could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{connectionName}' or specify a 'ConnectionString' or 'ServiceUri' in the '{configurationSectionName}' configuration section.");
                 }
 
-                return !string.IsNullOrEmpty(connectionString)
-                    ? new QueueServiceClient(connectionString, options)
-                    : cred is not null
-                        ? new QueueServiceClient(settings.ServiceUri, cred, options)
-                        : new QueueServiceClient(settings.ServiceUri, options);
+                var queueServiceClient = !string.IsNullOrEmpty(connectionString) ? new QueueServiceClient(connectionString, options) :
+                    cred is not null ? new QueueServiceClient(settings.ServiceUri, cred, options) :
+                    new QueueServiceClient(settings.ServiceUri, options);
+
+                var client = queueServiceClient.GetQueueClient(settings.QueueName);
+                return client;
             }, requiresCredential: false);
         }
 
-        protected override void BindClientOptionsToConfiguration(IAzureClientBuilder<QueueServiceClient, QueueClientOptions> clientBuilder, IConfiguration configuration)
+        protected override void BindClientOptionsToConfiguration(IAzureClientBuilder<QueueClient, QueueClientOptions> clientBuilder, IConfiguration configuration)
         {
 #pragma warning disable IDE0200 // Remove unnecessary lambda expression - needed so the ConfigBinder Source Generator works
             clientBuilder.ConfigureOptions(options => configuration.Bind(options));
 #pragma warning restore IDE0200
         }
 
-        protected override void BindSettingsToConfiguration(AzureStorageQueuesSettings settings, IConfiguration configuration)
+        protected override void BindSettingsToConfiguration(AzureStorageQueueSettings settings, IConfiguration configuration)
         {
             configuration.Bind(settings);
         }
 
-        protected override IHealthCheck CreateHealthCheck(QueueServiceClient client, AzureStorageQueuesSettings settings)
-            => new AzureQueueStorageHealthCheck(client, new AzureQueueStorageHealthCheckOptions());
+        protected override IHealthCheck CreateHealthCheck(QueueClient client, AzureStorageQueueSettings settings)
+            => new AzureQueueStorageHealthCheck(client.GetParentQueueServiceClient(), new AzureQueueStorageHealthCheckOptions { QueueName = client.Name });
 
-        protected override bool GetHealthCheckEnabled(AzureStorageQueuesSettings settings)
+        protected override bool GetHealthCheckEnabled(AzureStorageQueueSettings settings)
             => !settings.DisableHealthChecks;
 
-        protected override TokenCredential? GetTokenCredential(AzureStorageQueuesSettings settings)
+        protected override TokenCredential? GetTokenCredential(AzureStorageQueueSettings settings)
             => settings.Credential;
 
-        protected override bool GetMetricsEnabled(AzureStorageQueuesSettings settings)
+        protected override bool GetMetricsEnabled(AzureStorageQueueSettings settings)
             => false;
 
-        protected override bool GetTracingEnabled(AzureStorageQueuesSettings settings)
+        protected override bool GetTracingEnabled(AzureStorageQueueSettings settings)
             => !settings.DisableTracing;
     }
 }

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.StorageQueuesComponent.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.StorageQueuesComponent.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Azure.Common;
+using Aspire.Azure.Storage.Queues;
+using Azure.Core;
+using Azure.Core.Extensions;
+using Azure.Storage.Queues;
+using HealthChecks.Azure.Storage.Queues;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Extensions.Hosting;
+
+partial class AspireQueueStorageExtensions
+{
+    private sealed class StorageQueuesComponent : AzureComponent<AzureStorageQueuesSettings, QueueServiceClient, QueueClientOptions>
+    {
+        protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings, string connectionName,
+            string configurationSectionName)
+        {
+            return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<QueueServiceClient, QueueClientOptions>((options, cred) =>
+            {
+                var connectionString = settings.ConnectionString;
+                if (string.IsNullOrEmpty(connectionString) && settings.ServiceUri is null)
+                {
+                    throw new InvalidOperationException($"A QueueServiceClient could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{connectionName}' or specify a 'ConnectionString' or 'ServiceUri' in the '{configurationSectionName}' configuration section.");
+                }
+
+                return !string.IsNullOrEmpty(connectionString)
+                    ? new QueueServiceClient(connectionString, options)
+                    : cred is not null
+                        ? new QueueServiceClient(settings.ServiceUri, cred, options)
+                        : new QueueServiceClient(settings.ServiceUri, options);
+            }, requiresCredential: false);
+        }
+
+        protected override void BindClientOptionsToConfiguration(IAzureClientBuilder<QueueServiceClient, QueueClientOptions> clientBuilder, IConfiguration configuration)
+        {
+#pragma warning disable IDE0200 // Remove unnecessary lambda expression - needed so the ConfigBinder Source Generator works
+            clientBuilder.ConfigureOptions(options => configuration.Bind(options));
+#pragma warning restore IDE0200
+        }
+
+        protected override void BindSettingsToConfiguration(AzureStorageQueuesSettings settings, IConfiguration configuration)
+        {
+            configuration.Bind(settings);
+        }
+
+        protected override IHealthCheck CreateHealthCheck(QueueServiceClient client, AzureStorageQueuesSettings settings)
+            => new AzureQueueStorageHealthCheck(client, new AzureQueueStorageHealthCheckOptions());
+
+        protected override bool GetHealthCheckEnabled(AzureStorageQueuesSettings settings)
+            => !settings.DisableHealthChecks;
+
+        protected override TokenCredential? GetTokenCredential(AzureStorageQueuesSettings settings)
+            => settings.Credential;
+
+        protected override bool GetMetricsEnabled(AzureStorageQueuesSettings settings)
+            => false;
+
+        protected override bool GetTracingEnabled(AzureStorageQueuesSettings settings)
+            => !settings.DisableTracing;
+    }
+}

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
@@ -1,16 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Azure.Common;
 using Aspire.Azure.Storage.Queues;
-using Azure.Core;
 using Azure.Core.Extensions;
 using Azure.Storage.Queues;
-using HealthChecks.Azure.Storage.Queues;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -18,20 +12,27 @@ namespace Microsoft.Extensions.Hosting;
 /// Provides extension methods for registering <see cref="QueueServiceClient"/> as a singleton in the services provided by the <see cref="IHostApplicationBuilder"/>.
 /// Enables retries, corresponding health check, logging and telemetry.
 /// </summary>
-public static class AspireQueueStorageExtensions
+public static partial class AspireQueueStorageExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Azure:Storage:Queues";
 
     /// <summary>
-    /// Registers <see cref="QueueServiceClient"/> as a singleton in the services provided by the <paramref name="builder"/>.
-    /// Enables retries, corresponding health check, logging and telemetry.
+    ///  Registers <see cref="QueueServiceClient"/> as a singleton in the services provided by the <paramref name="builder"/>.
+    ///  Enables retries, corresponding health check, logging and telemetry.
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
     /// <param name="connectionName">A name used to retrieve the connection string from the ConnectionStrings configuration section.</param>
-    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureStorageQueuesSettings"/>. It's invoked after the settings are read from the configuration.</param>
-    /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
+    /// <param name="configureSettings">
+    ///  An optional method that can be used for customizing the <see cref="AzureStorageQueuesSettings"/>. It's invoked after
+    ///  the settings are read from the configuration.
+    /// </param>
+    /// <param name="configureClientBuilder">
+    ///  An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.
+    /// </param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Storage:Queues" section.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureStorageQueuesSettings.ConnectionString"/> nor <see cref="AzureStorageQueuesSettings.ServiceUri"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">
+    ///  Neither <see cref="AzureStorageQueuesSettings.ConnectionString"/> nor <see cref="AzureStorageQueuesSettings.ServiceUri"/> is provided.
+    /// </exception>
     public static void AddAzureQueueClient(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -45,15 +46,26 @@ public static class AspireQueueStorageExtensions
     }
 
     /// <summary>
-    /// Registers <see cref="QueueServiceClient"/> as a singleton for given <paramref name="name"/> in the services provided by the <paramref name="builder"/>.
-    /// Enables retries, corresponding health check, logging and telemetry.
+    ///  Registers <see cref="QueueServiceClient"/> as a singleton for given <paramref name="name"/> in the services provided
+    ///  by the <paramref name="builder"/>.
+    ///  Enables retries, corresponding health check, logging and telemetry.
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
-    /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection string from the ConnectionStrings configuration section.</param>
-    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureStorageQueuesSettings"/>. It's invoked after the settings are read from the configuration.</param>
-    /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
+    /// <param name="name">
+    ///  The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service
+    ///  and also to retrieve the connection string from the ConnectionStrings configuration section.
+    /// </param>
+    /// <param name="configureSettings">
+    ///  An optional method that can be used for customizing the <see cref="AzureStorageQueuesSettings"/>.
+    ///  It's invoked after the settings are read from the configuration.
+    /// </param>
+    /// <param name="configureClientBuilder">
+    ///  An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.
+    /// </param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Storage:Queues:{name}" section.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureStorageQueuesSettings.ConnectionString"/> nor <see cref="AzureStorageQueuesSettings.ServiceUri"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">
+    ///  Neither <see cref="AzureStorageQueuesSettings.ConnectionString"/> nor <see cref="AzureStorageQueuesSettings.ServiceUri"/> is provided.
+    /// </exception>
     public static void AddKeyedAzureQueueClient(
         this IHostApplicationBuilder builder,
         string name,
@@ -64,55 +76,5 @@ public static class AspireQueueStorageExtensions
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         new StorageQueueComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName: name, serviceKey: name);
-    }
-
-    private sealed class StorageQueueComponent : AzureComponent<AzureStorageQueuesSettings, QueueServiceClient, QueueClientOptions>
-    {
-        protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient(
-            AzureClientFactoryBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings, string connectionName,
-            string configurationSectionName)
-        {
-            return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<QueueServiceClient, QueueClientOptions>((options, cred) =>
-            {
-                var connectionString = settings.ConnectionString;
-                if (string.IsNullOrEmpty(connectionString) && settings.ServiceUri is null)
-                {
-                    throw new InvalidOperationException($"A QueueServiceClient could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{connectionName}' or specify a 'ConnectionString' or 'ServiceUri' in the '{configurationSectionName}' configuration section.");
-                }
-
-                return !string.IsNullOrEmpty(connectionString)
-                    ? new QueueServiceClient(connectionString, options)
-                    : cred is not null
-                        ? new QueueServiceClient(settings.ServiceUri, cred, options)
-                        : new QueueServiceClient(settings.ServiceUri, options);
-            }, requiresCredential: false);
-        }
-
-        protected override void BindClientOptionsToConfiguration(IAzureClientBuilder<QueueServiceClient, QueueClientOptions> clientBuilder, IConfiguration configuration)
-        {
-#pragma warning disable IDE0200 // Remove unnecessary lambda expression - needed so the ConfigBinder Source Generator works
-            clientBuilder.ConfigureOptions(options => configuration.Bind(options));
-#pragma warning restore IDE0200
-        }
-
-        protected override void BindSettingsToConfiguration(AzureStorageQueuesSettings settings, IConfiguration configuration)
-        {
-            configuration.Bind(settings);
-        }
-
-        protected override IHealthCheck CreateHealthCheck(QueueServiceClient client, AzureStorageQueuesSettings settings)
-            => new AzureQueueStorageHealthCheck(client, new AzureQueueStorageHealthCheckOptions());
-
-        protected override bool GetHealthCheckEnabled(AzureStorageQueuesSettings settings)
-            => !settings.DisableHealthChecks;
-
-        protected override TokenCredential? GetTokenCredential(AzureStorageQueuesSettings settings)
-            => settings.Credential;
-
-        protected override bool GetMetricsEnabled(AzureStorageQueuesSettings settings)
-            => false;
-
-        protected override bool GetTracingEnabled(AzureStorageQueuesSettings settings)
-            => !settings.DisableTracing;
     }
 }

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
@@ -42,7 +42,7 @@ public static partial class AspireQueueStorageExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(connectionName);
 
-        new StorageQueueComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName, serviceKey: null);
+        new StorageQueuesComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName, serviceKey: null);
     }
 
     /// <summary>
@@ -71,6 +71,71 @@ public static partial class AspireQueueStorageExtensions
         string name,
         Action<AzureStorageQueuesSettings>? configureSettings = null,
         Action<IAzureClientBuilder<QueueServiceClient, QueueClientOptions>>? configureClientBuilder = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        new StorageQueuesComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName: name, serviceKey: name);
+    }
+
+    /// <summary>
+    ///  Registers <see cref="QueueClient"/> as a singleton in the services provided by the <paramref name="builder"/>.
+    ///  Enables retries, corresponding health check, logging and telemetry.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
+    /// <param name="connectionName">A name used to retrieve the connection string from the ConnectionStrings configuration section.</param>
+    /// <param name="configureSettings">
+    ///  An optional method that can be used for customizing the <see cref="AzureStorageQueuesSettings"/>.
+    ///  It's invoked after the settings are read from the configuration.
+    /// </param>
+    /// <param name="configureClientBuilder">
+    ///  An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.
+    /// </param>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Storage:Queues:{name}" section.</remarks>
+    /// <exception cref="InvalidOperationException">
+    ///  Neither <see cref="AzureStorageQueuesSettings.ConnectionString"/> nor <see cref="AzureStorageQueuesSettings.ServiceUri"/> is provided.
+    ///  - or -
+    ///  <see cref="AzureStorageQueueSettings.QueueName"/> is not provided in the configuration section.
+    /// </exception>
+    public static void AddAzureQueue(
+        this IHostApplicationBuilder builder,
+        string connectionName,
+        Action<AzureStorageQueueSettings>? configureSettings = null,
+        Action<IAzureClientBuilder<QueueClient, QueueClientOptions>>? configureClientBuilder = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
+        new StorageQueueComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName, serviceKey: null);
+    }
+
+    /// <summary>
+    ///  Registers <see cref="QueueClient"/> as a singleton in the services provided by the <paramref name="builder"/>.
+    ///  Enables retries, corresponding health check, logging and telemetry.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
+    /// <param name="name">
+    ///  The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve
+    ///  the connection string from the ConnectionStrings configuration section.
+    /// </param>
+    /// <param name="configureSettings">
+    ///  An optional method that can be used for customizing the <see cref="AzureStorageQueuesSettings"/>.
+    ///  It's invoked after the settings are read from the configuration.
+    /// </param>
+    /// <param name="configureClientBuilder">
+    ///  An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.
+    /// </param>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Storage:Queues:{name}" section.</remarks>
+    /// <exception cref="InvalidOperationException">
+    ///  Neither <see cref="AzureStorageQueuesSettings.ConnectionString"/> nor <see cref="AzureStorageQueuesSettings.ServiceUri"/> is provided.
+    ///  - or -
+    ///  <see cref="AzureStorageQueueSettings.QueueName"/> is not provided in the configuration section.
+    /// </exception>
+    public static void AddKeyedAzureQueue(
+        this IHostApplicationBuilder builder,
+        string name,
+        Action<AzureStorageQueueSettings>? configureSettings = null,
+        Action<IAzureClientBuilder<QueueClient, QueueClientOptions>>? configureClientBuilder = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);

--- a/src/Components/Aspire.Azure.Storage.Queues/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Aspire;
 using Aspire.Azure.Storage.Queues;
 using Azure.Storage.Queues;
@@ -12,3 +13,5 @@ using Azure.Storage.Queues;
     "Azure",
     "Azure.Core",
     "Azure.Identity")]
+
+[assembly: InternalsVisibleTo("Aspire.Azure.Storage.Queues.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]

--- a/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueueSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueueSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data.Common;
+using System.Text.RegularExpressions;
 using Aspire.Azure.Common;
 
 namespace Aspire.Azure.Storage.Queues;
@@ -9,8 +10,11 @@ namespace Aspire.Azure.Storage.Queues;
 /// <summary>
 /// Provides the client configuration settings for connecting to Azure Storage queue.
 /// </summary>
-public sealed class AzureStorageQueueSettings : AzureStorageQueuesSettings, IConnectionStringSettings
+public sealed partial class AzureStorageQueueSettings : AzureStorageQueuesSettings, IConnectionStringSettings
 {
+    [GeneratedRegex(@"(?i)QueueName\s*=\s*([^;]+);?", RegexOptions.IgnoreCase)]
+    private static partial Regex QueueNameRegex();
+
     /// <summary>
     ///  Gets or sets the name of the blob container.
     /// </summary>
@@ -25,11 +29,29 @@ public sealed class AzureStorageQueueSettings : AzureStorageQueuesSettings, ICon
 
         DbConnectionStringBuilder builder = new() { ConnectionString = connectionString };
 
-        // NOTE: if ever these contants are changed, the AzureQueueStorageResource in Aspire.Hosting.Azure.Storage class should be updated as well.
-        if (builder.TryGetValue("Endpoint", out var endpoint) && builder.TryGetValue("QueueName", out var queueName))
+        if (builder.TryGetValue("QueueName", out var containerName))
         {
-            ConnectionString = endpoint.ToString();
-            QueueName = queueName.ToString();
+            QueueName = containerName?.ToString();
+
+            // Remove the QueueName property from the connection string as QueueServiceClient would fail to parse it.
+            connectionString = QueueNameRegex().Replace(connectionString, "");
+
+            // NB: we can't remove QueueName by using the DbConnectionStringBuilder as it would escape the AccountKey value
+            // when the connection string is built and QueueServiceClient doesn't support escape sequences. 
+        }
+
+        // Connection string built from a URI? E.g., Endpoint=https://{account_name}.queue.core.windows.net;QueueName=...;
+        if (builder.TryGetValue("Endpoint", out var endpoint) && endpoint is string)
+        {
+            if (Uri.TryCreate(endpoint.ToString(), UriKind.Absolute, out var uri))
+            {
+                ServiceUri = uri;
+            }
+        }
+        else
+        {
+            // Otherwise preserve the existing connection string
+            ConnectionString = connectionString;
         }
     }
 }

--- a/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueueSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueueSettings.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data.Common;
+using Aspire.Azure.Common;
+
+namespace Aspire.Azure.Storage.Queues;
+
+/// <summary>
+/// Provides the client configuration settings for connecting to Azure Storage queue.
+/// </summary>
+public sealed class AzureStorageQueueSettings : AzureStorageQueuesSettings, IConnectionStringSettings
+{
+    /// <summary>
+    ///  Gets or sets the name of the blob container.
+    /// </summary>
+    public string? QueueName { get; set; }
+
+    void IConnectionStringSettings.ParseConnectionString(string? connectionString)
+    {
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            return;
+        }
+
+        DbConnectionStringBuilder builder = new() { ConnectionString = connectionString };
+
+        // NOTE: if ever these contants are changed, the AzureQueueStorageResource in Aspire.Hosting.Azure.Storage class should be updated as well.
+        if (builder.TryGetValue("Endpoint", out var endpoint) && builder.TryGetValue("QueueName", out var queueName))
+        {
+            ConnectionString = endpoint.ToString();
+            QueueName = queueName.ToString();
+        }
+    }
+}

--- a/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
@@ -9,7 +9,7 @@ namespace Aspire.Azure.Storage.Queues;
 /// <summary>
 /// Provides the client configuration settings for connecting to Azure Storage Queues.
 /// </summary>
-public sealed class AzureStorageQueuesSettings : IConnectionStringSettings
+public class AzureStorageQueuesSettings : IConnectionStringSettings
 {
     /// <summary>
     /// Gets or sets the connection string used to connect to the blob service. 

--- a/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
@@ -52,16 +52,18 @@ public class AzureStorageQueuesSettings : IConnectionStringSettings
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {
-        if (!string.IsNullOrEmpty(connectionString))
+        if (string.IsNullOrEmpty(connectionString))
         {
-            if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
-            {
-                ServiceUri = uri;
-            }
-            else
-            {
-                ConnectionString = connectionString;
-            }
+            return;
+        }
+
+        if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
+        {
+            ServiceUri = uri;
+        }
+        else
+        {
+            ConnectionString = connectionString;
         }
     }
 }

--- a/tests/Aspire.Azure.Storage.Queues.Tests/AzureStorageQueueSettingsTests.cs
+++ b/tests/Aspire.Azure.Storage.Queues.Tests/AzureStorageQueueSettingsTests.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Azure.Common;
+using Aspire.Azure.Storage.Queues;
+using Xunit;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureStorageQueueSettingsTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(";")]
+    [InlineData("Endpoint=https://example.queues.core.windows.net;")]
+    [InlineData("QueueName=my-queue;")]
+    [InlineData("Endpoint=https://example.queueName.core.windows.net;ExtraParam=value;")]
+    public void ParseConnectionString_invalid_input(string? connectionString)
+    {
+        var settings = new AzureStorageQueueSettings();
+
+        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
+
+        Assert.Null(settings.ConnectionString);
+        Assert.Null(settings.QueueName);
+    }
+
+    [Fact]
+    public void ParseConnectionString_invalid_input_results_in_AE()
+    {
+        var settings = new AzureStorageQueueSettings();
+        string connectionString = "InvalidConnectionString";
+
+        Assert.Throws<ArgumentException>(() => ((IConnectionStringSettings)settings).ParseConnectionString(connectionString));
+    }
+
+    [Theory]
+    [InlineData("Endpoint=https://example.queueName.core.windows.net;QueueName=my-queue")]
+    [InlineData("Endpoint=https://example.queueName.core.windows.net;QueueName=my-queue;ExtraParam=value")]
+    [InlineData("endpoint=https://example.queueName.core.windows.net;queuename=my-queue")]
+    [InlineData("ENDPOINT=https://example.queueName.core.windows.net;QUEUENAME=my-queue")]
+    public void ParseConnectionString_valid_input(string connectionString)
+    {
+        var settings = new AzureStorageQueueSettings();
+
+        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
+
+        Assert.Equal("https://example.queueName.core.windows.net", settings.ConnectionString);
+        Assert.Equal("my-queue", settings.QueueName);
+    }
+}

--- a/tests/Aspire.Azure.Storage.Queues.Tests/AzureStorageQueueSettingsTests.cs
+++ b/tests/Aspire.Azure.Storage.Queues.Tests/AzureStorageQueueSettingsTests.cs
@@ -9,22 +9,7 @@ namespace Aspire.Hosting.Azure.Tests;
 
 public class AzureStorageQueueSettingsTests
 {
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData(";")]
-    [InlineData("Endpoint=https://example.queues.core.windows.net;")]
-    [InlineData("QueueName=my-queue;")]
-    [InlineData("Endpoint=https://example.queueName.core.windows.net;ExtraParam=value;")]
-    public void ParseConnectionString_invalid_input(string? connectionString)
-    {
-        var settings = new AzureStorageQueueSettings();
-
-        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
-
-        Assert.Null(settings.ConnectionString);
-        Assert.Null(settings.QueueName);
-    }
+    private const string EmulatorConnectionString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;QueueEndpoint=http://127.0.0.1:10000/devstoreaccount1";
 
     [Fact]
     public void ParseConnectionString_invalid_input_results_in_AE()
@@ -40,13 +25,42 @@ public class AzureStorageQueueSettingsTests
     [InlineData("Endpoint=https://example.queueName.core.windows.net;QueueName=my-queue;ExtraParam=value")]
     [InlineData("endpoint=https://example.queueName.core.windows.net;queuename=my-queue")]
     [InlineData("ENDPOINT=https://example.queueName.core.windows.net;QUEUENAME=my-queue")]
-    public void ParseConnectionString_valid_input(string connectionString)
+    [InlineData("Endpoint=\"https://example.queueName.core.windows.net\";QueueName=\"my-queue\"")]
+    public void ParseConnectionString_With_ServiceUri(string connectionString)
     {
         var settings = new AzureStorageQueueSettings();
 
         ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
 
-        Assert.Equal("https://example.queueName.core.windows.net", settings.ConnectionString);
+        Assert.Equal("https://example.queuename.core.windows.net/", settings.ServiceUri?.ToString());
         Assert.Equal("my-queue", settings.QueueName);
+    }
+
+    [Theory]
+    [InlineData($"{EmulatorConnectionString};QueueName=my-queue")]
+    [InlineData($"{EmulatorConnectionString};QueueName=\"my-queue\"")]
+    public void ParseConnectionString_With_ConnectionString(string connectionString)
+    {
+        var settings = new AzureStorageQueueSettings();
+
+        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
+
+        Assert.Contains(EmulatorConnectionString, settings.ConnectionString, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("QueueName", settings.ConnectionString, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("my-queue", settings.QueueName);
+        Assert.Null(settings.ServiceUri);
+    }
+
+    [Theory]
+    [InlineData($"Endpoint=not-a-uri;QueueName=my-queue")]
+    public void ParseConnectionString_With_NotAUri(string connectionString)
+    {
+        var settings = new AzureStorageQueueSettings();
+
+        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
+
+        Assert.True(string.IsNullOrEmpty(settings.ConnectionString));
+        Assert.Equal("my-queue", settings.QueueName);
+        Assert.Null(settings.ServiceUri);
     }
 }

--- a/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
@@ -24,6 +24,9 @@ public class ConformanceTests : ConformanceTests<QueueServiceClient, AzureStorag
 
     protected override string ActivitySourceName => "Azure.Storage.Queues.QueueClient";
 
+    // AzureStorageQueuesSettings subclassed by AzureStorageQueueSettings
+    protected override bool CheckOptionClassSealed => false;
+
     protected override string[] RequiredLogCategories => new string[]
     {
         "Azure.Core",

--- a/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Messaging.EventHubs\Aspire.Azure.Messaging.EventHubs.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Messaging.ServiceBus\Aspire.Azure.Messaging.ServiceBus.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Storage.Blobs\Aspire.Azure.Storage.Blobs.csproj" />
+    <ProjectReference Include="..\..\src\Components\Aspire.Azure.Storage.Queues\Aspire.Azure.Storage.Queues.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Microsoft.Azure.Cosmos\Aspire.Microsoft.Azure.Cosmos.csproj" />
     <ProjectReference Include="..\..\src\Components\Aspire.Microsoft.EntityFrameworkCore.Cosmos\Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -338,8 +338,8 @@ public class AzureStorageExtensionsTests
         var queues = storage.AddQueues("queues");
         var queue = queues.AddQueue(name: "myqueue", queueName);
 
-        string? blobConntionString = await ((IResourceWithConnectionString)queues.Resource).GetConnectionStringAsync();
-        string expected = $"Endpoint=\"{blobConntionString}\";QueueName={queueName};";
+        string? conntionString = await ((IResourceWithConnectionString)queues.Resource).GetConnectionStringAsync();
+        string expected = $"{conntionString};QueueName={queueName}";
 
         Assert.Equal(expected, await ((IResourceWithConnectionString)queue.Resource).GetConnectionStringAsync());
     }
@@ -353,13 +353,13 @@ public class AzureStorageExtensionsTests
 
         var storagesku = builder.AddParameter("storagesku");
         var storage = builder.AddAzureStorage("storage");
-        storage.Resource.Outputs["queueEndpoint"] = "https://myblob";
+        storage.Resource.Outputs["queueEndpoint"] = "https://myqueue";
 
         var queues = storage.AddQueues("queues");
         var queue = queues.AddQueue(name: "myqueue", queueName);
 
         string? connectionString = await ((IResourceWithConnectionString)queues.Resource).GetConnectionStringAsync();
-        string expected = $"Endpoint=\"{connectionString}\";QueueName={queueName};";
+        string expected = $"Endpoint={connectionString};QueueName={queueName}";
 
         Assert.Equal(expected, await ((IResourceWithConnectionString)queue.Resource).GetConnectionStringAsync());
     }
@@ -373,7 +373,7 @@ public class AzureStorageExtensionsTests
         var queues = storage.AddQueues("queues");
         var queue = queues.AddQueue(name: "myqueue");
 
-        Assert.Equal("Endpoint=\"{storage.outputs.queueEndpoint}\";QueueName=myqueue;", queue.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("Endpoint={storage.outputs.queueEndpoint};QueueName=myqueue", queue.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AddAzureStorageViaPublishMode.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AddAzureStorageViaPublishMode.verified.bicep
@@ -23,11 +23,6 @@ resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
-  name: 'default'
-  parent: storage
-}
-
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AddAzureStorageViaPublishModeEnableAllowSharedKeyAccessOverridesDefaultFalse.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AddAzureStorageViaPublishModeEnableAllowSharedKeyAccessOverridesDefaultFalse.verified.bicep
@@ -23,11 +23,6 @@ resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
-  name: 'default'
-  parent: storage
-}
-
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AddAzureStorageViaRunMode.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AddAzureStorageViaRunMode.verified.bicep
@@ -23,11 +23,6 @@ resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
-  name: 'default'
-  parent: storage
-}
-
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AddAzureStorageViaRunModeAllowSharedKeyAccessOverridesDefaultFalse.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AddAzureStorageViaRunModeAllowSharedKeyAccessOverridesDefaultFalse.verified.bicep
@@ -23,11 +23,6 @@ resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
-  name: 'default'
-  parent: storage
-}
-
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_CapturesParametersAndOutputsCorrectly_WithSnapshot#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_CapturesParametersAndOutputsCorrectly_WithSnapshot#01.verified.bicep
@@ -25,11 +25,6 @@ resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
-  name: 'default'
-  parent: storage
-}
-
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
@@ -31,6 +31,15 @@ resource myContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@
   parent: blobs
 }
 
+resource queues 'Microsoft.Storage/storageAccounts/queueServices@2024-01-01' = {
+  parent: storage
+}
+
+resource myqueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2024-01-01' = {
+  name: 'my-queue'
+  parent: queues
+}
+
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
@@ -32,6 +32,7 @@ resource myContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@
 }
 
 resource queues 'Microsoft.Storage/storageAccounts/queueServices@2024-01-01' = {
+  name: 'default'
   parent: storage
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingStorageAccountWithResourceGroup.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingStorageAccountWithResourceGroup.verified.bicep
@@ -7,11 +7,6 @@ resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
   name: existingResourceName
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
-  name: 'default'
-  parent: storage
-}
-
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingStorageAccountWithResourceGroupAndStaticArguments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingStorageAccountWithResourceGroupAndStaticArguments.verified.bicep
@@ -5,11 +5,6 @@ resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
   name: 'existingResourcename'
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
-  name: 'default'
-  parent: storage
-}
-
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -91,6 +91,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
         {
             "Aspire-injected EventHubProducerClient namespace: localhost",
             "Aspire-injected QueueServiceClient URI: http://127.0.0.1:*/devstoreaccount1",
+            "Aspire-injected QueueClient URI: http://127.0.0.1:*/devstoreaccount1/myqueue1",
             "Aspire-injected BlobServiceClient URI: http://127.0.0.1:*/devstoreaccount1",
             "Aspire-injected BlobContainerClient URI: http://127.0.0.1:*/devstoreaccount1/myblobcontainer"
         };


### PR DESCRIPTION
## Description

* Add the ability to register and deep link to individual Azure storage queues.
* Auto-create Azure storage queues upon registration.

This change is, essentially, a copy of #9008 adapter for Azure storage queues.

Addendum to #5167 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
