### PR TITLE
Don't clobber env files

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -111,28 +111,16 @@ internal sealed class DockerComposePublishingContext(
 
         // Write a .env file with the environment variable names
         // that are used in the compose file
-        var envFile = Path.Combine(OutputPath, ".env");
-        using var envWriter = new StreamWriter(envFile);
+        var envFilePath = Path.Combine(OutputPath, ".env");
+        var envFile = EnvFile.Load(envFilePath);
 
         foreach (var entry in environment.CapturedEnvironmentVariables ?? [])
         {
             var (key, (description, defaultValue)) = entry;
-
-            await envWriter.WriteLineAsync($"# {description}").ConfigureAwait(false);
-
-            if (defaultValue is not null)
-            {
-                await envWriter.WriteLineAsync($"{key}={defaultValue}").ConfigureAwait(false);
-            }
-            else
-            {
-                await envWriter.WriteLineAsync($"{key}=").ConfigureAwait(false);
-            }
-
-            await envWriter.WriteLineAsync().ConfigureAwait(false);
+            envFile.AddIfMissing(key, defaultValue, description);
         }
 
-        await envWriter.FlushAsync().ConfigureAwait(false);
+        envFile.Save(envFilePath);
     }
 
     private static void HandleComposeFileVolumes(DockerComposeServiceResource serviceResource, ComposeFile composeFile)

--- a/src/Aspire.Hosting.Docker/EnvFile.cs
+++ b/src/Aspire.Hosting.Docker/EnvFile.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Docker;
+
+internal sealed class EnvFile
+{
+    private readonly List<string> _lines = [];
+    private readonly HashSet<string> _keys = [];
+
+    public static EnvFile Load(string path)
+    {
+        var envFile = new EnvFile();
+        if (!File.Exists(path))
+        {
+            return envFile;
+        }
+
+        foreach (var line in File.ReadAllLines(path))
+        {
+            envFile._lines.Add(line);
+            var trimmed = line.TrimStart();
+            if (!trimmed.StartsWith('#') && trimmed.Contains('='))
+            {
+                var eqIndex = trimmed.IndexOf('=');
+                if (eqIndex > 0)
+                {
+                    var key = trimmed[..eqIndex].Trim();
+                    envFile._keys.Add(key);
+                }
+            }
+        }
+        return envFile;
+    }
+
+    public void AddIfMissing(string key, string? value, string? comment)
+    {
+        if (_keys.Contains(key))
+        {
+            return;
+        }
+        if (!string.IsNullOrWhiteSpace(comment))
+        {
+            _lines.Add($"# {comment}");
+        }
+        _lines.Add(value is not null ? $"{key}={value}" : $"{key}=");
+        _lines.Add(string.Empty);
+        _keys.Add(key);
+    }
+
+    public void Save(string path)
+    {
+        File.WriteAllLines(path, _lines);
+    }
+}

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppendsNewKeysToEnvFileOnPublish#00.verified.env
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppendsNewKeysToEnvFileOnPublish#00.verified.env
@@ -1,0 +1,3 @@
+﻿# Parameter param1
+PARAM1=changed
+

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppendsNewKeysToEnvFileOnPublish#01.verified.env
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppendsNewKeysToEnvFileOnPublish#01.verified.env
@@ -1,0 +1,6 @@
+﻿# Parameter param1
+PARAM1=changed
+
+# Parameter param2
+PARAM2=
+

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeDoesNotOverwriteEnvFileOnPublish#00.verified.env
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeDoesNotOverwriteEnvFileOnPublish#00.verified.env
@@ -1,0 +1,3 @@
+﻿# Parameter param1
+PARAM1=changed
+

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeDoesNotOverwriteEnvFileOnPublish#01.verified.env
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeDoesNotOverwriteEnvFileOnPublish#01.verified.env
@@ -1,0 +1,3 @@
+﻿# Parameter param1
+PARAM1=changed
+


### PR DESCRIPTION
## Description

- Env files aren't check into source control and overwriting them destroys the values.
- This change makes the env file updates purely additive (non existing new keys), and never overwrites or deleted values.
- Added tests

Fixes #9124

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
