### PR TITLE
Fix race causing `ResourceNotificationService.GetAllAsync` to fail

### DIFF
--- a/tests/Aspire.Hosting.Tests/ResourceLoggerServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceLoggerServiceTests.cs
@@ -268,13 +268,16 @@ public class ResourceLoggerServiceTests
         consoleLogsChannel1.Writer.Complete();
 
         var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+
+        // Get logger before SetConsoleLogsService is called so that we test there is no bad state stored on the resource logger instance.
+        var logger = service.GetLogger(testResource);
+
         service.SetConsoleLogsService(new TestConsoleLogsService(name => name switch
             {
                 "instance0" => consoleLogsChannel0,
                 "instance1" => consoleLogsChannel1,
                 string n => throw new InvalidOperationException($"Unexpected {n}")
             }));
-        var logger = service.GetLogger(testResource);
 
         // Log
         logger.LogInformation("Hello, world!");


### PR DESCRIPTION
## Description

I noticed `ResourceNotificationService.GetAllAsync` sometimes fails. The problem is console logs service field on `ResourceNotificationService` is mutable - it's set during start up - but the value of the field is cached against resource loggers.

If a resource logger is created before the field is changed then they will cache the old value. This causes `GetAllAsync` to fail.

The fix is to not cache the field on resource loggers. Instead it is used when `GetAllLogsAsync` is called.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
