### PR TITLE
Fix CLI to cleanup invalid project names

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -285,7 +285,7 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
 
 internal static partial class ProjectNameValidator
 {
-    [GeneratedRegex(@"^[a-zA-Z0-9_][a-zA-Z0-9_.]{0,253}[a-zA-Z0-9_]?$", RegexOptions.Compiled)]
+    [GeneratedRegex(@"^[a-zA-Z0-9_][a-zA-Z0-9_.]{0,98}[a-zA-Z0-9_]?$", RegexOptions.Compiled)]
     internal static partial Regex GetAssemblyNameRegex();
 
     [GeneratedRegex(@"[^a-zA-Z0-9_.]", RegexOptions.Compiled)]

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -14,6 +14,7 @@ internal interface IInteractionService
     Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull;
     int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingSdkVersion);
     void DisplayError(string errorMessage);
+    void DisplayWarning(string warningMessage);
     void DisplayMessage(string emoji, string message);
     void DisplaySuccess(string message);
     void DisplayDashboardUrls((string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken) dashboardUrls);

--- a/src/Aspire.Cli/Interaction/InteractionService.cs
+++ b/src/Aspire.Cli/Interaction/InteractionService.cs
@@ -87,6 +87,11 @@ internal class InteractionService : IInteractionService
         DisplayMessage("thumbs_down", $"[red bold]{errorMessage}[/]");
     }
 
+    public void DisplayWarning(string warningMessage)
+    {
+        DisplayMessage("warning", $"[yellow bold]{warningMessage}[/]");
+    }
+
     public void DisplayMessage(string emoji, string message)
     {
         _ansiConsole.MarkupLine($":{emoji}:  {message}");

--- a/tests/Aspire.Cli.Tests/Utils/ProjectNameValidatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ProjectNameValidatorTests.cs
@@ -18,35 +18,18 @@ public class ProjectNameValidatorTests
     [InlineData("invalid-name", "invalid_name")]
     [InlineData("invalid+name", "invalid_name")]
     [InlineData("invalid name", "invalid_name")]
-    public void SanitizeProjectName_ConvertInvalidChars(string input, string expectedOutput)
+    [InlineData(".", "_")]
+    [InlineData(
+        "0123456787901234567879012345678790123456787901234567879012345678790123456787901234567879012345678790123456787901234567879012345678790123456787901234567879012345678790123456787901234567879012345678790123456787901234567879012345678790123456787901234567879012345678790123456787901234567879012345678790123456787901234567879", "0123456787901234567879012345678790123456787901234567879012345678790123456787901234567879012345678790")]
+    public void IsProjectNameValid_ReturnsExpectedResult(string projectName, string expectedSanitized)
     {
-        // Act
-        var result = ProjectNameValidator.SanitizeProjectName(input);
+        // Valid names are recognized as valid
+        Assert.Equal(projectName == expectedSanitized, ProjectNameValidator.IsProjectNameValid(projectName));
 
-        // Assert
-        Assert.Equal(expectedOutput, result);
-    }
+        // Sanitized names are recognized as valid
+        Assert.True(ProjectNameValidator.IsProjectNameValid(ProjectNameValidator.SanitizeProjectName(projectName)));
 
-    [Theory]
-    [InlineData("validName", true)]
-    [InlineData("valid_name", true)]
-    [InlineData("valid.name", true)]
-    [InlineData("valid_name_1", true)]
-    [InlineData("invalid@name", false)]
-    [InlineData("invalid$name", false)]
-    [InlineData("invalid-name", false)]
-    [InlineData("invalid+name", false)]
-    [InlineData("invalid name", false)]
-    [InlineData("-invalidName", false)]
-    [InlineData("invalidName-", false)]
-    [InlineData("@invalidName", false)]
-    [InlineData("invalidName@", false)]
-    public void IsProjectNameValid_ReturnsExpectedResult(string projectName, bool expectedResult)
-    {
-        // Act
-        var result = ProjectNameValidator.IsProjectNameValid(projectName);
-
-        // Assert
-        Assert.Equal(expectedResult, result);
+        // Sanitization should produce expected result
+        Assert.Equal(expectedSanitized, ProjectNameValidator.SanitizeProjectName(projectName));
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/ProjectNameValidatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ProjectNameValidatorTests.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Commands;
+using Xunit;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class ProjectNameValidatorTests
+{
+    [Theory]
+    [InlineData("validName", "validName")]
+    [InlineData("valid_name", "valid_name")]
+    [InlineData("valid.name", "valid.name")]
+    [InlineData("valid_name_1", "valid_name_1")]
+    [InlineData("invalid@name", "invalid_name")]
+    [InlineData("invalid$name", "invalid_name")]
+    [InlineData("invalid-name", "invalid_name")]
+    [InlineData("invalid+name", "invalid_name")]
+    [InlineData("invalid name", "invalid_name")]
+    public void SanitizeProjectName_ConvertInvalidChars(string input, string expectedOutput)
+    {
+        // Act
+        var result = ProjectNameValidator.SanitizeProjectName(input);
+
+        // Assert
+        Assert.Equal(expectedOutput, result);
+    }
+
+    [Theory]
+    [InlineData("validName", true)]
+    [InlineData("valid_name", true)]
+    [InlineData("valid.name", true)]
+    [InlineData("valid_name_1", true)]
+    [InlineData("invalid@name", false)]
+    [InlineData("invalid$name", false)]
+    [InlineData("invalid-name", false)]
+    [InlineData("invalid+name", false)]
+    [InlineData("invalid name", false)]
+    [InlineData("-invalidName", false)]
+    [InlineData("invalidName-", false)]
+    [InlineData("@invalidName", false)]
+    [InlineData("invalidName@", false)]
+    public void IsProjectNameValid_ReturnsExpectedResult(string projectName, bool expectedResult)
+    {
+        // Act
+        var result = ProjectNameValidator.IsProjectNameValid(projectName);
+
+        // Assert
+        Assert.Equal(expectedResult, result);
+    }
+}


### PR DESCRIPTION
## Description

Vibe coded :)

Fixes https://github.com/dotnet/aspire/issues/9290
Fixes https://github.com/dotnet/aspire/issues/9327

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
