### PR TITLE
[CI] Add PR validation on macOS

### DIFF
--- a/.github/actions/enumerate-tests/action.yml
+++ b/.github/actions/enumerate-tests/action.yml
@@ -69,7 +69,7 @@ runs:
         "integrations_tests_matrix=$jsonString"
         "integrations_tests_matrix=$jsonString" | Out-File -FilePath $env:GITHUB_OUTPUT
 
-    - name: Generate tests matrix
+    - name: Generate templates matrix
       id: generate_templates_matrix
       if: ${{ inputs.includeTemplates }}
       shell: pwsh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -59,7 +59,7 @@ jobs:
           }
 
       - name: Setup vars (Linux)
-        if: ${{ inputs.os == 'ubuntu-latest' }}
+        if: ${{ inputs.os == 'ubuntu-latest' || inputs.os == 'macos-latest' }}
         run: |
           echo "DOTNET_SCRIPT=./dotnet.sh" >> $GITHUB_ENV
           echo "BUILD_SCRIPT=./build.sh" >> $GITHUB_ENV
@@ -273,7 +273,7 @@ jobs:
           path: result-*.rst
 
       - name: Dump docker info
-        if: always()
+        if: ${{ always() && inputs.os == 'ubuntu-latest' }}
         run: |
           docker container ls --all
           docker container ls --all --format json

--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -105,6 +105,8 @@ jobs:
                 $OS = "ubuntu"
             } elseif ($trxFile.FullName -match "windows") {
                 $OS = "windows"
+            } elseif ($trxFile.FullName -match "macos") {
+                $OS = "macos"
             } else {
                 $OS = "unknown"
             }

--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -62,6 +62,8 @@ jobs:
         run: ./dotnet.sh dev-certs https --trust
 
       - name: Test ${{ matrix.tests.project }}
+        env:
+          CI: false
         run: |
           ${{ matrix.tests.command }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,22 @@ jobs:
           includeIntegrations: true
           includeTemplates: true
 
+  setup_for_tests_macos:
+    name: Setup for tests (macOS)
+    if: ${{ github.repository_owner == 'dotnet' }}
+    runs-on: macos-latest
+    outputs:
+      integrations_tests_matrix: ${{ steps.generate_tests_matrix.outputs.integrations_tests_matrix }}
+      templates_tests_matrix: ${{ steps.generate_tests_matrix.outputs.templates_tests_matrix }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: ./.github/actions/enumerate-tests
+        id: generate_tests_matrix
+        with:
+          includeIntegrations: true
+          includeTemplates: true
+
   setup_for_tests_win:
     name: Setup for tests (Windows)
     if: ${{ github.repository_owner == 'dotnet' }}
@@ -79,6 +95,19 @@ jobs:
       os: "ubuntu-latest"
       extraTestArgs: "--filter-not-trait \"quarantined=true\""
 
+  integrations_test_macos:
+    uses: ./.github/workflows/run-tests.yml
+    name: Integrations macos
+    needs: setup_for_tests_macos
+    strategy:
+      fail-fast: false
+      matrix:
+        ${{ fromJson(needs.setup_for_tests_macos.outputs.integrations_tests_matrix) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      os: "macos-latest"
+      extraTestArgs: "--filter-not-trait \"quarantined=true\""
+
   integrations_test_win:
     uses: ./.github/workflows/run-tests.yml
     name: Integrations Windows
@@ -109,6 +138,23 @@ jobs:
       requiresNugets: true
       requiresTestSdk: true
 
+  templates_test_macos:
+    name: Templates macos
+    uses: ./.github/workflows/run-tests.yml
+    needs: [setup_for_tests_macos, build_packages]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup_for_tests_macos.outputs.templates_tests_matrix) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      os: "macos-latest"
+      testProjectPath: tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
+      testSessionTimeout: 20m
+      testHangTimeout: 12m
+      extraTestArgs: "--filter-not-trait quarantined=true --filter-class Aspire.Templates.Tests.${{ matrix.shortname }}"
+      requiresNugets: true
+      requiresTestSdk: true
+
   templates_test_win:
     name: Templates Windows
     uses: ./.github/workflows/run-tests.yml
@@ -132,7 +178,7 @@ jobs:
     needs: build_packages
     with:
       testShortName: EndToEnd
-      # EndToEnd is not run on Windows due to missing Docker support
+      # EndToEnd is not run on Windows/macOS due to missing Docker support
       os: ubuntu-latest
       testProjectPath: tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
       requiresNugets: true
@@ -141,7 +187,7 @@ jobs:
     if: ${{ always() && github.repository_owner == 'dotnet' }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [ integrations_test_lin, integrations_test_win, templates_test_lin, templates_test_win, endtoend_tests ]
+    needs: [ integrations_test_lin, integrations_test_win, integrations_test_macos, templates_test_lin, templates_test_win, templates_test_macos, endtoend_tests ]
     steps:
       # get all the test-job-result* artifacts into a single directory
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
@@ -161,6 +207,12 @@ jobs:
           pattern: logs-*-windows-latest
           merge-multiple: true
           path: testresults/windows-latest
+
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          pattern: logs-*-macos-latest
+          merge-multiple: true
+          path: testresults/macos-latest
 
       - name: Upload test results
         if: always()

--- a/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
+++ b/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
@@ -146,6 +146,7 @@
       <_TestCommand>$(_TestCommand) /p:IgnoreZeroTestResult=true</_TestCommand>
 
       <!-- Replace \ with /, and then escape " with \", so we have a compliant JSON -->
+      <_PreCommand>$([System.String]::Copy($(_PreCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_PreCommand>
       <_TestCommand>$([System.String]::Copy($(_TestCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_TestCommand>
 
       <_TestRunsheetWindows>{ "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>

--- a/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
+++ b/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
@@ -124,6 +124,10 @@
         we use the project name (which looks something like "Aspire.Cli.Tests").
         -->
       <_TestRunsheet>$(MSBuildProjectName)</_TestRunsheet>
+      <_TestRunsheetFileNameWindows>$(ArtifactsTmpDir)\$(_TestRunsheet).win.runsheet.json</_TestRunsheetFileNameWindows>
+      <_TestRunsheetFileNameLinux>$(ArtifactsTmpDir)\$(_TestRunsheet).linux.runsheet.json</_TestRunsheetFileNameLinux>
+      <_TestRunsheetFileNameMacOS>$(ArtifactsTmpDir)\$(_TestRunsheet).macos.runsheet.json</_TestRunsheetFileNameMacOS>
+
       <_TestBinLog>$([MSBuild]::NormalizePath($(ArtifactsLogDir), '$(_TestRunsheet).binlog'))</_TestBinLog>
 
       <_RelativeTestProjectPath>$([System.String]::Copy('$(MSBuildProjectFullPath)').Replace('$(RepoRoot)', '%24(pwd)/'))</_RelativeTestProjectPath>
@@ -144,19 +148,34 @@
 
       <_TestRunsheetWindows>{ "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
       <_TestRunsheetLinux>{ "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
+      <_TestRunsheetMacOS>{ "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
     </PropertyGroup>
+
+    <ItemGroup>
+      <_OutputFiles Include="$(_TestRunsheetFileNameWindows)" />
+      <_OutputFiles Include="$(_TestRunsheetFileNameLinux)" />
+      <_OutputFiles Include="$(_TestRunsheetFileNameMacOS)" />
+    </ItemGroup>
+
+    <MakeDir Directories="@(_OutputFiles->'%(RootDir)%(Directory)')"/>
+    <Delete Files="@(_OutputFiles)" />
 
     <WriteLinesToFile
             Condition=" '$(RunOnGithubActionsWindows)' == 'true' and  '$(_HasQuarantinedTests)' == 'true'"
-            File="$(ArtifactsTmpDir)/$(_TestRunsheet).win.runsheet.json"
+            File="$(_TestRunsheetFileNameWindows)"
             Lines="$(_TestRunsheetWindows)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
-
     <WriteLinesToFile
             Condition=" '$(RunOnGithubActionsLinux)' == 'true' and '$(_HasQuarantinedTests)' == 'true' "
-            File="$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json"
+            File="$(_TestRunsheetFileNameLinux)"
             Lines="$(_TestRunsheetLinux)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile
+            Condition=" '$(RunOnGithubActionsMacOS)' == 'true' and '$(_HasQuarantinedTests)' == 'true' "
+            File="$(_TestRunsheetFileNameMacOS)"
+            Lines="$(_TestRunsheetMacOS)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
 
@@ -164,10 +183,12 @@
       On Linux there's a bug in MSBuild, which "normalises" all slashes (see https://github.com/dotnet/msbuild/issues/3468).
       This is a workaround to replace `/"` with the required `\"`.
       -->
-    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).win.runsheet.json') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).win.runsheet.json'&quot; "
-          Condition=" '$(RunOnGithubActionsWindows)' == 'true' and '$(_HasQuarantinedTests)' == 'true' and '$(BuildOs)' != 'windows' " />
-    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json'&quot; "
-          Condition=" '$(RunOnGithubActionsLinux)' == 'true' and '$(_HasQuarantinedTests)' == 'true' and '$(BuildOs)' != 'windows' " />
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameWindows)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameWindows)'&quot; "
+          Condition=" Exists('$(_TestRunsheetFileNameWindows)') and '$(BuildOs)' != 'windows' " />
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameLinux)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameLinux)'&quot; "
+          Condition=" Exists('$(_TestRunsheetFileNameLinux)') and '$(BuildOs)' != 'windows' " />
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameMacOS)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameMacOS)'&quot; "
+          Condition=" Exists('$(_TestRunsheetFileNameMacOS)') and '$(BuildOs)' != 'windows' " />
 
     <!--
       The final piece of the puzzle is in eng/AfterSolutionBuild.targets, where we combine the runsheets from all the test projects into a single runsheet.

--- a/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
+++ b/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
@@ -137,6 +137,8 @@
       <_TestRunnerLinux>./eng/build.sh</_TestRunnerLinux>
       <_TestCommand>-restore -build -test -projects &quot;$(_RelativeTestProjectPath)&quot; /bl:&quot;$(_RelativeTestBinLog)&quot; -c $(Configuration) -ci /p:RunQuarantinedTests=true /p:CI=false</_TestCommand>
 
+      <_PreCommand>$(TestRunnerPreCommand)</_PreCommand>
+
       <!--
         Some quarantinted test may only be executable on Windows or Linux, however we can't possibly know that at this time.
         The MTP runner will return exit code 8 if no tests are found, and we need to ignore it instead of failing the test.
@@ -147,8 +149,8 @@
       <_TestCommand>$([System.String]::Copy($(_TestCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_TestCommand>
 
       <_TestRunsheetWindows>{ "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
-      <_TestRunsheetLinux>{ "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
-      <_TestRunsheetMacOS>{ "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
+      <_TestRunsheetLinux>{ "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
+      <_TestRunsheetMacOS>{ "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
+++ b/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
@@ -51,6 +51,7 @@
       <_TestRunsheet>$(MSBuildProjectName)</_TestRunsheet>
       <_TestRunsheetFileNameWindows>$(ArtifactsTmpDir)\$(_TestRunsheet).win.runsheet.json</_TestRunsheetFileNameWindows>
       <_TestRunsheetFileNameLinux>$(ArtifactsTmpDir)\$(_TestRunsheet).linux.runsheet.json</_TestRunsheetFileNameLinux>
+      <_TestRunsheetFileNameMacOS>$(ArtifactsTmpDir)\$(_TestRunsheet).macos.runsheet.json</_TestRunsheetFileNameMacOS>
 
       <_TestBinLog>$([MSBuild]::NormalizePath($(ArtifactsLogDir), '$(_TestRunsheet).binlog'))</_TestBinLog>
 
@@ -69,11 +70,13 @@
 
       <_TestRunsheetWindows>{ "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
       <_TestRunsheetLinux>{ "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
+      <_TestRunsheetMacOS>{ "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
     </PropertyGroup>
 
     <ItemGroup>
       <_OutputFiles Include="$(_TestRunsheetFileNameWindows)" />
       <_OutputFiles Include="$(_TestRunsheetFileNameLinux)" />
+      <_OutputFiles Include="$(_TestRunsheetFileNameMacOS)" />
     </ItemGroup>
 
     <MakeDir Directories="@(_OutputFiles->'%(RootDir)%(Directory)')"/>
@@ -91,6 +94,12 @@
             Lines="$(_TestRunsheetLinux)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile
+            Condition=" '$(RunOnGithubActionsMacOS)' == 'true' and '$(_CreateRunsheet)' == 'true' "
+            File="$(_TestRunsheetFileNameMacOS)"
+            Lines="$(_TestRunsheetMacOS)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
 
     <!--
       On Linux there's a bug in MSBuild, which "normalises" all slashes (see https://github.com/dotnet/msbuild/issues/3468).
@@ -100,6 +109,8 @@
           Condition=" Exists('$(_TestRunsheetFileNameWindows)') and '$(BuildOs)' != 'windows' " />
     <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameLinux)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameLinux)'&quot; "
           Condition=" Exists('$(_TestRunsheetFileNameLinux)') and '$(BuildOs)' != 'windows' " />
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameMacOS)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameMacOS)'&quot; "
+          Condition=" Exists('$(_TestRunsheetFileNameMacOS)') and '$(BuildOs)' != 'windows' " />
 
     <!--
       The final piece of the puzzle is in eng/AfterSolutionBuild.targets, where we combine the runsheets from all the test projects into a single runsheet.

--- a/eng/Testing.props
+++ b/eng/Testing.props
@@ -5,6 +5,7 @@
     <!-- By default any test can run on all test platforms -->
     <RunOnGithubActionsWindows>true</RunOnGithubActionsWindows>
     <RunOnGithubActionsLinux>true</RunOnGithubActionsLinux>
+    <RunOnGithubActionsMacOS>true</RunOnGithubActionsMacOS>
     <RunOnAzdoCIWindows>true</RunOnAzdoCIWindows>
     <RunOnAzdoCILinux>true</RunOnAzdoCILinux>
     <RunOnAzdoHelixWindows>true</RunOnAzdoHelixWindows>

--- a/eng/Testing.targets
+++ b/eng/Testing.targets
@@ -11,8 +11,9 @@
         - IncludeTestUtilities:        indicates whether the test project must not include the TestUtilities project reference; default is false; overridable.
 
       Project requirements:
-        - RunOnGithubActions:          indicates whether tests should run on GitHub Actions (either Windows or Linux); computed.
+        - RunOnGithubActions:          indicates whether tests should run on GitHub Actions (either Windows or Linux or macOS); computed.
         - RunOnGithubActionsWindows:   indicates whether tests should run on Windows in GitHub Actions; default is true; overridable.
+        - RunOnGithubActionsMacOS:     indicates whether tests should run on MacOS in GitHub Actions; default is true; overridable.
         - RunOnGithubActionsLinux:     indicates whether tests should run on Linux in GitHub Actions; default is true; overridable.
         - RunOnAzdoCI:                 indicates whether tests should run on Azure DevOps (either Windows or Linux); always false, if RunOnAzdoHelix=true; computed.
         - RunOnAzdoCIWindows:          indicates whether tests should run on Windows in Azure DevOps; default is true; overridable.
@@ -42,7 +43,7 @@
 
   <PropertyGroup>
     <RunOnGithubActions>false</RunOnGithubActions>
-    <RunOnGithubActions Condition=" '$(RunOnGithubActionsWindows)' == 'true' or '$(RunOnGithubActionsLinux)' == 'true' ">true</RunOnGithubActions>
+    <RunOnGithubActions Condition=" '$(RunOnGithubActionsWindows)' == 'true' or '$(RunOnGithubActionsLinux)' == 'true' or '$(RunOnGithubActionsMacOS)' == 'true' ">true</RunOnGithubActions>
 
     <RunOnAzdoHelix>false</RunOnAzdoHelix>
     <RunOnAzdoHelix Condition=" '$(RunOnAzdoHelixWindows)' == 'true' or '$(RunOnAzdoHelixLinux)' == 'true' ">true</RunOnAzdoHelix>
@@ -90,7 +91,7 @@
       <_Runner Include=" - GitHub Actions: $(_IsGitHubActionsRunner)" />
       <_Runner Include=" - Azure DevOps: $(_IsAzdoCIRunner)" />
       <_Runner Include=" - Helix: $(_IsAzdoHelixRunner)" />
-      <_Requirement Include=" - GitHub Actions: $(RunOnGithubActions) (Windows: $(RunOnGithubActionsWindows) / Linux: $(RunOnGithubActionsLinux))" />
+      <_Requirement Include=" - GitHub Actions: $(RunOnGithubActions) (Windows: $(RunOnGithubActionsWindows) / Linux: $(RunOnGithubActionsLinux) / MacOS: $(RunOnGithubActionsMacOS))" />
       <_Requirement Include=" - Azure DevOps: $(RunOnAzdoCI) (Windows: $(RunOnAzdoCIWindows) / Linux: $(RunOnAzdoCILinux))" />
       <_Requirement Include=" - Helix: $(RunOnAzdoHelix) (Windows: $(RunOnAzdoHelixWindows) / Linux: $(RunOnAzdoHelixLinux))" />
     </ItemGroup>

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
+using Aspire.TestUtilities;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -75,6 +76,7 @@ public class FormatHelpersTests
     [InlineData("15/06/2009 1:45:30.1234567 pm", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
     [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
     [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/9151", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOS))]
     public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -65,6 +65,7 @@ public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/9152", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOS))]
     public async Task AppBar_Change_Theme_ReloadPage()
     {
         // Arrange

--- a/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
+++ b/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <!-- Only run on Linux; no docker support on Windows yet -->
     <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
+    <!-- Issue: https://github.com/dotnet/aspire/issues/9198 -->
+    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
     <RunOnAzdoCIWindows>false</RunOnAzdoCIWindows>
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>
 

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -21,7 +21,7 @@
 
       FIXME: temporary workaround for https://github.com/Azure/azure-functions-dotnet-worker/issues/2969
      -->
-    <TestRunnerPreCommand>./dotnet.sh build &quot;%24(pwd)/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj&quot; -c $(Configuration) /p:SkipUnstableEmulators=true &amp;&amp; </TestRunnerPreCommand>
+    <TestRunnerPreCommand>./dotnet.sh build &quot;%24(pwd)/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj&quot; -c $(Configuration) /p:SkipUnstableEmulators=true /p:CI=false &amp;&amp; </TestRunnerPreCommand>
 
     <DeployOutsideOfRepoSupportFilesRelativeDir>staging-archive\</DeployOutsideOfRepoSupportFilesRelativeDir>
 

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -8,6 +8,7 @@
 
     <!-- Only run on Linux; no docker support on Windows yet -->
     <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
+    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
     <RunOnAzdoCIWindows>false</RunOnAzdoCIWindows>
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>
 

--- a/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
@@ -113,6 +113,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/9155", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOS))]
     public async Task ProjectWithNoHTTPSRequiresExplicitOverrideWithEnvironmentVariable()
     {
         string id = GetNewProjectId(prefix: "aspire");

--- a/tests/Aspire.TestUtilities/PlatformDetection.cs
+++ b/tests/Aspire.TestUtilities/PlatformDetection.cs
@@ -14,4 +14,5 @@ public static class PlatformDetection
 
     public static bool IsWindows => OperatingSystem.IsWindows();
     public static bool IsLinux => OperatingSystem.IsLinux();
+    public static bool IsMacOS => OperatingSystem.IsMacOS();
 }

--- a/tests/Aspire.TestUtilities/RequiresDockerAttribute.cs
+++ b/tests/Aspire.TestUtilities/RequiresDockerAttribute.cs
@@ -20,8 +20,7 @@ public class RequiresDockerAttribute : Attribute, ITraitAttribute
     //                - https://github.com/dotnet/aspire/issues/4291
     // - Linux - Local, or CI: always assume that docker is installed
     public static bool IsSupported =>
-        !OperatingSystem.IsWindows() ||
-        !PlatformDetection.IsRunningOnCI;
+        OperatingSystem.IsLinux() || !PlatformDetection.IsRunningOnCI; // non-linux on CI does not support docker
 
     public string? Reason { get; init; }
     public RequiresDockerAttribute(string? reason = null)

--- a/tests/Aspire.TestUtilities/RequiresSSLCertificateAttribute.cs
+++ b/tests/Aspire.TestUtilities/RequiresSSLCertificateAttribute.cs
@@ -8,8 +8,8 @@ namespace Aspire.TestUtilities;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
 public class RequiresSSLCertificateAttribute(string? reason = null) : Attribute, ITraitAttribute
 {
-    // Not supported on Windows CI
-    public static bool IsSupported => !PlatformDetection.IsRunningOnCI || !OperatingSystem.IsWindows();
+    // Always supported on linux (local and CI), but only local otherwise
+    public static bool IsSupported => OperatingSystem.IsLinux() || !PlatformDetection.IsRunningOnCI;
 
     public string? Reason { get; init; } = reason;
 

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -61,8 +61,9 @@
 
   <Target Name="GetRunTestsOnGithubActions" Returns="@(TestProject)">
     <ItemGroup>
-      <TestProject Condition="'$(OS)' == 'Windows_NT'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsWindows)" />
-      <TestProject Condition="'$(OS)' != 'Windows_NT'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsLinux)" />
+      <TestProject Condition="$([System.OperatingSystem]::IsWindows())" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsWindows)" />
+      <TestProject Condition="$([System.OperatingSystem]::IsLinux())" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsLinux)" />
+      <TestProject Condition="$([System.OperatingSystem]::IsMacOS())" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsMacOS)" />
     </ItemGroup>
   </Target>
 

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -61,9 +61,9 @@
 
   <Target Name="GetRunTestsOnGithubActions" Returns="@(TestProject)">
     <ItemGroup>
-      <TestProject Condition="$([System.OperatingSystem]::IsWindows())" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsWindows)" />
-      <TestProject Condition="$([System.OperatingSystem]::IsLinux())" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsLinux)" />
-      <TestProject Condition="$([System.OperatingSystem]::IsMacOS())" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsMacOS)" />
+      <TestProject Condition="'$(BuildOs)' == 'windows'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsWindows)" />
+      <TestProject Condition="'$(BuildOs)' == 'linux'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsLinux)" />
+      <TestProject Condition="'$(BuildOs)' == 'darwin'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsMacOS)" />
     </ItemGroup>
   </Target>
 

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -36,7 +36,7 @@
     <Error Condition="'$(ExtractTestClassNamesPrefix)' == ''"
            Text="%24(ExtractTestClassNamesPrefix) should be set, for example - Aspire.Templates.Tests" />
 
-    <Exec Command="&quot;$(RunCommand)&quot; --filter-not-trait category=failing --list-tests" ConsoleToMSBuild="true" EnvironmentVariables="DOTNET_ROOT=$(DotNetRoot);DOTNET_ROOT_X86=$(DotNetRoot)x86">
+    <Exec Command="&quot;$(RunCommand)&quot; --filter-not-trait category=failing --list-tests" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" ItemName="_ListOfTestsLines" />
     </Exec>
 


### PR DESCRIPTION
This adds PR validation for macOS with github actions. This is at par with Windows tests, with Docker based tests, and tests requiring trusted ssl certificate being disabled.

- **[tests] Run tests workflow on macos**
- **Adjust RequiresDocker and RequiresSSLCertificate to skip macos**
- **Disable tests failing on macos**
  - `FormatDateTime_WithMilliseconds_NewZealandCulture`
  - `AppBar_Change_Theme_ReloadPage`
  - `ProjectWithNoHTTPSRequiresExplicitOverrideWithEnvironmentVariable` 
- **Don't override DOTNET_ROOT when getting list of tests**
- **Skip playground tests on windows and macos**


