### PR TITLE
Support setting existing app identity on compute resources

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureUserAssignedIdentityExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureUserAssignedIdentityExtensions.cs
@@ -45,7 +45,8 @@ public static class AzureUserAssignedIdentityExtensions
     }
 
     /// <summary>
-    /// Sets the <see cref="AzureUserAssignedIdentityResource"/> as the target resource for the builder.
+    /// Attaches an existing <see cref="AzureUserAssignedIdentityResource"/> to a compute resource, 
+    /// setting it as the target identity for the builder.
     /// </summary>
     /// <param name="builder">The builder for the <see cref="IComputeResource"/> the identity will be associated with.</param>
     /// <param name="identityResourceBuilder">The builder for the <see cref="AzureUserAssignedIdentityResource"/>.</param>

--- a/src/Aspire.Hosting.Azure/AzureUserAssignedIdentityExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureUserAssignedIdentityExtensions.cs
@@ -1,3 +1,5 @@
+#pragma warning disable ASPIRECOMPUTE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
@@ -40,5 +42,31 @@ public static class AzureUserAssignedIdentityExtensions
         }
 
         return builder.AddResource(resource);
+    }
+
+    /// <summary>
+    /// Sets the <see cref="AzureUserAssignedIdentityResource"/> as the target resource for the builder.
+    /// </summary>
+    /// <param name="builder">The builder for the <see cref="IComputeResource"/> the identity will be associated with.</param>
+    /// <param name="identityResourceBuilder">The builder for the <see cref="AzureUserAssignedIdentityResource"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{IComputeResource}"/> builder.</returns>
+    /// <example>
+    /// <code>
+    /// var identity = builder.AddAzureUserAssignedIdentity("myIdentity");
+    /// var app = builder.AddProject("myApp")
+    ///     .WithAzureUserAssignedIdentity(identity);
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<T> WithAzureUserAssignedIdentity<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<AzureUserAssignedIdentityResource> identityResourceBuilder)
+        where T : IComputeResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(identityResourceBuilder);
+
+        builder.WithAnnotation(new AppIdentityAnnotation(identityResourceBuilder.Resource));
+
+        return builder;
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
@@ -90,13 +90,9 @@ public class AzureUserAssignedIdentityTests
         var identityRoleAssignments = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "myidentity-roles-myregistry");
         var (_, identityRoleAssignmentsBicep) = await GetManifestWithBicep(identityRoleAssignments, skipPreparer: true);
 
-        Target[] targets = [
-            new Target("bicep", identityBicep),
-            new Target("bicep", registryBicep),
-            new Target("bicep", identityRoleAssignmentsBicep)
-        ];
-
-        await Verify(targets);
+        await Verify(identityBicep, "bicep")
+            .AppendContentAsFile(registryBicep, "bicep")
+            .AppendContentAsFile(identityRoleAssignmentsBicep, "bicep");
     }
 
     [Fact]
@@ -183,13 +179,81 @@ public class AzureUserAssignedIdentityTests
         var (_, identityBicep) = await GetManifestWithBicep(identityResource, skipPreparer: true);
         var (_, roleBicep) = await GetManifestWithBicep(roleAssignmentResource, skipPreparer: true);
 
-        Target[] targets = [
-            new Target("bicep", computeResourceBicep),
-            new Target("bicep", identityBicep),
-            new Target("bicep", roleBicep)
-        ];
+        await Verify(computeResourceBicep, extension: "bicep")
+            .AppendContentAsFile(identityBicep, "bicep")
+            .AppendContentAsFile(roleBicep, "bicep");
+    }
 
-        await Verify(targets);
+    [Fact]
+    public async Task WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works()
+    {
+        // Arrange
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureAppServiceEnvironment("appservice");
+
+        // Use Azure Storage instead of Container Registry
+        var storage = builder.AddAzureStorage("mystorage");
+        var identity = builder.AddAzureUserAssignedIdentity("myidentity");
+
+        var projectBuilder = builder.AddProject<TestProject>("myapp", launchProfileName: null);
+        projectBuilder
+            .WithAzureUserAssignedIdentity(identity)
+            .WithRoleAssignments(storage, StorageBuiltInRole.StorageAccountContributor);
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Validate that only the resources we expect to see are in the model
+        Assert.Collection(model.Resources,
+            r => Assert.IsType<AzureEnvironmentResource>(r),
+            r => Assert.IsType<AzureAppServiceEnvironmentResource>(r),
+            r => Assert.IsType<AzureStorageResource>(r),
+            r => Assert.IsType<AzureUserAssignedIdentityResource>(r),
+            r => Assert.IsType<ProjectResource>(r),
+            r => Assert.IsType<AzureProvisioningResource>(r));
+
+        // Verify the identity resource is the only one that exists
+        var identityResource = Assert.Single(model.Resources.OfType<AzureUserAssignedIdentityResource>());
+        Assert.Equal("myidentity", identityResource.Name);
+
+        // Verify the compute resource has the identity annotation
+        var computeResource = Assert.Single(model.Resources.OfType<IComputeResource>(), r => r.Name == "myapp");
+        var identityAnnotation = Assert.Single(computeResource.Annotations.OfType<AppIdentityAnnotation>());
+        Assert.Same(identity.Resource, identityAnnotation.IdentityResource);
+
+        // Verify the role assignment resource for the project
+        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(),
+            r => r.Name == "myapp-roles-mystorage");
+
+        // Get the Bicep for all resources
+        var deploymentTarget = Assert.Single(computeResource.Annotations.OfType<DeploymentTargetAnnotation>());
+        var (_, computeResourceBicep) = await GetManifestWithBicep(deploymentTarget.DeploymentTarget, skipPreparer: true);
+        var (_, identityBicep) = await GetManifestWithBicep(identityResource, skipPreparer: true);
+        var (_, roleBicep) = await GetManifestWithBicep(roleAssignmentResource, skipPreparer: true);
+
+        await Verify(computeResourceBicep, extension: "bicep")
+            .AppendContentAsFile(identityBicep, "bicep")
+            .AppendContentAsFile(roleBicep, "bicep");
+    }
+
+    [Fact]
+    public async Task WithAzureUserAssignedIdentity_NoEnvironment_ThrowsException()
+    {
+        // Arrange
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var storage = builder.AddAzureStorage("mystorage");
+        var identity = builder.AddAzureUserAssignedIdentity("myidentity");
+
+        var projectBuilder = builder.AddProject<TestProject>("myapp", launchProfileName: null);
+        projectBuilder
+            .WithAzureUserAssignedIdentity(identity);
+
+        using var app = builder.Build();
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await ExecuteBeforeStartHooksAsync(app, default));
     }
 
     [Fact]
@@ -258,15 +322,11 @@ public class AzureUserAssignedIdentityTests
         var (_, roleBicep) = await GetManifestWithBicep(roleAssignmentResource, skipPreparer: true);
         var (_, roleBicep2) = await GetManifestWithBicep(roleAssignmentResource2, skipPreparer: true);
 
-        Target[] targets = [
-            new Target("bicep", computeResourceBicep),
-            new Target("bicep", computeResourceBicep2),
-            new Target("bicep", identityBicep),
-            new Target("bicep", roleBicep),
-            new Target("bicep", roleBicep2)
-        ];
-
-        await Verify(targets);
+        await Verify(computeResourceBicep, extension: "bicep")
+            .AppendContentAsFile(computeResourceBicep2, "bicep")
+            .AppendContentAsFile(identityBicep, "bicep")
+            .AppendContentAsFile(roleBicep, "bicep")
+            .AppendContentAsFile(roleBicep2, "bicep");
     }
 
     private sealed class TestProject : IProjectMetadata

--- a/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
@@ -137,7 +137,7 @@ public class AzureUserAssignedIdentityTests
 
         var env = builder.AddAzureContainerAppEnvironment("cae");
 
-        // Use Azure Storage instead of Container Registry
+        // Use Azure Storage instead of Container Registry to test role assignments on WithReference
         var storage = builder.AddAzureStorage("mystorage");
         var identity = builder.AddAzureUserAssignedIdentity("myidentity");
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureUserAssignedIdentityTests.cs
@@ -1,4 +1,5 @@
 #pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIRECOMPUTE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
@@ -7,6 +8,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.AppContainers;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.ContainerRegistry;
+using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
@@ -33,7 +35,6 @@ public class AzureUserAssignedIdentityTests
         var (_, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(bicep, extension: "bicep");
-            
     }
 
     [Fact]
@@ -52,7 +53,6 @@ public class AzureUserAssignedIdentityTests
         var (_, bicep) = await GetManifestWithBicep(resource);
 
         await Verify(bicep, extension: "bicep");
-            
     }
 
     [Fact]
@@ -97,5 +97,180 @@ public class AzureUserAssignedIdentityTests
         ];
 
         await Verify(targets);
+    }
+
+    [Fact]
+    public async Task WithAzureUserAssignedIdentity_Works()
+    {
+        // Arrange
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureContainerAppEnvironment("cae");
+
+        var identity = builder.AddAzureUserAssignedIdentity("myidentity");
+
+        // Use generic AddProject with TestProject type
+        var projectBuilder = builder.AddProject<TestProject>("myapp", launchProfileName: null);
+        projectBuilder.WithAzureUserAssignedIdentity(identity);
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Check that only one AzureUserAssignedIdentityResource is created, the one that we explicitly constructed
+        var identityResource = Assert.Single(model.Resources.OfType<AzureUserAssignedIdentityResource>());
+        Assert.Equal("myidentity", identityResource.Name);
+
+        // Check for IComputeResource having the correct identity
+        var computeResource = Assert.Single(model.Resources.OfType<IComputeResource>(), r => r.Name == "myapp");
+        var identityAnnotation = Assert.Single(computeResource.Annotations.OfType<AppIdentityAnnotation>());
+        Assert.Same(identity.Resource, identityAnnotation.IdentityResource);
+        var deploymentTarget = Assert.Single(computeResource.Annotations.OfType<DeploymentTargetAnnotation>());
+
+        var (_, computeResourceBicep) = await GetManifestWithBicep(deploymentTarget.DeploymentTarget, skipPreparer: true);
+
+        await Verify(computeResourceBicep, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task WithAzureUserAssignedIdentity_WithRoleAssignments_Works()
+    {
+        // Arrange
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureContainerAppEnvironment("cae");
+
+        // Use Azure Storage instead of Container Registry
+        var storage = builder.AddAzureStorage("mystorage");
+        var identity = builder.AddAzureUserAssignedIdentity("myidentity");
+
+        var projectBuilder = builder.AddProject<TestProject>("myapp", launchProfileName: null);
+        projectBuilder
+            .WithAzureUserAssignedIdentity(identity)
+            .WithRoleAssignments(storage, StorageBuiltInRole.StorageAccountContributor);
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Validate that only the resources we expect to see are in the model
+        Assert.Collection(model.Resources,
+            r => Assert.IsType<AzureEnvironmentResource>(r),
+            r => Assert.IsType<AzureContainerAppEnvironmentResource>(r),
+            r => Assert.IsType<AzureStorageResource>(r),
+            r => Assert.IsType<AzureUserAssignedIdentityResource>(r),
+            r => Assert.IsType<ProjectResource>(r),
+            r => Assert.IsType<AzureProvisioningResource>(r));
+
+        // Verify the identity resource is the only one that exists
+        var identityResource = Assert.Single(model.Resources.OfType<AzureUserAssignedIdentityResource>());
+        Assert.Equal("myidentity", identityResource.Name);
+
+        // Verify the compute resource has the identity annotation
+        var computeResource = Assert.Single(model.Resources.OfType<IComputeResource>(), r => r.Name == "myapp");
+        var identityAnnotation = Assert.Single(computeResource.Annotations.OfType<AppIdentityAnnotation>());
+        Assert.Same(identity.Resource, identityAnnotation.IdentityResource);
+
+        // Verify the role assignment resource for the project
+        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(),
+            r => r.Name == "myapp-roles-mystorage");
+
+        // Get the Bicep for all resources
+        var deploymentTarget = Assert.Single(computeResource.Annotations.OfType<DeploymentTargetAnnotation>());
+        var (_, computeResourceBicep) = await GetManifestWithBicep(deploymentTarget.DeploymentTarget, skipPreparer: true);
+        var (_, identityBicep) = await GetManifestWithBicep(identityResource, skipPreparer: true);
+        var (_, roleBicep) = await GetManifestWithBicep(roleAssignmentResource, skipPreparer: true);
+
+        Target[] targets = [
+            new Target("bicep", computeResourceBicep),
+            new Target("bicep", identityBicep),
+            new Target("bicep", roleBicep)
+        ];
+
+        await Verify(targets);
+    }
+
+    [Fact]
+    public async Task WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works()
+    {
+        // Arrange
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddAzureContainerAppEnvironment("cae");
+
+        // Use Azure Storage instead of Container Registry
+        var storage = builder.AddAzureStorage("mystorage");
+        var identity = builder.AddAzureUserAssignedIdentity("myidentity");
+
+        var projectBuilder = builder.AddProject<TestProject>("myapp", launchProfileName: null);
+        projectBuilder
+            .WithAzureUserAssignedIdentity(identity)
+            .WithRoleAssignments(storage, StorageBuiltInRole.StorageAccountContributor);
+        var projectBuilder2 = builder.AddProject<TestProject>("myapp2", launchProfileName: null);
+        projectBuilder2
+            .WithAzureUserAssignedIdentity(identity)
+            .WithRoleAssignments(storage, StorageBuiltInRole.StorageBlobDataOwner);
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Validate that only the resources we expect to see are in the model
+        Assert.Collection(model.Resources,
+            r => Assert.IsType<AzureEnvironmentResource>(r),
+            r => Assert.IsType<AzureContainerAppEnvironmentResource>(r),
+            r => Assert.IsType<AzureStorageResource>(r),
+            r => Assert.IsType<AzureUserAssignedIdentityResource>(r),
+            r => Assert.IsType<ProjectResource>(r),
+            r => Assert.IsType<ProjectResource>(r),
+            r => Assert.True(r is AzureProvisioningResource { Name: "myapp-roles-mystorage" }),
+            r => Assert.True(r is AzureProvisioningResource { Name: "myapp2-roles-mystorage" }));
+
+        // Verify the identity resource is the only one that exists
+        var identityResource = Assert.Single(model.Resources.OfType<AzureUserAssignedIdentityResource>());
+        Assert.Equal("myidentity", identityResource.Name);
+
+        // Verify that both compute resources have the same identity annotation
+        var computeResource = Assert.Single(model.Resources.OfType<IComputeResource>(), r => r.Name == "myapp");
+        var identityAnnotation = Assert.Single(computeResource.Annotations.OfType<AppIdentityAnnotation>());
+        var computeResource2 = Assert.Single(model.Resources.OfType<IComputeResource>(), r => r.Name == "myapp2");
+        var identityAnnotation2 = Assert.Single(computeResource2.Annotations.OfType<AppIdentityAnnotation>());
+        Assert.Same(identity.Resource, identityAnnotation.IdentityResource);
+        Assert.Same(identity.Resource, identityAnnotation2.IdentityResource);
+
+        // Verify the role assignment resource for the project
+        var roleAssignmentResource = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(),
+            r => r.Name == "myapp-roles-mystorage");
+        var roleAssignmentResource2 = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(),
+            r => r.Name == "myapp2-roles-mystorage");
+        // Each project uses the same identity, but assigns different roles
+        Assert.NotSame(roleAssignmentResource, roleAssignmentResource2);
+
+        // Get the Bicep for all resources
+        var deploymentTarget = Assert.Single(computeResource.Annotations.OfType<DeploymentTargetAnnotation>());
+        var deploymentTarget2 = Assert.Single(computeResource2.Annotations.OfType<DeploymentTargetAnnotation>());
+        var (_, computeResourceBicep) = await GetManifestWithBicep(deploymentTarget.DeploymentTarget, skipPreparer: true);
+        var (_, computeResourceBicep2) = await GetManifestWithBicep(deploymentTarget2.DeploymentTarget, skipPreparer: true);
+        var (_, identityBicep) = await GetManifestWithBicep(identityResource, skipPreparer: true);
+        var (_, roleBicep) = await GetManifestWithBicep(roleAssignmentResource, skipPreparer: true);
+        var (_, roleBicep2) = await GetManifestWithBicep(roleAssignmentResource2, skipPreparer: true);
+
+        Target[] targets = [
+            new Target("bicep", computeResourceBicep),
+            new Target("bicep", computeResourceBicep2),
+            new Target("bicep", identityBicep),
+            new Target("bicep", roleBicep),
+            new Target("bicep", roleBicep2)
+        ];
+
+        await Verify(targets);
+    }
+
+    private sealed class TestProject : IProjectMetadata
+    {
+        public string ProjectPath => "some-path";
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#00.verified.bicep
@@ -1,0 +1,66 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param appservice_outputs_azure_container_registry_endpoint string
+
+param appservice_outputs_planid string
+
+param appservice_outputs_azure_container_registry_managed_identity_id string
+
+param appservice_outputs_azure_container_registry_managed_identity_client_id string
+
+param myapp_containerimage string
+
+param myidentity_outputs_id string
+
+param myidentity_outputs_clientid string
+
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-04-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: myapp_containerimage
+    isMain: true
+    userManagedIdentityClientId: appservice_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+resource webapp 'Microsoft.Web/sites@2024-04-01' = {
+  name: take('${toLower('myapp')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: appservice_outputs_planid
+    keyVaultReferenceIdentity: myidentity_outputs_id
+    siteConfig: {
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: appservice_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'AZURE_CLIENT_ID'
+          value: myidentity_outputs_clientid
+        }
+      ]
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${appservice_outputs_azure_container_registry_managed_identity_id}': { }
+      '${myidentity_outputs_id}': { }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#01.verified.bicep
@@ -1,0 +1,15 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource myidentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: take('myidentity-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+}
+
+output id string = myidentity.id
+
+output clientId string = myidentity.properties.clientId
+
+output principalId string = myidentity.properties.principalId
+
+output principalName string = myidentity.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#02.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#02.verified.bicep
@@ -1,0 +1,20 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param mystorage_outputs_name string
+
+param principalId string
+
+resource mystorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+  name: mystorage_outputs_name
+}
+
+resource mystorage_StorageAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(mystorage.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')
+    principalType: 'ServicePrincipal'
+  }
+  scope: mystorage
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
@@ -1,0 +1,69 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param cae_outputs_azure_container_apps_environment_default_domain string
+
+param cae_outputs_azure_container_apps_environment_id string
+
+param cae_outputs_azure_container_registry_endpoint string
+
+param cae_outputs_azure_container_registry_managed_identity_id string
+
+param myapp_containerimage string
+
+param myidentity_outputs_id string
+
+param myidentity_outputs_clientid string
+
+resource myapp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'myapp'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: cae_outputs_azure_container_registry_endpoint
+          identity: cae_outputs_azure_container_registry_managed_identity_id
+        }
+      ]
+    }
+    environmentId: cae_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: myapp_containerimage
+          name: 'myapp'
+          env: [
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+              value: 'in_memory'
+            }
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: myidentity_outputs_clientid
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${myidentity_outputs_id}': { }
+      '${cae_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
@@ -1,0 +1,69 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param cae_outputs_azure_container_apps_environment_default_domain string
+
+param cae_outputs_azure_container_apps_environment_id string
+
+param cae_outputs_azure_container_registry_endpoint string
+
+param cae_outputs_azure_container_registry_managed_identity_id string
+
+param myapp2_containerimage string
+
+param myidentity_outputs_id string
+
+param myidentity_outputs_clientid string
+
+resource myapp2 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'myapp2'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: cae_outputs_azure_container_registry_endpoint
+          identity: cae_outputs_azure_container_registry_managed_identity_id
+        }
+      ]
+    }
+    environmentId: cae_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: myapp2_containerimage
+          name: 'myapp2'
+          env: [
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+              value: 'in_memory'
+            }
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: myidentity_outputs_clientid
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${myidentity_outputs_id}': { }
+      '${cae_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#02.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#02.verified.bicep
@@ -1,0 +1,15 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource myidentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: take('myidentity-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+}
+
+output id string = myidentity.id
+
+output clientId string = myidentity.properties.clientId
+
+output principalId string = myidentity.properties.principalId
+
+output principalName string = myidentity.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#03.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#03.verified.bicep
@@ -1,0 +1,20 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param mystorage_outputs_name string
+
+param principalId string
+
+resource mystorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+  name: mystorage_outputs_name
+}
+
+resource mystorage_StorageAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(mystorage.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')
+    principalType: 'ServicePrincipal'
+  }
+  scope: mystorage
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#04.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#04.verified.bicep
@@ -1,0 +1,20 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param mystorage_outputs_name string
+
+param principalId string
+
+resource mystorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+  name: mystorage_outputs_name
+}
+
+resource mystorage_StorageBlobDataOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(mystorage.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b')
+    principalType: 'ServicePrincipal'
+  }
+  scope: mystorage
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
@@ -1,0 +1,69 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param cae_outputs_azure_container_apps_environment_default_domain string
+
+param cae_outputs_azure_container_apps_environment_id string
+
+param cae_outputs_azure_container_registry_endpoint string
+
+param cae_outputs_azure_container_registry_managed_identity_id string
+
+param myapp_containerimage string
+
+param myidentity_outputs_id string
+
+param myidentity_outputs_clientid string
+
+resource myapp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'myapp'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: cae_outputs_azure_container_registry_endpoint
+          identity: cae_outputs_azure_container_registry_managed_identity_id
+        }
+      ]
+    }
+    environmentId: cae_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: myapp_containerimage
+          name: 'myapp'
+          env: [
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+              value: 'in_memory'
+            }
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: myidentity_outputs_clientid
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${myidentity_outputs_id}': { }
+      '${cae_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#01.verified.bicep
@@ -1,0 +1,15 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource myidentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: take('myidentity-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+}
+
+output id string = myidentity.id
+
+output clientId string = myidentity.properties.clientId
+
+output principalId string = myidentity.properties.principalId
+
+output principalName string = myidentity.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#02.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#02.verified.bicep
@@ -1,0 +1,20 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param mystorage_outputs_name string
+
+param principalId string
+
+resource mystorage 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+  name: mystorage_outputs_name
+}
+
+resource mystorage_StorageAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(mystorage.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')
+    principalType: 'ServicePrincipal'
+  }
+  scope: mystorage
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
@@ -1,0 +1,69 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param cae_outputs_azure_container_apps_environment_default_domain string
+
+param cae_outputs_azure_container_apps_environment_id string
+
+param cae_outputs_azure_container_registry_endpoint string
+
+param cae_outputs_azure_container_registry_managed_identity_id string
+
+param myapp_containerimage string
+
+param myidentity_outputs_id string
+
+param myidentity_outputs_clientid string
+
+resource myapp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'myapp'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: cae_outputs_azure_container_registry_endpoint
+          identity: cae_outputs_azure_container_registry_managed_identity_id
+        }
+      ]
+    }
+    environmentId: cae_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: myapp_containerimage
+          name: 'myapp'
+          env: [
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+              value: 'in_memory'
+            }
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: myidentity_outputs_clientid
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${myidentity_outputs_id}': { }
+      '${cae_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces the ability to associate an `AzureUserAssignedIdentityResource` with a compute resource via the `WithAzureUserAssignedIdentity` extension method.

Fixes https://github.com/dotnet/aspire/issues/8441

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [X] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] Yes
  - [ ] No
