### PR TITLE
Revert "Update xUnit.v3 to support MTP tests (#9261)"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "dotnet.previewSolution-freeWorkspaceMode": true,
-    "dotnet.testWindow.useTestingPlatformProtocol": true,
     "dotnet.defaultSolution": "./Aspire.slnx",
-    "dotnet.preview.enableSupportForSlnx": true
+    "dotnet.preview.enableSupportForSlnx": true,
+    "dotnet.testWindow.useTestingPlatformProtocol": false
 }

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,9 +12,9 @@
     <DotNetRuntimePreviousVersionForTesting>8.0.13</DotNetRuntimePreviousVersionForTesting>
     <!-- dotnet 8.0 versions for running tests - used for templates tests -->
     <DotNetSdkPreviousVersionForTesting>8.0.406</DotNetSdkPreviousVersionForTesting>
-    <XunitV3Version>2.0.2</XunitV3Version>
-    <XUnitAnalyzersVersion>1.21.0</XUnitAnalyzersVersion>
-    <XunitRunnerVisualStudioVersion>3.1.0</XunitRunnerVisualStudioVersion>
+    <XunitV3Version>2.0.0</XunitV3Version>
+    <XUnitAnalyzersVersion>1.20.0</XUnitAnalyzersVersion>
+    <XunitRunnerVisualStudioVersion>3.0.2</XunitRunnerVisualStudioVersion>
     <MicrosoftTestingPlatformVersion>1.6.3</MicrosoftTestingPlatformVersion>
     <MicrosoftNETTestSdkVersion>17.13.0</MicrosoftNETTestSdkVersion>
     <!-- Enable to remove prerelease label. -->


### PR DESCRIPTION
This reverts commit 0c5232d22d5b64055f46a8d404cafe3b350a9d4b.

This [broke the azdo builds](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1042724&view=logs&j=acc6f692-388e-5b31-5997-e154da29f5b3&t=2599f547-658e-512e-9bd7-e71978f5caa2) with:
```
  You must install or update .NET to run this application.

  App: /mnt/vss/_work/1/s/artifacts/bin/Aspire.Templates.Tests/Release/net8.0/Aspire.Templates.Tests
  Architecture: x64
  Framework: 'Microsoft.NETCore.App', version '8.0.0' (x64)
  .NET location: /usr/lib/dotnet

  The following frameworks were found:
    6.0.36 at [/usr/lib/dotnet/shared/Microsoft.NETCore.App]

  Learn about framework resolution:
  https://aka.ms/dotnet/app-launch-failed

  To install missing framework, download:
  https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=8.0.0&arch=x64&rid=ubuntu.22.04-x64
/mnt/vss/_work/1/s/tests/Directory.Build.targets(39,5): error MSB3073: The command ""/mnt/vss/_work/1/s/artifacts/bin/Aspire.Templates.Tests/Release/net8.0/Aspire.Templates.Tests" --filter-not-trait category=failing --list-tests" exited with code 150. [/mnt/vss/_work/1/s/tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj]
 ##[error]tests/Directory.Build.targets(39,5): error MSB3073: (NETCORE_ENGINEERING_TELEMETRY=Build) The command ""/mnt/vss/_work/1/s/artifacts/bin/Aspire.Templates.Tests/Release/net8.0/Aspire.Templates.Tests" --filter-not-trait category=failing --list-tests" exited with code 150.
```
