### PR TITLE
Fixed endpoint mapping in compose resources

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
@@ -2,19 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Docker;
 
 internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentResource environment, ILogger logger)
 {
-    private readonly Dictionary<IResource, DockerComposeServiceResource> _resourceMapping = [];
-    private readonly PortAllocator _portAllocator = new();
-
     public async Task<DockerComposeServiceResource> CreateDockerComposeServiceResourceAsync(IResource resource, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
     {
-        if (_resourceMapping.TryGetValue(resource, out var existingResource))
+        if (environment.ResourceMapping.TryGetValue(resource, out var existingResource))
         {
             return existingResource;
         }
@@ -22,7 +18,7 @@ internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentRe
         logger.LogInformation("Creating Docker Compose resource for {ResourceName}", resource.Name);
 
         var serviceResource = new DockerComposeServiceResource(resource.Name, resource, environment);
-        _resourceMapping[resource] = serviceResource;
+        environment.ResourceMapping[resource] = serviceResource;
 
         // Process endpoints
         ProcessEndpoints(serviceResource);
@@ -48,11 +44,11 @@ internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentRe
 
         foreach (var endpoint in endpoints)
         {
-            var internalPort = endpoint.TargetPort ?? _portAllocator.AllocatePort();
-            _portAllocator.AddUsedPort(internalPort);
+            var internalPort = endpoint.TargetPort ?? environment.PortAllocator.AllocatePort();
+            environment.PortAllocator.AddUsedPort(internalPort);
 
-            var exposedPort = endpoint.Port ?? _portAllocator.AllocatePort();
-            _portAllocator.AddUsedPort(exposedPort);
+            var exposedPort = endpoint.Port ?? environment.PortAllocator.AllocatePort();
+            environment.PortAllocator.AddUsedPort(exposedPort);
 
             serviceResource.EndpointMappings.Add(endpoint.Name, new(endpoint.UriScheme, serviceResource.TargetResource.Name, internalPort, exposedPort, false));
         }
@@ -83,11 +79,15 @@ internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentRe
         }
     }
 
-    private async Task ProcessEnvironmentVariablesAsync(DockerComposeServiceResource serviceResource, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
+    private static async Task ProcessEnvironmentVariablesAsync(DockerComposeServiceResource serviceResource, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
     {
         if (serviceResource.TargetResource.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var environmentCallbacks))
         {
-            var context = new EnvironmentCallbackContext(executionContext, serviceResource.TargetResource, cancellationToken: cancellationToken);
+            var context = new EnvironmentCallbackContext(
+                executionContext,
+                serviceResource.TargetResource,
+                serviceResource.EnvironmentVariables,
+                cancellationToken: cancellationToken);
 
             foreach (var callback in environmentCallbacks)
             {
@@ -96,12 +96,6 @@ internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentRe
 
             // Remove HTTPS service discovery variables as Docker Compose doesn't handle certificates
             RemoveHttpsServiceDiscoveryVariables(context.EnvironmentVariables);
-
-            foreach (var kv in context.EnvironmentVariables)
-            {
-                var value = await serviceResource.ProcessValueAsync(this, executionContext, kv.Value).ConfigureAwait(false);
-                serviceResource.EnvironmentVariables.Add(kv.Key, value?.ToString() ?? string.Empty);
-            }
         }
     }
 
@@ -118,26 +112,18 @@ internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentRe
         }
     }
 
-    private async Task ProcessArgumentsAsync(DockerComposeServiceResource serviceResource, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
+    private static async Task ProcessArgumentsAsync(DockerComposeServiceResource serviceResource, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
     {
         if (serviceResource.TargetResource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var commandLineArgsCallbacks))
         {
-            var context = new CommandLineArgsCallbackContext([], cancellationToken: cancellationToken);
+            var context = new CommandLineArgsCallbackContext(serviceResource.Args, cancellationToken: cancellationToken)
+            {
+                ExecutionContext = executionContext
+            };
 
             foreach (var callback in commandLineArgsCallbacks)
             {
                 await callback.Callback(context).ConfigureAwait(false);
-            }
-
-            foreach (var arg in context.Args)
-            {
-                var value = await serviceResource.ProcessValueAsync(this, executionContext, arg).ConfigureAwait(false);
-                if (value is not string str)
-                {
-                    throw new NotSupportedException("Command line args must be strings");
-                }
-
-                serviceResource.Commands.Add(str);
             }
         }
     }

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -41,6 +41,10 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
     /// </summary>
     internal Dictionary<string, (string? Description, string? DefaultValue, object? Source)> CapturedEnvironmentVariables { get; } = [];
 
+    internal Dictionary<IResource, DockerComposeServiceResource> ResourceMapping { get; } = new(new ResourceComparer());
+
+    internal PortAllocator PortAllocator { get; } = new();
+
     /// <param name="name">The name of the Docker Compose environment.</param>
     public DockerComposeEnvironmentResource(string name) : base(name)
     {

--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -74,7 +74,7 @@ internal sealed class DockerComposePublishingContext(
                     await ImageBuilder.BuildImageAsync(serviceResource.TargetResource, cancellationToken).ConfigureAwait(false);
                 }
 
-                var composeService = serviceResource.ComposeService;
+                var composeService = serviceResource.BuildComposeService();
 
                 HandleComposeFileVolumes(serviceResource, composeFile);
 

--- a/src/Aspire.Hosting.Docker/ResourceComparer.cs
+++ b/src/Aspire.Hosting.Docker/ResourceComparer.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIRECOMPUTE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Docker;
+
+internal sealed class ResourceComparer : IEqualityComparer<IResource>
+{
+    public bool Equals(IResource? x, IResource? y)
+    {
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return x.Name.Equals(y.Name, StringComparison.Ordinal);
+    }
+
+    public int GetHashCode(IResource obj) =>
+        obj.Name.GetHashCode(StringComparison.Ordinal);
+}

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeMapsPortsProperly.verified.txt
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeMapsPortsProperly.verified.txt
@@ -1,0 +1,12 @@
+﻿services:
+  service:
+    image: "${SERVICE_IMAGE}"
+    environment:
+      PORT: "8000"
+    ports:
+      - "8001:8000"
+    networks:
+      - "aspire"
+networks:
+  aspire:
+    driver: "bridge"


### PR DESCRIPTION
## Description

- Process arguments and env variables in the publish phase. This delays the resolution of endpoints until they are all processed.
- Also handled bait and switch resources (executable -> container)

Fixes #8674

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
