### PR TITLE
Stream logs from docker build on publish.

### DIFF
--- a/playground/withdockerfile/WithDockerfile.AppHost/Program.cs
+++ b/playground/withdockerfile/WithDockerfile.AppHost/Program.cs
@@ -3,6 +3,8 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+builder.AddDockerComposeEnvironment("docker-compose");
+
 // Just for validating parameter handling in Dockerfile builds.
 var goVersion = builder.AddParameter("goversion", "1.22");
 var secret = builder.AddParameter("secret", secret: true);

--- a/playground/withdockerfile/WithDockerfile.AppHost/Properties/launchSettings.json
+++ b/playground/withdockerfile/WithDockerfile.AppHost/Properties/launchSettings.json
@@ -40,6 +40,18 @@
         "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175"
       }
+    },
+    "publisher-default": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--operation publish --publisher default --output-path .",
+      "applicationUrl": "http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175"
+      }
     }
   }
 }

--- a/playground/withdockerfile/WithDockerfile.AppHost/WithDockerfile.AppHost.csproj
+++ b/playground/withdockerfile/WithDockerfile.AppHost/WithDockerfile.AppHost.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Redis" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Docker" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -168,12 +168,10 @@ internal sealed class PublishCommand : BaseCommand
                 _interactionService.DisplaySuccess($"Successfully published artifacts to: {fullyQualifiedOutputPath}");
                 return ExitCodeConstants.Success;
             }
-            else
-            {
-                _interactionService.DisplayLines(publishOutputCollector.GetLines());
-                _interactionService.DisplayError($"Publishing artifacts failed with exit code {exitCode}. For more information run with --debug switch.");
-                return ExitCodeConstants.FailedToBuildArtifacts;
-            }
+
+            _interactionService.DisplayLines(publishOutputCollector.GetLines());
+            _interactionService.DisplayError($"Publishing artifacts failed with exit code {exitCode}. For more information run with --debug switch.");
+            return ExitCodeConstants.FailedToBuildArtifacts;
         }
         catch (OperationCanceledException)
         {
@@ -273,10 +271,6 @@ internal sealed class PublishCommand : BaseCommand
                         progressTask.Description = $"[red bold]:cross_mark:  {publishingActivity.StatusText}[/]";
                         progressTask.Value = 0;
                         return false;
-                    }
-                    else
-                    {
-                        // Keep going man!
                     }
                 }
                 

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -122,139 +122,57 @@ internal sealed class PublishCommand : BaseCommand
 
             _interactionService.DisplayMessage($"hammer_and_wrench", $"Generating artifacts...");
             
-            var exitCode = await AnsiConsole.Progress()
-                .AutoRefresh(true)
-                .Columns(
-                    new TaskDescriptionColumn() { Alignment = Justify.Left },
-                    new ProgressBarColumn() { Width = 10 },
-                    new ElapsedTimeColumn())
-                .StartAsync(async context => {
+            var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
 
-                    using var generateArtifactsActivity = _activitySource.StartActivity(
-                        $"{nameof(ExecuteAsync)}-Action-GenerateArtifacts",
-                        ActivityKind.Internal);
-                    
-                    var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
+            var publishRunOptions = new DotNetCliRunnerInvocationOptions
+            {
+                StandardOutputCallback = publishOutputCollector.AppendOutput,
+                StandardErrorCallback = publishOutputCollector.AppendError,
+                NoLaunchProfile = true
+            };
 
-                    var launchingAppHostTask = context.AddTask(":play_button:  Launching apphost");
-                    launchingAppHostTask.IsIndeterminate();
-                    launchingAppHostTask.StartTask();
+            var unmatchedTokens = parseResult.UnmatchedTokens.ToArray();
 
-                    var publishRunOptions = new DotNetCliRunnerInvocationOptions
-                    {
-                        StandardOutputCallback = publishOutputCollector.AppendOutput,
-                        StandardErrorCallback = publishOutputCollector.AppendError,
-                        NoLaunchProfile = true
-                    };
+            var pendingRun = _runner.RunAsync(
+                effectiveAppHostProjectFile,
+                false,
+                true,
+                ["--operation", "publish", "--publisher", "default", "--output-path", fullyQualifiedOutputPath, ..unmatchedTokens],
+                env,
+                backchannelCompletionSource,
+                publishRunOptions,
+                cancellationToken);
 
-                    var unmatchedTokens = parseResult.UnmatchedTokens.ToArray();
+            // If we use the --wait-for-debugger option we print out the process ID
+            // of the apphost so that the user can attach to it.
+            if (waitForDebugger)
+            {
+                _interactionService.DisplayMessage("bug", $"Waiting for debugger to attach to app host process");
+            }
 
-                    var pendingRun = _runner.RunAsync(
-                        effectiveAppHostProjectFile,
-                        false,
-                        true,
-                        ["--operation", "publish", "--publisher", "default", "--output-path", fullyQualifiedOutputPath, ..unmatchedTokens],
-                        env,
-                        backchannelCompletionSource,
-                        publishRunOptions,
-                        cancellationToken);
+            var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
+            var publishingActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
 
-                    ProgressTask? attachDebuggerTask = null;
-                    if (waitForDebugger)
-                    {
-                        attachDebuggerTask = context.AddTask($":bug:  Waiting for debugger to attach to app host process");
-                        attachDebuggerTask.IsIndeterminate();
-                        attachDebuggerTask.StartTask();
-                    }
+            var debugMode = parseResult.GetValue<bool?>("--debug") ?? false;
 
-                    var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
+            var noFailuresReported = debugMode switch {
+                true => await ProcessPublishingActivitiesAsync(publishingActivities, cancellationToken),
+                false => await ProcessAndDisplayPublishingActivitiesAsync(publishingActivities, cancellationToken),
+            };
 
-                    if (attachDebuggerTask is not null)
-                    {
-                        attachDebuggerTask.Description = $":check_mark:  Debugger attached (or timed out)";
-                        attachDebuggerTask.Value = 100;
-                        attachDebuggerTask.StopTask();
-                    }
+            await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
+            var exitCode = await pendingRun;
 
-                    launchingAppHostTask.Description = $":check_mark:  Launching apphost";
-                    launchingAppHostTask.Value = 100;
-                    launchingAppHostTask.StopTask();
-
-                    var publishingActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
-
-                    var progressTasks = new Dictionary<string, ProgressTask>();
-
-                    await foreach (var publishingActivity in publishingActivities)
-                    {
-                        if (!progressTasks.TryGetValue(publishingActivity.Id, out var progressTask))
-                        {
-                            progressTask = context.AddTask(publishingActivity.Id);
-                            progressTask.StartTask();
-                            progressTask.IsIndeterminate();
-                            progressTasks.Add(publishingActivity.Id, progressTask);
-                        }
-
-                        progressTask.Description = $":play_button:  {publishingActivity.StatusText}";
-
-                        if (publishingActivity.IsComplete && !publishingActivity.IsError)
-                        {
-                            progressTask.Description = $":check_mark:  {publishingActivity.StatusText}";
-                            progressTask.Value = 100;
-                            progressTask.StopTask();
-                        }
-                        else if (publishingActivity.IsError)
-                        {
-                            progressTask.Description = $"[red bold]:cross_mark:  {publishingActivity.StatusText}[/]";
-                            progressTask.Value = 0;
-                            break;
-                        }
-                        else
-                        {
-                            // Keep going man!
-                        }
-                    }
-
-                    // When we are running in publish mode we don't want the app host to
-                    // stop itself while we might still be streaming data back across
-                    // the RPC backchannel. So we need to take responsibility for stopping
-                    // the app host. If the CLI exits/crashes without explicitly stopping
-                    // the app host the orphan detector in the app host will kick in.
-                    if (progressTasks.Any(kvp => !kvp.Value.IsFinished))
-                    {
-                        // Depending on the failure the publisher may return a zero
-                        // exit code.
-                        await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
-                        var exitCode = await pendingRun;
-
-                        // If we are in the state where we've detected an error because there
-                        // is an incomplete task then we stop the app host, but depending on
-                        // where/how the failure occured, we might still get a zero exit
-                        // code. If we get a non-zero exit code we want to return that
-                        // as it might be useful for diagnostic purposes, however if we don't
-                        // get a non-zero exit code we want to return our built-in exit code
-                        // for failed artifact build.
-                        return exitCode == 0 ? ExitCodeConstants.FailedToBuildArtifacts : exitCode;
-                    }
-                    else
-                    {
-                        // If we are here then all the tasks are finished and we can
-                        // stop the app host.
-                        await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
-                        var exitCode = await pendingRun;
-                        return exitCode; // should be zero for orderly shutdown but we pass it along anyway.
-                    }
-                });
-
-            if (exitCode != 0)
+            if (exitCode == 0 && noFailuresReported)
+            {
+                _interactionService.DisplaySuccess($"Successfully published artifacts to: {fullyQualifiedOutputPath}");
+                return ExitCodeConstants.Success;
+            }
+            else
             {
                 _interactionService.DisplayLines(publishOutputCollector.GetLines());
                 _interactionService.DisplayError($"Publishing artifacts failed with exit code {exitCode}. For more information run with --debug switch.");
                 return ExitCodeConstants.FailedToBuildArtifacts;
-            }
-            else
-            {
-                _interactionService.DisplaySuccess($"Successfully published artifacts to: {fullyQualifiedOutputPath}");
-                return ExitCodeConstants.Success;
             }
         }
         catch (OperationCanceledException)
@@ -300,5 +218,69 @@ internal sealed class PublishCommand : BaseCommand
             _interactionService.DisplayError($"An unexpected error occurred: {ex.Message}");
             return ExitCodeConstants.FailedToBuildArtifacts;
         }
+    }
+
+    public static async Task<bool> ProcessPublishingActivitiesAsync(IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> publishingActivities, CancellationToken cancellationToken)
+    {
+        var lastActivityUpdateLookup = new Dictionary<string, (string Id, string StatusText, bool IsComplete, bool IsError)>();
+        await foreach (var publishingActivity in publishingActivities.WithCancellation(cancellationToken))
+        {
+            lastActivityUpdateLookup[publishingActivity.Id] = publishingActivity;
+
+            if (lastActivityUpdateLookup.Any(kvp => kvp.Value.IsError) || lastActivityUpdateLookup.All(kvp => kvp.Value.IsComplete))
+            {
+                // If we have an error or all tasks are complete then we can stop
+                // processing the publishing activities.
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static async Task<bool> ProcessAndDisplayPublishingActivitiesAsync(IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> publishingActivities, CancellationToken cancellationToken)
+    {
+        return await AnsiConsole.Progress()
+            .AutoRefresh(true)
+            .Columns(
+                new TaskDescriptionColumn() { Alignment = Justify.Left },
+                new ProgressBarColumn() { Width = 10 },
+                new ElapsedTimeColumn())
+            .StartAsync<bool>(async context => {
+
+                var progressTasks = new Dictionary<string, ProgressTask>();
+
+                await foreach (var publishingActivity in publishingActivities.WithCancellation(cancellationToken))
+                {
+                    if (!progressTasks.TryGetValue(publishingActivity.Id, out var progressTask))
+                    {
+                        progressTask = context.AddTask(publishingActivity.Id);
+                        progressTask.StartTask();
+                        progressTask.IsIndeterminate();
+                        progressTasks.Add(publishingActivity.Id, progressTask);
+                    }
+
+                    progressTask.Description = $":play_button:  {publishingActivity.StatusText}";
+
+                    if (publishingActivity.IsComplete && !publishingActivity.IsError)
+                    {
+                        progressTask.Description = $":check_mark:  {publishingActivity.StatusText}";
+                        progressTask.Value = 100;
+                        progressTask.StopTask();
+                    }
+                    else if (publishingActivity.IsError)
+                    {
+                        progressTask.Description = $"[red bold]:cross_mark:  {publishingActivity.StatusText}[/]";
+                        progressTask.Value = 0;
+                        return false;
+                    }
+                    else
+                    {
+                        // Keep going man!
+                    }
+                }
+                
+                return true;
+            });
     }
 }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -144,9 +144,7 @@ internal sealed class RunCommand : BaseCommand
                     async () => {
 
                         // If we use the --wait-for-debugger option we print out the process ID
-                        // of the apphost so that the user can attach to it. The process ID comes
-                        // from the ProcessIdCallback on the invocation options and we just await
-                        // the completion source to be set.
+                        // of the apphost so that the user can attach to it.
                         if (waitForDebugger)
                         {
                             _interactionService.DisplayMessage("bug", $"Waiting for debugger to attach to app host process");

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -456,7 +456,7 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
             while (!cancellationToken.IsCancellationRequested && !reader.EndOfStream)
             {
                 var line = await reader.ReadLineAsync(cancellationToken);
-                logger.LogTrace(
+                logger.LogDebug(
                     "dotnet({ProcessId}) {Identifier}: {Line}",
                     process.Id,
                     identifier,

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -1,77 +1,63 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
+using Aspire.Hosting.Dcp.Process;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Publishing;
 
 internal sealed class DockerContainerRuntime(ILogger<DockerContainerRuntime> logger) : IContainerRuntime
 {
-    private async Task<(int ExitCode, string? Output)> RunDockerBuildAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
+    private async Task<int> RunDockerBuildAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
     {
-        var startInfo = new ProcessStartInfo
+        var spec = new ProcessSpec("docker")
         {
-            FileName = "docker",
-            RedirectStandardError = true,
-            RedirectStandardOutput = true,
+            Arguments = $"build --file {dockerfilePath} --tag {imageName} {contextPath}",
+            OnOutputData = output =>
+            {
+                logger.LogInformation("docker build (stdout): {Output}", output);
+            },
+            OnErrorData = error =>
+            {
+                logger.LogInformation("docker build (stderr): {Error}", error);
+            },
+            ThrowOnNonZeroReturnCode = false,
+            InheritEnv = true
         };
 
-        startInfo.ArgumentList.Add("build");
-        startInfo.ArgumentList.Add("--file");
-        startInfo.ArgumentList.Add(dockerfilePath);
-        startInfo.ArgumentList.Add("--tag");
-        startInfo.ArgumentList.Add(imageName);
-        startInfo.ArgumentList.Add("--quiet");
-        startInfo.ArgumentList.Add(contextPath);
+        logger.LogInformation("Running Docker CLI with arguments: {ArgumentList}", spec.Arguments);
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
 
-        logger.LogInformation("Running Docker CLI with arguments: {ArgumentList}", startInfo.ArgumentList);
-
-        using var process = Process.Start(startInfo);
-
-        if (process is null)
+        await using (processDisposable)
         {
-            throw new DistributedApplicationException("Failed to start Docker CLI.");
-        }
+            var processResult = await pendingProcessResult
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
 
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-
-        if (process.ExitCode != 0)
-        {
-            var stderr = process.StandardError.ReadToEnd();
-            var stdout = process.StandardOutput.ReadToEnd();
-
-            logger.LogError(
-                "Docker CLI failed with exit code {ExitCode}. Output: {Stdout}, Error: {Stderr}",
-                process.ExitCode,
-                stdout,
-                stderr);
-
-            return (process.ExitCode, null);
-        }
-        else
-        {
-            var stdout = process.StandardOutput.ReadToEnd();
-            logger.LogInformation("Docker CLI succeeded. Output: {Stdout}", stdout);
-            return (process.ExitCode, stdout);
+            if (processResult.ExitCode != 0)
+            {
+                logger.LogError("Docker build for {ImageName} failed with exit code {ExitCode}.", imageName, processResult.ExitCode);
+                return processResult.ExitCode;
+            }
+            else
+            {
+                logger.LogInformation("Docker build for {ImageName} succeeded.", imageName);
+                return processResult.ExitCode;
+            }
         }
     }
 
-    public async Task<string> BuildImageAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
+    public async Task BuildImageAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
     {
-        var result = await RunDockerBuildAsync(
+        var exitCode = await RunDockerBuildAsync(
             contextPath,
             dockerfilePath,
             imageName,
             cancellationToken).ConfigureAwait(false);
 
-        if (result.ExitCode == 0)
+        if (exitCode != 0)
         {
-            return result.Output!;
-        }
-        else
-        {
-            throw new DistributedApplicationException($"Docker build failed with exit code {result.ExitCode}.");
+            throw new DistributedApplicationException($"Docker build failed with exit code {exitCode}.");
         }
     }
 }

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -39,11 +39,9 @@ internal sealed class DockerContainerRuntime(ILogger<DockerContainerRuntime> log
                 logger.LogError("Docker build for {ImageName} failed with exit code {ExitCode}.", imageName, processResult.ExitCode);
                 return processResult.ExitCode;
             }
-            else
-            {
-                logger.LogInformation("Docker build for {ImageName} succeeded.", imageName);
-                return processResult.ExitCode;
-            }
+            
+            logger.LogInformation("Docker build for {ImageName} succeeded.", imageName);
+            return processResult.ExitCode;
         }
     }
 

--- a/src/Aspire.Hosting/Publishing/IContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/IContainerRuntime.cs
@@ -5,5 +5,5 @@ namespace Aspire.Hosting.Publishing;
 
 internal interface IContainerRuntime
 {
-    public Task<string> BuildImageAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken);
+    public Task BuildImageAsync(string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -39,11 +39,9 @@ internal sealed class PodmanContainerRuntime(ILogger<PodmanContainerRuntime> log
                 logger.LogError("Podman build for {ImageName} failed with exit code {ExitCode}.", imageName, processResult.ExitCode);
                 return processResult.ExitCode;
             }
-            else
-            {
-                logger.LogInformation("Podman build for {ImageName} succeeded.", imageName);
-                return processResult.ExitCode;
-            }
+            
+            logger.LogInformation("Podman build for {ImageName} succeeded.", imageName);
+            return processResult.ExitCode;
         }
     }
 

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -150,7 +150,7 @@ internal sealed class ResourceContainerImageBuilder(
         }
     }
 
-    private async Task<string> BuildContainerImageFromDockerfileAsync(string resourceName, string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
+    private async Task BuildContainerImageFromDockerfileAsync(string resourceName, string contextPath, string dockerfilePath, string imageName, CancellationToken cancellationToken)
     {
         var publishingActivity = await activityReporter.CreateActivityAsync(
             $"{resourceName}-build-image",
@@ -167,7 +167,7 @@ internal sealed class ResourceContainerImageBuilder(
                 null => serviceProvider.GetRequiredKeyedService<IContainerRuntime>("docker")
             };
 
-            var image = await containerRuntime.BuildImageAsync(
+            await containerRuntime.BuildImageAsync(
                 contextPath,
                 dockerfilePath,
                 imageName,
@@ -176,8 +176,6 @@ internal sealed class ResourceContainerImageBuilder(
             await activityReporter.UpdateActivityStatusAsync(
                 publishingActivity, (status) => status with { IsComplete = true },
                 cancellationToken).ConfigureAwait(false);
-
-            return image;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Fixes: #9233

This PR changes the implementations of `IContainerRuntime` (for Podman and Docker) so that they publish stdout and stderr messages to the appropriate `ILogger`. This then makes them available for streaming output when using the `aspire publish --debug` command.

We need to make this change because although we provide some debuggability for docker build issues - if the Docker build hangs for whatever reason (unhealthy container runtime as we've seen a few times) or something in the Dockerfile itself, it can be difficult to debug what is going on.

So this PR includes a few elements to make this overall experience better:

1. `DockerContainerRunetime` and `PodmanContainerRuntime` move over to using `ProcessSpec` and friends instead of using `System.Diagnostics.Process` directly. This is to try and introduce more commonality into process launching within the apphost and hopefully reduce potential bugs.
2. Modified the `ResourceContainerImageBuilder` to no longer return the image ID. The reason for this was that if you run the docker build without the `--quiet` switch the image ID isn't output as the last line of STDOUT, its hidden in the STDERR stream and we'd have to do string parsing to pick it out. This wasn't worth retaining as we actually drop it higher up in the call stack.
3. Modified withdockerfile to better support debugging container build issues (just added the compose environment).
4. Publish command; this was actually the biggest change. Once I had the logs streaming back I found that the pretty rendering of publisher status was fighting with the log outputs, so I refactored the code so that the progress display just takes publishing activities and renders them until they complete or this an error. I added another mechanism to process the publishing activities but not display them (since the logs give us what we need) but just to make sure that we don't prematurely request the apphost to stop. This also required hoisting a fair amount of code that was in the Progress(..) call into earlier in the publish command - but to be honest we should have been doing this anyway so its building to a better future.

# `aspire publish`

https://github.com/user-attachments/assets/86562fdd-ad0c-4b55-8831-02173644072c

# `aspire publish --debug`

https://github.com/user-attachments/assets/d6386187-1267-4bbf-94fc-3ec34fce8937

