### PR TITLE
Introduce InitializeResourceEvent & fix parent/child & URLs for custom resources

### DIFF
--- a/playground/CustomResources/CustomResources.AppHost/Program.cs
+++ b/playground/CustomResources/CustomResources.AppHost/Program.cs
@@ -1,7 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using CustomResources.AppHost;
+
 var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddTalkingClock("talking-clock");
 
 builder.AddTestResource("test");
 

--- a/playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs
+++ b/playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace CustomResources.AppHost;
+
+// Define the custom resource type. It inherits from the base Aspire 'Resource' class.
+// This class is primarily a data container; Aspire behavior is added via eventing and extension methods.
+public sealed class TalkingClockResource(string name) : Resource(name);
+
+// Define Aspire extension methods for adding the TalkingClockResource to the application builder.
+// This provides a fluent API for users to add the custom resource.
+public static class TalkingClockExtensions
+{
+    // The main Aspire extension method to add a TalkingClockResource.
+    public static IResourceBuilder<TalkingClockResource> AddTalkingClock(
+        this IDistributedApplicationBuilder builder, // Extends the Aspire application builder.
+        string name)                                 // The name for this resource instance.
+    {
+        // Create a new instance of the TalkingClockResource.
+        var clockResource = new TalkingClockResource(name);
+
+        builder.Eventing.Subscribe<InitializeResourceEvent>(clockResource, static async (@event, token) =>
+        {
+            // This event is published when the resource is initialized.
+            // You add custom logic here to establish the lifecycle for your custom resource.
+
+            var log = @event.Logger; // Get the logger for this resource instance.
+            var eventing = @event.Eventing; // Get the eventing service for publishing events.
+            var notification = @event.Notifications; // Get the notification service for state updates.
+            var resource = @event.Resource; // Get the resource instance.
+            var services = @event.Services; // Get the service provider for dependency injection.
+
+            // Publish an Aspire event indicating that this resource is about to start.
+            // Other components could subscribe to this event for pre-start actions.
+            await eventing.PublishAsync(new BeforeResourceStartedEvent(resource, services), token);
+
+            // Log an informational message associated with the resource.
+            log.LogInformation("Starting Talking Clock...");
+
+            // Publish an initial state update to the Aspire notification service.
+            // This sets the resource's state to 'Running' and records the start time.
+            // The Aspire dashboard and other orchestrators observe these state updates.
+            await notification.PublishUpdateAsync(resource, s => s with
+            {
+                StartTimeStamp = DateTime.UtcNow,
+                State = KnownResourceStates.Running // Use an Aspire well-known state.
+            });
+
+            // Enter the main loop that runs as long as cancellation is not requested.
+            while (!token.IsCancellationRequested)
+            {
+                // Log the current time, associated with the resource.
+                log.LogInformation("The time is {time}", DateTime.UtcNow);
+
+                // Publish a custom state update "Tick" using Aspire's ResourceStateSnapshot.
+                // This demonstrates using custom state strings and styles in the Aspire dashboard.
+                await notification.PublishUpdateAsync(resource,
+                    s => s with { State = new ResourceStateSnapshot("Tick", KnownResourceStateStyles.Info) });
+
+                await Task.Delay(1000, token);
+
+                // Publish another custom state update "Tock" using Aspire's ResourceStateSnapshot.
+                await notification.PublishUpdateAsync(resource,
+                    s => s with { State = new ResourceStateSnapshot("Tock", KnownResourceStateStyles.Success) });
+
+                await Task.Delay(1000, token);
+            }
+        });
+
+        // Add the resource instance to the Aspire application builder and configure it using fluent APIs.
+        return builder.AddResource(clockResource)
+            // Use Aspire's ExcludeFromManifest to prevent this resource from being included in deployment manifests.
+            .ExcludeFromManifest()
+            // Set a URL for the resource, which will be displayed in the Aspire dashboard.
+            .WithUrl("https://www.speaking-clock.com/", "Speaking Clock")
+            // Use Aspire's WithInitialState to set an initial state snapshot for the resource.
+            // This provides initial metadata visible in the Aspire dashboard.
+            .WithInitialState(new CustomResourceSnapshot // Aspire type for custom resource state.
+            {
+                ResourceType = "TalkingClock", // A string identifying the type of resource for Aspire, this shows in the dashboard.
+                CreationTimeStamp = DateTime.UtcNow,
+                State = KnownResourceStates.NotStarted, // Use an Aspire well-known state.
+                // Add custom properties displayed in the Aspire dashboard's resource details.
+                Properties =
+                [
+                    // Use Aspire's known property key for source information.
+                    new(CustomResourceKnownProperties.Source, "Talking Clock")
+                ]
+            });
+    }
+}

--- a/playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs
+++ b/playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs
@@ -9,6 +9,8 @@ namespace CustomResources.AppHost;
 // This class is primarily a data container; Aspire behavior is added via eventing and extension methods.
 public sealed class TalkingClockResource(string name) : Resource(name);
 
+public sealed class ClockHandResource(string name) : Resource(name);
+
 // Define Aspire extension methods for adding the TalkingClockResource to the application builder.
 // This provides a fluent API for users to add the custom resource.
 public static class TalkingClockExtensions
@@ -20,6 +22,7 @@ public static class TalkingClockExtensions
     {
         // Create a new instance of the TalkingClockResource.
         var clockResource = new TalkingClockResource(name);
+        var handResource = new ClockHandResource(name + "-hand");
 
         builder.Eventing.Subscribe<InitializeResourceEvent>(clockResource, static async (@event, token) =>
         {
@@ -70,7 +73,7 @@ public static class TalkingClockExtensions
         });
 
         // Add the resource instance to the Aspire application builder and configure it using fluent APIs.
-        return builder.AddResource(clockResource)
+        var clockBuilder = builder.AddResource(clockResource)
             // Use Aspire's ExcludeFromManifest to prevent this resource from being included in deployment manifests.
             .ExcludeFromManifest()
             // Set a URL for the resource, which will be displayed in the Aspire dashboard.
@@ -89,5 +92,10 @@ public static class TalkingClockExtensions
                     new(CustomResourceKnownProperties.Source, "Talking Clock")
                 ]
             });
+
+        builder.AddResource(handResource)
+            .WithParentRelationship(clockResource); // Establish a parent-child relationship with the TalkingClockResource.
+
+        return clockBuilder;
     }
 }

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
@@ -13,7 +13,6 @@
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessResult.cs" Link="Provisioning\Utils\ProcessResult.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" Link="Provisioning\Utils\ProcessSpec.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Provisioning\Utils\ProcessUtil.cs" />
-    <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="Provisioning\Utils\KnownProperties.cs" />
     <Compile Include="$(SharedDir)CustomResourceSnapshotExtensions.cs" Link="Provisioning\Utils\CustomResourceSnapshotExtensions.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Provisioning\Utils\StringComparers.cs" />
     <Compile Include="$(SharedDir)BicepFunction2.cs" Link="Provisioning\Utils\BicepFunction2.cs" />

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -17,8 +17,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 internal sealed class AzureResourcePreparer(
     IOptions<AzureProvisioningOptions> provisioningOptions,
-    DistributedApplicationExecutionContext executionContext,
-    ResourceNotificationService notificationService
+    DistributedApplicationExecutionContext executionContext
     ) : IDistributedApplicationLifecycleHook
 {
     public async Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
@@ -210,7 +209,7 @@ internal sealed class AzureResourcePreparer(
 
         if (globalRoleAssignments.Count > 0)
         {
-            await CreateGlobalRoleAssignments(appModel, globalRoleAssignments, options).ConfigureAwait(false);
+            CreateGlobalRoleAssignments(appModel, globalRoleAssignments, options);
         }
 
         // We can derive role assignments for compute resources and declared
@@ -422,7 +421,7 @@ internal sealed class AzureResourcePreparer(
         existingRoles.UnionWith(newRoles);
     }
 
-    private async Task CreateGlobalRoleAssignments(DistributedApplicationModel appModel, Dictionary<AzureProvisioningResource, HashSet<RoleDefinition>> globalRoleAssignments, AzureProvisioningOptions provisioningOptions)
+    private static void CreateGlobalRoleAssignments(DistributedApplicationModel appModel, Dictionary<AzureProvisioningResource, HashSet<RoleDefinition>> globalRoleAssignments, AzureProvisioningOptions provisioningOptions)
     {
         foreach (var (azureResource, roles) in globalRoleAssignments)
         {
@@ -432,10 +431,6 @@ internal sealed class AzureResourcePreparer(
             azureResource.Annotations.Add(new RoleAssignmentResourceAnnotation(roleAssignmentResource));
 
             roleAssignmentResource.Annotations.Add(new ResourceRelationshipAnnotation(azureResource, KnownRelationshipTypes.Parent));
-            await notificationService.PublishUpdateAsync(roleAssignmentResource, s => s with
-            {
-                Properties = s.Properties.SetResourceProperty(KnownProperties.Resource.ParentName, azureResource.Name)
-            }).ConfigureAwait(false);
         }
     }
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Azure.Utils;
@@ -91,12 +90,6 @@ internal sealed class AzureProvisioner(
                         childResources.Add(grandChild);
                     }
                 }
-
-                await notificationService.PublishUpdateAsync(child, s =>
-                {
-                    s = s with { Properties = s.Properties.SetResourceProperty(KnownProperties.Resource.ParentName, child.Parent.Name) };
-                    return stateFactory(s);
-                }).ConfigureAwait(false);
             }
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/InitializeResourceEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InitializeResourceEvent.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Eventing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// 
+/// </summary>
+/// <param name="resource"></param>
+/// <param name="services"></param>
+public class InitializeResourceEvent(IResource resource, IServiceProvider services) : IDistributedApplicationResourceEvent
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public IDistributedApplicationEventing Eventing { get; } = services.GetRequiredService<IDistributedApplicationEventing>();
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public ILogger Logger { get; } = services.GetRequiredService<ResourceLoggerService>().GetLogger(resource);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public ResourceNotificationService Notifications { get; } = services.GetRequiredService<ResourceNotificationService>();
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public IResource Resource { get; } = resource;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public IServiceProvider Services { get; } = services;
+}

--- a/src/Aspire.Hosting/ApplicationModel/InitializeResourceEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InitializeResourceEvent.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Eventing;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -11,23 +10,31 @@ namespace Aspire.Hosting.ApplicationModel;
 /// 
 /// </summary>
 /// <param name="resource"></param>
+/// <param name="distributedApplicationEventing"></param>
+/// <param name="resourceLoggerService"></param>
+/// <param name="resourceNotificationService"></param>
 /// <param name="services"></param>
-public class InitializeResourceEvent(IResource resource, IServiceProvider services) : IDistributedApplicationResourceEvent
+public class InitializeResourceEvent(
+    IResource resource,
+    IDistributedApplicationEventing distributedApplicationEventing,
+    ResourceLoggerService resourceLoggerService,
+    ResourceNotificationService resourceNotificationService,
+    IServiceProvider services) : IDistributedApplicationResourceEvent
 {
     /// <summary>
     /// 
     /// </summary>
-    public IDistributedApplicationEventing Eventing { get; } = services.GetRequiredService<IDistributedApplicationEventing>();
+    public IDistributedApplicationEventing Eventing { get; } = distributedApplicationEventing;
 
     /// <summary>
     /// 
     /// </summary>
-    public ILogger Logger { get; } = services.GetRequiredService<ResourceLoggerService>().GetLogger(resource);
+    public ILogger Logger { get; } = resourceLoggerService.GetLogger(resource);
 
     /// <summary>
     /// 
     /// </summary>
-    public ResourceNotificationService Notifications { get; } = services.GetRequiredService<ResourceNotificationService>();
+    public ResourceNotificationService Notifications { get; } = resourceNotificationService;
 
     /// <summary>
     /// 

--- a/src/Aspire.Hosting/ApplicationModel/InitializeResourceEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InitializeResourceEvent.cs
@@ -7,13 +7,17 @@ using Microsoft.Extensions.Logging;
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// 
+/// This event is raised by orchestrators to signal to resources that they should initialize themselves.
 /// </summary>
-/// <param name="resource"></param>
-/// <param name="distributedApplicationEventing"></param>
-/// <param name="resourceLoggerService"></param>
-/// <param name="resourceNotificationService"></param>
-/// <param name="services"></param>
+/// <param name="resource">The resource that is being created.</param>
+/// <param name="distributedApplicationEventing">The <see cref="IDistributedApplicationEventing"/> service for the app host.</param>
+/// <param name="resourceLoggerService">The <see cref="ResourceLoggerService"/> for the app host.</param>
+/// <param name="resourceNotificationService">The <see cref="ResourceNotificationService"/> for the app host.</param>
+/// <param name="services">The <see cref="IServiceProvider"/> for the app host.</param>
+/// <remarks>
+/// Custom resources can subscribe to this event to perform initialization tasks, including starting background tasks
+/// that manage the resource's lifecycle.
+/// </remarks>
 public class InitializeResourceEvent(
     IResource resource,
     IDistributedApplicationEventing distributedApplicationEventing,
@@ -21,28 +25,26 @@ public class InitializeResourceEvent(
     ResourceNotificationService resourceNotificationService,
     IServiceProvider services) : IDistributedApplicationResourceEvent
 {
+    /// <inheritdoc />
+    public IResource Resource { get; } = resource;
+
     /// <summary>
-    /// 
+    /// The <see cref="IDistributedApplicationEventing"/> service for the app host.
     /// </summary>
     public IDistributedApplicationEventing Eventing { get; } = distributedApplicationEventing;
 
     /// <summary>
-    /// 
+    /// An instance of <see cref="ILogger"/> that can be used to log messages for the resource.
     /// </summary>
     public ILogger Logger { get; } = resourceLoggerService.GetLogger(resource);
 
     /// <summary>
-    /// 
+    /// The <see cref="ResourceNotificationService"/> for the app host.
     /// </summary>
     public ResourceNotificationService Notifications { get; } = resourceNotificationService;
 
     /// <summary>
-    /// 
-    /// </summary>
-    public IResource Resource { get; } = resource;
-
-    /// <summary>
-    /// 
+    /// The <see cref="IServiceProvider"/> for the app host.
     /// </summary>
     public IServiceProvider Services { get; } = services;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceEndpointsAllocatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceEndpointsAllocatedEvent.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Eventing;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// This event is raised by orchestrators to signal to resources that their endpoints have been allocated.
+/// </summary>
+/// <remarks>
+/// Any resources that customize their URLs via a <see cref="ResourceUrlsCallbackAnnotation"/> will have their callbacks invoked during this event.
+/// </remarks>
+public class ResourceEndpointsAllocatedEvent(IResource resource) : IDistributedApplicationEvent
+{
+    /// <inheritdoc />
+    public IResource Resource { get; } = resource;
+}

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -945,9 +945,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IConsoleLogsService, IAsyncDis
 
                 try
                 {
-                    await ProcessUrls(resource, cancellationToken).ConfigureAwait(false);
-
-                    // Publish snapshots built from DCP resources. Do this now to populate more values from DCP (URLs, source) to ensure they're
+                    // Publish snapshots built from DCP resources. Do this now to populate more values from DCP (source) to ensure they're
                     // available if the resource isn't immediately started because it's waiting or is configured for explicit start.
                     foreach (var er in executables)
                     {
@@ -1219,9 +1217,7 @@ internal sealed class DcpExecutor : IDcpExecutor, IConsoleLogsService, IAsyncDis
 
             foreach (var cr in containerResources)
             {
-                await ProcessUrls(cr.ModelResource, cancellationToken).ConfigureAwait(false);
-
-                // Publish snapshot built from DCP resource. Do this now to populate more values from DCP (URLs, source) to ensure they're
+                // Publish snapshot built from DCP resource. Do this now to populate more values from DCP (source) to ensure they're
                 // available if the resource isn't immediately started because it's waiting or is configured for explicit start.
                 await _executorEvents.PublishAsync(new OnResourceChangedContext(_shutdownCancellation.Token, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResourceName, new ResourceStatus(null, null, null), s => _snapshotBuilder.ToSnapshot((Container)cr.DcpResource, s))).ConfigureAwait(false);
 
@@ -1453,74 +1449,6 @@ internal sealed class DcpExecutor : IDcpExecutor, IConsoleLogsService, IAsyncDis
             // We catch and suppress the OperationCancelledException because the user may CTRL-C
             // during start up of the resources.
             _logger.LogDebug(ex, "Cancellation during creation of resources.");
-        }
-    }
-
-    private async Task ProcessUrls(IResource resource, CancellationToken cancellationToken)
-    {
-        // Call the callbacks to configure resource URLs
-
-        if (resource is not IResourceWithEndpoints resourceWithEndpoints)
-        {
-            return;
-        }
-
-        // Project endpoints to URLS
-        var urls = new List<ResourceUrlAnnotation>();
-
-        if (resource.TryGetEndpoints(out var endpoints))
-        {
-            foreach (var endpoint in endpoints)
-            {
-                // Create a URL for each endpoint
-                if (endpoint.AllocatedEndpoint is { } allocatedEndpoint)
-                {
-                    var url = new ResourceUrlAnnotation { Url = allocatedEndpoint.UriString, Endpoint = new EndpointReference(resourceWithEndpoints, endpoint) };
-                    urls.Add(url);
-                }
-            }
-        }
-
-        // Run the URL callbacks
-        if (resource.TryGetAnnotationsOfType<ResourceUrlsCallbackAnnotation>(out var callbacks))
-        {
-            var urlsCallbackContext = new ResourceUrlsCallbackContext(_executionContext, resource, urls, cancellationToken)
-            {
-                Logger = _loggerService.GetLogger(resource.Name)
-            };
-            foreach (var callback in callbacks)
-            {
-                await callback.Callback(urlsCallbackContext).ConfigureAwait(false);
-            }
-        }
-
-        // Clear existing URLs
-        if (resource.TryGetUrls(out var existingUrls))
-        {
-            var existing = existingUrls.ToArray();
-            for (var i = existing.Length - 1; i >= 0; i--)
-            {
-                var url = existing[i];
-                resource.Annotations.Remove(url);
-            }
-        }
-
-        // Convert relative endpoint URLs to absolute URLs
-        foreach (var url in urls)
-        {
-            if (url.Endpoint is { } endpoint)
-            {
-                if (url.Url.StartsWith('/') && endpoint.AllocatedEndpoint is { } allocatedEndpoint)
-                {
-                    url.Url = allocatedEndpoint.UriString.TrimEnd('/') + url.Url;
-                }
-            }
-        }
-
-        // Add URLs
-        foreach (var url in urls)
-        {
-            resource.Annotations.Add(url);
         }
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
@@ -44,6 +44,8 @@
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.Azure.Storage\AzureStorageEmulatorConnectionString.cs" />
     <Compile Include="$(TestsSharedDir)\VerifyExtensions.cs" />
     <Compile Include="$(TestsSharedDir)\TestModuleInitializer.cs" />
+    <Compile Include="..\..\src\Shared\Model\KnownProperties.cs" Link="KnownProperties.cs" />
+    <Compile Include="..\..\src\Shared\StringComparers.cs" Link="StringComparers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureManifestUtils.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureManifestUtils.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
-using Aspire.Hosting.Tests.Utils;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Utils;
@@ -23,7 +22,7 @@ public sealed class AzureManifestUtils
         if (!skipPreparer)
         {
             var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
-            var azurePreparer = new AzureResourcePreparer(Options.Create(new AzureProvisioningOptions()), executionContext, ResourceNotificationServiceTestHelpers.Create());
+            var azurePreparer = new AzureResourcePreparer(Options.Create(new AzureProvisioningOptions()), executionContext);
             await azurePreparer.BeforeStartAsync(appModel, cancellationToken: default);
         }
 


### PR DESCRIPTION
## Description

This introduces two new events: `InitializeResourceEvent` and `ResourceEndpointsAllocated`.

`InitializeResourceEvent` is published to resources to signal that they should initialize themselves, including kicking off the lifecycle logic for custom resources.

`ResourceEndpointsAllocated` is published to resources once their endpoints have been allocated. During this event is when resource URLs are processed.

`ApplicationOrchestrator` is updated to centrally process parent/child relationships for all resources (including custom resources) and the specific logic to do this in Azure resources was removed.

`ApplicationOrchestrator` was also updated to process resource URLs differently so that it works for all resource types, not just DCP-controlled resources.

Fixes #9128
Fixes #8080
Contributes to #9146

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - dotnet/aspire-docs#3372
