### PR TITLE
SPIKE: Spike parameter prompting from CLI

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -18,6 +18,7 @@ internal interface IAppHostBackchannel
     Task ConnectAsync(string socketPath, CancellationToken cancellationToken);
     IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync(CancellationToken cancellationToken);
     Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken);
+    Task RequestParameterPromptsAsync(CancellationToken cancellationToken);
 }
 
 internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, CliRpcTarget target) : IAppHostBackchannel
@@ -77,7 +78,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         return url;
     }
 
-    public async IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> GetResourceStatesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
+    public async IAsyncEnumerable<(string Resource, string Type, string State, string[] Endpoints)> GetResourceStatesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -143,7 +144,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
         }
     }
 
-    public async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
+    public async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         using var activity = _activitySource.StartActivity();
 
@@ -178,5 +179,19 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Cli
             cancellationToken).ConfigureAwait(false);
 
         return capabilities;
+    }
+
+    public async Task RequestParameterPromptsAsync(CancellationToken cancellationToken)
+    {
+        using var activity = _activitySource.StartActivity();
+
+        var rpc = await _rpcTaskCompletionSource.Task.ConfigureAwait(false);
+
+        logger.LogDebug("Requesting parameter prompts");
+
+        await rpc.InvokeWithCancellationAsync(
+            "RequestParameterPromptsAsync",
+            Array.Empty<object>(),
+            cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Cli/Backchannel/CliRpcTarget.cs
+++ b/src/Aspire.Cli/Backchannel/CliRpcTarget.cs
@@ -5,4 +5,17 @@ namespace Aspire.Cli.Backchannel;
 
 internal class CliRpcTarget
 {
+#pragma warning disable CA1822 // Mark members as static
+    public async Task<string> GetParameterValue(string parameterName, CancellationToken cancellationToken)
+#pragma warning restore CA1822 // Mark members as static
+    {
+        if (GetParameterValueCallback is null)
+        {
+            throw new InvalidOperationException("GetParameterValueCallback is not set.");
+        }
+
+        return await GetParameterValueCallback(parameterName).WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public Func<string, Task<string>>? GetParameterValueCallback { get; set; } = null!;
 }

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -151,6 +151,9 @@ internal sealed class PublishCommand : BaseCommand
             }
 
             var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
+
+            await backchannel.RequestParameterPromptsAsync(cancellationToken);
+
             var publishingActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
 
             var debugMode = parseResult.GetValue<bool?>("--debug") ?? false;

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -122,7 +122,7 @@ public class Program
         builder.Services.AddSingleton<ICertificateService, CertificateService>();
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
         builder.Services.AddTransient<IAppHostBackchannel, AppHostBackchannel>();
-        builder.Services.AddSingleton<CliRpcTarget>();
+        builder.Services.AddSingleton<CliRpcTarget>(BuildCliRpcTarget);
         builder.Services.AddTransient<INuGetPackageCache, NuGetPackageCache>();
 
         // Commands.
@@ -134,6 +134,24 @@ public class Program
 
         var app = builder.Build();
         return app;
+    }
+
+    private static CliRpcTarget BuildCliRpcTarget(IServiceProvider serviceProvider)
+    {
+        var ansiConsole = serviceProvider.GetRequiredService<IAnsiConsole>();
+
+        return new CliRpcTarget()
+        {
+            GetParameterValueCallback = async (parameterName) =>
+            {
+                var textPrompt = new TextPrompt<string>($"Enter value for {parameterName}:")
+                    .AllowEmpty()
+                    .ShowDefaultValue()
+                    .PromptStyle("green");
+
+                return await ansiConsole.PromptAsync(textPrompt);
+            }
+        };
     }
 
     private static IAnsiConsole BuildAnsiConsole(IServiceProvider serviceProvider)

--- a/src/Aspire.Hosting/Backchannel/BackchannelService.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelService.cs
@@ -49,6 +49,7 @@ internal sealed class BackchannelService(ILogger<BackchannelService> logger, ICo
             var stream = new NetworkStream(clientSocket, true);
             var rpc = JsonRpc.Attach(stream, appHostRpcTarget);
             _rpc = rpc;
+            appHostRpcTarget.ClientRpc = rpc;
 
             // NOTE: The DistributedApplicationRunner will await this TCS
             //       when a backchannel is expected, and will not stop


### PR DESCRIPTION
Fixes: #8915

This is a spike on parameter prompting. Plenty of more work to do here but this is just something basic which works.

What I'll probably look to do is have parameter resources fire an event which the backchannel hooks if it is available and drives prompting AFTER the back channel is connected and has asked for parameters.

This will help control flow.