### PR TITLE
Fix access denied error when searching Application Data for apphost project.

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -23,7 +23,10 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
         var appHostProjects = new List<FileInfo>();
 
         logger.LogDebug("Searching for project files in {SearchDirectory}", searchDirectory.FullName);
-        var projectFiles = searchDirectory.GetFiles("*.csproj", SearchOption.AllDirectories);
+        var enumerationOptions = new EnumerationOptions();
+        enumerationOptions.RecurseSubdirectories = true;
+        enumerationOptions.IgnoreInaccessible = true;
+        var projectFiles = searchDirectory.GetFiles("*.csproj", enumerationOptions);
         logger.LogDebug("Found {ProjectFileCount} project files in {SearchDirectory}", projectFiles.Length, searchDirectory.FullName);
 
         foreach (var projectFile in projectFiles)

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -23,9 +23,11 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
         var appHostProjects = new List<FileInfo>();
 
         logger.LogDebug("Searching for project files in {SearchDirectory}", searchDirectory.FullName);
-        var enumerationOptions = new EnumerationOptions();
-        enumerationOptions.RecurseSubdirectories = true;
-        enumerationOptions.IgnoreInaccessible = true;
+        var enumerationOptions = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true
+        };
         var projectFiles = searchDirectory.GetFiles("*.csproj", enumerationOptions);
         logger.LogDebug("Found {ProjectFileCount} project files in {SearchDirectory}", projectFiles.Length, searchDirectory.FullName);
 


### PR DESCRIPTION
Fixes: #9049

Uses enumeration options to skip over inaccessible directories. This solution is still not perfect though because launch aspire run from a directory that has a lot of files results in the GetFiles(...) call taking a long time to run.

We would only make this worse if we manually tried to traverse the directory tree (although we could give feedback on what is going on).

One option I was considering is whether we timeout the search if necessary and tell people to use the `--project` option if we can't complete the search.