### PR TITLE
TestsReportGenerator: Always show the error message, and truncate only the stdout

### DIFF
--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -367,6 +367,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9340")]
     public async Task TestServicesWithMultipleReplicas()
     {
         var replicaCount = 3;

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
@@ -11,6 +11,7 @@ public class YarpFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
     [RequiresDocker]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9344")]
     public async Task VerifyYarpResource()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));

--- a/tools/GenerateTestSummary/TestSummaryGenerator.cs
+++ b/tools/GenerateTestSummary/TestSummaryGenerator.cs
@@ -147,7 +147,7 @@ sealed partial class TestSummaryGenerator
                 reportBuilder.AppendLine();
                 reportBuilder.AppendLine("```yml");
 
-                reportBuilder.AppendLine(test.Output?.ErrorInfo?.InnerText ?? string.Empty);
+                reportBuilder.AppendLine(test.Output?.ErrorInfo?.InnerText);
                 if (test.Output?.StdOut is not null)
                 {
                     reportBuilder.AppendLine();

--- a/tools/GenerateTestSummary/TestSummaryGenerator.cs
+++ b/tools/GenerateTestSummary/TestSummaryGenerator.cs
@@ -144,21 +144,17 @@ sealed partial class TestSummaryGenerator
 
                 """);
 
-                var errorMsgBuilder = new StringBuilder();
-                errorMsgBuilder.AppendLine(test.Output?.ErrorInfo?.InnerText ?? string.Empty);
-                if (test.Output?.StdOut is not null)
-                {
-                    errorMsgBuilder.AppendLine();
-                    errorMsgBuilder.AppendLine("### StdOut");
-                    errorMsgBuilder.AppendLine(test.Output.StdOut);
-                }
-
-                // Truncate long error messages for readability
-                var errorMsgTruncated = TruncateTheStart(errorMsgBuilder.ToString(), 50_000);
-
                 reportBuilder.AppendLine();
                 reportBuilder.AppendLine("```yml");
-                reportBuilder.AppendLine(errorMsgTruncated);
+
+                reportBuilder.AppendLine(test.Output?.ErrorInfo?.InnerText ?? string.Empty);
+                if (test.Output?.StdOut is not null)
+                {
+                    reportBuilder.AppendLine();
+                    reportBuilder.AppendLine("### StdOut");
+                    reportBuilder.AppendLine(TruncateTheStart(test.Output.StdOut, 50_000));
+                }
+
                 reportBuilder.AppendLine("```");
                 reportBuilder.AppendLine();
                 reportBuilder.AppendLine("</div>");


### PR DESCRIPTION
The combined error message and stdout were being truncated, which meant that the former would not show, like:

<img width="1792" alt="Screenshot 2025-05-15 at 14 31 58" src="https://github.com/user-attachments/assets/f53c5232-b05b-4f02-88e3-af3cc8a16472" />

Also:
- Quarantine Aspire.Hosting.Tests.DistributedApplicationTests.TestServicesWithMultipleReplicas - https://github.com/dotnet/aspire/issues/9340
- Quarantine YarpFunctionalTests.VerifyYarpResource - https://github.com/dotnet/aspire/issues/9344
