### PR TITLE
Update outerloop workflow

### DIFF
--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -33,7 +33,7 @@ jobs:
           ./build.cmd -test /p:TestRunnerName=QuarantinedTestRunsheetBuilder /p:RunQuarantinedTests=true -c Release -ci /p:CI=false /p:Restore=false /p:Build=false /bl:./artifacts/log/Release/runsheet.binlog
 
       - name: Upload logs, and test results
-        if: ${{ always() }}
+        if: failure()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: logs-runsheet
@@ -55,23 +55,49 @@ jobs:
     if: ${{ github.repository_owner == 'dotnet' }}
 
     steps:
+      - name: Trust HTTPS development certificate
+        if: runner.os == 'Linux'
+        run: dotnet dev-certs https --trust
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Trust HTTPS development certificate (Linux)
-        if: matrix.tests.os == 'ubuntu-latest'
-        run: ./dotnet.sh dev-certs https --trust
+      - name: Verify Docker is running
+        # nested docker containers not supported on windows
+        if: runner.os == 'Linux'
+        run: docker info
+
+      - name: Install Azure Functions Core Tools
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y azure-functions-core-tools-4
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Test ${{ matrix.tests.label }}
+        env:
+          CI: false
         run: |
           ${{ matrix.tests.command }}
 
       - name: Upload logs, and test results
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: ${{ matrix.tests.project }}-${{ matrix.tests.os }}-logs
           path: |
             ${{ github.workspace }}/artifacts/log/*/TestLogs/**/*.log
+            ${{ github.workspace }}/artifacts/TestResults/*/*.dmp
+          # Longer retention time to allow scanning runs for quarantined test results
+          retention-days: 30
+
+      - name: Trx results
+        if: always()
+        id: upload-logs
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: ${{ matrix.tests.project }}-${{ matrix.tests.os }}-trx
+          path: |
             ${{ github.workspace }}/artifacts/TestResults/*/*.trx
           # Longer retention time to allow scanning runs for quarantined test results
           retention-days: 30
@@ -82,96 +108,18 @@ jobs:
     name: Final Results
     needs: run_tests
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       # get all the test-job-result* artifacts into a single directory
+      # note: download after the checkout, otherwise the checkout will clear the downloaded
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          pattern: '*-logs'
-          path: ${{ github.workspace }}/artifacts/all-logs
+          pattern: '*-trx'
+          path: ${{ github.workspace }}/artifacts/all-trx
 
-      - name: Process logs and post results
-        if: ${{ always() && github.repository_owner == 'dotnet' }}
-        shell: pwsh
-        run: |
-          $logDirectory = "${{ github.workspace }}/artifacts/all-logs"
-          $trxFiles = Get-ChildItem -Path $logDirectory -Filter *.trx -Recurse
-
-          $testResults = @() # Initialize an array to store test results
-
-          foreach ($trxFile in $trxFiles) {
-            # Determine the OS based on the file path
-            if ($trxFile.FullName -match "ubuntu") {
-                $OS = "ubuntu"
-            } elseif ($trxFile.FullName -match "windows") {
-                $OS = "windows"
-            } else {
-                $OS = "unknown"
-            }
-
-            # Load the .trx file as XML
-            try {
-                # Attempt to load the .trx file as XML
-                $xmlContent = [xml](Get-Content -Path $trxFile.FullName)
-
-                # Extract test results from the XML
-                foreach ($testResult in $xmlContent.TestRun.Results.UnitTestResult) {
-                    $testName = $testResult.testName
-                    $outcome = $testResult.outcome
-                    $duration = $testResult.duration
-
-                    # Map outcome to emoji
-                    switch ($outcome) {
-                        "Passed" { $emoji = "✅" }
-                        "Failed" { $emoji = "❌" }
-                        default { $emoji = "❔" }
-                    }
-
-                    # Normalize the duration to a consistent format (hh:mm:ss.fff)
-                    $normalizedDuration = [TimeSpan]::Parse($duration).ToString("mm\:ss\.fff")
-
-                    # Add the test result to the array
-                    $testResults += [PSCustomObject]@{
-                        TestName    = $testName
-                        Outcome     = $outcome
-                        OutcomeIcon = $emoji
-                        Duration    = $normalizedDuration
-                        OS          = $OS
-                    }
-                }
-            } catch {
-                Write-Host "::error::Failed to process $($trxFile.FullName): $($_.Exception.Message)"
-            }
-          }
-
-          if ($testResults.Length -lt 1) {
-              Write-Host "::notice::Tests Summary: no quaratined tests found"
-              return;
-          }
-
-          # Sort the test results by test name
-          $testResults = $testResults | Sort-Object -Property TestName
-
-          # Calculate summary statistics
-          $totalTests = $testResults.Count
-          $passedTests = ($testResults | Where-Object { $_.Outcome -eq "Passed" }).Count
-          $failedTests = ($testResults | Where-Object { $_.Outcome -eq "Failed" }).Count
-          $skippedTests = ($testResults | Where-Object { $_.Outcome -eq "NotExecuted" }).Count
-
-          # Add the summary to the annotation
-          $summary = "total: $totalTests, passed: $passedTests, failed: $failedTests, skipped: $skippedTests"
-          if ($failedTests -gt 0) {
-              Write-Host "::error::Tests Summary: $summary"
-          } else {
-              Write-Host "::notice::Tests Summary: $summary"
-          }
-
-          # Format the test results as a console-friendly table
-          $tableHeader = "{0,-12} {1,-10} {2,-140} {3,-16}" -f "Result", "OS", "Test Name", "Duration"
-          $tableSeparator = "-" * 190
-          $tableRows = $testResults | ForEach-Object { "{0,-12} {1,-10} {2,-140} {3,-16}" -f "$($_.OutcomeIcon) $($_.Outcome)", $_.OS, $_.TestName, $_.Duration }
-          $table = "$tableHeader`n$tableSeparator`n" + ($tableRows -join "`n") + "`n$tableSeparator`n"
-          Write-Host "`nTest Results:`n`n$table"
-
-          # Optionally, save the results to a file for further processing
-          $outputPath = "${{ github.workspace }}/artifacts/summary.log"
-          $table | Out-File -FilePath $outputPath -Encoding utf8
-          Write-Host "Test results saved to $outputPath"
+      - name: Generate test results summary
+        if: always()
+        env:
+          CI: false
+        run: >
+          ${{ github.workspace }}/dotnet.sh run --project ${{ github.workspace }}/tools/GenerateTestSummary/GenerateTestSummary.csproj -- ${{ github.workspace }}/artifacts/all-trx --combined

--- a/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
+++ b/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
@@ -124,6 +124,9 @@
         we use the project name (which looks something like "Aspire.Cli.Tests").
         -->
       <_TestRunsheet>$([System.String]::Copy('$(MSBuildProjectName)').Replace('Aspire.', ''))</_TestRunsheet>
+      <_TestRunsheetFileNameWindows>$(ArtifactsTmpDir)/$(_TestRunsheet).win.runsheet.json</_TestRunsheetFileNameWindows>
+      <_TestRunsheetFileNameLinux>$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json</_TestRunsheetFileNameLinux>
+
       <_TestBinLog>$([MSBuild]::NormalizePath($(ArtifactsLogDir), '$(_TestRunsheet).binlog'))</_TestBinLog>
 
       <_RelativeTestProjectPath>$([System.String]::Copy('$(MSBuildProjectFullPath)').Replace('$(RepoRoot)', '%24(pwd)/'))</_RelativeTestProjectPath>
@@ -133,6 +136,8 @@
       <_TestRunnerLinux>./eng/build.sh</_TestRunnerLinux>
       <_TestCommand>-restore -build -test -projects &quot;$(_RelativeTestProjectPath)&quot; /bl:&quot;$(_RelativeTestBinLog)&quot; -c $(Configuration) -ci /p:RunQuarantinedTests=true /p:CI=false</_TestCommand>
 
+      <_PreCommand>$(TestRunnerPreCommand)</_PreCommand>
+
       <!--
         Some quarantinted test may only be executable on Windows or Linux, however we can't possibly know that at this time.
         The MTP runner will return exit code 8 if no tests are found, and we need to ignore it instead of failing the test.
@@ -140,22 +145,30 @@
       <_TestCommand>$(_TestCommand) /p:IgnoreZeroTestResult=true</_TestCommand>
 
       <!-- Replace \ with /, and then escape " with \", so we have a compliant JSON -->
+      <_PreCommand>$([System.String]::Copy($(_PreCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_PreCommand>
       <_TestCommand>$([System.String]::Copy($(_TestCommand)).Replace("\", "/").Replace('&quot;', '\&quot;'))</_TestCommand>
 
       <_TestRunsheetWindows>{ "label": "w: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
-      <_TestRunsheetLinux>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
+      <_TestRunsheetLinux>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
     </PropertyGroup>
+
+    <ItemGroup>
+      <_OutputFiles Include="$(_TestRunsheetFileNameWindows)" />
+      <_OutputFiles Include="$(_TestRunsheetFileNameLinux)" />
+    </ItemGroup>
+
+    <MakeDir Directories="@(_OutputFiles->'%(RootDir)%(Directory)')"/>
+    <Delete Files="@(_OutputFiles)" />
 
     <WriteLinesToFile
             Condition=" '$(RunOnGithubActionsWindows)' == 'true' and  '$(_HasQuarantinedTests)' == 'true'"
-            File="$(ArtifactsTmpDir)/$(_TestRunsheet).win.runsheet.json"
+            File="$(_TestRunsheetFileNameWindows)"
             Lines="$(_TestRunsheetWindows)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
-
     <WriteLinesToFile
             Condition=" '$(RunOnGithubActionsLinux)' == 'true' and '$(_HasQuarantinedTests)' == 'true' "
-            File="$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json"
+            File="$(_TestRunsheetFileNameLinux)"
             Lines="$(_TestRunsheetLinux)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
@@ -164,10 +177,10 @@
       On Linux there's a bug in MSBuild, which "normalises" all slashes (see https://github.com/dotnet/msbuild/issues/3468).
       This is a workaround to replace `/"` with the required `\"`.
       -->
-    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).win.runsheet.json') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).win.runsheet.json'&quot; "
-          Condition=" '$(RunOnGithubActionsWindows)' == 'true' and '$(_HasQuarantinedTests)' == 'true' and '$(BuildOs)' != 'windows' " />
-    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json'&quot; "
-          Condition=" '$(RunOnGithubActionsLinux)' == 'true' and '$(_HasQuarantinedTests)' == 'true' and '$(BuildOs)' != 'windows' " />
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameWindows)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameWindows)'&quot; "
+          Condition=" Exists('$(_TestRunsheetFileNameWindows)') and '$(BuildOs)' != 'windows' " />
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameLinux)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameLinux)'&quot; "
+          Condition=" Exists('$(_TestRunsheetFileNameLinux)') and '$(BuildOs)' != 'windows' " />
 
     <!--
       The final piece of the puzzle is in eng/AfterSolutionBuild.targets, where we combine the runsheets from all the test projects into a single runsheet.

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -35,7 +35,7 @@ public class AppHostTests
     {
         var appHostType = testEndpoints.AppHostType!;
         var resourceEndpoints = testEndpoints.ResourceEndpoints!;
-        var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostType, _testOutput);
+        var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostType, _testOutput, testEndpoints.EnableParameterRandomisation);
         var projects = appHost.Resources.OfType<ProjectResource>();
         await using var app = await appHost.BuildAsync();
 
@@ -144,6 +144,7 @@ public class AppHostTests
             //    whenReady: TestEventHubsAppHost),
             new TestEndpoints(typeof(Projects.Redis_AppHost),
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/garnet/ping", "/garnet/get", "/garnet/set", "/redis/ping", "/redis/get", "/redis/set", "/valkey/ping", "/valkey/get", "/valkey/set"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("redis", "Ready to accept connections tcp"),
                     new ("valkey", "Ready to accept connections tcp"),
@@ -152,11 +153,13 @@ public class AppHostTests
                 ]),
             new TestEndpoints(typeof(Projects.AzureStorageEndToEnd_AppHost),
                 resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("storage", "Azurite Table service is successfully listening")
                 ]),
             new TestEndpoints(typeof(Projects.MilvusPlayground_AppHost),
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/create", "/search"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("milvus", "Milvus Proxy successfully initialized and ready to serve"),
                 ]),
@@ -166,12 +169,14 @@ public class AppHostTests
             //    // "/ef" - disabled due to https://github.com/dotnet/aspire/issues/5415
             //    waitForTexts: [
             //        new ("cosmos", "Started$"),
-            //        new ("api", "Application started")
+            //        new("api", "Application started")
             //    ]),
             new TestEndpoints(typeof(Projects.Keycloak_AppHost),
-                resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } }),
+                resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } },
+                enableParameterRandomisation: false),
             new TestEndpoints(typeof(Projects.Mongo_AppHost),
                 resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("mongo", "Waiting for connections"),
                     new ("mongo-mongoexpress", "Mongo Express server listening"),
@@ -179,6 +184,7 @@ public class AppHostTests
                 ]),
             new TestEndpoints(typeof(Projects.MySqlDb_AppHost),
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/catalog"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("mysql", "ready for connections.* port: 33060"),
                     new ("apiservice", "Application started")
@@ -188,12 +194,14 @@ public class AppHostTests
                     { "api", ["/alive", "/health"] },
                     { "backend", ["/alive", "/health"] }
                 },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("nats", "Server is ready"),
                     new("api", "Application started")
                 ]),
             new TestEndpoints(typeof(Projects.ParameterEndToEnd_AppHost),
                 resourceEndpoints: new() { { "api", ["/", "/alive", "/health"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("sql", "SQL Server is now ready for client connections."),
                 ]),
@@ -202,6 +210,7 @@ public class AppHostTests
                     // Invoking "/" first as that *creates* the databases
                     { "api", ["/", "/alive", "/health"] }
                 },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("pg1", "PostgreSQL init process complete; ready for start up"),
                     new ("pg2", "PostgreSQL init process complete; ready for start up"),
@@ -213,6 +222,7 @@ public class AppHostTests
                 ]),
             new TestEndpoints(typeof(Projects.ProxylessEndToEnd_AppHost),
                 resourceEndpoints: new() { { "api", ["/alive", "/health", "/redis"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("redis", "Ready to accept connections"),
                     new("api", "Application started"),
@@ -220,12 +230,14 @@ public class AppHostTests
                 ]),
             new TestEndpoints(typeof(Projects.Qdrant_AppHost),
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("qdrant", "Qdrant HTTP listening"),
                     new ("apiservice", "Application started")
                 ]),
             new TestEndpoints(typeof(Projects.Seq_AppHost),
                 resourceEndpoints: new() { { "api", ["/alive", "/health"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("seq", "Seq listening"),
                     new ("api", "Application started")
@@ -233,6 +245,7 @@ public class AppHostTests
             // Invoke "/" first to create the databases
             new TestEndpoints(typeof(Projects.SqlServerEndToEnd_AppHost),
                 resourceEndpoints: new() { { "api", ["/", "/alive", "/health"] } },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("sql1", "SQL Server is now ready for client connections"),
                     new ("sql2", "SQL Server is now ready for client connections"),
@@ -242,6 +255,7 @@ public class AppHostTests
                     { "catalogdbapp", ["/alive", "/health"] },
                     { "frontend", ["/alive", "/health"] }
                 },
+                enableParameterRandomisation: false,
                 waitForTexts: [
                     new ("messaging", "started TCP listener"),
                     new ("basketcache", "Ready to accept connections"),
@@ -279,14 +293,18 @@ public class TestEndpoints
 {
     public TestEndpoints(Type appHostType,
                          Dictionary<string, List<string>> resourceEndpoints,
+                         bool enableParameterRandomisation,
                          List<ReadyStateText>? waitForTexts = null)
     {
         AppHostType = appHostType;
         ResourceEndpoints = resourceEndpoints;
         WaitForTexts = waitForTexts;
+        EnableParameterRandomisation = enableParameterRandomisation;
     }
 
     public Type AppHostType { get; set; }
+
+    public bool EnableParameterRandomisation { get; set; }
 
     public List<ResourceWait>? WaitForResources { get; set; }
 

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -17,6 +17,7 @@ using Xunit.Sdk;
 
 namespace Aspire.Playground.Tests;
 
+[Collection("AppHostTests")]
 [RequiresDocker]
 public class AppHostTests
 {
@@ -29,9 +30,21 @@ public class AppHostTests
     }
 
     [Theory]
-    [MemberData(nameof(TestEndpoints))]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/6866")]
+    [MemberData(nameof(TestEndpoints_Data))]
     public async Task TestEndpointsReturnOk(TestEndpoints testEndpoints)
+    {
+        await TestEndpointsReturnOkAsync(testEndpoints);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestEndpoints_FlakyData))]
+    [QuarantinedTest("Flaky tests")]
+    public async Task TestEndpointsReturnOk_flaky(TestEndpoints testEndpoints)
+    {
+        await TestEndpointsReturnOkAsync(testEndpoints);
+    }
+
+    private async Task TestEndpointsReturnOkAsync(TestEndpoints testEndpoints)
     {
         var appHostType = testEndpoints.AppHostType!;
         var resourceEndpoints = testEndpoints.ResourceEndpoints!;
@@ -128,150 +141,9 @@ public class AppHostTests
                 });
         });
 
-    public static IList<TestEndpoints> GetAllTestEndpoints()
+    public static TheoryData<TestEndpoints> TestEndpoints_Data()
     {
-        IList<TestEndpoints> candidates =
-        [
-            // Disable due to https://github.com/dotnet/aspire/issues/5959
-            //new TestEndpoints(typeof(Projects.EventHubs.AppHost",
-            //    resourceEndpoints: new() { { "api", ["/alive", "/health"] } },
-            //    waitForTexts: [
-            //        new ("eventhubns", "Emulator Service is Successfully Up"),
-            //        new ("eventhubns-storage", "Azurite Table service is successfully listening"),
-            //        new ("ehstorage", "Azurite Table service is successfully listening"),
-            //        new ("consumer", "Completed retrieving properties for Event Hub")
-            //    ],
-            //    whenReady: TestEventHubsAppHost),
-            new TestEndpoints(typeof(Projects.Redis_AppHost),
-                resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/garnet/ping", "/garnet/get", "/garnet/set", "/redis/ping", "/redis/get", "/redis/set", "/valkey/ping", "/valkey/get", "/valkey/set"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("redis", "Ready to accept connections tcp"),
-                    new ("valkey", "Ready to accept connections tcp"),
-                    new ("garnet", "Ready to accept connections"),
-                    new ("apiservice", "Application started")
-                ]),
-            new TestEndpoints(typeof(Projects.AzureStorageEndToEnd_AppHost),
-                resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("storage", "Azurite Table service is successfully listening")
-                ]),
-            new TestEndpoints(typeof(Projects.MilvusPlayground_AppHost),
-                resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/create", "/search"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("milvus", "Milvus Proxy successfully initialized and ready to serve"),
-                ]),
-            // Cosmos emulator is extremely slow to start up and unreliable in CI
-            //new TestEndpoints(typeof(Projects.CosmosEndToEnd_AppHost),
-            //    resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
-            //    // "/ef" - disabled due to https://github.com/dotnet/aspire/issues/5415
-            //    waitForTexts: [
-            //        new ("cosmos", "Started$"),
-            //        new("api", "Application started")
-            //    ]),
-            new TestEndpoints(typeof(Projects.Keycloak_AppHost),
-                resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } },
-                enableParameterRandomisation: false),
-            new TestEndpoints(typeof(Projects.Mongo_AppHost),
-                resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("mongo", "Waiting for connections"),
-                    new ("mongo-mongoexpress", "Mongo Express server listening"),
-                    new("api", "Application started.")
-                ]),
-            new TestEndpoints(typeof(Projects.MySqlDb_AppHost),
-                resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/catalog"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("mysql", "ready for connections.* port: 33060"),
-                    new ("apiservice", "Application started")
-                ]),
-            new TestEndpoints(typeof(Projects.Nats_AppHost),
-                resourceEndpoints: new() {
-                    { "api", ["/alive", "/health"] },
-                    { "backend", ["/alive", "/health"] }
-                },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("nats", "Server is ready"),
-                    new("api", "Application started")
-                ]),
-            new TestEndpoints(typeof(Projects.ParameterEndToEnd_AppHost),
-                resourceEndpoints: new() { { "api", ["/", "/alive", "/health"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("sql", "SQL Server is now ready for client connections."),
-                ]),
-            new TestEndpoints(typeof(Projects.PostgresEndToEnd_AppHost),
-                resourceEndpoints: new() {
-                    // Invoking "/" first as that *creates* the databases
-                    { "api", ["/", "/alive", "/health"] }
-                },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("pg1", "PostgreSQL init process complete; ready for start up"),
-                    new ("pg2", "PostgreSQL init process complete; ready for start up"),
-                    new ("pg3", "PostgreSQL init process complete; ready for start up"),
-                    new ("pg4", "PostgreSQL init process complete; ready for start up"),
-                    new ("pg5", "PostgreSQL init process complete; ready for start up"),
-                    new ("pg6", "PostgreSQL init process complete; ready for start up"),
-                    new ("pg10", "PostgreSQL init process complete; ready for start up"),
-                ]),
-            new TestEndpoints(typeof(Projects.ProxylessEndToEnd_AppHost),
-                resourceEndpoints: new() { { "api", ["/alive", "/health", "/redis"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("redis", "Ready to accept connections"),
-                    new("api", "Application started"),
-                    new("api2", "Application started")
-                ]),
-            new TestEndpoints(typeof(Projects.Qdrant_AppHost),
-                resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("qdrant", "Qdrant HTTP listening"),
-                    new ("apiservice", "Application started")
-                ]),
-            new TestEndpoints(typeof(Projects.Seq_AppHost),
-                resourceEndpoints: new() { { "api", ["/alive", "/health"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("seq", "Seq listening"),
-                    new ("api", "Application started")
-                ]),
-            // Invoke "/" first to create the databases
-            new TestEndpoints(typeof(Projects.SqlServerEndToEnd_AppHost),
-                resourceEndpoints: new() { { "api", ["/", "/alive", "/health"] } },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("sql1", "SQL Server is now ready for client connections"),
-                    new ("sql2", "SQL Server is now ready for client connections"),
-                ]),
-            new TestEndpoints(typeof(Projects.TestShop_AppHost),
-                resourceEndpoints: new() {
-                    { "catalogdbapp", ["/alive", "/health"] },
-                    { "frontend", ["/alive", "/health"] }
-                },
-                enableParameterRandomisation: false,
-                waitForTexts: [
-                    new ("messaging", "started TCP listener"),
-                    new ("basketcache", "Ready to accept connections"),
-                    new ("frontend", "Application started"),
-                    new ("catalogdbapp", "Application started"),
-                    new ("basketservice", "Application started"),
-                    new ("postgres", "database system is ready to accept connections"),
-                ]),
-        ];
-
-        return candidates;
-    }
-
-    public static TheoryData<TestEndpoints> TestEndpoints()
-    {
-        TheoryData<TestEndpoints> theoryData = new();
+        TheoryData<TestEndpoints> theoryData = [];
         foreach (var candidateTestEndpoint in GetAllTestEndpoints())
         {
             if (string.IsNullOrEmpty(s_appHostNameFilter) || candidateTestEndpoint.AppHostType?.Name.Contains(s_appHostNameFilter, StringComparison.OrdinalIgnoreCase) == true)
@@ -286,46 +158,219 @@ public class AppHostTests
         }
 
         return theoryData;
-    }
-}
 
-public class TestEndpoints
-{
-    public TestEndpoints(Type appHostType,
-                         Dictionary<string, List<string>> resourceEndpoints,
-                         bool enableParameterRandomisation,
-                         List<ReadyStateText>? waitForTexts = null)
-    {
-        AppHostType = appHostType;
-        ResourceEndpoints = resourceEndpoints;
-        WaitForTexts = waitForTexts;
-        EnableParameterRandomisation = enableParameterRandomisation;
-    }
-
-    public Type AppHostType { get; set; }
-
-    public bool EnableParameterRandomisation { get; set; }
-
-    public List<ResourceWait>? WaitForResources { get; set; }
-
-    public List<ReadyStateText>? WaitForTexts { get; set; }
-
-    public Dictionary<string, List<string>>? ResourceEndpoints { get; set; }
-
-    public override string? ToString() => $"{AppHostType} ({ResourceEndpoints?.Count ?? 0} resources)";
-
-    public class ResourceWait(string resourceName, string targetState)
-    {
-        public string ResourceName { get; } = resourceName;
-
-        public string TargetState { get; } = targetState;
-
-        public void Deconstruct(out string resourceName, out string targetState)
+        static IList<TestEndpoints> GetAllTestEndpoints()
         {
-            resourceName = ResourceName;
-            targetState = TargetState;
+            IList<TestEndpoints> candidates =
+            [
+                new TestEndpoints(typeof(Projects.Redis_AppHost),
+                    resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/garnet/ping", "/garnet/get", "/garnet/set", "/redis/ping", "/redis/get", "/redis/set", "/valkey/ping", "/valkey/get", "/valkey/set"] } },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("redis", "Ready to accept connections tcp"),
+                        new ("valkey", "Ready to accept connections tcp"),
+                        new ("garnet", "Ready to accept connections"),
+                        new ("apiservice", "Application started")
+                    ]),
+                new TestEndpoints(typeof(Projects.AzureStorageEndToEnd_AppHost),
+                    resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("storage", "Azurite Table service is successfully listening")
+                    ]),
+                new TestEndpoints(typeof(Projects.MilvusPlayground_AppHost),
+                    resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/create", "/search"] } },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("milvus", "Milvus Proxy successfully initialized and ready to serve"),
+                    ]),
+                new TestEndpoints(typeof(Projects.Keycloak_AppHost),
+                    resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } },
+                    enableParameterRandomisation: false),
+                new TestEndpoints(typeof(Projects.Mongo_AppHost),
+                    resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("mongo", "Waiting for connections"),
+                        new ("mongo-mongoexpress", "Mongo Express server listening"),
+                        new("api", "Application started.")
+                    ]),
+                new TestEndpoints(typeof(Projects.MySqlDb_AppHost),
+                    resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/catalog"] } },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("mysql", "ready for connections.* port: 33060"),
+                        new ("apiservice", "Application started")
+                    ]),
+                new TestEndpoints(typeof(Projects.Nats_AppHost),
+                    resourceEndpoints: new() {
+                        { "api", ["/alive", "/health"] },
+                        { "backend", ["/alive", "/health"] }
+                    },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("nats", "Server is ready"),
+                        new("api", "Application started")
+                    ]),
+                new TestEndpoints(typeof(Projects.ParameterEndToEnd_AppHost),
+                    resourceEndpoints: new() { { "api", ["/", "/alive", "/health"] } },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("sql", "SQL Server is now ready for client connections."),
+                    ]),
+                new TestEndpoints(typeof(Projects.PostgresEndToEnd_AppHost),
+                    resourceEndpoints: new() {
+                        // Invoking "/" first as that *creates* the databases
+                        { "api", ["/", "/alive", "/health"] }
+                    },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("pg1", "PostgreSQL init process complete; ready for start up"),
+                        new ("pg2", "PostgreSQL init process complete; ready for start up"),
+                        new ("pg3", "PostgreSQL init process complete; ready for start up"),
+                        new ("pg4", "PostgreSQL init process complete; ready for start up"),
+                        new ("pg5", "PostgreSQL init process complete; ready for start up"),
+                        new ("pg6", "PostgreSQL init process complete; ready for start up"),
+                        new ("pg10", "PostgreSQL init process complete; ready for start up"),
+                    ]),
+                new TestEndpoints(typeof(Projects.ProxylessEndToEnd_AppHost),
+                    resourceEndpoints: new() { { "api", ["/alive", "/health", "/redis"] } },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("redis", "Ready to accept connections"),
+                        new("api", "Application started"),
+                        new("api2", "Application started")
+                    ]),
+                new TestEndpoints(typeof(Projects.Qdrant_AppHost),
+                    resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("qdrant", "Qdrant HTTP listening"),
+                        new ("apiservice", "Application started")
+                    ]),
+                new TestEndpoints(typeof(Projects.Seq_AppHost),
+                    resourceEndpoints: new() { { "api", ["/alive", "/health"] } },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("seq", "Seq listening"),
+                        new ("api", "Application started")
+                    ]),
+                new TestEndpoints(typeof(Projects.TestShop_AppHost),
+                    resourceEndpoints: new() {
+                        { "catalogdbapp", ["/alive", "/health"] },
+                        { "frontend", ["/alive", "/health"] }
+                    },
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("messaging", "started TCP listener"),
+                        new ("basketcache", "Ready to accept connections"),
+                        new ("frontend", "Application started"),
+                        new ("catalogdbapp", "Application started"),
+                        new ("basketservice", "Application started"),
+                        new ("postgres", "database system is ready to accept connections"),
+                    ]),
+            ];
+
+            return candidates;
         }
     }
 
-    public record class ReadyStateText(string ResourceName, string Pattern);
+    public static TheoryData<TestEndpoints> TestEndpoints_FlakyData()
+    {
+        TheoryData<TestEndpoints> theoryData = [];
+        foreach (var candidateTestEndpoint in GetAllFlakyTestEndpoints())
+        {
+            if (string.IsNullOrEmpty(s_appHostNameFilter) || candidateTestEndpoint.AppHostType?.Name.Contains(s_appHostNameFilter, StringComparison.OrdinalIgnoreCase) == true)
+            {
+                theoryData.Add(candidateTestEndpoint);
+            }
+        }
+
+        if (!theoryData.Any() && !string.IsNullOrEmpty(s_appHostNameFilter))
+        {
+            Assert.Skip($"No test endpoints found matching filter '{s_appHostNameFilter}'");
+        }
+
+        return theoryData;
+
+        static IList<TestEndpoints> GetAllFlakyTestEndpoints()
+        {
+            IList<TestEndpoints> candidates =
+            [
+                // Disable due to https://github.com/dotnet/aspire/issues/5959
+                //new TestEndpoints(typeof(Projects.EventHubs.AppHost",
+                //    resourceEndpoints: new() { { "api", ["/alive", "/health"] } },
+                //    enableParameterRandomisation: false,
+                //    waitForTexts: [
+                //        new ("eventhubns", "Emulator Service is Successfully Up"),
+                //        new ("eventhubns-storage", "Azurite Table service is successfully listening"),
+                //        new ("ehstorage", "Azurite Table service is successfully listening"),
+                //        new ("consumer", "Completed retrieving properties for Event Hub")
+                //    ],
+                //    whenReady: TestEventHubsAppHost),
+
+                // Cosmos emulator is extremely slow to start up and unreliable in CI
+                new TestEndpoints(typeof(Projects.CosmosEndToEnd_AppHost),
+                    resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } }, // "/ef" - disabled due to https://github.com/dotnet/aspire/issues/5415
+                    enableParameterRandomisation: false,
+                    waitForTexts: [
+                        new ("cosmos", "Started$"),
+                        new("api", "Application started")
+                    ]),
+
+                // Disabled due to https://github.com/dotnet/aspire/issues/9274
+                // Invoke "/" first to create the databases
+                //new TestEndpoints(typeof(Projects.SqlServerEndToEnd_AppHost),
+                //    resourceEndpoints: new() { { "api", ["/", "/alive", "/health"] } },
+                //    enableParameterRandomisation: false,
+                //    waitForTexts: [
+                //        new ("sql1", "SQL Server is now ready for client connections"),
+                //        new ("sql2", "SQL Server is now ready for client connections"),
+                //    ]),
+            ];
+
+            return candidates;
+        }
+    }
+
+    public class TestEndpoints
+    {
+        public TestEndpoints(Type appHostType,
+                             Dictionary<string, List<string>> resourceEndpoints,
+                             bool enableParameterRandomisation,
+                             List<ReadyStateText>? waitForTexts = null)
+        {
+            AppHostType = appHostType;
+            ResourceEndpoints = resourceEndpoints;
+            WaitForTexts = waitForTexts;
+            EnableParameterRandomisation = enableParameterRandomisation;
+        }
+
+        public Type AppHostType { get; set; }
+
+        public bool EnableParameterRandomisation { get; set; }
+
+        public List<ResourceWait>? WaitForResources { get; set; }
+
+        public List<ReadyStateText>? WaitForTexts { get; set; }
+
+        public Dictionary<string, List<string>>? ResourceEndpoints { get; set; }
+
+        public override string? ToString() => $"{AppHostType} ({ResourceEndpoints?.Count ?? 0} resources)";
+
+        public class ResourceWait(string resourceName, string targetState)
+        {
+            public string ResourceName { get; } = resourceName;
+
+            public string TargetState { get; } = targetState;
+
+            public void Deconstruct(out string resourceName, out string targetState)
+            {
+                resourceName = ResourceName;
+                targetState = TargetState;
+            }
+        }
+
+        public record class ReadyStateText(string ResourceName, string Pattern);
+    }
 }

--- a/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
+++ b/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
@@ -15,7 +15,7 @@ internal static class DistributedApplicationTestFactory
     /// <summary>
     /// Creates an <see cref="IDistributedApplicationTestingBuilder"/> for the specified app host assembly.
     /// </summary>
-    public static async Task<IDistributedApplicationTestingBuilder> CreateAsync(Type appHostProgramType, ITestOutputHelper? testOutput)
+    public static async Task<IDistributedApplicationTestingBuilder> CreateAsync(Type appHostProgramType, ITestOutputHelper? testOutput, bool enableParameterRandomisation)
     {
         var builder = await DistributedApplicationTestingBuilder.CreateAsync(appHostProgramType);
 
@@ -24,7 +24,11 @@ internal static class DistributedApplicationTestFactory
         // always override.
         builder.Services.AddLifecycleHook<ContainerRegistryHook>();
 
-        builder.WithRandomParameterValues();
+        if (enableParameterRandomisation)
+        {
+            builder.WithRandomParameterValues();
+        }
+
         builder.WithRandomVolumeNames();
 
         builder.Services.AddLogging(logging =>

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Aspire.Playground.Tests;
 
+[Collection("AppHostTests")]
 [RequiresDocker]
 public class ProjectSpecificTests(ITestOutputHelper _testOutput)
 {

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -19,7 +19,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/9171")]
     public async Task WithDockerfileTest()
     {
-        var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.WithDockerfile_AppHost), _testOutput);
+        var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.WithDockerfile_AppHost), _testOutput, enableParameterRandomisation: false);
         await using var app = await appHost.BuildAsync();
 
         await app.StartAsync();
@@ -36,7 +36,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/6867")]
     public async Task KafkaTest()
     {
-        var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.KafkaBasic_AppHost), _testOutput);
+        var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.KafkaBasic_AppHost), _testOutput, enableParameterRandomisation: false);
         await using var app = await appHost.BuildAsync();
 
         await app.StartAsync();
@@ -63,7 +63,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     [ActiveIssue("https://github.com/dotnet/aspire/issues/9243")]
     public async Task AzureFunctionsTest()
     {
-        var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.AzureFunctionsEndToEnd_AppHost), _testOutput);
+        var appHost = await DistributedApplicationTestFactory.CreateAsync(typeof(Projects.AzureFunctionsEndToEnd_AppHost), _testOutput, enableParameterRandomisation: false);
         await using var app = await appHost.BuildAsync();
 
         await app.StartAsync();


### PR DESCRIPTION
* Tweak the outerloop workflow to align with the interloop runsheet-based workflow. That is, include the "pre-command". Also, add the new GHA test reporter built by @radical. Test run: https://github.com/RussKie/aspire/actions/runs/14984406738
* Explicitly opt-in to parameter randomisation. Resolves #9193
* Restructure playground's AppHostTests
	* Move known flaky/unhealthy tests into own theory. This allows other
tests can be executed in the interloop run, and the flaky to be constrained to the outerloop.
	* Disable SqlServerEndToEnd test, see #9274
	* Add collections to serialise test execution