### PR TITLE
Fix failure in MongoDbFunctionalTests.VerifyWithInitFiles

### DIFF
--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -355,6 +355,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             .Build();
 
         var initFilesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(initFilesPath);
 
         try
         {


### PR DESCRIPTION
## Description

Fix test failure due to a temp folder not being created before config files were written to it.

Fixes #5937

