### PR TITLE
Ensure all grid columns have tooltips

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Grid/AspirePropertyColumn.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Grid/AspirePropertyColumn.cs
@@ -14,6 +14,11 @@ public class AspirePropertyColumn<TGridItem, TProp> : PropertyColumn<TGridItem, 
     [Parameter]
     public string? ColumnId { get; set; }
 
+    protected override void OnInitialized()
+    {
+        Tooltip = true;
+    }
+
     protected override bool ShouldRender()
     {
         if (ColumnManager is not null && ColumnId is not null && !ColumnManager.IsColumnVisible(ColumnId))

--- a/src/Aspire.Dashboard/Components/Controls/Grid/AspireTemplateColumn.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Grid/AspireTemplateColumn.cs
@@ -14,6 +14,11 @@ public class AspireTemplateColumn<TGridItem> : TemplateColumn<TGridItem>, IAspir
     [Parameter]
     public string? ColumnId { get; set; }
 
+    protected override void OnInitialized()
+    {
+        Tooltip = true;
+    }
+
     protected override bool ShouldRender()
     {
         if (ColumnManager is not null && ColumnId is not null && !ColumnManager.IsColumnVisible(ColumnId))


### PR DESCRIPTION
## Description

Ensure that all columns have tooltips. Since we use AspireTemplateColumn/AspirePropertyColumn everywhere, we can just set this property. This issue was only affecting certain columns.

After:
<img width="680" alt="image" src="https://github.com/user-attachments/assets/d0813830-8a4c-4d47-98b5-94fbfe4e4af1" />

Before:
<img width="680" alt="image" src="https://github.com/user-attachments/assets/05375c38-4037-47df-9a70-cb05d3cf7868" />

(no tooltip)

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
