### PR TITLE
Don't duplicate adding secrets to the infrastructure

### DIFF
--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsBicepGenerationIsIdempotent.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsBicepGenerationIsIdempotent.verified.bicep
@@ -1,0 +1,77 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_apps_environment_default_domain string
+
+param env_outputs_azure_container_apps_environment_id string
+
+param api_identity_outputs_id string
+
+@secure()
+param secret_value string
+
+param kv_outputs_name string
+
+param api_identity_outputs_clientid string
+
+resource kv_outputs_name_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: kv_outputs_name
+}
+
+resource kv_outputs_name_kv_secret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
+  name: 'secret'
+  parent: kv_outputs_name_kv
+}
+
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'api'
+  location: location
+  properties: {
+    configuration: {
+      secrets: [
+        {
+          name: 'top-secret'
+          value: secret_value
+        }
+        {
+          name: 'top-secret2'
+          identity: api_identity_outputs_id
+          keyVaultUrl: kv_outputs_name_kv_secret.properties.secretUri
+        }
+      ]
+      activeRevisionsMode: 'Single'
+    }
+    environmentId: env_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: 'myimage:latest'
+          name: 'api'
+          env: [
+            {
+              name: 'TOP_SECRET'
+              secretRef: 'top-secret'
+            }
+            {
+              name: 'TOP_SECRET2'
+              secretRef: 'top-secret2'
+            }
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: api_identity_outputs_clientid
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${api_identity_outputs_id}': { }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsBicepGenerationIsIdempotent.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsBicepGenerationIsIdempotent.verified.json
@@ -1,0 +1,12 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "api.module.bicep",
+  "params": {
+    "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+    "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+    "api_identity_outputs_id": "{api-identity.outputs.id}",
+    "secret_value": "{secret.value}",
+    "kv_outputs_name": "{kv.outputs.name}",
+    "api_identity_outputs_clientid": "{api-identity.outputs.clientId}"
+  }
+}


### PR DESCRIPTION
## Description

Calling GetBicepTemplate multiple times on the same AzureProvisioningResource for ACA would add duplicate secrets. This changes the logic to use the underling infrastructure as the source of truth instead of the outer context.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
