### PR TITLE
Improve GHA presentation

### DIFF
--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -61,7 +61,7 @@ jobs:
         if: matrix.tests.os == 'ubuntu-latest'
         run: ./dotnet.sh dev-certs https --trust
 
-      - name: Test ${{ matrix.tests.project }}
+      - name: Test ${{ matrix.tests.label }}
         run: |
           ${{ matrix.tests.command }}
 

--- a/.github/workflows/tests-runner.yml
+++ b/.github/workflows/tests-runner.yml
@@ -120,7 +120,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y azure-functions-core-tools-4
 
-      - name: Test ${{ matrix.tests.project }}
+      - name: Test ${{ matrix.tests.label }}
         env:
           CI: false
         run: |
@@ -184,7 +184,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y azure-functions-core-tools-4
 
-      - name: Test ${{ matrix.tests.project }}
+      - name: Test ${{ matrix.tests.label }}
         env:
           CI: false
           BUILT_NUGETS_PATH: ${{ github.workspace }}/artifacts/packages/Release/Shipping

--- a/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
+++ b/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
@@ -123,7 +123,7 @@
         So, instead of using "%(TestToRun.ResultsFilePathWithoutExtension)" (which looks something like "Aspire.Cli.Tests_net8.0_x64")
         we use the project name (which looks something like "Aspire.Cli.Tests").
         -->
-      <_TestRunsheet>$(MSBuildProjectName)</_TestRunsheet>
+      <_TestRunsheet>$([System.String]::Copy('$(MSBuildProjectName)').Replace('Aspire.', ''))</_TestRunsheet>
       <_TestBinLog>$([MSBuild]::NormalizePath($(ArtifactsLogDir), '$(_TestRunsheet).binlog'))</_TestBinLog>
 
       <_RelativeTestProjectPath>$([System.String]::Copy('$(MSBuildProjectFullPath)').Replace('$(RepoRoot)', '%24(pwd)/'))</_RelativeTestProjectPath>
@@ -142,8 +142,8 @@
       <!-- Replace \ with /, and then escape " with \", so we have a compliant JSON -->
       <_TestCommand>$([System.String]::Copy($(_TestCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_TestCommand>
 
-      <_TestRunsheetWindows>{ "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
-      <_TestRunsheetLinux>{ "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
+      <_TestRunsheetWindows>{ "label": "w: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
+      <_TestRunsheetLinux>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
     </PropertyGroup>
 
     <WriteLinesToFile

--- a/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
+++ b/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
@@ -50,9 +50,9 @@
         So, instead of using "%(TestToRun.ResultsFilePathWithoutExtension)" (which looks something like "Aspire.Cli.Tests_net8.0_x64")
         we use the project name (which looks something like "Aspire.Cli.Tests").
         -->
-      <_TestRunsheet>$(MSBuildProjectName)</_TestRunsheet>
-      <_TestRunsheetFileNameWindows>$(ArtifactsTmpDir)\$(_TestRunsheet).win.runsheet.json</_TestRunsheetFileNameWindows>
-      <_TestRunsheetFileNameLinux>$(ArtifactsTmpDir)\$(_TestRunsheet).linux.runsheet.json</_TestRunsheetFileNameLinux>
+      <_TestRunsheet>$([System.String]::Copy('$(MSBuildProjectName)').Replace('Aspire.', ''))</_TestRunsheet>
+      <_TestRunsheetFileNameWindows>$(ArtifactsTmpDir)/$(_TestRunsheet).win.runsheet.json</_TestRunsheetFileNameWindows>
+      <_TestRunsheetFileNameLinux>$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json</_TestRunsheetFileNameLinux>
 
       <_TestBinLog>$([MSBuild]::NormalizePath($(ArtifactsLogDir), '$(_TestRunsheet).binlog'))</_TestBinLog>
 
@@ -70,8 +70,8 @@
       <_PreCommand>$([System.String]::Copy($(_PreCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_PreCommand>
       <_TestCommand>$([System.String]::Copy($(_TestCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_TestCommand>
 
-      <_TestRunsheetWindows>{ "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
-      <_TestRunsheetLinux>{ "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
+      <_TestRunsheetWindows>{ "label": "w: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
+      <_TestRunsheetLinux>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
* Remove "Aspire." prefix from all tests to shorten names
* Add "w/l" (Windows/Linux) label prefix for display purposes

For example: https://github.com/dotnet/aspire/actions/runs/14962844244
![image](https://github.com/user-attachments/assets/6e790cf2-4019-45b0-a2ff-08f5db87fba9)
