### PR TITLE
Add health endpoint to dashboard and call from app host

### DIFF
--- a/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
@@ -14,6 +14,11 @@ namespace Aspire.Dashboard;
 
 public static class DashboardEndpointsBuilder
 {
+    public static void MapDashboardHealthChecks(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapHealthChecks($"/{DashboardUrls.HealthBasePath}").AllowAnonymous();
+    }
+
     public static void MapDashboardApi(this IEndpointRouteBuilder endpoints, DashboardOptions dashboardOptions)
     {
         if (dashboardOptions.Frontend.AuthMode == FrontendAuthMode.BrowserToken)

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -204,6 +204,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             // See https://learn.microsoft.com/aspnet/core/performance/response-compression#compression-with-https for more information
             options.MimeTypes = ["text/javascript", "application/javascript", "text/css", "image/svg+xml"];
         });
+        builder.Services.AddHealthChecks();
         if (dashboardOptions.Otlp.Cors.IsCorsEnabled)
         {
             builder.Services.AddCors(options =>
@@ -441,6 +442,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         _app.MapGrpcService<OtlpGrpcLogsService>();
 
         _app.MapDashboardApi(dashboardOptions);
+        _app.MapDashboardHealthChecks();
     }
 
     private ILogger<DashboardWebApplication> GetLogger()

--- a/src/Aspire.Dashboard/Utils/DashboardUrls.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUrls.cs
@@ -14,6 +14,7 @@ internal static class DashboardUrls
     public const string StructuredLogsBasePath = "structuredlogs";
     public const string TracesBasePath = "traces";
     public const string LoginBasePath = "login";
+    public const string HealthBasePath = "health";
 
     public static string ResourcesUrl(string? resource = null, string? view = null, string? hiddenTypes = null, string? hiddenStates = null, string? hiddenHealthStates = null)
     {

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -179,7 +179,7 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
         dashboardResource.Annotations.Add(new ResourceSnapshotAnnotation(snapshot));
 
         dashboardResource.Annotations.Add(new EnvironmentCallbackAnnotation(ConfigureEnvironmentVariables));
-        dashboardResource.Annotations.Add(new HealthCheckAnnotation(KnownHealthCheckNames.DasboardHealthCheck));
+        dashboardResource.Annotations.Add(new HealthCheckAnnotation(KnownHealthCheckNames.DashboardHealthCheck));
     }
 
     internal async Task ConfigureEnvironmentVariables(EnvironmentCallbackContext context)

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -395,15 +395,19 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             var dashboardOptions = sp.GetRequiredService<IOptions<DashboardOptions>>().Value;
             if (StringUtils.TryGetUriFromDelimitedString(dashboardOptions.DashboardUrl, ";", out var firstDashboardUrl))
             {
-                return firstDashboardUrl;
+                // Health checks to the dashboard should go to the /health endpoint. This endpoint allows anonymous requests.
+                // Sending a request to other dashboard endpoints triggered auth, which the request fails, and is redirected to the login page.
+                var uriBuilder = new UriBuilder(firstDashboardUrl);
+                uriBuilder.Path = "/health";
+                return uriBuilder.Uri;
             }
             else
             {
                 throw new DistributedApplicationException($"The dashboard resource '{KnownResourceNames.AspireDashboard}' does not have endpoints.");
             }
-        }, KnownHealthCheckNames.DasboardHealthCheck);
+        }, KnownHealthCheckNames.DashboardHealthCheck);
 
-        _innerBuilder.Services.SuppressHealthCheckHttpClientLogging(KnownHealthCheckNames.DasboardHealthCheck);
+        _innerBuilder.Services.SuppressHealthCheckHttpClientLogging(KnownHealthCheckNames.DashboardHealthCheck);
     }
 
     private void ConfigureHealthChecks()

--- a/src/Shared/KnownHealthCheckNames.cs
+++ b/src/Shared/KnownHealthCheckNames.cs
@@ -8,5 +8,5 @@ internal static class KnownHealthCheckNames
     /// <summary>
     /// Common name for dashboard health check.
     /// </summary>
-    public const string DasboardHealthCheck = "aspire_dashboard_check";
+    public const string DashboardHealthCheck = "aspire_dashboard_check";
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/HealthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/HealthTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using System.Net;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Integration;
+
+public class HealthTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task HealthEndpoint_SendRequest_200Response()
+    {
+        // Arrange
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper);
+        await app.StartAsync().DefaultTimeout();
+
+        await MakeRequestAndAssert($"http://{app.FrontendSingleEndPointAccessor().EndPoint}", HttpVersion.Version11).DefaultTimeout();
+        await MakeRequestAndAssert($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}", HttpVersion.Version11).DefaultTimeout();
+        await MakeRequestAndAssert($"http://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}", HttpVersion.Version20).DefaultTimeout();
+
+        static async Task MakeRequestAndAssert(string basePath, Version httpVersion)
+        {
+            using var httpClientHandler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var client = new HttpClient(httpClientHandler) { BaseAddress = new Uri(basePath) };
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, $"/{DashboardUrls.HealthBasePath}");
+            request.Version = httpVersion;
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+            var response = await client.SendAsync(request).DefaultTimeout();
+
+            // Assert 
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
## Description

* Add health endpoint to dashboard. Allows anonymous requests
* Update app host to use health endpoint

**Before (an auth failed log added every health check):**
![image](https://github.com/user-attachments/assets/64a309f1-dab6-4326-94db-2db88ec9176e)

**After (no auth failed logs):**
![image](https://github.com/user-attachments/assets/b655eb46-f300-4dcf-814a-11b4da0bc44f)


Fixes https://github.com/dotnet/aspire/issues/9153

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
