### PR TITLE
Update port allocation logic and environment variables in Docker Compose

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
@@ -51,7 +51,7 @@ internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentRe
             var internalPort = endpoint.TargetPort ?? _portAllocator.AllocatePort();
             _portAllocator.AddUsedPort(internalPort);
 
-            var exposedPort = _portAllocator.AllocatePort();
+            var exposedPort = endpoint.Port ?? _portAllocator.AllocatePort();
             _portAllocator.AddUsedPort(exposedPort);
 
             serviceResource.EndpointMappings.Add(endpoint.Name, new(endpoint.UriScheme, serviceResource.TargetResource.Name, internalPort, exposedPort, false));

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile.verified.yaml
@@ -7,7 +7,13 @@
     entrypoint:
       - "/bin/sh"
     environment:
+      REDIS_PORT: "8000"
       MSG: "world"
+      TP: "8000"
+      TPH2: "5001"
+    ports:
+      - "5000:5001"
+      - "8001:8000"
     networks:
       - "aspire"
   something:
@@ -22,13 +28,13 @@
       - "Url=${PARAM0}, Secret=${PARAM1}"
     environment:
       ASPNETCORE_ENVIRONMENT: "Development"
-      PORT: "8000"
+      PORT: "8002"
       param0: "${PARAM0}"
       param1: "${PARAM1}"
       param2: "${PARAM2}"
       ConnectionStrings__cs: "Url=${PARAM0}, Secret=${PARAM1}"
     ports:
-      - "8001:8000"
+      - "8003:8002"
     depends_on:
       cache:
         condition: "service_started"
@@ -42,7 +48,7 @@
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "true"
       OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
       OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "in_memory"
-      services__myapp__http__0: "http://myapp:8000"
+      services__myapp__http__0: "http://myapp:8002"
     networks:
       - "aspire"
 networks:


### PR DESCRIPTION
## Description

Use the host port by default in docker compose outputs.

Fixes #8817

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
