### PR TITLE
Handle bait and switch resources in ACA

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppEnvironmentContext.cs
@@ -18,7 +18,7 @@ internal sealed class ContainerAppEnvironmentContext(
 
     public IAzureContainerAppEnvironment Environment => environment;
 
-    private readonly Dictionary<IResource, ContainerAppContext> _containerApps = [];
+    private readonly Dictionary<IResource, ContainerAppContext> _containerApps = new(new ResourceComparer());
 
     public ContainerAppContext GetContainerAppContext(IResource resource)
     {

--- a/src/Aspire.Hosting.Azure.AppContainers/ResourceComparer.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ResourceComparer.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.AppContainers;
+
+internal sealed class ResourceComparer : IEqualityComparer<IResource>
+{
+    public bool Equals(IResource? x, IResource? y)
+    {
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return x.Name.Equals(y.Name, StringComparison.Ordinal);
+    }
+
+    public int GetHashCode(IResource obj) =>
+        obj.Name.GetHashCode(StringComparison.Ordinal);
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -147,7 +147,7 @@ public class AzureContainerAppsTests
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-       var container = Assert.IsType<IComputeResource>(Assert.Single(model.GetContainerResources()), exactMatch: false);
+        var container = Assert.IsType<IComputeResource>(Assert.Single(model.GetContainerResources()), exactMatch: false);
 
         var target = container.GetDeploymentTargetAnnotation();
 
@@ -423,6 +423,38 @@ public class AzureContainerAppsTests
               .AppendContentAsFile(bicep, "bicep")
               .AppendContentAsFile(identityManifest.ToString(), "json")
               .AppendContentAsFile(identityBicep, "bicep")
+              .UseHelixAwareDirectory();
+    }
+
+    [Fact]
+    public async Task AzureContainerAppsMapsPortsForBaitAndSwitchResources()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureContainerAppEnvironment("env");
+
+        builder.AddExecutable("api", "node", ".")
+            .PublishAsDockerFile()
+            .WithHttpEndpoint(env: "PORT");
+
+        using var app = builder.Build();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var container = Assert.Single(model.GetContainerResources());
+
+        container.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep")
               .UseHelixAwareDirectory();
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsMapsPortsForBaitAndSwitchResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsMapsPortsForBaitAndSwitchResources.verified.bicep
@@ -1,0 +1,57 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_apps_environment_default_domain string
+
+param env_outputs_azure_container_apps_environment_id string
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param api_containerimage string
+
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'api'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 8000
+        transport: 'http'
+      }
+      registries: [
+        {
+          server: env_outputs_azure_container_registry_endpoint
+          identity: env_outputs_azure_container_registry_managed_identity_id
+        }
+      ]
+    }
+    environmentId: env_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: api_containerimage
+          name: 'api'
+          env: [
+            {
+              name: 'PORT'
+              value: '8000'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsMapsPortsForBaitAndSwitchResources.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsMapsPortsForBaitAndSwitchResources.verified.json
@@ -1,0 +1,11 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "api.module.bicep",
+  "params": {
+    "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+    "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "api_containerimage": "{api.containerImage}"
+  }
+}


### PR DESCRIPTION
## Description

- Discovered while fixing issues in docker compose, we don't properly handle bailt and switch resources properly. Since we remove and add a new resource, we end up needing to treat both as the same resource when we encounter it.
- Added test for aca and app service (which is missing this feature)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
