### PR TITLE
Increase retry time in AppBar_Change_Theme_ReloadPage

### DIFF
--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -104,7 +104,8 @@ public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
 
                 await AsyncTestHelpers.AssertIsTrueRetryAsync(
                     async () => await checkbox.IsCheckedAsync(),
-                    "Checkbox isn't immediately checked.");
+                    "Checkbox isn't immediately checked.",
+                    retries: 15 /* this seems to take a very long time to run, so needs a long timeout */);
             }
         });
     }

--- a/tests/Shared/AsyncTestHelpers.cs
+++ b/tests/Shared/AsyncTestHelpers.cs
@@ -195,18 +195,16 @@ internal static class AsyncTestHelpers
         ? $"The operation timed out after reaching the limit of {timeout.TotalMilliseconds}ms."
         : $"The operation at {filePath}:{lineNumber} timed out after reaching the limit of {timeout.TotalMilliseconds}ms.";
 
-    public static Task AssertIsTrueRetryAsync(Func<bool> assert, string message, ILogger? logger = null)
+    public static Task AssertIsTrueRetryAsync(Func<bool> assert, string message, ILogger? logger = null, int retries = 10)
     {
-        return AssertIsTrueRetryAsync(() => Task.FromResult(assert()), message, logger);
+        return AssertIsTrueRetryAsync(() => Task.FromResult(assert()), message, logger, retries);
     }
 
-    public static async Task AssertIsTrueRetryAsync(Func<Task<bool>> assert, string message, ILogger? logger = null)
+    public static async Task AssertIsTrueRetryAsync(Func<Task<bool>> assert, string message, ILogger? logger = null, int retries = 10)
     {
-        const int Retries = 10;
-
         logger?.LogInformation("Start: " + message);
 
-        for (var i = 0; i < Retries; i++)
+        for (var i = 0; i < retries; i++)
         {
             if (i > 0)
             {
@@ -220,6 +218,6 @@ internal static class AsyncTestHelpers
             }
         }
 
-        throw new InvalidOperationException($"Assert failed after {Retries} retries: {message}");
+        throw new InvalidOperationException($"Assert failed after {retries} retries: {message}");
     }
 }


### PR DESCRIPTION
## Description

This test seems to take a looong time to complete even on hardware (~15-20 seconds). Based on the test failing on the test runner, I think we just need to increase the timeout. A lot.

Fixes #9152

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
