### PR TITLE
Address follow-ups on AzureEnvironmentResource

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -19,12 +19,17 @@ public sealed class AzureEnvironmentResource : Resource
     /// <summary>
     /// Gets or sets the Azure location that the resources will be deployed to.
     /// </summary>
-    internal ParameterResource Location { get; set; }
+    public ParameterResource Location { get; set; }
 
     /// <summary>
     /// Gets or sets the Azure resource group name that the resources will be deployed to.
     /// </summary>
-    internal ParameterResource ResourceGroupName { get; set; }
+    public ParameterResource ResourceGroupName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Azure principal ID that will be used to deploy the resources.
+    /// </summary>
+    public ParameterResource PrincipalId { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureEnvironmentResource"/> class.
@@ -32,27 +37,24 @@ public sealed class AzureEnvironmentResource : Resource
     /// <param name="name">The name of the Azure environment resource.</param>
     /// <param name="location">The Azure location that the resources will be deployed to.</param>
     /// <param name="resourceGroupName">The Azure resource group name that the resources will be deployed to.</param>
+    /// <param name="principalId">The Azure principal ID that will be used to deploy the resources.</param>
     /// <exception cref="ArgumentNullException">Thrown when the name is null or empty.</exception>
     /// <exception cref="ArgumentException">Thrown when the name is invalid.</exception>
-    public AzureEnvironmentResource(string name, ParameterResource location, ParameterResource resourceGroupName) : base(name)
+    public AzureEnvironmentResource(string name, ParameterResource location, ParameterResource resourceGroupName, ParameterResource principalId) : base(name)
     {
         Annotations.Add(new PublishingCallbackAnnotation(PublishAsync));
 
         Location = location;
         ResourceGroupName = resourceGroupName;
+        PrincipalId = principalId;
     }
 
     private Task PublishAsync(PublishingContext context)
     {
-        var options = new AzurePublisherOptions
-        {
-            OutputPath = context.OutputPath
-        };
-
         var azureProvisioningOptions = context.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>();
 
         var azureCtx = new AzurePublishingContext(
-            options,
+            context.OutputPath,
             azureProvisioningOptions.Value,
             context.Logger);
 

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.cs
@@ -26,10 +26,11 @@ public static class AzureEnvironmentResourceExtensions
         }
 
         var resourceName = builder.CreateDefaultAzureEnvironmentName();
-        var locationParam = ParameterResourceBuilderExtensions.CreateParameter(builder, "azure-location-default", false);
-        var resourceGroupName = ParameterResourceBuilderExtensions.CreateParameter(builder, "azure-rg-default", false);
+        var locationParam = ParameterResourceBuilderExtensions.CreateParameter(builder, "location", false);
+        var resourceGroupName = ParameterResourceBuilderExtensions.CreateParameter(builder, "resourceGroupName", false);
+        var principalId = ParameterResourceBuilderExtensions.CreateParameter(builder, "principalId", false);
 
-        var resource = new AzureEnvironmentResource(resourceName, locationParam, resourceGroupName);
+        var resource = new AzureEnvironmentResource(resourceName, locationParam, resourceGroupName, principalId);
         if (builder.ExecutionContext.IsRunMode)
         {
             // Return a builder that isn't added to the top-level application builder

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -21,12 +21,11 @@ namespace Aspire.Hosting.Azure;
 /// </remarks>
 [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
 public sealed class AzurePublishingContext(
-    AzurePublisherOptions publisherOptions,
+    string outputPath,
     AzureProvisioningOptions provisioningOptions,
     ILogger logger)
 {
     private ILogger Logger => logger;
-    private AzurePublisherOptions PublisherOptions => publisherOptions;
 
     /// <summary>
     /// Gets the main.bicep infrastructure for the distributed application.
@@ -64,7 +63,7 @@ public sealed class AzurePublishingContext(
     internal async Task WriteModelAsync(DistributedApplicationModel model, AzureEnvironmentResource environment, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(model);
-        ArgumentNullException.ThrowIfNull(PublisherOptions.OutputPath);
+        ArgumentNullException.ThrowIfNull(outputPath);
 
         if (model.Resources.Count == 0)
         {
@@ -74,12 +73,12 @@ public sealed class AzurePublishingContext(
 
         await WriteAzureArtifactsOutputAsync(model, environment, cancellationToken).ConfigureAwait(false);
 
-        await SaveToDiskAsync(PublisherOptions.OutputPath).ConfigureAwait(false);
+        await SaveToDiskAsync(outputPath).ConfigureAwait(false);
     }
 
     private Task WriteAzureArtifactsOutputAsync(DistributedApplicationModel model, AzureEnvironmentResource environment, CancellationToken _)
     {
-        var outputDirectory = new DirectoryInfo(PublisherOptions.OutputPath!);
+        var outputDirectory = new DirectoryInfo(outputPath);
         if (!outputDirectory.Exists)
         {
             outputDirectory.Create();
@@ -89,6 +88,7 @@ public sealed class AzurePublishingContext(
 
         MapParameter(environment.ResourceGroupName);
         MapParameter(environment.Location);
+        MapParameter(environment.PrincipalId);
 
         var resourceGroupParam = ParameterLookup[environment.ResourceGroupName];
         MainInfrastructure.Add(resourceGroupParam);
@@ -96,22 +96,13 @@ public sealed class AzurePublishingContext(
         var locationParam = ParameterLookup[environment.Location];
         MainInfrastructure.Add(locationParam);
 
-        var principalId = new ProvisioningParameter("principalId", typeof(string));
+        var principalId = ParameterLookup[environment.PrincipalId];
         MainInfrastructure.Add(principalId);
-
-        var tags = new ProvisioningVariable("tags", typeof(object))
-        {
-            Value = new BicepDictionary<string>
-            {
-                ["aspire-env-name"] = resourceGroupParam
-            }
-        };
 
         var rg = new ResourceGroup("rg")
         {
             Name = resourceGroupParam,
             Location = locationParam,
-            Tags = tags
         };
 
         var moduleMap = new Dictionary<AzureBicepResource, ModuleImport>();
@@ -271,7 +262,6 @@ public sealed class AzurePublishingContext(
             MainInfrastructure.Add(pp);
         }
 
-        MainInfrastructure.Add(tags);
         MainInfrastructure.Add(rg);
 
         foreach (var (_, module) in moduleMap)

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_CapturesParametersAndOutputsCorrectly_WithSnapshot#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_CapturesParametersAndOutputsCorrectly_WithSnapshot#00.verified.bicep
@@ -1,8 +1,8 @@
 ﻿targetScope = 'subscription'
 
-param azure_rg_default string
+param resourceGroupName string
 
-param azure_location_default string
+param location string
 
 param principalId string
 
@@ -10,21 +10,16 @@ param storage_Sku string = 'Standard_LRS'
 
 param skuDescription string = 'The sku is '
 
-var tags = {
-  'aspire-env-name': azure_rg_default
-}
-
 resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
-  name: azure_rg_default
-  location: azure_location_default
-  tags: tags
+  name: resourceGroupName
+  location: location
 }
 
 module acaEnv 'acaEnv/acaEnv.bicep' = {
   name: 'acaEnv'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     userPrincipalId: principalId
   }
 }
@@ -33,7 +28,7 @@ module kv 'kv/kv.bicep' = {
   name: 'kv'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
   }
 }
 
@@ -41,7 +36,7 @@ module account 'account/account.bicep' = {
   name: 'account'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
   }
 }
 
@@ -49,7 +44,7 @@ module storage 'storage/storage.bicep' = {
   name: 'storage'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     storage_Sku: storage_Sku
     sku_description: '${skuDescription} ${storage_Sku}'
   }
@@ -59,7 +54,7 @@ module fe_identity 'fe-identity/fe-identity.bicep' = {
   name: 'fe-identity'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
   }
 }
 
@@ -67,7 +62,7 @@ module fe_roles_storage 'fe-roles-storage/fe-roles-storage.bicep' = {
   name: 'fe-roles-storage'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     storage_outputs_name: storage.outputs.name
     principalId: fe_identity.outputs.principalId
   }
@@ -77,7 +72,7 @@ module fe_roles_account 'fe-roles-account/fe-roles-account.bicep' = {
   name: 'fe-roles-account'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     account_outputs_name: account.outputs.name
     principalId: fe_identity.outputs.principalId
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.PublishAsync_GeneratesMainBicep_WithSnapshots.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.PublishAsync_GeneratesMainBicep_WithSnapshots.verified.bicep
@@ -1,8 +1,8 @@
 ﻿targetScope = 'subscription'
 
-param azure_rg_default string
+param resourceGroupName string
 
-param azure_location_default string
+param location string
 
 param principalId string
 
@@ -14,21 +14,16 @@ param storageSku string = 'Standard_LRS'
 
 param skuDescription string = 'The sku is '
 
-var tags = {
-  'aspire-env-name': azure_rg_default
-}
-
 resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
-  name: azure_rg_default
-  location: azure_location_default
-  tags: tags
+  name: resourceGroupName
+  location: location
 }
 
 module acaEnv 'acaEnv/acaEnv.bicep' = {
   name: 'acaEnv'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     userPrincipalId: principalId
   }
 }
@@ -37,7 +32,7 @@ module kv 'kv/kv.bicep' = {
   name: 'kv'
   scope: resourceGroup(kvRg)
   params: {
-    location: azure_location_default
+    location: location
     kvName: kvName
   }
 }
@@ -46,7 +41,7 @@ module existing_storage 'existing-storage/existing-storage.bicep' = {
   name: 'existing-storage'
   scope: resourceGroup('rg-shared')
   params: {
-    location: azure_location_default
+    location: location
   }
 }
 
@@ -54,7 +49,7 @@ module pg 'pg/pg.bicep' = {
   name: 'pg'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
   }
 }
 
@@ -62,7 +57,7 @@ module account 'account/account.bicep' = {
   name: 'account'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
   }
 }
 
@@ -70,7 +65,7 @@ module storage 'storage/storage.bicep' = {
   name: 'storage'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     storageSku: storageSku
     sku_description: '${skuDescription} ${storageSku}'
   }
@@ -80,7 +75,7 @@ module mod 'mod/mod.bicep' = {
   name: 'mod'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     pgdb: '${pg.outputs.connectionString};Database=pgdb'
   }
 }
@@ -89,7 +84,7 @@ module myapp_identity 'myapp-identity/myapp-identity.bicep' = {
   name: 'myapp-identity'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
   }
 }
 
@@ -97,7 +92,7 @@ module myapp_roles_account 'myapp-roles-account/myapp-roles-account.bicep' = {
   name: 'myapp-roles-account'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     account_outputs_name: account.outputs.name
     principalId: myapp_identity.outputs.principalId
   }
@@ -107,7 +102,7 @@ module fe_identity 'fe-identity/fe-identity.bicep' = {
   name: 'fe-identity'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
   }
 }
 
@@ -115,7 +110,7 @@ module fe_roles_storage 'fe-roles-storage/fe-roles-storage.bicep' = {
   name: 'fe-roles-storage'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     storage_outputs_name: storage.outputs.name
     principalId: fe_identity.outputs.principalId
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#00.verified.bicep
@@ -1,26 +1,21 @@
 ﻿targetScope = 'subscription'
 
-param azure_rg_default string
+param resourceGroupName string
 
-param azure_location_default string
+param location string
 
 param principalId string
 
-var tags = {
-  'aspire-env-name': azure_rg_default
-}
-
 resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
-  name: azure_rg_default
-  location: azure_location_default
-  tags: tags
+  name: resourceGroupName
+  location: location
 }
 
 module env 'env/env.bicep' = {
   name: 'env'
   scope: rg
   params: {
-    location: azure_location_default
+    location: location
     userPrincipalId: principalId
   }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_RespectsStronglyTypedProperties.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_RespectsStronglyTypedProperties.verified.bicep
@@ -6,14 +6,9 @@ param location string
 
 param principalId string
 
-var tags = {
-  'aspire-env-name': resourceGroup
-}
-
 resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: resourceGroup
   location: location
-  tags: tags
 }
 
 module env 'env/env.bicep' = {


### PR DESCRIPTION
This pull request introduces changes to enhance the `AzureEnvironmentResource` class by adding support for a `PrincipalId` parameter and refactors the `AzurePublishingContext` class to simplify its implementation. Additionally, it updates related Bicep templates and test snapshots to align with these changes.

### Enhancements to `AzureEnvironmentResource`:

* Added a new `PrincipalId` property to the `AzureEnvironmentResource` class, making it publicly accessible. Updated the constructor to accept `PrincipalId` as a parameter. (`src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs`, [src/Aspire.Hosting.Azure/AzureEnvironmentResource.csL22-R57](diffhunk://#diff-b34360748c523f8c9d43fbf82642c374e81f4dc6b8f1a68780cc7a5017e5b95cL22-R57))
* Updated `AddAzureEnvironment` to create and pass the `PrincipalId` parameter when initializing `AzureEnvironmentResource`. (`src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.cs`, [src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.csL29-R33](diffhunk://#diff-cc045c92a6ca7104dd6c8b1f60a811ed83cd9a7eaa1967d209360c8a5c4d9e7cL29-R33))

### Refactoring of `AzurePublishingContext`:

* Replaced the `AzurePublisherOptions` dependency with a direct `outputPath` parameter for simplicity. Updated all references to use `outputPath`. (`src/Aspire.Hosting.Azure/AzurePublishingContext.cs`, [[1]](diffhunk://#diff-86b4ae887912c3dbe34b3c97beb99e9b12272fd077b7b57e675818b0a83205b5L24-L29) [[2]](diffhunk://#diff-86b4ae887912c3dbe34b3c97beb99e9b12272fd077b7b57e675818b0a83205b5L67-R66) [[3]](diffhunk://#diff-86b4ae887912c3dbe34b3c97beb99e9b12272fd077b7b57e675818b0a83205b5L77-R81)
* Removed unused `tags` logic from the `WriteAzureArtifactsOutputAsync` method to streamline the resource generation process. (`src/Aspire.Hosting.Azure/AzurePublishingContext.cs`, [[1]](diffhunk://#diff-86b4ae887912c3dbe34b3c97beb99e9b12272fd077b7b57e675818b0a83205b5R91-L114) [[2]](diffhunk://#diff-86b4ae887912c3dbe34b3c97beb99e9b12272fd077b7b57e675818b0a83205b5L274)

### Updates to Bicep templates and test snapshots:

* Replaced default parameter names (`azure_rg_default`, `azure_location_default`) with more descriptive ones (`resourceGroupName`, `location`) across all Bicep templates and test snapshots. (`tests/Aspire.Hosting.Azure.Tests/Snapshots/*.bicep`, [[1]](diffhunk://#diff-cf28804b14f4c769221a364569afd2eec7aa532a4ebf51a823b2aca1e301299bL3-R22) [[2]](diffhunk://#diff-18944e77070c7c28612fe72f6c4b226c05395c508dc4ba02abf9568f2642f4e0L3-R5) [[3]](diffhunk://#diff-a0a077c61fc94123bb219b002f7afdd6ebf793ae860b7b08d7e61e1393c722d7L3-R18) [[4]](diffhunk://#diff-28ad17a65ec410531c8de5d1e83e2170ce5970fc7d635473dcde2164f73100a3L9-L16)
* Added `principalId` as a parameter in Bicep templates and ensured it is correctly mapped in the generated infrastructure. (`tests/Aspire.Hosting.Azure.Tests/Snapshots/*.bicep`, [[1]](diffhunk://#diff-cf28804b14f4c769221a364569afd2eec7aa532a4ebf51a823b2aca1e301299bL3-R22) [[2]](diffhunk://#diff-18944e77070c7c28612fe72f6c4b226c05395c508dc4ba02abf9568f2642f4e0L17-R26) [[3]](diffhunk://#diff-a0a077c61fc94123bb219b002f7afdd6ebf793ae860b7b08d7e61e1393c722d7L3-R18)

These changes improve the flexibility of the `AzureEnvironmentResource` class and simplify the implementation of `AzurePublishingContext`, while ensuring consistency across related templates and tests.