### PR TITLE
Allow for resource groupings

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
@@ -216,6 +216,8 @@ public static class DistributedApplicationTestingBuilder
 
             public IResourceCollection Resources => innerBuilder.Resources;
 
+            public ResourceGroupCollection Groups { get; } = [];
+
             public IDistributedApplicationEventing Eventing => innerBuilder.Eventing;
 
             public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource => innerBuilder.AddResource(resource);
@@ -352,6 +354,8 @@ public static class DistributedApplicationTestingBuilder
         public DistributedApplicationExecutionContext ExecutionContext => _innerBuilder.ExecutionContext;
 
         public IResourceCollection Resources => _innerBuilder.Resources;
+
+        public ResourceGroupCollection Groups { get; } = [];
 
         public IDistributedApplicationEventing Eventing => _innerBuilder.Eventing;
 

--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
@@ -446,6 +446,9 @@ public interface IDistributedApplicationTestingBuilder : IDistributedApplication
     /// <inheritdoc cref="IDistributedApplicationBuilder.Resources" />
     new IResourceCollection Resources => ((IDistributedApplicationBuilder)this).Resources;
 
+    /// <inheritdoc cref="IDistributedApplicationBuilder.Groups" />
+    new ResourceGroupCollection Groups => ((IDistributedApplicationBuilder)this).Groups;
+
     /// <inheritdoc cref="IDistributedApplicationBuilder.AddResource{T}(T)" />
     new IResourceBuilder<T> AddResource<T>(T resource) where T : IResource => ((IDistributedApplicationBuilder)this).AddResource(resource);
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceGroupAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceGroupAnnotation.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// A collection of resources logically grouped together that will appear grouped in the Aspire Dashboard.
+/// </summary>
+[DebuggerDisplay("Name = {Name}")]
+public sealed class ResourceGroupAnnotation : IResourceAnnotation
+{
+    /// <summary>
+    /// The group name. Must be unique.
+    /// </summary>
+    public required string Name { get; init; }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceGroupAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceGroupAnnotation.cs
@@ -15,4 +15,9 @@ public sealed class ResourceGroupAnnotation : IResourceAnnotation
     /// The group name. Must be unique.
     /// </summary>
     public required string Name { get; init; }
+
+    /// <summary>
+    /// The group parent's name, if one exists.
+    /// </summary>
+    public string? Parent { get; init; }
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -509,6 +509,15 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                 throw new DistributedApplicationException($"Multiple resources with the name '{duplicateResourceName}'. Resource names are case-insensitive.");
             }
 
+            // CreateGroup validates that a name is unique but it's possible to add groups directly to the group collection.
+            // Validate names for duplicates while building the application.
+            foreach (var duplicateGroupName in Groups.GroupBy(g => g.Name, StringComparers.ResourceName)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key))
+            {
+                throw new DistributedApplicationException($"Multiple resource groups with the name '{duplicateGroupName}'. Resource group names are case-insensitive.");
+            }
+
             foreach (var group in Groups)
             {
                 group.BuildGroup();

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -84,6 +84,9 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     public IResourceCollection Resources { get; } = new ResourceCollection();
 
     /// <inheritdoc />
+    public ResourceGroupCollection Groups { get; } = new();
+
+    /// <inheritdoc />
     public IDistributedApplicationEventing Eventing { get; } = new DistributedApplicationEventing();
 
     /// <summary>
@@ -504,6 +507,11 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                 .Select(g => g.Key))
             {
                 throw new DistributedApplicationException($"Multiple resources with the name '{duplicateResourceName}'. Resource names are case-insensitive.");
+            }
+
+            foreach (var group in Groups)
+            {
+                group.BuildGroup();
             }
 
             var application = new DistributedApplication(_innerBuilder.Build());

--- a/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
@@ -80,12 +80,13 @@ public static class DistributedApplicationBuilderExtensions
     /// </summary>
     /// <param name="builder">The distributed application builder.</param>
     /// <param name="name">The unique name of the group.</param>
+    /// <param name="parent">The parent group.</param>
     /// <returns></returns>
-    public static IDistributedApplicationGroupBuilder CreateGroup(this IDistributedApplicationBuilder builder, string name)
+    public static IDistributedApplicationGroupBuilder CreateGroup(this IDistributedApplicationBuilder builder, string name, IDistributedApplicationGroupBuilder? parent = null)
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
         ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
-        var groupBuilder = new DistributedApplicationGroupBuilder(builder, name);
+        var groupBuilder = new DistributedApplicationGroupBuilder(builder, name, parent);
         builder.Groups.Add(groupBuilder);
         return groupBuilder;
     }

--- a/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
@@ -75,10 +75,18 @@ public static class DistributedApplicationBuilderExtensions
         return builder.CreateResourceBuilder(typedResource);
     }
 
-    public static IResourceBuilder<IResource> CreateGroup(this IDistributedApplicationBuilder builder)
+    /// <summary>
+    /// Creates a new resource group builder based on a unique name. Resources created using this group builder will be added to the group.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The unique name of the group.</param>
+    /// <returns></returns>
+    public static IDistributedApplicationGroupBuilder CreateGroup(this IDistributedApplicationBuilder builder, string name)
     {
         ArgumentNullException.ThrowIfNull(builder, nameof(builder));
-        var groupBuilder = new DistributedApplicationGroupBuilder(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
+        var groupBuilder = new DistributedApplicationGroupBuilder(builder, name);
+        builder.Groups.Add(groupBuilder);
         return groupBuilder;
     }
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilderExtensions.cs
@@ -74,5 +74,12 @@ public static class DistributedApplicationBuilderExtensions
 
         return builder.CreateResourceBuilder(typedResource);
     }
+
+    public static IResourceBuilder<IResource> CreateGroup(this IDistributedApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+        var groupBuilder = new DistributedApplicationGroupBuilder(builder);
+        return groupBuilder;
+    }
 }
 

--- a/src/Aspire.Hosting/DistributedApplicationGroupBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationGroupBuilder.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+internal sealed class DistributedApplicationGroupBuilder(IDistributedApplicationBuilder applicationBuilder): IResourceBuilder<IResource>
+{
+    private readonly List<IResourceBuilder<IResource>> _groupResourceBuilders = new();
+    private readonly List<Action<IResourceBuilder<IResource>>> _groupAnnotations = new();
+
+    public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource
+    {
+        var builder = applicationBuilder.AddResource(resource);
+        _groupResourceBuilders.Add((IResourceBuilder<IResource>)builder);
+        return builder;
+    }
+
+    public IDistributedApplicationBuilder ApplicationBuilder => applicationBuilder;
+    public IResource Resource => throw new InvalidOperationException();
+
+    public IResourceBuilder<IResource> WithAnnotation<TAnnotation>(TAnnotation annotation,
+        ResourceAnnotationMutationBehavior behavior = ResourceAnnotationMutationBehavior.Append) where TAnnotation : IResourceAnnotation
+    {
+        _groupAnnotations.Add(resourceBuilder => resourceBuilder.WithAnnotation(annotation, behavior));
+        return this;
+    }
+
+    public void Build()
+    {
+        foreach (var resourceBuilder in _groupResourceBuilders)
+        {
+            foreach (var annotation in _groupAnnotations)
+            {
+                annotation(resourceBuilder);
+            }
+        }
+    }
+}

--- a/src/Aspire.Hosting/DistributedApplicationGroupBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationGroupBuilder.cs
@@ -1,39 +1,72 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting;
 
-internal sealed class DistributedApplicationGroupBuilder(IDistributedApplicationBuilder applicationBuilder): IResourceBuilder<IResource>
+internal sealed class DistributedApplicationGroupBuilder : IDistributedApplicationGroupBuilder
 {
-    private readonly List<IResourceBuilder<IResource>> _groupResourceBuilders = new();
-    private readonly List<Action<IResourceBuilder<IResource>>> _groupAnnotations = new();
+    private readonly List<IResourceBuilder<IResource>> _groupResourceBuilders = [];
+    private readonly ResourceAnnotationCollection _annotations = [];
+
+    public ConfigurationManager Configuration { get; }
+    public string AppHostDirectory { get; }
+    public Assembly? AppHostAssembly { get; }
+    public IHostEnvironment Environment { get; }
+    public IServiceCollection Services { get; }
+    public IDistributedApplicationEventing Eventing { get; }
+    public DistributedApplicationExecutionContext ExecutionContext { get; }
+    public IResourceCollection Resources { get; }
+    public ResourceGroupCollection Groups { get; }
+    public IDistributedApplicationBuilder ApplicationBuilder { get; }
+
+    public IDistributedApplicationGroupBuilder Resource => this;
+
+    public DistributedApplicationGroupBuilder(IDistributedApplicationBuilder applicationBuilder, string name)
+    {
+        _annotations.Add(new ResourceGroupAnnotation { Name = name });
+
+        Configuration = applicationBuilder.Configuration;
+        AppHostDirectory = applicationBuilder.AppHostDirectory;
+        AppHostAssembly = applicationBuilder.AppHostAssembly;
+        Environment = applicationBuilder.Environment;
+        Services = applicationBuilder.Services;
+        Eventing = applicationBuilder.Eventing;
+        ExecutionContext = applicationBuilder.ExecutionContext;
+        Resources = applicationBuilder.Resources;
+        Groups = [this];
+        ApplicationBuilder = applicationBuilder;
+    }
 
     public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource
     {
-        var builder = applicationBuilder.AddResource(resource);
+        var builder = ApplicationBuilder.AddResource(resource);
         _groupResourceBuilders.Add((IResourceBuilder<IResource>)builder);
         return builder;
     }
 
-    public IDistributedApplicationBuilder ApplicationBuilder => applicationBuilder;
-    public IResource Resource => throw new InvalidOperationException();
-
-    public IResourceBuilder<IResource> WithAnnotation<TAnnotation>(TAnnotation annotation,
-        ResourceAnnotationMutationBehavior behavior = ResourceAnnotationMutationBehavior.Append) where TAnnotation : IResourceAnnotation
+    public IResourceBuilder<T> CreateResourceBuilder<T>(T resource) where T : IResource
     {
-        _groupAnnotations.Add(resourceBuilder => resourceBuilder.WithAnnotation(annotation, behavior));
-        return this;
+        return ApplicationBuilder.CreateResourceBuilder(resource);
     }
 
-    public void Build()
+    public DistributedApplication Build() => throw new InvalidOperationException();
+
+    DistributedApplication IDistributedApplicationBuilder.Build() => throw new InvalidOperationException();
+
+    public void BuildGroup()
     {
         foreach (var resourceBuilder in _groupResourceBuilders)
         {
-            foreach (var annotation in _groupAnnotations)
+            foreach (var annotation in _annotations)
             {
-                annotation(resourceBuilder);
+                resourceBuilder.WithAnnotation(annotation);
             }
         }
     }

--- a/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
@@ -38,7 +38,7 @@ namespace Aspire.Hosting;
 /// methods are used to add Redis and PostgreSQL container resources. The results of the methods are stored in variables for
 /// later use.
 /// </para>
-/// 
+///
 /// <code lang="csharp">
 /// var builder = DistributedApplication.CreateBuilder(args);
 /// var cache = builder.AddRedis("cache");
@@ -106,7 +106,7 @@ public interface IDistributedApplicationBuilder
     ///             context.EnvironmentVariables["RABBITMQ_NODENAME"] = nodeName;
     ///         });
     ///     }
-    /// 
+    ///
     ///     return builder;
     /// }
     /// </code>
@@ -121,6 +121,14 @@ public interface IDistributedApplicationBuilder
     /// This can be mutated by adding more resources, which will update its current view.
     /// </remarks>
     public IResourceCollection Resources { get; }
+
+    /// <summary>
+    /// Gets the collection of resource groups for the distributed application.
+    /// </summary>
+    /// <remarks>
+    /// This can be mutated by adding more resource groups using <see cref="DistributedApplicationBuilderExtensions.CreateGroup"/>, which will update its current view.
+    /// </remarks>
+    public ResourceGroupCollection Groups { get; }
 
     /// <summary>
     /// Adds a resource of type <typeparamref name="T"/> to the distributed application.
@@ -201,7 +209,7 @@ public interface IDistributedApplicationBuilder
     ///     },
     ///     secret: true,
     ///     connectionString: true);
-    /// 
+    ///
     ///     var surrogate = new ConnectionStringParameterResource(parameterBuilder.Resource, environmentVariableName);
     ///     return builder.CreateResourceBuilder(surrogate);
     /// }

--- a/src/Aspire.Hosting/IDistributedApplicationGroupBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationGroupBuilder.cs
@@ -8,6 +8,11 @@ namespace Aspire.Hosting;
 /// </summary>
 public interface IDistributedApplicationGroupBuilder : IDistributedApplicationBuilder
 {
+    /// <summary>
+    /// The unique name of the group. This name is used to identify the group in the Aspire Dashboard.
+    /// </summary>
+    public string Name { get; }
+
     internal void BuildGroup();
 
     [Obsolete("Use BuildGroup instead.")]

--- a/src/Aspire.Hosting/IDistributedApplicationGroupBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationGroupBuilder.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// TODO document this type
+/// </summary>
+public interface IDistributedApplicationGroupBuilder : IDistributedApplicationBuilder
+{
+    internal void BuildGroup();
+
+    [Obsolete("Use BuildGroup instead.")]
+    internal new DistributedApplication Build();
+}

--- a/src/Aspire.Hosting/IDistributedApplicationGroupBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationGroupBuilder.cs
@@ -4,7 +4,9 @@
 namespace Aspire.Hosting;
 
 /// <summary>
-/// TODO document this type
+/// A builder for creating instances of resource groupings. It cannot be built directly, but applies annotations to
+/// its contained resources when <see cref="IDistributedApplicationBuilder.Build"/> is called. This type can be used to
+/// visually group resources in the Aspire Dashboard.
 /// </summary>
 public interface IDistributedApplicationGroupBuilder : IDistributedApplicationBuilder
 {
@@ -13,6 +15,9 @@ public interface IDistributedApplicationGroupBuilder : IDistributedApplicationBu
     /// </summary>
     public string Name { get; }
 
+    /// <summary>
+    /// Applies annotations to resources in the group.
+    /// </summary>
     internal void BuildGroup();
 
     [Obsolete("Use BuildGroup instead.")]

--- a/src/Aspire.Hosting/ResourceGroupCollection.cs
+++ b/src/Aspire.Hosting/ResourceGroupCollection.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.ObjectModel;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Represents a collection of resource groups.
+/// </summary>
+public class ResourceGroupCollection : Collection<IDistributedApplicationGroupBuilder>;

--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -7,6 +7,7 @@ namespace Aspire;
 
 internal static class StringComparers
 {
+    public static StringComparer ResourceGroupName => StringComparer.OrdinalIgnoreCase;
     public static StringComparer ResourceName => StringComparer.OrdinalIgnoreCase;
     public static StringComparer ResourceState => StringComparer.OrdinalIgnoreCase;
     public static StringComparer EndpointAnnotationName => StringComparer.OrdinalIgnoreCase;
@@ -34,6 +35,7 @@ internal static class StringComparers
 
 internal static class StringComparisons
 {
+    public static StringComparison ResourceGroupName => StringComparison.OrdinalIgnoreCase;
     public static StringComparison ResourceName => StringComparison.OrdinalIgnoreCase;
     public static StringComparison ResourceState => StringComparison.OrdinalIgnoreCase;
     public static StringComparison EndpointAnnotationName => StringComparison.OrdinalIgnoreCase;

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderExtensionsTests.cs
@@ -43,4 +43,33 @@ public class DistributedApplicationBuilderExtensionsTests
         var newRedisBuilder = appBuilder.CreateResourceBuilder<RedisResource>("redis");
         Assert.Same(originalRedis.Resource, newRedisBuilder.Resource);
     }
+
+    [Fact]
+    public void GroupBuilderAddsGroupAnnotationToAllResources()
+    {
+        var appBuilder = (DistributedApplicationBuilder)DistributedApplication.CreateBuilder();
+
+        var group = appBuilder.CreateGroup("test-group");
+        var redis1 = group.AddRedis("redis1");
+        var redis2 = group.AddRedis("redis2");
+
+        var container = appBuilder.AddContainer("test-container", "test-image");
+        appBuilder.Build();
+
+        Assert.Equal("test-group", Assert.Single(redis1.Resource.Annotations.OfType<ResourceGroupAnnotation>()).Name);
+        Assert.Equal("test-group", Assert.Single(redis2.Resource.Annotations.OfType<ResourceGroupAnnotation>()).Name);
+        Assert.Empty(container.Resource.Annotations.OfType<ResourceGroupAnnotation>());
+    }
+
+    [Fact]
+    public void GroupBuilderBuildThrowsException()
+    {
+        var appBuilder = (DistributedApplicationBuilder)DistributedApplication.CreateBuilder();
+        var group = appBuilder.CreateGroup("test-group");
+        group.AddRedis("redis1");
+        group.AddRedis("redis2");
+#pragma warning disable CS0618 // Type or member is obsolete
+        Assert.Throws<InvalidOperationException>(group.Build);
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
 }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderExtensionsTests.cs
@@ -47,7 +47,7 @@ public class DistributedApplicationBuilderExtensionsTests
     [Fact]
     public void GroupBuilderAddsGroupAnnotationToAllResources()
     {
-        var appBuilder = (DistributedApplicationBuilder)DistributedApplication.CreateBuilder();
+        var appBuilder = DistributedApplication.CreateBuilder();
 
         var group = appBuilder.CreateGroup("test-group");
         var redis1 = group.AddRedis("redis1");
@@ -64,12 +64,20 @@ public class DistributedApplicationBuilderExtensionsTests
     [Fact]
     public void GroupBuilderBuildThrowsException()
     {
-        var appBuilder = (DistributedApplicationBuilder)DistributedApplication.CreateBuilder();
+        var appBuilder = DistributedApplication.CreateBuilder();
         var group = appBuilder.CreateGroup("test-group");
         group.AddRedis("redis1");
         group.AddRedis("redis2");
 #pragma warning disable CS0618 // Type or member is obsolete
         Assert.Throws<InvalidOperationException>(group.Build);
 #pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    [Fact]
+    public void GroupBuilderThrowsExceptionOnDuplicateGroupName()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.CreateGroup("test-group");
+        Assert.Throws<DistributedApplicationException>(() => appBuilder.CreateGroup("test-group"));
     }
 }


### PR DESCRIPTION
## Description

This is a proposed AppHost change to add logic that allows for grouping resources with the purpose of fixing #521. In the future, common group-wide configuration could be added as well. For now, grouped resources would only have a `ResourceGroupAnnotation` added to them to identify their group.

The `IDistributedApplicationGroupBuilder` type inherits from `IDistributedApplicationBuilder` in order to allow the same resource creation extension methods to be used. Since it's _not_ a real distributed application builder, I obsoleted the `Build` method.

An arbitrary amount of nesting is supported. 

Example:
```csharp
var appBuilder = DistributedApplication.CreateBuilder();

// create new groups
var backendGroup = appBuilder.CreateGroup("backend");
var databasesGroup = appBuilder.CreateGroup("databases", parent: backendGroup);

var redis = databasesGroup.AddRedis("redis");
var postgres = databasesGroup.AddPostgres("postgres");

appBuilder.Build();
```

Fixes #521

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [X] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [X] Not yet, draft
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [X] Not yet, draft
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
