### PR TITLE
Remove Task.Delay from mongodb tests

### DIFF
--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -179,8 +179,6 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                //mongodb shutdown has delay,so without delay to running instance using same data and second instance failed to start.
-                await Task.Delay(TimeSpan.FromSeconds(10));
                 mongodb2.WithDataBindMount(bindMountPath!);
             }
 


### PR DESCRIPTION
https://github.com/dotnet/aspire/issues/4878 has been resolved, so there is no need for this delay.

Fixes #5199 