### PR TITLE
markdown lint

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -23,5 +23,5 @@ jobs:
     - name: Run Markdownlint
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-        npm i -g markdownlint-cli
+        npm i -g markdownlint-cli@0.45.0
         markdownlint --ignore '.dotnet/' --ignore '**/AnalyzerReleases.*.md' '**/*.md'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 [Tooling](https://learn.microsoft.com/dotnet/aspire/get-started/aspire-overview?#project-templates-and-tooling): .NET Aspire comes with project templates and tooling experiences for Visual Studio and the dotnet CLI which help you create and interact with .NET Aspire apps.
 
-To learn more, read the full [.NET Aspire overview and documentation](https://learn.microsoft.com/dotnet/aspire/). Samples are available in the [.NET Aspire samples repository](https://github.com/dotnet/aspire-samples). You can find the eShop sample [here](https://github.com/dotnet/eshop) and the Azure version [here](https://github.com/Azure-Samples/eShopOnAzure).
+To learn more, read the full [.NET Aspire overview and documentation](https://learn.microsoft.com/dotnet/aspire/). Samples are available in the [.NET Aspire samples repository](https://github.com/dotnet/aspire-samples). You can find the [eShop sample here](https://github.com/dotnet/eshop) and the [Azure version here](https://github.com/Azure-Samples/eShopOnAzure).
 
 ## What is in this repo?
 

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -130,4 +130,4 @@ The software may collect information about you and your use of the software and 
 
 ### Opting out of data collection
 
-The .NET Aspire dashboard collects usage telemetry. Learn what's collected and why [here](https://aka.ms/dotnet/aspire/microsoft-collected-telemetry).  To opt out of dashboard telemetry, set the environment variable `ASPIRE_DASHBOARD_TELEMETRY_OPTOUT` to `true` or disable telemetry in Visual Studio or Visual Studio Code.
+The .NET Aspire dashboard collects usage telemetry. Learn [what's collected and why](https://aka.ms/dotnet/aspire/microsoft-collected-telemetry).  To opt out of dashboard telemetry, set the environment variable `ASPIRE_DASHBOARD_TELEMETRY_OPTOUT` to `true` or disable telemetry in Visual Studio or Visual Studio Code.

--- a/src/Components/Aspire_Components_Progress.md
+++ b/src/Components/Aspire_Components_Progress.md
@@ -50,7 +50,7 @@ Nomenclature used in the table above:
 
 ### Contains README
 
-Each .NET Aspire integration must contain a README.md file which is included in the package. This README should contain the integration's main description, usage examples, and basic getting started documentation. The goal of this file is to contain everything a developer will need in the first 5 minutes. Finally, README should have a link pointed back to the full documentation of the integration, which will include a list of logging categories used, tracing activity names, and Metric names. For a concrete example of a README file, please look [here](./Aspire.StackExchange.Redis/README.md).
+Each .NET Aspire integration must contain a README.md file which is included in the package. This README should contain the integration's main description, usage examples, and basic getting started documentation. The goal of this file is to contain everything a developer will need in the first 5 minutes. Finally, README should have a link pointed back to the full documentation of the integration, which will include a list of logging categories used, tracing activity names, and Metric names. [Here's a concrete example of a README file](./Aspire.StackExchange.Redis/README.md).
 
 ### Public API
 
@@ -62,7 +62,7 @@ Each integration should provide a `sealed` `Settings` type as well as named conf
 
 ### DI Services
 
-Integrations must have extension methods which will "glue" the services with the DI container. For an example of this, please check out the `AspireRedisExtensions` class [here](./Aspire.StackExchange.Redis/AspireRedisExtensions.cs). The extension methods that are registering the main integration's service to the container should be listed in the README file. The full list of registered services by the integration should be included in the main integration's documentation page.
+Integrations must have extension methods which will "glue" the services with the DI container. For an example of this, please check out the `AspireRedisExtensions` [class here](./Aspire.StackExchange.Redis/AspireRedisExtensions.cs). The extension methods that are registering the main integration's service to the container should be listed in the README file. The full list of registered services by the integration should be included in the main integration's documentation page.
 
 ### Health Checks
 


### PR DESCRIPTION
## Description

Fix these issues, and pin markdownlint so new rules don't appear out of the blue again.
```
dan@danmose50:/mnt/c/git/aspire$ markdownlint --ignore '.dotnet/' --ignore '**/AnalyzerReleases.*.md' '**/*.md'
README.md:20:252 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
README.md:20:314 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
src/Aspire.Dashboard/README.md:133:85 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
src/Components/Aspire_Components_Progress.md:53:551 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
src/Components/Aspire_Components_Progress.md:65:172 MD059/descriptive-link-text Link text should be descriptive [Context: "[here]"]
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
