### PR TITLE
Update copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
         env:
           # prevent GitInfo errors
           CI: false
-        run: ./build.sh /p:PrepareForHelix=true
+        run: ./build.sh /p:PrepareForHelix=true /p:CI=false


### PR DESCRIPTION
Add /p:CI=false which apparently will fix `eng/Versions.targets(49,67): error MSB4057: The target "GitInfo" does not exist in the project.`