### PR TITLE
[CI] Github actions rolling builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,11 @@ on:
       - main
       - 'release/**'
 
+  push:
+    branches:
+      - 'main'
+      - 'release/**'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
   push:
     branches:
-      - 'main'
+      - main
       - 'release/**'
 
 concurrency:


### PR DESCRIPTION
Adds rolling builds for `main`, and `release/*` branches on Github Actions for the `tests` workflow.