### PR TITLE
Fix visibility updates during resource upserts

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -244,9 +244,12 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                         {
                             UpdateFromResource(
                                 resource,
-                                t => AreAllTypesVisible,
-                                s => AreAllStatesVisible,
-                                s => AreAllHealthStatesVisible);
+                                // The new type/state/health status should be visible if it's either
+                                // 1) new, or
+                                // 2) previously visible
+                                t => !PageViewModel.ResourceTypesToVisibility.TryGetValue(t, out var value) || value,
+                                s => !PageViewModel.ResourceStatesToVisibility.TryGetValue(s, out var value) || value,
+                                s => !PageViewModel.ResourceHealthStatusesToVisibility.TryGetValue(s, out var value) || value);
 
                             if (string.Equals(SelectedResource?.Name, resource.Name, StringComparisons.ResourceName))
                             {

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -305,6 +305,53 @@ public partial class ResourcesTests : DashboardTestContext
         Assert.Equal(healthStates, healthSelect.Instance.Values.ToImmutableSortedDictionary() /* sort for equality comparison */);
     }
 
+    [Fact]
+    public void ResourcesShouldRemainUnchangedWhenFilterDoesNotMatchUpdatedResource()
+    {
+        // Arrange
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource("Resource1", "Type1", "Running", null),
+            CreateResource("Resource2", "Type2", "Stopping", null),
+        };
+        var channel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: () => channel);
+
+        ResourceSetupHelpers.SetupResourcesPage(this, viewport, dashboardClient);
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        // Open the resource filter and apply a filter
+        cut.Find("#resourceFilterButton").Click();
+        cut.FindComponents<SelectResourceOptions<string>>()
+            .First(f => f.Instance.Id == "resource-types")
+            .FindComponents<FluentCheckbox>()
+            .First(checkbox => checkbox.Instance.Label == "Type1")
+            .Find("fluent-checkbox")
+            .TriggerEvent("oncheckedchange", new CheckboxChangeEventArgs { Checked = false });
+
+        cut.WaitForState(() => cut.Instance.GetFilteredResources().Count() == 1);
+
+        // Act
+        channel.Writer.TryWrite(new[]
+        {
+            new ResourceViewModelChange(
+                ResourceViewModelChangeType.Upsert,
+                CreateResource("Resource3", "Type3", "Running", null))
+        });
+
+        cut.WaitForState(() => cut.Instance.GetFilteredResources().Count() == 2);
+
+        // Assert
+        var filteredResources = cut.Instance.GetFilteredResources().ToList();
+        Assert.Contains(filteredResources, r => r.Name == "Resource2");
+        Assert.Contains(filteredResources, r => r.Name == "Resource3");
+    }
+
     private static ResourceViewModel CreateResource(string name, string type, string? state, ImmutableArray<HealthReportViewModel>? healthReports)
     {
         return new ResourceViewModel


### PR DESCRIPTION
## Description

Previously, when upserting a resource, the visibility function passed to `UpdateFromResource` would return false in the event that any value in the dictionary was false. For example, if `container` and `project` are values, `container` is marked as hidden (false), and then a resource of type `project` is updated, `project` will then be set to hidden. This is incorrect. Instead, the value should be visible if it was previously visible in the dictionary or if it's new (ie, when stopping a command, you may see the state `Stopping` for the first time).

Fixes #9220

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
