### PR TITLE
Update diagnostic URLs

### DIFF
--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -36,11 +36,11 @@
   </ItemGroup>
 
   <Target Name="__WarnOnAspireCapabilityMissing" BeforeTargets="PrepareForBuild" Condition="!@(ProjectCapability->AnyHaveMetadataValue('Identity', 'Aspire'))">
-    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting.AppHost PackageReference?" />
+    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting.AppHost PackageReference?" HelpLink="https://aka.ms/aspire/diagnostic/aspire002" />
   </Target>
 
   <Target Name="__WarnOnMininumVsVersionMissing" BeforeTargets="PrepareForBuild" Condition="'$(BuildingInsideVisualStudio)' == 'true' and $([MSBuild]::VersionLessThan('$(MSBuildVersion)', '17.10.0'))">
-    <Warning Code="ASPIRE003" Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that requires Visual Studio version 17.10 or above to work correctly. You are using version $(MSBuildVersion)." />
+    <Warning Code="ASPIRE003" Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that requires Visual Studio version 17.10 or above to work correctly. You are using version $(MSBuildVersion)." HelpLink="https://aka.ms/aspire/diagnostic/aspire003" />
   </Target>
 
   <PropertyGroup>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -36,11 +36,11 @@
   </ItemGroup>
 
   <Target Name="__WarnOnAspireCapabilityMissing" BeforeTargets="PrepareForBuild" Condition="!@(ProjectCapability->AnyHaveMetadataValue('Identity', 'Aspire'))">
-    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting.AppHost PackageReference?" HelpLink="https://aka.ms/aspire/diagnostic/aspire002" />
+    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting.AppHost PackageReference?" HelpLink="https://aka.ms/aspire/diagnostics/aspire002" />
   </Target>
 
   <Target Name="__WarnOnMininumVsVersionMissing" BeforeTargets="PrepareForBuild" Condition="'$(BuildingInsideVisualStudio)' == 'true' and $([MSBuild]::VersionLessThan('$(MSBuildVersion)', '17.10.0'))">
-    <Warning Code="ASPIRE003" Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that requires Visual Studio version 17.10 or above to work correctly. You are using version $(MSBuildVersion)." HelpLink="https://aka.ms/aspire/diagnostic/aspire003" />
+    <Warning Code="ASPIRE003" Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that requires Visual Studio version 17.10 or above to work correctly. You are using version $(MSBuildVersion)." HelpLink="https://aka.ms/aspire/diagnostics/aspire003" />
   </Target>
 
   <PropertyGroup>

--- a/src/Aspire.Hosting.Analyzers/AppHostAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Analyzers/AppHostAnalyzer.Diagnostics.cs
@@ -18,7 +18,7 @@ public partial class AppHostAnalyzer
             category: "Design",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            helpLinkUri: $"https://aka.ms/dotnet/aspire/diagnostics#{ModelNameMustBeValidId}");
+            helpLinkUri: $"https://aka.ms/aspire/diagnostic/{ModelNameMustBeValidId}");
 
         public static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics = ImmutableArray.Create(
             s_modelNameMustBeValid

--- a/src/Aspire.Hosting.Analyzers/AppHostAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Analyzers/AppHostAnalyzer.Diagnostics.cs
@@ -18,7 +18,7 @@ public partial class AppHostAnalyzer
             category: "Design",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            helpLinkUri: $"https://aka.ms/aspire/diagnostic/{ModelNameMustBeValidId}");
+            helpLinkUri: $"https://aka.ms/aspire/diagnostics/{ModelNameMustBeValidId}");
 
         public static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics = ImmutableArray.Create(
             s_modelNameMustBeValid

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -109,7 +109,7 @@ namespace Projects%3B
   </Target>
 
   <Target Name="_WarnOnUnsupportedLanguage" Condition="'$(Language)' != 'C#'">
-    <Warning Code="ASPIRE001" Text="The '$(Language)' language isn't fully supported by Aspire - some code generation targets will not run, so will require manual authoring." HelpLink="https://aka.ms/aspire/diagnostic/aspire001" />
+    <Warning Code="ASPIRE001" Text="The '$(Language)' language isn't fully supported by Aspire - some code generation targets will not run, so will require manual authoring." HelpLink="https://aka.ms/aspire/diagnostics/aspire001" />
   </Target>
 
   <!--
@@ -179,7 +179,7 @@ namespace Projects%3B
     <Warning Code="ASPIRE004"
              Condition="'@(_AspireNonExecutableProjectResource)' != ''"
              Text="'%(_AspireNonExecutableProjectResource.OriginalItemSpec)' is referenced by an Aspire Host project, but it is not an executable. Did you mean to set IsAspireProjectResource=&quot;false&quot;?"
-             HelpLink="https://aka.ms/aspire/diagnostic/aspire004" />
+             HelpLink="https://aka.ms/aspire/diagnostics/aspire004" />
   </Target>
 
   <PropertyGroup>
@@ -272,7 +272,7 @@ namespace Projects%3B
     <Error Code="ASPIRE007"
       Text="$(MSBuildProjectName) project requires a reference to &quot;Aspire.AppHost.Sdk&quot; with version &quot;9.0.0&quot; or greater to work correctly. Please add the following line after the Project declaration `&lt;Sdk Name=&quot;Aspire.AppHost.Sdk&quot; Version=&quot;9.0.0&quot; /&gt;`."
       File="$(MSBuildProjectFullPath)"
-      HelpLink="https://aka.ms/aspire/diagnostic/aspire007" />
+      HelpLink="https://aka.ms/aspire/diagnostics/aspire007" />
   </Target>
 
   <!-- Entrypoint to allow for generation of an aspire manifest to a given location -->

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -109,7 +109,7 @@ namespace Projects%3B
   </Target>
 
   <Target Name="_WarnOnUnsupportedLanguage" Condition="'$(Language)' != 'C#'">
-    <Warning Code="ASPIRE001" Text="The '$(Language)' language isn't fully supported by Aspire - some code generation targets will not run, so will require manual authoring." />
+    <Warning Code="ASPIRE001" Text="The '$(Language)' language isn't fully supported by Aspire - some code generation targets will not run, so will require manual authoring." HelpLink="https://aka.ms/aspire/diagnostic/aspire001" />
   </Target>
 
   <!--
@@ -178,7 +178,8 @@ namespace Projects%3B
 
     <Warning Code="ASPIRE004"
              Condition="'@(_AspireNonExecutableProjectResource)' != ''"
-             Text="'%(_AspireNonExecutableProjectResource.OriginalItemSpec)' is referenced by an Aspire Host project, but it is not an executable. Did you mean to set IsAspireProjectResource=&quot;false&quot;?" />
+             Text="'%(_AspireNonExecutableProjectResource.OriginalItemSpec)' is referenced by an Aspire Host project, but it is not an executable. Did you mean to set IsAspireProjectResource=&quot;false&quot;?"
+             HelpLink="https://aka.ms/aspire/diagnostic/aspire004" />
   </Target>
 
   <PropertyGroup>
@@ -270,7 +271,8 @@ namespace Projects%3B
   Condition="'$(IsAspireHost)' == 'true' and ('$(AspireHostingSDKVersion)' == '' or $([MSBuild]::VersionLessThan('$(AspireHostingSDKVersion)', '9.0.0')))">
     <Error Code="ASPIRE007"
       Text="$(MSBuildProjectName) project requires a reference to &quot;Aspire.AppHost.Sdk&quot; with version &quot;9.0.0&quot; or greater to work correctly. Please add the following line after the Project declaration `&lt;Sdk Name=&quot;Aspire.AppHost.Sdk&quot; Version=&quot;9.0.0&quot; /&gt;`."
-      File="$(MSBuildProjectFullPath)" />
+      File="$(MSBuildProjectFullPath)"
+      HelpLink="https://aka.ms/aspire/diagnostic/aspire007" />
   </Target>
 
   <!-- Entrypoint to allow for generation of an aspire manifest to a given location -->

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
@@ -54,7 +54,7 @@ public static class ContainerAppExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public static void ConfigureCustomDomain(this ContainerApp app, IResourceBuilder<ParameterResource> customDomain, IResourceBuilder<ParameterResource> certificateName)
     {
         ArgumentNullException.ThrowIfNull(app);

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
@@ -54,7 +54,7 @@ public static class ContainerAppExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static void ConfigureCustomDomain(this ContainerApp app, IResourceBuilder<ParameterResource> customDomain, IResourceBuilder<ParameterResource> certificateName)
     {
         ArgumentNullException.ThrowIfNull(app);

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -65,7 +65,7 @@ public static class AzureCosmosExtensions
     /// <remarks>
     /// This version of the package defaults to the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.TagVNextPreview"/> tag of the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="CosmosDBEmulatorContainerImageTags.Image"/> container image.
     /// </remarks>
-    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureCosmosDBResource> RunAsPreviewEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer = null)
         => RunAsEmulator(builder, configureContainer, useVNextPreview: true);
 
@@ -289,7 +289,7 @@ public static class AzureCosmosExtensions
     /// <remarks>
     /// The Data Explorer is only available with <see cref="RunAsPreviewEmulator"/>.
     /// </remarks>
-    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureCosmosDBEmulatorResource> WithDataExplorer(this IResourceBuilder<AzureCosmosDBEmulatorResource> builder, int? port = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -65,7 +65,7 @@ public static class AzureCosmosExtensions
     /// <remarks>
     /// This version of the package defaults to the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.TagVNextPreview"/> tag of the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="CosmosDBEmulatorContainerImageTags.Image"/> container image.
     /// </remarks>
-    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public static IResourceBuilder<AzureCosmosDBResource> RunAsPreviewEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer = null)
         => RunAsEmulator(builder, configureContainer, useVNextPreview: true);
 
@@ -289,7 +289,7 @@ public static class AzureCosmosExtensions
     /// <remarks>
     /// The Data Explorer is only available with <see cref="RunAsPreviewEmulator"/>.
     /// </remarks>
-    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public static IResourceBuilder<AzureCosmosDBEmulatorResource> WithDataExplorer(this IResourceBuilder<AzureCosmosDBEmulatorResource> builder, int? port = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.cs
@@ -16,7 +16,7 @@ public static class AzureEnvironmentResourceExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <returns>The <see cref="IResourceBuilder{AzureEnvironmentResource}"/>.</returns>
-    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureEnvironmentResource> AddAzureEnvironment(this IDistributedApplicationBuilder builder)
     {
         if (builder.Resources.OfType<AzureEnvironmentResource>().SingleOrDefault() is { } existingResource)
@@ -56,7 +56,7 @@ public static class AzureEnvironmentResourceExtensions
     /// This method is used to set the location of the Azure environment resource.
     /// The location is used to determine where the resources will be deployed.
     /// </remarks>
-    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureEnvironmentResource> WithLocation(
         this IResourceBuilder<AzureEnvironmentResource> builder,
         IResourceBuilder<ParameterResource> location)
@@ -79,7 +79,7 @@ public static class AzureEnvironmentResourceExtensions
     /// This method is used to set the resource group name of the Azure environment resource.
     /// The resource group name is used to determine where the resources will be deployed.
     /// </remarks>
-    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureEnvironmentResource> WithResourceGroup(
         this IResourceBuilder<AzureEnvironmentResource> builder,
         IResourceBuilder<ParameterResource> resourceGroup)

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResourceExtensions.cs
@@ -16,7 +16,7 @@ public static class AzureEnvironmentResourceExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <returns>The <see cref="IResourceBuilder{AzureEnvironmentResource}"/>.</returns>
-    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public static IResourceBuilder<AzureEnvironmentResource> AddAzureEnvironment(this IDistributedApplicationBuilder builder)
     {
         if (builder.Resources.OfType<AzureEnvironmentResource>().SingleOrDefault() is { } existingResource)
@@ -56,7 +56,7 @@ public static class AzureEnvironmentResourceExtensions
     /// This method is used to set the location of the Azure environment resource.
     /// The location is used to determine where the resources will be deployed.
     /// </remarks>
-    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public static IResourceBuilder<AzureEnvironmentResource> WithLocation(
         this IResourceBuilder<AzureEnvironmentResource> builder,
         IResourceBuilder<ParameterResource> location)
@@ -79,7 +79,7 @@ public static class AzureEnvironmentResourceExtensions
     /// This method is used to set the resource group name of the Azure environment resource.
     /// The resource group name is used to determine where the resources will be deployed.
     /// </remarks>
-    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public static IResourceBuilder<AzureEnvironmentResource> WithResourceGroup(
         this IResourceBuilder<AzureEnvironmentResource> builder,
         IResourceBuilder<ParameterResource> resourceGroup)

--- a/src/Aspire.Hosting.Azure/AzurePublisherOptions.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisherOptions.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Options which control generation of artifacts for deploying to Azure.
 /// </summary>
-[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public sealed class AzurePublisherOptions : PublishingOptions
 {
 }

--- a/src/Aspire.Hosting.Azure/AzurePublisherOptions.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublisherOptions.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Options which control generation of artifacts for deploying to Azure.
 /// </summary>
-[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class AzurePublisherOptions : PublishingOptions
 {
 }

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -19,7 +19,7 @@ namespace Aspire.Hosting.Azure;
 /// publisher options, and execution context. It handles resource configuration and ensures
 /// that the bicep template is created in the specified output path.
 /// </remarks>
-[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public sealed class AzurePublishingContext(
     AzurePublisherOptions publisherOptions,
     AzureProvisioningOptions provisioningOptions,

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -19,7 +19,7 @@ namespace Aspire.Hosting.Azure;
 /// publisher options, and execution context. It handles resource configuration and ensures
 /// that the bicep template is created in the specified output path.
 /// </remarks>
-[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class AzurePublishingContext(
     AzurePublisherOptions publisherOptions,
     AzureProvisioningOptions provisioningOptions,

--- a/src/Aspire.Hosting.Azure/IAzureContainerRegistry.cs
+++ b/src/Aspire.Hosting.Azure/IAzureContainerRegistry.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Represents Azure Container Registry information for deployment targets.
 /// </summary>
-[Experimental("ASPIRECOMPUTE001")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public interface IAzureContainerRegistry : IContainerRegistry
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/IAzureContainerRegistry.cs
+++ b/src/Aspire.Hosting.Azure/IAzureContainerRegistry.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Represents Azure Container Registry information for deployment targets.
 /// </summary>
-[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public interface IAzureContainerRegistry : IContainerRegistry
 {
     /// <summary>

--- a/src/Aspire.Hosting.Python/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.Python/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: Experimental("ASPIREHOSTINGPYTHON001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[assembly: Experimental("ASPIREHOSTINGPYTHON001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]

--- a/src/Aspire.Hosting.Python/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.Python/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: Experimental("ASPIREHOSTINGPYTHON001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+[assembly: Experimental("ASPIREHOSTINGPYTHON001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]

--- a/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.ApplicationModel;
 
-[Experimental("ASPIRECOMPUTE001")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 internal sealed class ComputeEnvironmentAnnotation(IComputeEnvironmentResource computeEnvironment) : IResourceAnnotation
 {
     public IComputeEnvironmentResource ComputeEnvironment { get; } = computeEnvironment;

--- a/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.ApplicationModel;
 
-[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 internal sealed class ComputeEnvironmentAnnotation(IComputeEnvironmentResource computeEnvironment) : IResourceAnnotation
 {
     public IComputeEnvironmentResource ComputeEnvironment { get; } = computeEnvironment;

--- a/src/Aspire.Hosting/ApplicationModel/DeploymentTargetAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DeploymentTargetAnnotation.cs
@@ -19,12 +19,12 @@ public sealed class DeploymentTargetAnnotation(IResource target) : IResourceAnno
     /// Gets or sets the container registry information associated with
     /// the deployment target, if the deployment target is an image-based environment.
     /// </summary>
-    [Experimental("ASPIRECOMPUTE001")]
+    [Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public IContainerRegistry? ContainerRegistry { get; set; }
 
     /// <summary>
     /// Gets or sets the compute environment resource associated with the deployment target.
     /// </summary>
-    [Experimental("ASPIRECOMPUTE001")]
+    [Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public IComputeEnvironmentResource? ComputeEnvironment { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/DeploymentTargetAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DeploymentTargetAnnotation.cs
@@ -19,12 +19,12 @@ public sealed class DeploymentTargetAnnotation(IResource target) : IResourceAnno
     /// Gets or sets the container registry information associated with
     /// the deployment target, if the deployment target is an image-based environment.
     /// </summary>
-    [Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public IContainerRegistry? ContainerRegistry { get; set; }
 
     /// <summary>
     /// Gets or sets the compute environment resource associated with the deployment target.
     /// </summary>
-    [Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public IComputeEnvironmentResource? ComputeEnvironment { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a compute environment resource.
 /// </summary>
-[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public interface IComputeEnvironmentResource : IResource
 {
 }

--- a/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a compute environment resource.
 /// </summary>
-[Experimental("ASPIRECOMPUTE001")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public interface IComputeEnvironmentResource : IResource
 {
 }

--- a/src/Aspire.Hosting/ApplicationModel/IComputeResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IComputeResource.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// A compute resource is a resource that can be hosted/executed on an <see cref="IComputeEnvironmentResource"/>. Examples
 /// include projects, containers, and other resources that can be executed on a compute environment.
 /// </remarks>
-[Experimental("ASPIRECOMPUTE001")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public interface IComputeResource : IResource
 {
 }

--- a/src/Aspire.Hosting/ApplicationModel/IComputeResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IComputeResource.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// A compute resource is a resource that can be hosted/executed on an <see cref="IComputeEnvironmentResource"/>. Examples
 /// include projects, containers, and other resources that can be executed on a compute environment.
 /// </remarks>
-[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public interface IComputeResource : IResource
 {
 }

--- a/src/Aspire.Hosting/ApplicationModel/IContainerRegistry.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IContainerRegistry.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents container registry information for deployment targets.
 /// </summary>
-[Experimental("ASPIRECOMPUTE001")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public interface IContainerRegistry
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/IContainerRegistry.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IContainerRegistry.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents container registry information for deployment targets.
 /// </summary>
-[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public interface IContainerRegistry
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ProxySupportAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProxySupportAnnotation.cs
@@ -15,7 +15,7 @@ public sealed class ProxySupportAnnotation : IResourceAnnotation
     /// <summary>
     /// Create a new instance of the <see cref="ProxySupportAnnotation"/> class.
     /// </summary>
-    [Experimental("ASPIREPROXYENDPOINTS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREPROXYENDPOINTS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public ProxySupportAnnotation()
     {}
 

--- a/src/Aspire.Hosting/ApplicationModel/ProxySupportAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProxySupportAnnotation.cs
@@ -15,7 +15,7 @@ public sealed class ProxySupportAnnotation : IResourceAnnotation
     /// <summary>
     /// Create a new instance of the <see cref="ProxySupportAnnotation"/> class.
     /// </summary>
-    [Experimental("ASPIREPROXYENDPOINTS001")]
+    [Experimental("ASPIREPROXYENDPOINTS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public ProxySupportAnnotation()
     {}
 

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -850,7 +850,7 @@ public static class ContainerResourceBuilderExtensions
     /// The user needs to be careful to ensure that container endpoints are using unique ports when disabling proxy support as by default for proxy-less
     /// endpoints, Aspire will allocate the internal container port as the host port, which will increase the chance of port conflicts.
     /// </remarks>
-    [Experimental("ASPIREPROXYENDPOINTS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREPROXYENDPOINTS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<T> WithEndpointProxySupport<T>(this IResourceBuilder<T> builder, bool proxyEnabled) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -850,7 +850,7 @@ public static class ContainerResourceBuilderExtensions
     /// The user needs to be careful to ensure that container endpoints are using unique ports when disabling proxy support as by default for proxy-less
     /// endpoints, Aspire will allocate the internal container port as the host port, which will increase the chance of port conflicts.
     /// </remarks>
-    [Experimental("ASPIREPROXYENDPOINTS001")]
+    [Experimental("ASPIREPROXYENDPOINTS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public static IResourceBuilder<T> WithEndpointProxySupport<T>(this IResourceBuilder<T> builder, bool proxyEnabled) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class PublisherDistributedApplicationBuilderExtensions
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>. </param>
     /// <param name="name">The name of the publisher.</param>
     /// <param name="configureOptions">Callback to configure options for the publisher.</param>
-    [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IDistributedApplicationBuilder AddPublisher<TPublisher, TPublisherOptions>(this IDistributedApplicationBuilder builder, string name, Action<TPublisherOptions>? configureOptions = null)
         where TPublisher : class, IDistributedApplicationPublisher
         where TPublisherOptions : class

--- a/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/PublisherDistributedApplicationBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class PublisherDistributedApplicationBuilderExtensions
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>. </param>
     /// <param name="name">The name of the publisher.</param>
     /// <param name="configureOptions">Callback to configure options for the publisher.</param>
-    [Experimental("ASPIREPUBLISHERS001")]
+    [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public static IDistributedApplicationBuilder AddPublisher<TPublisher, TPublisherOptions>(this IDistributedApplicationBuilder builder, string name, Action<TPublisherOptions>? configureOptions = null)
         where TPublisher : class, IDistributedApplicationPublisher
         where TPublisherOptions : class

--- a/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Publishing;
 /// <summary>
 /// Minimalistic reporter that does nothing.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class NullPublishingActivityProgressReporter : IPublishingActivityProgressReporter
 {
     /// <summary>

--- a/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Publishing;
 /// <summary>
 /// Minimalistic reporter that does nothing.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public sealed class NullPublishingActivityProgressReporter : IPublishingActivityProgressReporter
 {
     /// <summary>

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Publishing;
 /// <summary>
 /// Represents a publishing activity.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class PublishingActivity
 {
     /// <summary>
@@ -44,7 +44,7 @@ public sealed class PublishingActivity
 /// <summary>
 /// Represents the status of a publishing activity.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed record PublishingActivityStatus
 {
     /// <summary>
@@ -71,7 +71,7 @@ public sealed record PublishingActivityStatus
 /// <summary>
 /// Interface for reporting publishing activity progress.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public interface IPublishingActivityProgressReporter
 {
     /// <summary>

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Publishing;
 /// <summary>
 /// Represents a publishing activity.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public sealed class PublishingActivity
 {
     /// <summary>
@@ -44,7 +44,7 @@ public sealed class PublishingActivity
 /// <summary>
 /// Represents the status of a publishing activity.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public sealed record PublishingActivityStatus
 {
     /// <summary>
@@ -71,7 +71,7 @@ public sealed record PublishingActivityStatus
 /// <summary>
 /// Interface for reporting publishing activity progress.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public interface IPublishingActivityProgressReporter
 {
     /// <summary>

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -16,7 +16,7 @@ namespace Aspire.Hosting.Publishing;
 /// <summary>
 /// Provides a service to publishers for building containers that represent a resource.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
 public interface IResourceContainerImageBuilder
 {
     /// <summary>

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -16,7 +16,7 @@ namespace Aspire.Hosting.Publishing;
 /// <summary>
 /// Provides a service to publishers for building containers that represent a resource.
 /// </summary>
-[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public interface IResourceContainerImageBuilder
 {
     /// <summary>

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1991,7 +1991,7 @@ public static class ResourceBuilderExtensions
     /// <remarks>
     /// This method allows associating a specific compute environment with the compute resource.
     /// </remarks>
-    [Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<T> WithComputeEnvironment<T>(this IResourceBuilder<T> builder, IResourceBuilder<IComputeEnvironmentResource> computeEnvironmentResource)
         where T : IComputeResource
     {

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1991,7 +1991,7 @@ public static class ResourceBuilderExtensions
     /// <remarks>
     /// This method allows associating a specific compute environment with the compute resource.
     /// </remarks>
-    [Experimental("ASPIRECOMPUTE001")]
+    [Experimental("ASPIRECOMPUTE001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public static IResourceBuilder<T> WithComputeEnvironment<T>(this IResourceBuilder<T> builder, IResourceBuilder<IComputeEnvironmentResource> computeEnvironmentResource)
         where T : IComputeResource
     {

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
@@ -113,7 +113,7 @@ public class AppContainersPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public void ConfigureCustomDomainShouldThrowWhenAppIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -128,7 +128,7 @@ public class AppContainersPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public void ConfigureCustomDomainShouldThrowWhenCustomDomainIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -143,7 +143,7 @@ public class AppContainersPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public void ConfigureCustomDomainShouldThrowWhenCertificateNameIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
@@ -113,7 +113,7 @@ public class AppContainersPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public void ConfigureCustomDomainShouldThrowWhenAppIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -128,7 +128,7 @@ public class AppContainersPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public void ConfigureCustomDomainShouldThrowWhenCustomDomainIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -143,7 +143,7 @@ public class AppContainersPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public void ConfigureCustomDomainShouldThrowWhenCertificateNameIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
@@ -212,7 +212,7 @@ public class CosmosDBPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public void RunAsPreviewEmulatorShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<AzureCosmosDBResource> builder = null!;
@@ -371,7 +371,7 @@ public class CosmosDBPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
     public void WithDataExplorerShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<AzureCosmosDBEmulatorResource> builder = null!;

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
@@ -212,7 +212,7 @@ public class CosmosDBPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public void RunAsPreviewEmulatorShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<AzureCosmosDBResource> builder = null!;
@@ -371,7 +371,7 @@ public class CosmosDBPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostic/{0}")]
+    [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public void WithDataExplorerShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<AzureCosmosDBEmulatorResource> builder = null!;


### PR DESCRIPTION
## Description

~Technically depends on dotnet/docs-aspire#3379 but it's not required to merge. Docs will ship soon.~ Done

Intellisense didn't show `HelpLink` on the MSBuild actions, but the MSBuild docs said it's supported.

Fixes #8936

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes, already in progress