### PR TITLE
Don't throw from component telemetry context dispose if not initialized

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ComponentTelemetryContext.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ComponentTelemetryContext.cs
@@ -92,7 +92,7 @@ public sealed class ComponentTelemetryContext : IDisposable
     {
         if (_telemetryService == null)
         {
-            throw new InvalidOperationException("InitializeAsync has not been called");
+            throw new InvalidOperationException("InitializeAsync has not been called.");
         }
 
         _telemetryService.PostOperation(

--- a/src/Aspire.Dashboard/Components/Pages/ComponentTelemetryContext.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ComponentTelemetryContext.cs
@@ -41,8 +41,6 @@ public sealed class ComponentTelemetryContext : IDisposable
     // Internal for testing
     internal Dictionary<string, AspireTelemetryProperty> Properties { get; } = [];
 
-    private DashboardTelemetryService TelemetryService => _telemetryService ?? throw new ArgumentNullException(nameof(_telemetryService), "InitializeAsync has not been called");
-
     public void Initialize(DashboardTelemetryService telemetryService, string? browserUserAgent)
     {
         _telemetryService = telemetryService;
@@ -92,7 +90,12 @@ public sealed class ComponentTelemetryContext : IDisposable
 
     private void PostProperties()
     {
-        TelemetryService.PostOperation(
+        if (_telemetryService == null)
+        {
+            throw new InvalidOperationException("InitializeAsync has not been called");
+        }
+
+        _telemetryService.PostOperation(
             TelemetryEventKeys.ParametersSet,
             TelemetryResult.Success,
             properties: Properties,
@@ -103,7 +106,7 @@ public sealed class ComponentTelemetryContext : IDisposable
     {
         if (!_disposed)
         {
-            TelemetryService.PostOperation(
+            _telemetryService?.PostOperation(
                 TelemetryEventKeys.ComponentDispose,
                 TelemetryResult.Success,
                 properties: new Dictionary<string, AspireTelemetryProperty>

--- a/tests/Aspire.Dashboard.Tests/Telemetry/ComponentTelemetryContextTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Telemetry/ComponentTelemetryContextTests.cs
@@ -13,6 +13,7 @@ public class ComponentTelemetryContextTests
     [Fact]
     public async Task ComponentTelemetryContext_TelemetryEnabled_EndToEnd()
     {
+        // Arrange
         var telemetryContext = new ComponentTelemetryContext(nameof(ComponentTelemetryContextTests));
         var telemetrySender = new TestDashboardTelemetrySender { IsTelemetryEnabled = true };
         var telemetryService = new DashboardTelemetryService(NullLogger<DashboardTelemetryService>.Instance, telemetrySender);
@@ -20,6 +21,7 @@ public class ComponentTelemetryContextTests
         telemetryContextProvider.SetBrowserUserAgent("mozilla");
         await telemetryService.InitializeAsync();
 
+        // Act & assert initialize
         telemetryContextProvider.Initialize(telemetryContext);
         for (var i = 0; i < telemetryService.GetDefaultProperties().Count; i++)
         {
@@ -35,6 +37,7 @@ public class ComponentTelemetryContextTests
 
         OperationContext? parametersUpdateOperation;
 
+        // Act & assert update properties
         telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("Value"))]);
         Assert.Equal(3, telemetryContext.Properties.Count);
         Assert.True(telemetrySender.ContextChannel.Reader.TryRead(out parametersUpdateOperation));
@@ -50,6 +53,7 @@ public class ComponentTelemetryContextTests
         Assert.Equal(3, telemetryContext.Properties.Count);
         Assert.True(telemetrySender.ContextChannel.Reader.TryRead(out parametersUpdateOperation));
 
+        // Act & assert dispose
         telemetryContext.Dispose();
         Assert.True(telemetrySender.ContextChannel.Reader.TryRead(out var disposeOperation));
         Assert.Equal("/telemetry/operation - $aspire/dashboard/component/dispose", disposeOperation.Name);
@@ -58,6 +62,7 @@ public class ComponentTelemetryContextTests
     [Fact]
     public async Task ComponentTelemetryContext_TelemetryDisabled_EndToEnd()
     {
+        // Arrange
         var telemetryContext = new ComponentTelemetryContext(nameof(ComponentTelemetryContextTests));
         var telemetrySender = new TestDashboardTelemetrySender { IsTelemetryEnabled = false };
         var telemetryService = new DashboardTelemetryService(NullLogger<DashboardTelemetryService>.Instance, telemetrySender);
@@ -65,14 +70,27 @@ public class ComponentTelemetryContextTests
         telemetryContextProvider.SetBrowserUserAgent("mozilla");
         await telemetryService.InitializeAsync();
 
+        // Act & assert initialize
         telemetryContextProvider.Initialize(telemetryContext);
         Assert.False(telemetrySender.ContextChannel.Reader.TryRead(out _));
 
+        // Act & assert update properties
         telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("Value"))]);
         Assert.Equal(3, telemetryContext.Properties.Count);
         Assert.False(telemetrySender.ContextChannel.Reader.TryRead(out _));
 
+        // Act & assert dispose
         telemetryContext.Dispose();
         Assert.False(telemetrySender.ContextChannel.Reader.TryRead(out _));
+    }
+
+    [Fact]
+    public void ComponentTelemetryContext_DisposeWithoutInitialize_NoThrow()
+    {
+        // Arrange
+        var telemetryContext = new ComponentTelemetryContext(nameof(ComponentTelemetryContextTests));
+
+        // Act
+        telemetryContext.Dispose();
     }
 }


### PR DESCRIPTION
## Description

I noticed that `ComponentTelemetryContext.Dispose()` would throw if called without the context being initialized. This could happen if there is an error in a component before initialization and then the context is dispose with the component.

It's a bug but not a critical one. Requires other things to go wrong first.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
