### PR TITLE
Fix commands left in a disabled state

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -75,8 +75,8 @@ public partial class ResourceActions : ComponentBase
             ControlLoc,
             Loc,
             CommandsLoc,
-            OnViewDetails.InvokeAsync,
-            CommandSelected.InvokeAsync,
+            OnViewDetails,
+            CommandSelected,
             IsCommandExecuting,
             showConsoleLogsItem: true,
             showUrls: false);

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -67,7 +67,6 @@ public partial class ResourceActions : ComponentBase
 
         ResourceMenuItems.AddMenuItems(
             _menuItems,
-            _menuButton?.MenuButtonId,
             Resource,
             NavigationManager,
             TelemetryRepository,
@@ -75,7 +74,7 @@ public partial class ResourceActions : ComponentBase
             ControlLoc,
             Loc,
             CommandsLoc,
-            OnViewDetails,
+            EventCallback.Factory.Create(this, () => OnViewDetails.InvokeAsync(_menuButton?.MenuButtonId)),
             CommandSelected,
             IsCommandExecuting,
             showConsoleLogsItem: true,

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -352,7 +352,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
             ResourceMenuItems.AddMenuItems(
                 _resourceMenuItems,
-                openingMenuButtonId: null,
                 PageViewModel.SelectedResource,
                 NavigationManager,
                 TelemetryRepository,
@@ -360,7 +359,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 ControlsStringsLoc,
                 ResourcesLoc,
                 CommandsLoc,
-                EventCallback.Factory.Create<string?>(this, buttonId =>
+                EventCallback.Factory.Create(this, () =>
                 {
                     NavigationManager.NavigateTo(DashboardUrls.ResourcesUrl(resource: PageViewModel.SelectedResource.Name));
                     return Task.CompletedTask;

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -360,12 +360,12 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 ControlsStringsLoc,
                 ResourcesLoc,
                 CommandsLoc,
-                buttonId =>
+                EventCallback.Factory.Create<string?>(this, buttonId =>
                 {
                     NavigationManager.NavigateTo(DashboardUrls.ResourcesUrl(resource: PageViewModel.SelectedResource.Name));
                     return Task.CompletedTask;
-                },
-                ExecuteResourceCommandAsync,
+                }),
+                EventCallback.Factory.Create<CommandViewModel>(this, ExecuteResourceCommandAsync),
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
                 showConsoleLogsItem: false,
                 showUrls: true);
@@ -384,8 +384,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
     private async Task ExecuteResourceCommandAsync(CommandViewModel command)
     {
-        await DashboardCommandExecutor.ExecuteAsync(PageViewModel.SelectedResource!, command, GetResourceName, StateHasChanged);
-        //StateHasChanged();
+        await DashboardCommandExecutor.ExecuteAsync(PageViewModel.SelectedResource!, command, GetResourceName);
     }
 
     private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName);

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -384,7 +384,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
     private async Task ExecuteResourceCommandAsync(CommandViewModel command)
     {
-        await DashboardCommandExecutor.ExecuteAsync(PageViewModel.SelectedResource!, command, GetResourceName);
+        await DashboardCommandExecutor.ExecuteAsync(PageViewModel.SelectedResource!, command, GetResourceName, StateHasChanged);
+        //StateHasChanged();
     }
 
     private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName);

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -646,7 +646,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private async Task ExecuteResourceCommandAsync(ResourceViewModel resource, CommandViewModel command)
     {
-        await DashboardCommandExecutor.ExecuteAsync(resource, command, GetResourceName);
+        await DashboardCommandExecutor.ExecuteAsync(resource, command, GetResourceName, StateHasChanged);
     }
 
     private static string GetUrlsTooltip(ResourceViewModel resource)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -533,7 +533,6 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             _contextMenuItems.Clear();
             ResourceMenuItems.AddMenuItems(
                 _contextMenuItems,
-                openingMenuButtonId: null,
                 resource,
                 NavigationManager,
                 TelemetryRepository,
@@ -541,7 +540,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 ControlsStringsLoc,
                 Loc,
                 CommandsLoc,
-                EventCallback.Factory.Create<string?>(this, (buttonId) => ShowResourceDetailsAsync(resource, buttonId)),
+                EventCallback.Factory.Create(this, () => ShowResourceDetailsAsync(resource, buttonId: null)),
                 EventCallback.Factory.Create<CommandViewModel>(this, (command) => ExecuteResourceCommandAsync(resource, command)),
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
                 showConsoleLogsItem: true,

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -541,8 +541,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 ControlsStringsLoc,
                 Loc,
                 CommandsLoc,
-                (buttonId) => ShowResourceDetailsAsync(resource, buttonId),
-                (command) => ExecuteResourceCommandAsync(resource, command),
+                EventCallback.Factory.Create<string?>(this, (buttonId) => ShowResourceDetailsAsync(resource, buttonId)),
+                EventCallback.Factory.Create<CommandViewModel>(this, (command) => ExecuteResourceCommandAsync(resource, command)),
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
                 showConsoleLogsItem: true,
                 showUrls: true);
@@ -646,7 +646,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private async Task ExecuteResourceCommandAsync(ResourceViewModel resource, CommandViewModel command)
     {
-        await DashboardCommandExecutor.ExecuteAsync(resource, command, GetResourceName, StateHasChanged);
+        await DashboardCommandExecutor.ExecuteAsync(resource, command, GetResourceName);
     }
 
     private static string GetUrlsTooltip(ResourceViewModel resource)

--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -32,7 +32,7 @@ public sealed class DashboardCommandExecutor(
         }
     }
 
-    public async Task ExecuteAsync(ResourceViewModel resource, CommandViewModel command, Func<ResourceViewModel, string> getResourceName, Action updateState)
+    public async Task ExecuteAsync(ResourceViewModel resource, CommandViewModel command, Func<ResourceViewModel, string> getResourceName)
     {
         var executingCommandKey = (resource.Name, command.Name);
         lock (_lock)
@@ -67,8 +67,6 @@ public sealed class DashboardCommandExecutor(
         }
         finally
         {
-            updateState();
-
             // There may be a delay between a command finishing and the arrival of a new resource state with updated commands sent to the client.
             // For example:
             // 1. Click the stop command on a resource. The command is disabled while running.
@@ -83,8 +81,6 @@ public sealed class DashboardCommandExecutor(
             {
                 _executingCommands.Remove(executingCommandKey);
             }
-
-            updateState();
         }
     }
 

--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -32,7 +32,7 @@ public sealed class DashboardCommandExecutor(
         }
     }
 
-    public async Task ExecuteAsync(ResourceViewModel resource, CommandViewModel command, Func<ResourceViewModel, string> getResourceName)
+    public async Task ExecuteAsync(ResourceViewModel resource, CommandViewModel command, Func<ResourceViewModel, string> getResourceName, Action updateState)
     {
         var executingCommandKey = (resource.Name, command.Name);
         lock (_lock)
@@ -67,6 +67,8 @@ public sealed class DashboardCommandExecutor(
         }
         finally
         {
+            updateState();
+
             // There may be a delay between a command finishing and the arrival of a new resource state with updated commands sent to the client.
             // For example:
             // 1. Click the stop command on a resource. The command is disabled while running.
@@ -81,6 +83,8 @@ public sealed class DashboardCommandExecutor(
             {
                 _executingCommands.Remove(executingCommandKey);
             }
+
+            updateState();
         }
     }
 

--- a/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
@@ -30,8 +30,8 @@ public static class ResourceMenuItems
         IStringLocalizer<ControlsStrings> controlLoc,
         IStringLocalizer<Resources.Resources> loc,
         IStringLocalizer<Commands> commandsLoc,
-        Func<string?, Task> onViewDetails,
-        Func<CommandViewModel, Task> commandSelected,
+        EventCallback<string?> onViewDetails,
+        EventCallback<CommandViewModel> commandSelected,
         Func<ResourceViewModel, CommandViewModel, bool> isCommandExecuting,
         bool showConsoleLogsItem,
         bool showUrls)
@@ -40,7 +40,7 @@ public static class ResourceMenuItems
         {
             Text = controlLoc[nameof(ControlsStrings.ActionViewDetailsText)],
             Icon = s_viewDetailsIcon,
-            OnClick = () => onViewDetails(openingMenuButtonId)
+            OnClick = () => onViewDetails.InvokeAsync(openingMenuButtonId)
         });
 
         if (showConsoleLogsItem)
@@ -123,7 +123,7 @@ public static class ResourceMenuItems
                     Text = command.GetDisplayName(commandsLoc),
                     Tooltip = command.GetDisplayDescription(commandsLoc),
                     Icon = icon,
-                    OnClick = () => commandSelected(command),
+                    OnClick = () => commandSelected.InvokeAsync(command),
                     IsDisabled = command.State == CommandViewModelState.Disabled || isCommandExecuting(resource, command)
                 });
             }

--- a/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuItems.cs
@@ -22,7 +22,6 @@ public static class ResourceMenuItems
 
     public static void AddMenuItems(
         List<MenuButtonItem> menuItems,
-        string? openingMenuButtonId,
         ResourceViewModel resource,
         NavigationManager navigationManager,
         TelemetryRepository telemetryRepository,
@@ -30,7 +29,7 @@ public static class ResourceMenuItems
         IStringLocalizer<ControlsStrings> controlLoc,
         IStringLocalizer<Resources.Resources> loc,
         IStringLocalizer<Commands> commandsLoc,
-        EventCallback<string?> onViewDetails,
+        EventCallback onViewDetails,
         EventCallback<CommandViewModel> commandSelected,
         Func<ResourceViewModel, CommandViewModel, bool> isCommandExecuting,
         bool showConsoleLogsItem,
@@ -40,7 +39,7 @@ public static class ResourceMenuItems
         {
             Text = controlLoc[nameof(ControlsStrings.ActionViewDetailsText)],
             Icon = s_viewDetailsIcon,
-            OnClick = () => onViewDetails.InvokeAsync(openingMenuButtonId)
+            OnClick = onViewDetails.InvokeAsync
         });
 
         if (showConsoleLogsItem)

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceMenuItemsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceMenuItemsTests.cs
@@ -37,8 +37,8 @@ public sealed class ResourceMenuItemsTests
             new TestStringLocalizer<Resources.ControlsStrings>(),
             new TestStringLocalizer<Resources.Resources>(),
             new TestStringLocalizer<Commands>(),
-            _ => Task.CompletedTask,
-            _ => Task.CompletedTask,
+            EventCallback<string?>.Empty,
+            EventCallback<CommandViewModel>.Empty,
             (_, _) => false,
             true,
             true);
@@ -89,8 +89,8 @@ public sealed class ResourceMenuItemsTests
             new TestStringLocalizer<Resources.ControlsStrings>(),
             new TestStringLocalizer<Resources.Resources>(),
             new TestStringLocalizer<Commands>(),
-            _ => Task.CompletedTask,
-            _ => Task.CompletedTask,
+            EventCallback<string?>.Empty,
+            EventCallback<CommandViewModel>.Empty,
             (_, _) => false,
             true,
             true);
@@ -141,8 +141,8 @@ public sealed class ResourceMenuItemsTests
             new TestStringLocalizer<Resources.ControlsStrings>(),
             new TestStringLocalizer<Resources.Resources>(),
             new TestStringLocalizer<Commands>(),
-            _ => Task.CompletedTask,
-            _ => Task.CompletedTask,
+            EventCallback<string?>.Empty,
+            EventCallback<CommandViewModel>.Empty,
             (_, _) => false,
             true,
             true);

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceMenuItemsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceMenuItemsTests.cs
@@ -29,7 +29,6 @@ public sealed class ResourceMenuItemsTests
         var menuItems = new List<MenuButtonItem>();
         ResourceMenuItems.AddMenuItems(
             menuItems,
-            openingMenuButtonId: null,
             resource,
             new TestNavigationManager(),
             telemetryRespository,
@@ -37,7 +36,7 @@ public sealed class ResourceMenuItemsTests
             new TestStringLocalizer<Resources.ControlsStrings>(),
             new TestStringLocalizer<Resources.Resources>(),
             new TestStringLocalizer<Commands>(),
-            EventCallback<string?>.Empty,
+            EventCallback.Empty,
             EventCallback<CommandViewModel>.Empty,
             (_, _) => false,
             true,
@@ -81,7 +80,6 @@ public sealed class ResourceMenuItemsTests
         var menuItems = new List<MenuButtonItem>();
         ResourceMenuItems.AddMenuItems(
             menuItems,
-            openingMenuButtonId: null,
             resource,
             new TestNavigationManager(),
             repository,
@@ -89,7 +87,7 @@ public sealed class ResourceMenuItemsTests
             new TestStringLocalizer<Resources.ControlsStrings>(),
             new TestStringLocalizer<Resources.Resources>(),
             new TestStringLocalizer<Commands>(),
-            EventCallback<string?>.Empty,
+            EventCallback.Empty,
             EventCallback<CommandViewModel>.Empty,
             (_, _) => false,
             true,
@@ -133,7 +131,6 @@ public sealed class ResourceMenuItemsTests
         var menuItems = new List<MenuButtonItem>();
         ResourceMenuItems.AddMenuItems(
             menuItems,
-            openingMenuButtonId: null,
             resource,
             new TestNavigationManager(),
             repository,
@@ -141,7 +138,7 @@ public sealed class ResourceMenuItemsTests
             new TestStringLocalizer<Resources.ControlsStrings>(),
             new TestStringLocalizer<Resources.Resources>(),
             new TestStringLocalizer<Commands>(),
-            EventCallback<string?>.Empty,
+            EventCallback.Empty,
             EventCallback<CommandViewModel>.Empty,
             (_, _) => false,
             true,


### PR DESCRIPTION
## Description

I think this issue is caused by UI state not updating because of the delay. Fix is to switch to using `EventCallback` rather than func. `EventCallback` will always update state after it has finished running.

Fixes https://github.com/dotnet/aspire/issues/8815

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
