### PR TITLE
Fix confusing error message when test project doesn't reference an AppHost project

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
@@ -329,7 +329,7 @@ public static class DistributedApplicationTestingBuilder
                     }
                 }
 
-                throw new InvalidOperationException("No application host assembly was found. Ensure that your project references 'Aspire.Hosting.AppHost'.");
+                throw new InvalidOperationException("No application host assembly was found. Ensure that you have a project that references the 'Aspire.Hosting.AppHost' package and imports the 'Aspire.AppHost.Sdk' SDK.");
             }
 
             static string? GetDcpCliPath(Assembly? assembly)


### PR DESCRIPTION
## Description

As described in issue #8629, there are cases when testing aspire integrations where it may not always be desired to declare an AppHost project, and instead you may want to have your test project being the AppHost itself. For these cases, it is necessary to make sure that both the Aspire SDK is referenced as well as the `Aspire.Hosting.Apphost` NuGet package. Today, the error message is confusing as it only indicates that you need one of those but not both, so this PR updates the error message so that it is more clear that both are required

cc: @afscrome 

Fixes #8629 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
