### PR TITLE
Minor improvements to resource changed log

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -541,6 +541,7 @@ public class ResourceNotificationService : IDisposable
                     "ResourceType = {ResourceType}, " +
                     "CreationTimeStamp = {CreationTimeStamp:s}, " +
                     "State = {{ Text = {StateText}, Style = {StateStyle} }}, " +
+                    "IsHidden = {IsHidden}, " +
                     "HeathStatus = {HealthStatus}, " +
                     "ResourceReady = {ResourceReady}, " +
                     "ExitCode = {ExitCode}, " +
@@ -548,8 +549,7 @@ public class ResourceNotificationService : IDisposable
                     "EnvironmentVariables = {{ {EnvironmentVariables} }}, " +
                     "Properties = {{ {Properties} }}, " +
                     "HealthReports = {{ {HealthReports} }}, " +
-                    "Commands = {{ {Commands} }}, " +
-                    "IsHidden = {{ {IsHidden} }}",
+                    "Commands = {{ {Commands} }}",
                     newState.Version,
                     resource.Name,
                     resourceId,
@@ -557,6 +557,7 @@ public class ResourceNotificationService : IDisposable
                     newState.CreationTimeStamp,
                     newState.State?.Text,
                     newState.State?.Style,
+                    newState.IsHidden,
                     newState.HealthStatus,
                     newState.ResourceReadyEvent is not null,
                     newState.ExitCode,
@@ -564,8 +565,7 @@ public class ResourceNotificationService : IDisposable
                     string.Join(" ", newState.EnvironmentVariables.Where(e => e.IsFromSpec).Select(e => $"{e.Name} = {e.Value}")),
                     string.Join(" ", newState.Properties.Select(p => $"{p.Name} = {Stringify(p.Value)}")),
                     string.Join(" ", newState.HealthReports.Select(p => $"{p.Name} = {Stringify(p.Status)}")),
-                    string.Join(" ", newState.Commands.Select(c => $"{c.DisplayName} ({c.Name}) = {Stringify(c.State)}")),
-                    newState.IsHidden);
+                    string.Join(" ", newState.Commands.Select(c => $"{c.Name} ({c.DisplayName}) = {Stringify(c.State)}")));
 
                 static string Stringify(object? o) => o switch
                 {


### PR DESCRIPTION
## Description

* Remove extra braces around IsHidden
* Move IsHidden next to state
* Make commands consistent with other name values by making name come first

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
