### PR TITLE
[CI] Fix copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,4 +18,7 @@ jobs:
 
         # Include PrepareForHelix to maximise what is downloaded here
       - name: Build solution
+        env:
+          # prevent GitInfo errors
+          CI: false
         run: ./build.sh /p:PrepareForHelix=true


### PR DESCRIPTION
Prompted by:
```
/home/runner/work/aspire/aspire/eng/Versions.targets(49,67): error MSB4057: The target "GitInfo" does not exist in the project. [/home/runner/work/aspire/aspire/src/Aspire.AppHost.Sdk/Aspire.RuntimeIdentifier.Tool/Aspire.RuntimeIdentifier.Tool.csproj]
```
