### PR TITLE
[CI] Fix azdo builds for `main`

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -61,6 +61,7 @@ steps:
         RunOnlyBasicBuildTemplateTests: true
         # test root path for template test projects
         DEV_TEMP: $(Build.SourcesDirectory)\..
+        DOTNET_ROOT: $(Build.SourcesDirectory)\.dotnet
         TEST_LOG_PATH: $(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Aspire.Templates.Tests
       displayName: Run Template tests
 
@@ -74,6 +75,8 @@ steps:
               /bl:${{ parameters.repoLogPath }}/build.binlog
               $(_OfficialBuildIdArgs)
       displayName: Build
+      env:
+        DOTNET_ROOT: "$(Build.SourcesDirectory)/.dotnet"
 
     - task: DockerInstaller@0
       inputs:

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -30,6 +30,7 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9345")]
     public async Task BrowserToken_LoginPage_Success_RedirectToResources()
     {
         // Arrange


### PR DESCRIPTION
 ## What broke?

Template tests run `dotnet test --list-tests` to get the list of tests so they can
be run on separate helix jobs. This run of `dotnet` [failed the builds on
azdo](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1041473&view=logs&j=acc6f692-388e-5b31-5997-e154da29f5b3&t=2599f547-658e-512e-9bd7-e71978f5caa2) with:

```
  You must install or update .NET to run this application.

  App: /mnt/vss/_work/1/s/artifacts/bin/Aspire.Templates.Tests/Release/net8.0/Aspire.Templates.Tests
  Architecture: x64
  Framework: 'Microsoft.NETCore.App', version '8.0.0' (x64)
  .NET location: /usr/lib/dotnet

  The following frameworks were found:
    6.0.36 at [/usr/lib/dotnet/shared/Microsoft.NETCore.App]

  Learn about framework resolution:
  https://aka.ms/dotnet/app-launch-failed

  To install missing framework, download:
  https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=8.0.0&arch=x64&rid=ubuntu.22.04-x64
/mnt/vss/_work/1/s/tests/Directory.Build.targets(39,5): error MSB3073: The command ""/mnt/vss/_work/1/s/artifacts/bin/Aspire.Templates.Tests/Release/net8.0/Aspire.Templates.Tests" --filter-no>
 ##[error]tests/Directory.Build.targets(39,5): error MSB3073: (NETCORE_ENGINEERING_TELEMETRY=Build) The command ""/mnt/vss/_work/1/s/artifacts/bin/Aspire.Templates.Tests/Release/net8.0/Aspire>
```

 ## Why did it break?

[1] added a change where that `dotnet test` was run with
`EnvironmentVariables="DOTNET_ROOT=$(DotNetRoot);DOTNET_ROOT_X86=$(DotNetRoot)x86"`,
so it does not use the system dotnet. This helped on Azdo builds where
we have older system dotnet (6.0x).

Then [2] removed that change so the system dotnet on github actions
could be used because a newer one was being installed. But this now
broke the Azdo builds.

To fix this set the `DOTNET_ROOT` on Azdo builds, so the correct dotnet is
used.

References:
1.
commit 0af9e7888160d7ae97e49119c9b1733c8ea058e8
Author: Youssef Victor <youssefvictor00@gmail.com>
Date:   Sat Apr 19 14:34:54 2025 +0200

    Revert to MTP and disable server capability as a workaround (#8833)

2.
```
commit 6ca2de945a44868673e12fa43e2a76055c34bf4a
Author: Ankit Jain <radical@gmail.com>
Date:   Wed May 14 11:39:18 2025 -0400

    [CI] Add PR validation on macOS (#9287)
```
