### PR TITLE
Test that ensures legacy dashboard token env var is honored

### DIFF
--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -650,15 +650,17 @@ public class DistributedApplicationTests
         }
     }
 
-    [Fact]
-    public async Task StartAsync_DashboardAuthConfig_PassedToDashboardProcess()
+    [Theory]
+    [InlineData(KnownConfigNames.DashboardFrontendBrowserToken)]
+    [InlineData(KnownConfigNames.Legacy.DashboardFrontendBrowserToken)]
+    public async Task StartAsync_DashboardAuthConfig_PassedToDashboardProcess(string tokenEnvVarName)
     {
         const string testName = "dashboard-auth-config";
         var browserToken = "ThisIsATestToken";
         var args = new string[] {
             $"{KnownConfigNames.AspNetCoreUrls}=http://localhost:0",
             $"{KnownConfigNames.DashboardOtlpGrpcEndpointUrl}=http://localhost:0",
-            $"{KnownConfigNames.DashboardFrontendBrowserToken}={browserToken}"
+            $"{tokenEnvVarName}={browserToken}"
         };
         using var testProgram = CreateTestProgram(testName, args: args, disableDashboard: false);
 


### PR DESCRIPTION
## Description

Updates a test to ensure the dashboard honors the legacy environment variable for the dashboard token.

Fixes #8487