### PR TITLE
Revert "Revert "Update xUnit.v3 to support MTP tests (#9261)" (#9336)"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "dotnet.previewSolution-freeWorkspaceMode": true,
+    "dotnet.testWindow.useTestingPlatformProtocol": true,
     "dotnet.defaultSolution": "./Aspire.slnx",
-    "dotnet.preview.enableSupportForSlnx": true,
-    "dotnet.testWindow.useTestingPlatformProtocol": false
+    "dotnet.preview.enableSupportForSlnx": true
 }

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,9 +12,9 @@
     <DotNetRuntimePreviousVersionForTesting>8.0.13</DotNetRuntimePreviousVersionForTesting>
     <!-- dotnet 8.0 versions for running tests - used for templates tests -->
     <DotNetSdkPreviousVersionForTesting>8.0.406</DotNetSdkPreviousVersionForTesting>
-    <XunitV3Version>2.0.0</XunitV3Version>
-    <XUnitAnalyzersVersion>1.20.0</XUnitAnalyzersVersion>
-    <XunitRunnerVisualStudioVersion>3.0.2</XunitRunnerVisualStudioVersion>
+    <XunitV3Version>2.0.2</XunitV3Version>
+    <XUnitAnalyzersVersion>1.21.0</XUnitAnalyzersVersion>
+    <XunitRunnerVisualStudioVersion>3.1.0</XunitRunnerVisualStudioVersion>
     <MicrosoftTestingPlatformVersion>1.6.3</MicrosoftTestingPlatformVersion>
     <MicrosoftNETTestSdkVersion>17.13.0</MicrosoftNETTestSdkVersion>
     <!-- Enable to remove prerelease label. -->


### PR DESCRIPTION
The earlier revert was incorrect. That wasn't commit responsible for breaking the build. It was:
```
commit 6ca2de945a44868673e12fa43e2a76055c34bf4a
Author: Ankit Jain <radical@gmail.com>
Date:   Wed May 14 11:39:18 2025 -0400

    [CI] Add PR validation on macOS (#9287)
```

This reverts commit 3850afa8f78e1c04c0c8ca7ec97d1f7893a4a64f.