### PR TITLE
Centralize Verify convention

### DIFF
--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -48,8 +48,7 @@ public class AzureAppServiceTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -70,8 +69,7 @@ public class AzureAppServiceTests
         var (manifest, bicep) = await GetManifestWithBicep(environment);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -104,8 +102,7 @@ public class AzureAppServiceTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -140,8 +137,7 @@ public class AzureAppServiceTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -324,8 +324,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
 
         Assert.NotNull(callbackDatabases);
         Assert.Collection(
@@ -368,8 +367,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         output.WriteLine(manifest.ManifestNode.ToString());
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
 
         Assert.NotNull(callbackDatabases);
         Assert.Collection(
@@ -445,8 +443,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         output.WriteLine(m);
         Assert.Equal(expectedManifest, m);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
 
         Assert.NotNull(callbackDatabases);
         Assert.Collection(
@@ -487,8 +484,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                                """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
 
         Assert.NotNull(callbackDatabases);
         Assert.Collection(
@@ -611,8 +607,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
            """;
         Assert.Equal(expectedManifest, appInsightsManifest.ManifestNode.ToString());
 
-        await Verifier.Verify(appInsightsManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(appInsightsManifest.BicepText, extension: "bicep");
     }
 
     [Fact]
@@ -640,8 +635,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
            """;
         Assert.Equal(expectedManifest, appInsightsManifest.ManifestNode.ToString());
 
-        await Verifier.Verify(appInsightsManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(appInsightsManifest.BicepText, extension: "bicep");
     }
 
     [Fact]
@@ -673,8 +667,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
            """;
         Assert.Equal(expectedManifest, appInsightsManifest.ManifestNode.ToString());
 
-        await Verifier.Verify(appInsightsManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(appInsightsManifest.BicepText, extension: "bicep");            
     }
 
     [Fact]
@@ -696,8 +689,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
            """;
         Assert.Equal(expectedManifest, appInsightsManifest.ManifestNode.ToString());
 
-        await Verifier.Verify(appInsightsManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(appInsightsManifest.BicepText, extension: "bicep");
     }
 
     [Fact]
@@ -846,8 +838,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
     }
 
     [Fact]
@@ -878,8 +869,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
     }
 
     [Fact]
@@ -910,8 +900,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
     }
 
     [Fact]
@@ -954,8 +943,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
     }
 
     [Fact]
@@ -998,8 +986,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
     }
 
     [Fact]
@@ -1154,8 +1141,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expected, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
 
         var sbRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "sb-roles");
         var sbRolesManifest = await GetManifestWithBicep(sbRoles, skipPreparer: true);
@@ -1215,8 +1201,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
         Assert.Equal("wps1", wps.Resource.Name);
         output.WriteLine(manifest.BicepText);
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
 
         var wpsRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "wps1-roles");
         var wpsRolesManifest = await GetManifestWithBicep(wpsRoles, skipPreparer: true);
@@ -1274,8 +1259,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
         Assert.Equal("wps1", wps.Resource.Name);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
     }
 
     [Fact]
@@ -1352,8 +1336,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedStorageManifest, storageManifest.ManifestNode.ToString());
 
-        await Verifier.Verify(storageManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(storageManifest.BicepText, extension: "bicep");
 
         // Check blob resource.
         var blob = storage.AddBlobs("blob");
@@ -1438,8 +1421,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedStorageManifest, storageManifest.ManifestNode.ToString());
 
-        await Verifier.Verify(storageManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(storageManifest.BicepText, extension: "bicep");
 
         // Check blob resource.
         var blob = storage.AddBlobs("blob");
@@ -1529,8 +1511,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedStorageManifest, storageManifest.ManifestNode.ToString());
 
-        await Verifier.Verify(storageManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(storageManifest.BicepText, extension: "bicep");
 
         var storageRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "storage-roles");
         var storageRolesManifest = await GetManifestWithBicep(storageRoles, skipPreparer: true);
@@ -1660,8 +1641,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
         Assert.Equal(expectedStorageManifest, storageManifest.ManifestNode.ToString());
 
-        await Verifier.Verify(storageManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(storageManifest.BicepText, extension: "bicep");
 
         // Check blob resource.
         var blob = storage.AddBlobs("blob");
@@ -1752,8 +1732,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
 
         var searchRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "search-roles");
         var searchRolesManifest = await GetManifestWithBicep(searchRoles, skipPreparer: true);
@@ -1884,8 +1863,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
 
         var openaiRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "openai-roles");
         var openaiRolesManifest = await GetManifestWithBicep(openaiRoles, skipPreparer: true);
@@ -1985,8 +1963,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             """;
         Assert.Equal(expectedManifest, manifest.ToString());
 
-        await Verifier.Verify(bicep, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(bicep, extension: "bicep");
     }
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -49,8 +49,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -84,8 +83,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -117,8 +115,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -160,8 +157,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -192,8 +188,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -235,8 +230,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -266,8 +260,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -344,8 +337,7 @@ public class AzureContainerAppsTests
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep")
               .AppendContentAsFile(identityManifest.ToString(), "json")
-              .AppendContentAsFile(identityBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(identityBicep, "bicep");
     }
 
     [Fact]
@@ -422,8 +414,7 @@ public class AzureContainerAppsTests
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep")
               .AppendContentAsFile(identityManifest.ToString(), "json")
-              .AppendContentAsFile(identityBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(identityBicep, "bicep");
     }
 
     [Fact]
@@ -458,8 +449,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -490,8 +480,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -552,8 +541,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -589,8 +577,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -628,8 +615,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -669,8 +655,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -702,8 +687,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -755,8 +739,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -827,8 +810,7 @@ public class AzureContainerAppsTests
 
         var (_, bicep) = await GetManifestWithBicep(resource);
 
-        await Verify(bicep, "bicep")
-              .UseHelixAwareDirectory();
+        await Verify(bicep, "bicep");
     }
 
     private sealed class MyResourceNamePropertyResolver : DynamicResourceNamePropertyResolver
@@ -872,8 +854,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -904,8 +885,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -937,8 +917,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -969,8 +948,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -1015,8 +993,7 @@ public class AzureContainerAppsTests
               .AppendContentAsFile(rolesStorageManifest.ToString(), "json")
               .AppendContentAsFile(rolesStorageBicep, "bicep")
               .AppendContentAsFile(identityManifest.ToString(), "json")
-              .AppendContentAsFile(identityBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(identityBicep, "bicep");
     }
 
     [Fact]
@@ -1060,8 +1037,7 @@ public class AzureContainerAppsTests
               .AppendContentAsFile(rolesCosmosManifest.ToString(), "json")
               .AppendContentAsFile(rolesCosmosBicep, "bicep")
               .AppendContentAsFile(identityManifest.ToString(), "json")
-              .AppendContentAsFile(identityBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(identityBicep, "bicep");
     }
 
     [Fact]
@@ -1102,8 +1078,7 @@ public class AzureContainerAppsTests
               .AppendContentAsFile(rolesRedisManifest.ToString(), "json")
               .AppendContentAsFile(rolesRedisBicep, "bicep")
               .AppendContentAsFile(identityManifest.ToString(), "json")
-              .AppendContentAsFile(identityBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(identityBicep, "bicep");
     }
 
     [Fact]
@@ -1313,8 +1288,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(environment);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     // see https://github.com/dotnet/aspire/issues/8381 for more information on this scenario
@@ -1340,8 +1314,7 @@ public class AzureContainerAppsTests
         var (manifest, bicep) = await GetManifestWithBicep(sql.Resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -1392,8 +1365,7 @@ public class AzureContainerAppsTests
               .AppendContentAsFile(containerManifest.ToString(), "json")
               .AppendContentAsFile(containerBicep, "bicep")
               .AppendContentAsFile(registryManifest.ToString(), "json")
-              .AppendContentAsFile(registryBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(registryBicep, "bicep");
     }
 
     private static Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource) =>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerRegistryTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerRegistryTests.cs
@@ -65,8 +65,7 @@ public class AzureContainerRegistryTests
         var (manifest, bicep) = await GetManifestWithBicep(acr.Resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
@@ -91,8 +90,8 @@ public class AzureContainerRegistryTests
         var (rolesManifest, rolesBicep) = await GetManifestWithBicep(rolesResource);
 
         await Verify(rolesManifest.ToString(), "json")
-              .AppendContentAsFile(rolesBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(rolesBicep, "bicep");
+              
     }
 
     private sealed class Project : IProjectMetadata

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -200,8 +200,8 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var manifest = await GetManifestWithBicep(model, cosmos.Resource);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
 
         var cosmosRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "cosmos-roles");
         var cosmosRolesManifest = await GetManifestWithBicep(cosmosRoles, skipPreparer: true);
@@ -255,7 +255,6 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         var manifest = await GetManifestWithBicep(cosmos.Resource);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
@@ -39,9 +39,8 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
         Assert.True(File.Exists(envBicepPath));
         var envBicep = File.ReadAllText(envBicepPath);
 
-        await Verifier.Verify(mainBicep, "bicep")
-            .AppendContentAsFile(envBicep, "bicep")
-            .UseHelixAwareDirectory();
+        await Verify(mainBicep, "bicep")
+            .AppendContentAsFile(envBicep, "bicep");
 
         tempDir.Delete(recursive: true);
     }
@@ -73,8 +72,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
         Assert.True(File.Exists(mainBicepPath));
         var mainBicep = File.ReadAllText(mainBicepPath);
 
-        await Verify(mainBicep, "bicep")
-            .UseHelixAwareDirectory();
+        await Verify(mainBicep, "bicep");            
 
         tempDir.Delete(recursive: true);
     }
@@ -126,7 +124,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
         Assert.True(File.Exists(mainBicepPath));
         var content = File.ReadAllText(mainBicepPath);
 
-        await Verifier.Verify(content, extension: "bicep").UseHelixAwareDirectory();
+        await Verify(content, extension: "bicep");
     }
 
     [Fact]
@@ -175,8 +173,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
         var storageBicep = File.ReadAllText(Path.Combine(tempDir.FullName, "storage", "storage.bicep"));
 
         await Verify(mainBicep, "bicep")
-            .AppendContentAsFile(storageBicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(storageBicep, "bicep");
     }
 
     private sealed class TestProject : IProjectMetadata

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -295,8 +295,8 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep")
               .AppendContentAsFile(ehRolesManifest.ToString(), "json")
-              .AppendContentAsFile(ehRolesBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(ehRolesBicep, "bicep");
+              
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -320,8 +320,8 @@ public class AzureFunctionsTests
         var (rolesManifest, rolesBicep) = await GetManifestWithBicep(projRolesStorage);
 
         await Verify(rolesManifest.ToString(), "json")
-              .AppendContentAsFile(rolesBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(rolesBicep, "bicep");
+              
     }
 
     [Fact]
@@ -347,8 +347,8 @@ public class AzureFunctionsTests
         var (rolesManifest, rolesBicep) = await GetManifestWithBicep(projRolesStorage);
 
         await Verify(rolesManifest.ToString(), "json")
-              .AppendContentAsFile(rolesBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(rolesBicep, "bicep");
+              
     }
 
     [Fact]
@@ -375,8 +375,8 @@ public class AzureFunctionsTests
         var (rolesManifest, rolesBicep) = await GetManifestWithBicep(projRolesStorage);
 
         await Verify(rolesManifest.ToString(), "json")
-              .AppendContentAsFile(rolesBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(rolesBicep, "bicep");
+              
     }
 
     [Fact]
@@ -409,8 +409,8 @@ public class AzureFunctionsTests
         await Verify(rolesManifest.ToString(), "json")
               .AppendContentAsFile(rolesBicep, "bicep")
               .AppendContentAsFile(rolesManifest2.ToString(), "json")
-              .AppendContentAsFile(rolesBicep2, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(rolesBicep2, "bicep");
+              
     }
 
     private static Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource) =>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
@@ -20,8 +20,8 @@ public class AzureKeyVaultTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(mykv.Resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
+              
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public class AzureKeyVaultTests
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep")
               .AppendContentAsFile(kvRolesBicep, "bicep")
-              .AppendContentAsFile(kvRolesManifest.ToString(), "json")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(kvRolesManifest.ToString(), "json");
+              
     }
 
     [Fact]
@@ -110,7 +110,7 @@ public class AzureKeyVaultTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(module.Resource, skipPreparer: true);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
+              
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
@@ -44,8 +44,8 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep")
               .AppendContentAsFile(postgresRolesManifest.ToString(), "json")
-              .AppendContentAsFile(postgresRolesBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(postgresRolesBicep, "bicep");
+              
     }
 
     [Fact]
@@ -112,8 +112,8 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
         output.WriteLine(m);
         Assert.Equal(expectedManifest, m);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureProvisioningResourceExtensionsTests.cs
@@ -59,8 +59,8 @@ public class AzureProvisioningResourceExtensionsTests
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     private sealed class Project : IProjectMetadata

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -42,8 +42,8 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep")
               .AppendContentAsFile(redisRolesManifest.ToString(), "json")
-              .AppendContentAsFile(redisRolesBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(redisRolesBicep, "bicep");
+              
     }
 
     [Fact]
@@ -96,8 +96,8 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
         output.WriteLine(m);
         Assert.Equal(expectedManifest, m);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
@@ -43,9 +43,9 @@ public class AzureResourceOptionsTests(ITestOutputHelper output)
 
             var sqlBicep = await File.ReadAllTextAsync(Path.Combine(tempDir.FullName, "sql-server.module.bicep"));
 
-            await Verifier.Verify(sbBicep, extension: "bicep")
-                .AppendContentAsFile(sqlBicep, "bicep")
-                .UseHelixAwareDirectory();
+            await Verify(sbBicep, extension: "bicep")
+                .AppendContentAsFile(sqlBicep, "bicep");
+                
 
             await app.StopAsync();
         }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -70,8 +70,8 @@ public class AzureResourcePreparerTests
             var storageRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "storage-roles");
 
             var storageRolesManifest = await GetManifestWithBicep(storageRoles, skipPreparer: true);
-            await Verifier.Verify(storageRolesManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+            await Verify(storageRolesManifest.BicepText, extension: "bicep");
+            
         }
         else
         {
@@ -114,8 +114,8 @@ public class AzureResourcePreparerTests
             var storageRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "storage-roles");
 
             var storageRolesManifest = await GetManifestWithBicep(storageRoles, skipPreparer: true);
-            await Verifier.Verify(storageRolesManifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+            await Verify(storageRolesManifest.BicepText, extension: "bicep");
+            
         }
         else
         {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -36,8 +36,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
         var manifest = await AzureManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Theory]
@@ -61,8 +61,8 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
         var manifest = await AzureManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Fact(Skip = "Azure ServiceBus emulator is not reliable in CI - https://github.com/dotnet/aspire/issues/7066")]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSignalRExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSignalRExtensionsTests.cs
@@ -28,8 +28,8 @@ public class AzureSignalRExtensionsTests
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep")
               .AppendContentAsFile(signalrRolesManifest.ToString(), "json")
-              .AppendContentAsFile(signalrRolesBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(signalrRolesBicep, "bicep");
+              
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class AzureSignalRExtensionsTests
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep")
               .AppendContentAsFile(signalrRolesManifest.ToString(), "json")
-              .AppendContentAsFile(signalrRolesBicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(signalrRolesBicep, "bicep");
+              
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
@@ -54,8 +54,8 @@ public class AzureSqlExtensionsTests()
             """;
         Assert.Equal(expectedManifest, manifest.ManifestNode.ToString(), ignoreLineEndingDifferences: true);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory();
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -282,7 +282,7 @@ public class AzureStorageExtensionsTests
 
         var manifest = await AzureManifestUtils.GetManifestWithBicep(storage.Resource);
 
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
@@ -33,8 +33,8 @@ public class AzureUserAssignedIdentityTests
 
         var (_, bicep) = await GetManifestWithBicep(resource);
 
-        await Verifier.Verify(bicep, extension: "bicep")
-            .UseHelixAwareDirectory();
+        await Verify(bicep, extension: "bicep");
+            
     }
 
     [Fact]
@@ -52,8 +52,8 @@ public class AzureUserAssignedIdentityTests
 
         var (_, bicep) = await GetManifestWithBicep(resource);
 
-        await Verifier.Verify(bicep, extension: "bicep")
-            .UseHelixAwareDirectory();
+        await Verify(bicep, extension: "bicep");
+            
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class AzureUserAssignedIdentityTests
             new Target("bicep", registryBicep),
             new Target("bicep", identityRoleAssignmentsBicep)
         ];
-        await Verifier.Verify(targets)
-            .UseHelixAwareDirectory();
+
+        await Verify(targets);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
@@ -59,8 +59,8 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
 
         Assert.Equal(expectedManifest, manifestString);
         Assert.Equal("wps1", wps.Resource.Name);
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Fact]
@@ -104,8 +104,8 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
 
         Assert.Equal(expectedManifest, manifestString);
         Assert.Equal("wps1", wps.Resource.Name);
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Fact]
@@ -134,8 +134,8 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
 
         Assert.Equal(expectedManifest, manifestString);
         Assert.Equal("wps1", wps.Resource.Name);
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Fact]
@@ -160,8 +160,8 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         output.WriteLine(manifest.BicepText);
 
         Assert.Equal("wps1", wps.Resource.Name);
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Fact]
@@ -214,8 +214,8 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         Assert.Equal(expectedManifest, manifestString);
 
         Assert.Equal("wps1", wps.Resource.Name);
-        await Verifier.Verify(manifest.BicepText, extension: "bicep")
-            .UseHelixAwareDirectory("Snapshots");
+        await Verify(manifest.BicepText, extension: "bicep");
+            
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -23,8 +23,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
+              
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
+              
     }
 
     [Fact]
@@ -57,8 +57,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
+              
     }
 
     [Fact]
@@ -83,8 +83,7 @@ public class ExistingAzureResourceTests
         await Verify(manifest.ToString(), "json")
                 .AppendContentAsFile(bicep, "bicep")
                 .AppendContentAsFile(rolesManifest.ToString(), "json")
-                .AppendContentAsFile(rolesBicep, "bicep")
-                .UseHelixAwareDirectory();
+                .AppendContentAsFile(rolesBicep, "bicep");
     }
 
     [Fact]
@@ -98,8 +97,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(serviceBus.Resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
+              
     }
 
     [Fact]
@@ -115,8 +114,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(storageAccount.Resource);
 
         await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep")
-              .UseHelixAwareDirectory();
+              .AppendContentAsFile(bicep, "bicep");
+              
     }
 
     [Fact]
@@ -130,8 +129,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(storageAccount.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -147,8 +146,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(appConfiguration.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -164,8 +163,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(eventHubs.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -181,8 +180,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(keyVault.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -198,8 +197,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(logAnalytics.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -215,8 +214,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(postgresSql.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -236,8 +235,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(postgresSql.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -253,8 +252,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(search.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -270,8 +269,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(signalR.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -287,8 +286,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(webPubSub.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -304,8 +303,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(sqlServer.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -320,8 +319,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(sqlServer.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -337,8 +336,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(redis.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -353,8 +352,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(redis.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -370,8 +369,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(appInsights.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -393,8 +392,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(openAI.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -413,8 +412,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -434,8 +433,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -450,8 +449,8 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(acr.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 
     [Fact]
@@ -467,7 +466,7 @@ public class ExistingAzureResourceTests
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(acr.Resource);
 
         await Verify(manifest.ToString(), "json")
-            .AppendContentAsFile(bicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(bicep, "bicep");
+            
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
@@ -196,8 +196,8 @@ public class RoleAssignmentTests()
         var (rolesManifest, rolesBicep) = await GetManifestWithBicep(projRoles);
 
         await Verify(rolesManifest.ToString(), "json")
-            .AppendContentAsFile(rolesBicep, "bicep")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(rolesBicep, "bicep");
+            
     }
 
     private static Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource) =>

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -79,7 +79,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
 
         await Verify(File.ReadAllText(composePath), "yaml")
             .AppendContentAsFile(File.ReadAllText(envPath), "env")
-            .UseHelixAwareDirectory();
+            
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         Assert.True(File.Exists(composePath));
 
         await Verify(File.ReadAllText(composePath), "yaml")
-            .UseHelixAwareDirectory();
+            
     }
 
     [Theory]
@@ -189,7 +189,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
 
         await Verify(File.ReadAllText(composePath), "yaml")
             .AppendContentAsFile(File.ReadAllText(envPath), "env")
-            .UseHelixAwareDirectory();
+            
     }
 
     [Fact]
@@ -219,7 +219,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
 
         await Verify(firstContent, "env")
             .AppendContentAsFile(secondContent, "env")
-            .UseHelixAwareDirectory();
+            
     }
 
     [Fact]
@@ -259,7 +259,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
 
         await Verify(firstContent, "env")
             .AppendContentAsFile(secondContent, "env")
-            .UseHelixAwareDirectory();
+            
     }
 
     [Fact]
@@ -285,7 +285,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         var composeFile = File.ReadAllText(composePath);
 
         await Verify(composeFile)
-            .UseHelixAwareDirectory();
+            
     }
 
     private sealed class MockImageBuilder : IResourceContainerImageBuilder

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -78,8 +78,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         Assert.True(File.Exists(envPath));
 
         await Verify(File.ReadAllText(composePath), "yaml")
-            .AppendContentAsFile(File.ReadAllText(envPath), "env")
-            
+            .AppendContentAsFile(File.ReadAllText(envPath), "env");
     }
 
     [Fact]
@@ -102,8 +101,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         var composePath = Path.Combine(tempDir.Path, "docker-compose.yaml");
         Assert.True(File.Exists(composePath));
 
-        await Verify(File.ReadAllText(composePath), "yaml")
-            
+        await Verify(File.ReadAllText(composePath), "yaml");
     }
 
     [Theory]
@@ -188,8 +186,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         Assert.True(File.Exists(envPath));
 
         await Verify(File.ReadAllText(composePath), "yaml")
-            .AppendContentAsFile(File.ReadAllText(envPath), "env")
-            
+            .AppendContentAsFile(File.ReadAllText(envPath), "env");
     }
 
     [Fact]
@@ -218,8 +215,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         var secondContent = File.ReadAllText(envFilePath);
 
         await Verify(firstContent, "env")
-            .AppendContentAsFile(secondContent, "env")
-            
+            .AppendContentAsFile(secondContent, "env");
     }
 
     [Fact]
@@ -258,8 +254,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
         var secondContent = File.ReadAllText(envFilePath);
 
         await Verify(firstContent, "env")
-            .AppendContentAsFile(secondContent, "env")
-            
+            .AppendContentAsFile(secondContent, "env");
     }
 
     [Fact]
@@ -284,8 +279,7 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
 
         var composeFile = File.ReadAllText(composePath);
 
-        await Verify(composeFile)
-            
+        await Verify(composeFile);
     }
 
     private sealed class MockImageBuilder : IResourceContainerImageBuilder

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesEnvironmentResourceTests.cs
@@ -27,8 +27,7 @@ public class KubernetesEnvironmentResourceTests(ITestOutputHelper output)
 
         await Verify(File.ReadAllText(chartYaml), "yaml")
             .AppendContentAsFile(File.ReadAllText(valuesYaml), "yaml")
-            .AppendContentAsFile(File.ReadAllText(deploymentYaml), "yaml")
-            .UseHelixAwareDirectory();
+            .AppendContentAsFile(File.ReadAllText(deploymentYaml), "yaml");
 
         tempDir.Delete(recursive: true);
     }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -71,7 +71,7 @@ public class KubernetesPublisherTests()
             }
         }
 
-        await settingsTask.UseHelixAwareDirectory();
+        await settingsTask;
     }
 
     [Fact]
@@ -101,8 +101,7 @@ public class KubernetesPublisherTests()
 
         var content = await File.ReadAllTextAsync(deploymentPath);
 
-        await Verify(content, "yaml")
-        .UseHelixAwareDirectory();
+        await Verify(content, "yaml");
     }
 
     public sealed class TempDirectory : IDisposable

--- a/tests/Shared/TestModuleInitializer.cs
+++ b/tests/Shared/TestModuleInitializer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using Aspire.TestUtilities;
 using EmptyFiles;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Shared/TestModuleInitializer.cs
+++ b/tests/Shared/TestModuleInitializer.cs
@@ -17,5 +17,18 @@ sealed class TestModuleInitializer
         FileExtensions.AddTextExtension("yml");
         FileExtensions.AddTextExtension("dockerfile");
         FileExtensions.AddTextExtension("env");
+
+        // Set the directory for all Verify calls in test projects
+        var target = PlatformDetection.IsRunningOnHelix
+            ? Path.Combine(Environment.GetEnvironmentVariable("HELIX_CORRELATION_PAYLOAD")!, "Snapshots")
+            : "Snapshots";
+
+        // If target contains an absolute path it will use it as is.
+        // If it contains a relative path, it will be combined with the project directory.
+        DerivePathInfo(
+            (sourceFile, projectDirectory, type, method) => new(
+                directory: Path.Combine(projectDirectory, target),
+                typeName: type.Name,
+                methodName: method.Name));
     }
 }

--- a/tests/Shared/VerifyExtensions.cs
+++ b/tests/Shared/VerifyExtensions.cs
@@ -1,10 +1,32 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Aspire.TestUtilities;
 
 internal static class VerifyExtensions
 {
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        // Set the directory for all Verify calls in test projects
+
+        var target = PlatformDetection.IsRunningOnHelix
+            ? Path.Combine(Environment.GetEnvironmentVariable("HELIX_CORRELATION_PAYLOAD")!, "Snapshots")
+            : "Snapshots";
+
+        // If target contains an absolute path it will use it as is.
+        // If it contains a relative path, it will be combined with the project directory.
+        DerivePathInfo(
+            (sourceFile, projectDirectory, type, method) => new(
+                directory: Path.Combine(projectDirectory, target),
+                typeName: type.Name,
+                methodName: method.Name));
+    }
+
+    /// <summary>
+    /// Sets the directory for the Verify call in a way it's also compatible with Helix.
+    /// </summary>
     public static SettingsTask UseHelixAwareDirectory(this SettingsTask settings, string directory = "Snapshots")
     {
         settings.UseDirectory(PlatformDetection.IsRunningOnHelix

--- a/tests/Shared/VerifyExtensions.cs
+++ b/tests/Shared/VerifyExtensions.cs
@@ -1,29 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
 using Aspire.TestUtilities;
 
 internal static class VerifyExtensions
 {
-    [ModuleInitializer]
-    public static void Initialize()
-    {
-        // Set the directory for all Verify calls in test projects
-
-        var target = PlatformDetection.IsRunningOnHelix
-            ? Path.Combine(Environment.GetEnvironmentVariable("HELIX_CORRELATION_PAYLOAD")!, "Snapshots")
-            : "Snapshots";
-
-        // If target contains an absolute path it will use it as is.
-        // If it contains a relative path, it will be combined with the project directory.
-        DerivePathInfo(
-            (sourceFile, projectDirectory, type, method) => new(
-                directory: Path.Combine(projectDirectory, target),
-                typeName: type.Name,
-                methodName: method.Name));
-    }
-
     /// <summary>
     /// Sets the directory for the Verify call in a way it's also compatible with Helix.
     /// </summary>


### PR DESCRIPTION
Found a way to centrally apply the HELIX contraints on `Verify` calls.