### PR TITLE
Remove ACA Environment Contributor role assignment

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -69,8 +69,9 @@ public static class AzureContainerAppExtensions
         var containerAppEnvResource = new AzureContainerAppEnvironmentResource(name, static infra =>
         {
             var appEnvResource = (AzureContainerAppEnvironmentResource)infra.AspireResource;
-            var userPrincipalId = new ProvisioningParameter("userPrincipalId", typeof(string));
 
+            // This tells azd to avoid creating infrastructure
+            var userPrincipalId = new ProvisioningParameter(AzureBicepResource.KnownParameters.UserPrincipalId, typeof(string));
             infra.Add(userPrincipalId);
 
             var tags = new ProvisioningParameter("tags", typeof(object))

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -8,7 +8,6 @@ using Aspire.Hosting.Azure.AppContainers;
 using Aspire.Hosting.Lifecycle;
 using Azure.Provisioning;
 using Azure.Provisioning.AppContainers;
-using Azure.Provisioning.Authorization;
 using Azure.Provisioning.ContainerRegistry;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.OperationalInsights;
@@ -160,15 +159,6 @@ public static class AzureContainerAppExtensions
             };
 
             infra.Add(dashboard);
-
-            var roleAssignment = containerAppEnvironment.CreateRoleAssignment(AppContainersBuiltInRole.Contributor,
-                RoleManagementPrincipalType.ServicePrincipal,
-                userPrincipalId);
-
-            // We need to set the principal type to null to let ARM infer the principal id
-            roleAssignment.PrincipalType.ClearValue();
-
-            infra.Add(roleAssignment);
 
             var managedStorages = new Dictionary<string, ContainerAppManagedEnvironmentStorage>();
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
@@ -70,15 +70,6 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: env
 }
 
-resource env_Contributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(env.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c'))
-  properties: {
-    principalId: userPrincipalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-  }
-  scope: env
-}
-
 resource env_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: take('envstoragevolume${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
@@ -72,15 +72,6 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: env
 }
 
-resource env_Contributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(env.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c'))
-  properties: {
-    principalId: userPrincipalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-  }
-  scope: env
-}
-
 resource env_storageVolume 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: 'vol${resourceToken}'
   kind: 'StorageV2'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#00.verified.bicep
@@ -67,15 +67,6 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: env
 }
 
-resource env_Contributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(env.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c'))
-  properties: {
-    principalId: userPrincipalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-  }
-  scope: env
-}
-
 output MANAGED_IDENTITY_NAME string = env_mi.name
 
 output MANAGED_IDENTITY_PRINCIPAL_ID string = env_mi.properties.principalId

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#01.verified.bicep
@@ -70,15 +70,6 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: env
 }
 
-resource env_Contributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(env.id, userPrincipalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c'))
-  properties: {
-    principalId: userPrincipalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-  }
-  scope: env
-}
-
 output MANAGED_IDENTITY_NAME string = env_mi.name
 
 output MANAGED_IDENTITY_PRINCIPAL_ID string = env_mi.properties.principalId


### PR DESCRIPTION
## Description

This role assignment was necessary as an early workaround for getting access to the Aspire Dashboard hosted in ACA.

The explicitly role assignment is no longer necessary because the user doing the deployment will automatically inherit the permission because they are the user who created the ACA environment.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
