### PR TITLE
fix: Dashboard URL Token without dot. 

### DIFF
--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -19,7 +19,7 @@ internal static class LoggingHelpers
         {
             var message = !isContainer
                 ? "Login to the dashboard at {DashboardLoginUrl}"
-                : "Login to the dashboard at {DashboardLoginUrl} The URL may need changes depending on how network access to the container is configured.";
+                : "Login to the dashboard at {DashboardLoginUrl} . The URL may need changes depending on how network access to the container is configured.";
 
             var dashboardUrl = $"{firstDashboardUrl.GetLeftPart(UriPartial.Authority)}/login?t={token}";
             logger.LogInformation(message, dashboardUrl);

--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -19,7 +19,7 @@ internal static class LoggingHelpers
         {
             var message = !isContainer
                 ? "Login to the dashboard at {DashboardLoginUrl}"
-                : "Login to the dashboard at {DashboardLoginUrl}. The URL may need changes depending on how network access to the container is configured.";
+                : "Login to the dashboard at {DashboardLoginUrl} The URL may need changes depending on how network access to the container is configured.";
 
             var dashboardUrl = $"{firstDashboardUrl.GetLeftPart(UriPartial.Authority)}/login?t={token}";
             logger.LogInformation(message, dashboardUrl);

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -258,7 +258,7 @@ public class FrontendBrowserTokenAuthTests
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
 
         // Testing via the log template is kind of hacky. If this becomes a problem then consider adding proper log definitions and match via ID.
-        Assert.Single(l, w => (string?)GetValue(w.State, "{OriginalFormat}") == "Login to the dashboard at {DashboardLoginUrl}. The URL may need changes depending on how network access to the container is configured.");
+        Assert.Single(l, w => (string?)GetValue(w.State, "{OriginalFormat}") == "Login to the dashboard at {DashboardLoginUrl} The URL may need changes depending on how network access to the container is configured.");
     }
 
     private static object? GetValue(object? values, string key)

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -258,7 +258,7 @@ public class FrontendBrowserTokenAuthTests
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
 
         // Testing via the log template is kind of hacky. If this becomes a problem then consider adding proper log definitions and match via ID.
-        Assert.Single(l, w => (string?)GetValue(w.State, "{OriginalFormat}") == "Login to the dashboard at {DashboardLoginUrl} The URL may need changes depending on how network access to the container is configured.");
+        Assert.Single(l, w => (string?)GetValue(w.State, "{OriginalFormat}") == "Login to the dashboard at {DashboardLoginUrl} . The URL may need changes depending on how network access to the container is configured.");
     }
 
     private static object? GetValue(object? values, string key)


### PR DESCRIPTION
## Description

In Docker Desktop the link to the dashboard is automatically made a clickable link. The link looks something like this: http://localhost:18888/login?t=e2cf886a8b50cc5434ef3035e2d0d03f.. Because the last dot, when you click on the link and the dashboard is opened, the login token is not working and you are not automatically logged in into the dashboard.

This PR will remove the dot and will make the link working as expected.

Fixes #9196 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
