### PR TITLE
[CI] Add PR validation on macOS

### DIFF
--- a/.github/actions/enumerate-tests/action.yml
+++ b/.github/actions/enumerate-tests/action.yml
@@ -69,7 +69,7 @@ runs:
         "integrations_tests_matrix=$jsonString"
         "integrations_tests_matrix=$jsonString" | Out-File -FilePath $env:GITHUB_OUTPUT
 
-    - name: Generate tests matrix
+    - name: Generate templates matrix
       id: generate_templates_matrix
       if: ${{ inputs.includeTemplates }}
       shell: pwsh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -59,7 +59,7 @@ jobs:
           }
 
       - name: Setup vars (Linux)
-        if: ${{ inputs.os == 'ubuntu-latest' }}
+        if: ${{ inputs.os == 'ubuntu-latest' || inputs.os == 'macos-latest' }}
         run: |
           echo "DOTNET_SCRIPT=./dotnet.sh" >> $GITHUB_ENV
           echo "BUILD_SCRIPT=./build.sh" >> $GITHUB_ENV
@@ -277,7 +277,7 @@ jobs:
           path: result-*.rst
 
       - name: Dump docker info
-        if: always()
+        if: ${{ always() && inputs.os == 'ubuntu-latest' }}
         run: |
           docker container ls --all
           docker container ls --all --format json

--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -103,6 +103,8 @@ jobs:
                 $OS = "ubuntu"
             } elseif ($trxFile.FullName -match "windows") {
                 $OS = "windows"
+            } elseif ($trxFile.FullName -match "macos") {
+                $OS = "macos"
             } else {
                 $OS = "unknown"
             }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,22 @@ jobs:
           includeIntegrations: true
           includeTemplates: true
 
+  setup_for_tests_macos:
+    name: Setup for tests (macOS)
+    if: ${{ github.repository_owner == 'dotnet' }}
+    runs-on: macos-latest
+    outputs:
+      integrations_tests_matrix: ${{ steps.generate_tests_matrix.outputs.integrations_tests_matrix }}
+      templates_tests_matrix: ${{ steps.generate_tests_matrix.outputs.templates_tests_matrix }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: ./.github/actions/enumerate-tests
+        id: generate_tests_matrix
+        with:
+          includeIntegrations: true
+          includeTemplates: true
+
   setup_for_tests_win:
     name: Setup for tests (Windows)
     if: ${{ github.repository_owner == 'dotnet' }}
@@ -84,6 +100,19 @@ jobs:
       os: "ubuntu-latest"
       extraTestArgs: "--filter-not-trait \"quarantined=true\""
 
+  integrations_test_macos:
+    uses: ./.github/workflows/run-tests.yml
+    name: Integrations macos
+    needs: setup_for_tests_macos
+    strategy:
+      fail-fast: false
+      matrix:
+        ${{ fromJson(needs.setup_for_tests_macos.outputs.integrations_tests_matrix) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      os: "macos-latest"
+      extraTestArgs: "--filter-not-trait \"quarantined=true\""
+
   integrations_test_win:
     uses: ./.github/workflows/run-tests.yml
     name: Integrations Windows
@@ -114,6 +143,23 @@ jobs:
       requiresNugets: true
       requiresTestSdk: true
 
+  templates_test_macos:
+    name: Templates macos
+    uses: ./.github/workflows/run-tests.yml
+    needs: [setup_for_tests_macos, build_packages]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup_for_tests_macos.outputs.templates_tests_matrix) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      os: "macos-latest"
+      testProjectPath: tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
+      testSessionTimeout: 20m
+      testHangTimeout: 12m
+      extraTestArgs: "--filter-not-trait quarantined=true --filter-class Aspire.Templates.Tests.${{ matrix.shortname }}"
+      requiresNugets: true
+      requiresTestSdk: true
+
   templates_test_win:
     name: Templates Windows
     uses: ./.github/workflows/run-tests.yml
@@ -137,7 +183,7 @@ jobs:
     needs: build_packages
     with:
       testShortName: EndToEnd
-      # EndToEnd is not run on Windows due to missing Docker support
+      # EndToEnd is not run on Windows/macOS due to missing Docker support
       os: ubuntu-latest
       testProjectPath: tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
       requiresNugets: true
@@ -146,7 +192,7 @@ jobs:
     if: ${{ always() && github.repository_owner == 'dotnet' }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [ integrations_test_lin, integrations_test_win, templates_test_lin, templates_test_win, endtoend_tests ]
+    needs: [ integrations_test_lin, integrations_test_win, integrations_test_macos, templates_test_lin, templates_test_win, templates_test_macos, endtoend_tests ]
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -169,6 +215,12 @@ jobs:
           pattern: logs-*-windows-latest
           merge-multiple: true
           path: ${{ github.workspace }}/testresults/windows-latest
+
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          pattern: logs-*-macos-latest
+          merge-multiple: true
+          path: testresults/macos-latest
 
       - name: Upload test results
         if: always()

--- a/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
+++ b/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
@@ -131,6 +131,7 @@
 
       <_TestRunnerWindows>./eng/build.ps1</_TestRunnerWindows>
       <_TestRunnerLinux>./eng/build.sh</_TestRunnerLinux>
+      <_TestRunnerMacOS>./eng/build.sh</_TestRunnerMacOS>
       <_TestCommand>-restore -build -test -projects &quot;$(_RelativeTestProjectPath)&quot; /bl:&quot;$(_RelativeTestBinLog)&quot; -c $(Configuration) -ci /p:RunQuarantinedTests=true /p:CI=false</_TestCommand>
 
       <!--
@@ -144,6 +145,7 @@
 
       <_TestRunsheetWindows>{ "label": "w: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
       <_TestRunsheetLinux>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
+      <_TestRunsheetMacOS>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
     </PropertyGroup>
 
     <WriteLinesToFile
@@ -152,11 +154,16 @@
             Lines="$(_TestRunsheetWindows)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
-
     <WriteLinesToFile
             Condition=" '$(RunOnGithubActionsLinux)' == 'true' and '$(_HasQuarantinedTests)' == 'true' "
             File="$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json"
             Lines="$(_TestRunsheetLinux)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile
+            Condition=" '$(RunOnGithubActionsMacOS)' == 'true' and '$(_HasQuarantinedTests)' == 'true' "
+            File="$(ArtifactsTmpDir)/$(_TestRunsheet).macos.runsheet.json"
+            Lines="$(_TestRunsheetMacOS)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
 
@@ -168,6 +175,8 @@
           Condition=" '$(RunOnGithubActionsWindows)' == 'true' and '$(_HasQuarantinedTests)' == 'true' and '$(BuildOs)' != 'windows' " />
     <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json'&quot; "
           Condition=" '$(RunOnGithubActionsLinux)' == 'true' and '$(_HasQuarantinedTests)' == 'true' and '$(BuildOs)' != 'windows' " />
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).macos.runsheet.json') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(ArtifactsTmpDir)/$(_TestRunsheet).macos.runsheet.json'&quot; "
+          Condition=" '$(RunOnGithubActionsMacOS)' == 'true' and '$(_HasQuarantinedTests)' == 'true' and '$(BuildOs)' != 'windows' " />
 
     <!--
       The final piece of the puzzle is in eng/AfterSolutionBuild.targets, where we combine the runsheets from all the test projects into a single runsheet.

--- a/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
+++ b/eng/QuarantinedTestRunsheetBuilder/QuarantinedTestRunsheetBuilder.targets
@@ -145,7 +145,7 @@
 
       <_TestRunsheetWindows>{ "label": "w: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
       <_TestRunsheetLinux>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
-      <_TestRunsheetMacOS>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
+      <_TestRunsheetMacOS>{ "label": "m: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
     </PropertyGroup>
 
     <WriteLinesToFile

--- a/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
+++ b/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
@@ -74,7 +74,7 @@
 
       <_TestRunsheetWindows>{ "label": "w: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
       <_TestRunsheetLinux>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
-      <_TestRunsheetMacOS>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
+      <_TestRunsheetMacOS>{ "label": "m: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
+++ b/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
@@ -74,7 +74,7 @@
 
       <_TestRunsheetWindows>{ "label": "w: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
       <_TestRunsheetLinux>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
-      <_TestRunsheetMacOS>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
+      <_TestRunsheetMacOS>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "macos-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
+++ b/eng/TestRunsheetBuilder/TestRunsheetBuilder.targets
@@ -53,6 +53,7 @@
       <_TestRunsheet>$([System.String]::Copy('$(MSBuildProjectName)').Replace('Aspire.', ''))</_TestRunsheet>
       <_TestRunsheetFileNameWindows>$(ArtifactsTmpDir)/$(_TestRunsheet).win.runsheet.json</_TestRunsheetFileNameWindows>
       <_TestRunsheetFileNameLinux>$(ArtifactsTmpDir)/$(_TestRunsheet).linux.runsheet.json</_TestRunsheetFileNameLinux>
+      <_TestRunsheetFileNameMacOS>$(ArtifactsTmpDir)/$(_TestRunsheet).macos.runsheet.json</_TestRunsheetFileNameMacOS>
 
       <_TestBinLog>$([MSBuild]::NormalizePath($(ArtifactsLogDir), '$(_TestRunsheet).binlog'))</_TestBinLog>
 
@@ -61,6 +62,7 @@
 
       <_TestRunnerWindows>./eng/build.ps1</_TestRunnerWindows>
       <_TestRunnerLinux>./eng/build.sh</_TestRunnerLinux>
+      <_TestRunnerMacOS>./eng/build.sh</_TestRunnerMacOS>
       <_TestCommand>-restore -build -test -projects &quot;$(_RelativeTestProjectPath)&quot; /bl:&quot;$(_RelativeTestBinLog)&quot; -c $(Configuration) -ci</_TestCommand>
 
       <!-- Tests requiring packages must be run in the "out of repo" mode -->
@@ -72,11 +74,13 @@
 
       <_TestRunsheetWindows>{ "label": "w: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "windows-latest", "command": "./eng/build.ps1 $(_TestCommand)" }</_TestRunsheetWindows>
       <_TestRunsheetLinux>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetLinux>
+      <_TestRunsheetMacOS>{ "label": "l: $(_TestRunsheet)", "project": "$(_TestRunsheet)", "os": "ubuntu-latest", "command": "$(_PreCommand)./eng/build.sh $(_TestCommand)" }</_TestRunsheetMacOS>
     </PropertyGroup>
 
     <ItemGroup>
       <_OutputFiles Include="$(_TestRunsheetFileNameWindows)" />
       <_OutputFiles Include="$(_TestRunsheetFileNameLinux)" />
+      <_OutputFiles Include="$(_TestRunsheetFileNameMacOS)" />
     </ItemGroup>
 
     <MakeDir Directories="@(_OutputFiles->'%(RootDir)%(Directory)')"/>
@@ -94,6 +98,12 @@
             Lines="$(_TestRunsheetLinux)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile
+            Condition=" '$(RunOnGithubActionsMacOS)' == 'true' and '$(_CreateRunsheet)' == 'true' "
+            File="$(_TestRunsheetFileNameMacOS)"
+            Lines="$(_TestRunsheetMacOS)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true" />
 
     <!--
       On Linux there's a bug in MSBuild, which "normalises" all slashes (see https://github.com/dotnet/msbuild/issues/3468).
@@ -103,6 +113,8 @@
           Condition=" Exists('$(_TestRunsheetFileNameWindows)') and '$(BuildOs)' != 'windows' " />
     <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameLinux)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameLinux)'&quot; "
           Condition=" Exists('$(_TestRunsheetFileNameLinux)') and '$(BuildOs)' != 'windows' " />
+    <Exec Command="pwsh -Command &quot;(Get-Content -Path '$(_TestRunsheetFileNameMacOS)') -replace '/\&quot;', '\\\&quot;' | Set-Content -Path '$(_TestRunsheetFileNameMacOS)'&quot; "
+          Condition=" Exists('$(_TestRunsheetFileNameMacOS)') and '$(BuildOs)' != 'windows' " />
 
     <!--
       The final piece of the puzzle is in eng/AfterSolutionBuild.targets, where we combine the runsheets from all the test projects into a single runsheet.

--- a/eng/Testing.props
+++ b/eng/Testing.props
@@ -5,6 +5,7 @@
     <!-- By default any test can run on all test platforms -->
     <RunOnGithubActionsWindows>true</RunOnGithubActionsWindows>
     <RunOnGithubActionsLinux>true</RunOnGithubActionsLinux>
+    <RunOnGithubActionsMacOS>true</RunOnGithubActionsMacOS>
     <RunOnAzdoCIWindows>true</RunOnAzdoCIWindows>
     <RunOnAzdoCILinux>true</RunOnAzdoCILinux>
     <RunOnAzdoHelixWindows>true</RunOnAzdoHelixWindows>

--- a/eng/Testing.targets
+++ b/eng/Testing.targets
@@ -11,8 +11,9 @@
         - IncludeTestUtilities:        indicates whether the test project must not include the TestUtilities project reference; default is false; overridable.
 
       Project requirements:
-        - RunOnGithubActions:          indicates whether tests should run on GitHub Actions (either Windows or Linux); computed.
+        - RunOnGithubActions:          indicates whether tests should run on GitHub Actions (either Windows or Linux or macOS); computed.
         - RunOnGithubActionsWindows:   indicates whether tests should run on Windows in GitHub Actions; default is true; overridable.
+        - RunOnGithubActionsMacOS:     indicates whether tests should run on MacOS in GitHub Actions; default is true; overridable.
         - RunOnGithubActionsLinux:     indicates whether tests should run on Linux in GitHub Actions; default is true; overridable.
         - RunOnAzdoCI:                 indicates whether tests should run on Azure DevOps (either Windows or Linux); always false, if RunOnAzdoHelix=true; computed.
         - RunOnAzdoCIWindows:          indicates whether tests should run on Windows in Azure DevOps; default is true; overridable.
@@ -42,7 +43,7 @@
 
   <PropertyGroup>
     <RunOnGithubActions>false</RunOnGithubActions>
-    <RunOnGithubActions Condition=" '$(RunOnGithubActionsWindows)' == 'true' or '$(RunOnGithubActionsLinux)' == 'true' ">true</RunOnGithubActions>
+    <RunOnGithubActions Condition=" '$(RunOnGithubActionsWindows)' == 'true' or '$(RunOnGithubActionsLinux)' == 'true' or '$(RunOnGithubActionsMacOS)' == 'true' ">true</RunOnGithubActions>
 
     <RunOnAzdoHelix>false</RunOnAzdoHelix>
     <RunOnAzdoHelix Condition=" '$(RunOnAzdoHelixWindows)' == 'true' or '$(RunOnAzdoHelixLinux)' == 'true' ">true</RunOnAzdoHelix>
@@ -90,7 +91,7 @@
       <_Runner Include=" - GitHub Actions: $(_IsGitHubActionsRunner)" />
       <_Runner Include=" - Azure DevOps: $(_IsAzdoCIRunner)" />
       <_Runner Include=" - Helix: $(_IsAzdoHelixRunner)" />
-      <_Requirement Include=" - GitHub Actions: $(RunOnGithubActions) (Windows: $(RunOnGithubActionsWindows) / Linux: $(RunOnGithubActionsLinux))" />
+      <_Requirement Include=" - GitHub Actions: $(RunOnGithubActions) (Windows: $(RunOnGithubActionsWindows) / Linux: $(RunOnGithubActionsLinux) / MacOS: $(RunOnGithubActionsMacOS))" />
       <_Requirement Include=" - Azure DevOps: $(RunOnAzdoCI) (Windows: $(RunOnAzdoCIWindows) / Linux: $(RunOnAzdoCILinux))" />
       <_Requirement Include=" - Helix: $(RunOnAzdoHelix) (Windows: $(RunOnAzdoHelixWindows) / Linux: $(RunOnAzdoHelixLinux))" />
     </ItemGroup>

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
+using Aspire.TestUtilities;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -75,6 +76,7 @@ public class FormatHelpersTests
     [InlineData("15/06/2009 1:45:30.1234567 pm", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
     [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
     [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/9151", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOS))]
     public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -65,7 +65,7 @@ public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9152")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/9152", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOS))]
     public async Task AppBar_Change_Theme_ReloadPage()
     {
         // Arrange

--- a/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
+++ b/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <!-- Only run on Linux; no docker support on Windows yet -->
     <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
+    <!-- Issue: https://github.com/dotnet/aspire/issues/9198 -->
+    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
     <RunOnAzdoCIWindows>false</RunOnAzdoCIWindows>
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>
 

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -11,6 +11,7 @@
 
     <!-- Only run on Linux; no docker support on Windows yet -->
     <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
+    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
     <RunOnAzdoCIWindows>false</RunOnAzdoCIWindows>
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>
 
@@ -20,7 +21,7 @@
 
       FIXME: temporary workaround for https://github.com/Azure/azure-functions-dotnet-worker/issues/2969
      -->
-    <TestRunnerPreCommand>./dotnet.sh build &quot;%24(pwd)/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj&quot; -c $(Configuration) /p:SkipUnstableEmulators=true &amp;&amp; </TestRunnerPreCommand>
+    <TestRunnerPreCommand>./dotnet.sh build &quot;%24(pwd)/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj&quot; -c $(Configuration) /p:SkipUnstableEmulators=true /p:CI=false &amp;&amp; </TestRunnerPreCommand>
 
     <DeployOutsideOfRepoSupportFilesRelativeDir>staging-archive\</DeployOutsideOfRepoSupportFilesRelativeDir>
 

--- a/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
@@ -113,6 +113,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/9155", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOS))]
     public async Task ProjectWithNoHTTPSRequiresExplicitOverrideWithEnvironmentVariable()
     {
         string id = GetNewProjectId(prefix: "aspire");

--- a/tests/Aspire.TestUtilities/PlatformDetection.cs
+++ b/tests/Aspire.TestUtilities/PlatformDetection.cs
@@ -14,4 +14,5 @@ public static class PlatformDetection
 
     public static bool IsWindows => OperatingSystem.IsWindows();
     public static bool IsLinux => OperatingSystem.IsLinux();
+    public static bool IsMacOS => OperatingSystem.IsMacOS();
 }

--- a/tests/Aspire.TestUtilities/RequiresDockerAttribute.cs
+++ b/tests/Aspire.TestUtilities/RequiresDockerAttribute.cs
@@ -20,8 +20,7 @@ public class RequiresDockerAttribute : Attribute, ITraitAttribute
     //                - https://github.com/dotnet/aspire/issues/4291
     // - Linux - Local, or CI: always assume that docker is installed
     public static bool IsSupported =>
-        !OperatingSystem.IsWindows() ||
-        !PlatformDetection.IsRunningOnCI;
+        OperatingSystem.IsLinux() || !PlatformDetection.IsRunningOnCI; // non-linux on CI does not support docker
 
     public string? Reason { get; init; }
     public RequiresDockerAttribute(string? reason = null)

--- a/tests/Aspire.TestUtilities/RequiresSSLCertificateAttribute.cs
+++ b/tests/Aspire.TestUtilities/RequiresSSLCertificateAttribute.cs
@@ -8,8 +8,8 @@ namespace Aspire.TestUtilities;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
 public class RequiresSSLCertificateAttribute(string? reason = null) : Attribute, ITraitAttribute
 {
-    // Not supported on Windows CI
-    public static bool IsSupported => !PlatformDetection.IsRunningOnCI || !OperatingSystem.IsWindows();
+    // Always supported on linux (local and CI), but only local otherwise
+    public static bool IsSupported => OperatingSystem.IsLinux() || !PlatformDetection.IsRunningOnCI;
 
     public string? Reason { get; init; } = reason;
 

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -36,7 +36,7 @@
     <Error Condition="'$(ExtractTestClassNamesPrefix)' == ''"
            Text="%24(ExtractTestClassNamesPrefix) should be set, for example - Aspire.Templates.Tests" />
 
-    <Exec Command="&quot;$(RunCommand)&quot; --filter-not-trait category=failing --list-tests" ConsoleToMSBuild="true" EnvironmentVariables="DOTNET_ROOT=$(DotNetRoot);DOTNET_ROOT_X86=$(DotNetRoot)x86">
+    <Exec Command="&quot;$(RunCommand)&quot; --filter-not-trait category=failing --list-tests" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" ItemName="_ListOfTestsLines" />
     </Exec>
 
@@ -61,8 +61,9 @@
 
   <Target Name="GetRunTestsOnGithubActions" Returns="@(TestProject)">
     <ItemGroup>
-      <TestProject Condition="'$(OS)' == 'Windows_NT'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsWindows)" />
-      <TestProject Condition="'$(OS)' != 'Windows_NT'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsLinux)" />
+      <TestProject Condition="'$(BuildOs)' == 'windows'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsWindows)" />
+      <TestProject Condition="'$(BuildOs)' == 'linux'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsLinux)" />
+      <TestProject Condition="'$(BuildOs)' == 'darwin'" Include="$(MSBuildProjectFullPath)" RunTestsOnGithubActions="$(RunOnGithubActionsMacOS)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This is reverting "Revert "[CI] Add PR validation on macOS (#9175)" (#9208)" commit e5b2802e701ee644049eeb963fbe64f4cd756b15.

This is from the original commit message:

* [tests] Run tests workflow on macos

* Adjust RequiresDocker and RequiresSSLCertificate to skip macos

* Disable tests failing on macos

* Don't override DOTNET_ROOT when getting list of tests

* Skip playground tests on windows and macos

.. and add RunOnGithubActionsMacOS

* Update runsheet runners

* fixup! Update runsheet runners

* fixup! Update runsheet runners

* Address review feedback from @ russkie

* Address review feedback from @ russkie - skip E2E tests on macos as they

.. are timing out.

Issue: https://github.com/dotnet/aspire/issues/9198

* Add missing CI: false for outerloop test runs

Fixes
```
/home/runner/work/aspire/aspire/eng/Versions.targets(49,67): error MSB4057: The target "GitInfo" does not exist in the project. [/home/runner/work/aspire/aspire/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Microsoft.Extensions.ServiceDiscovery.Abstractions.csproj]
/home/runner/work/aspire/aspire/eng/Versions.targets(49,67): error MSB4057: The target "GitInfo" does not exist in the project. [/home/runner/work/aspire/aspire/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Microsoft.Extensions.ServiceDiscovery.Abstractions.csproj]
/home/runner/work/aspire/aspire/eng/Versions.targets(49,67): error MSB4057: The target "GitInfo" does not exist in the project. [/home/runner/work/aspire/aspire/src/Tools/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj]
/home/runner/work/aspire/aspire/eng/Versions.targets(49,67): error MSB4057: The target "GitInfo" does not exist in the project. [/home/runner/work/aspire/aspire/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Microsoft.Extensions.ServiceDiscovery.Abstractions.csproj]
/home/runner/work/aspire/aspire/eng/Versions.targets(49,67): error MSB4057: The target "GitInfo" does not exist in the project. [/home/runner/work/aspire/aspire/src/Tools/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj]
```

* Add macos to the quarantined tests report generator

---------

Co-authored-by: Igor Velikorossov <igor.velikorossov@microsoft.com>
Co-authored-by: Igor Velikorossov <RussKie@users.noreply.github.com>
