### PR TITLE
Do not fail on partial trust warning.

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -70,7 +70,7 @@ internal sealed class CertificateService(IInteractionService interactionService)
         }
     }
 
-    private const string DevCertsPartialTrustMessage = "There was an error trusting the HTTPS developer certificate. It will be trusted by some clients but not by others.";
+    internal const string DevCertsPartialTrustMessage = "There was an error trusting the HTTPS developer certificate. It will be trusted by some clients but not by others.";
 }
 
 public sealed class CertificateServiceException(string message) : Exception(message)

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Certificates;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Cli.Tests.Certificates;
+
+public class CertificateServiceTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task EnsureCertificatesTrustedAsyncSucceedsOnExitCode4IfPartialTrustMessageDetected()
+    {
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.DotNetCliRunnerFactory = sp =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.CheckHttpCertificateAsyncCallback = (_, _) => 1;
+                runner.TrustHttpCertificateAsyncCallback = (options, _) =>
+                {
+                    Assert.NotNull(options.StandardErrorCallback);
+                    options.StandardErrorCallback!.Invoke("There was an error trusting the HTTPS developer certificate. It will be trusted by some clients but not by others.");
+                    return 4;
+                };
+                return runner;
+            };
+        });
+
+        var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+        var runner = sp.GetRequiredService<IDotNetCliRunner>();
+
+        // If this does not throw then the code is behaving correctly.
+        await cs.EnsureCertificatesTrustedAsync(runner, TestContext.Current.CancellationToken).WaitAsync(CliTestConstants.DefaultTimeout);
+    }
+
+    [Fact]
+    public async Task EnsureCertificatesTrustedAsyncFailsOnExitCode4IfPartialTrustMessageNotDetected()
+    {
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.DotNetCliRunnerFactory = sp =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.CheckHttpCertificateAsyncCallback = (_, _) => 1;
+                runner.TrustHttpCertificateAsyncCallback = (options, _) => 4;
+                return runner;
+            };
+        });
+
+        var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+        var runner = sp.GetRequiredService<IDotNetCliRunner>();
+
+        var ex = await Assert.ThrowsAsync<CertificateServiceException>(async () =>
+        {
+            await cs.EnsureCertificatesTrustedAsync(runner, TestContext.Current.CancellationToken).WaitAsync(CliTestConstants.DefaultTimeout);
+
+        });
+
+        Assert.Equal("Failed to trust certificates, trust command failed with exit code: 4", ex.Message);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -23,7 +23,7 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 runner.TrustHttpCertificateAsyncCallback = (options, _) =>
                 {
                     Assert.NotNull(options.StandardErrorCallback);
-                    options.StandardErrorCallback!.Invoke("There was an error trusting the HTTPS developer certificate. It will be trusted by some clients but not by others.");
+                    options.StandardErrorCallback!.Invoke(CertificateService.DevCertsPartialTrustMessage);
                     return 4;
                 };
                 return runner;


### PR DESCRIPTION
This PR fixes an issue that was reported where the underlying shell out to `dotnet dev-certs` to trust a certificate might result in a non-zero exit code where the cert is partially trusted.

In these circumstances we probably want to "let it slide" and continue starting up the apphost because there are lots of corner cases around certificate trust particularly on Linux distros which might result in this issue.

Rather than hard blocking we detect we are in this partial trust situation and just display a warning (mostly to help our own diagnostics if it later doesn't actually work).

We should consider modifying dev-certs to return a different exit code for this partial trust situation.