### PR TITLE
Enable MTP tests via MSBuild property

### DIFF
--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.props
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.props
@@ -19,9 +19,7 @@
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformCaptureOutput>false</TestingPlatformCaptureOutput>
 
-    <!-- Workaround for VSCode issues, until it's figured out and resolved. -->
-    <!-- This basically causes Test Explorer in VS and VS Code to use VSTest -->
-    <DisableTestingPlatformServerCapability>true</DisableTestingPlatformServerCapability>
+    <DisableTestingPlatformServerCapability>false</DisableTestingPlatformServerCapability>
     <OutputType Condition="$(MSBuildProjectName.EndsWith('.Tests'))">Exe</OutputType>
 
   </PropertyGroup>

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.props
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.props
@@ -19,6 +19,7 @@
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformCaptureOutput>false</TestingPlatformCaptureOutput>
 
+    <!-- MTP-based tests are enabled in the repo. Change this to true to use VSTest. -->
     <DisableTestingPlatformServerCapability>false</DisableTestingPlatformServerCapability>
     <OutputType Condition="$(MSBuildProjectName.EndsWith('.Tests'))">Exe</OutputType>
 


### PR DESCRIPTION
I've verified that the run-debug-test loop works or me in Codespaces with this change and the one from https://github.com/dotnet/aspire/pull/9261.

cc: @peterwald @Youssef1313 

cc: @radical I noticed there were some reverts/re-reverts on the PR mentioned above but I think everything is back to the state introduced by the commit from the PR.