### PR TITLE
chore: logging messages to use consistent placeholder names for resources

### DIFF
--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -21,7 +21,7 @@ internal class AppHostRpcTarget(
     PublishingActivityProgressReporter activityReporter,
     IHostApplicationLifetime lifetime,
     DistributedApplicationOptions options
-    ) 
+    )
 {
     public async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
     {
@@ -66,10 +66,10 @@ internal class AppHostRpcTarget(
 
             if (!resourceEvent.Resource.TryGetEndpoints(out var endpoints))
             {
-                logger.LogTrace("Resource {Resource} does not have endpoints.", resourceEvent.Resource.Name);
+                logger.LogTrace("Resource {ResourceName} does not have endpoints.", resourceEvent.Resource.Name);
                 endpoints = Enumerable.Empty<EndpointAnnotation>();
             }
-    
+
             var endpointUris = endpoints
                 .Where(e => e.AllocatedEndpoint != null)
                 .Select(e => e.AllocatedEndpoint!.UriString)
@@ -77,7 +77,7 @@ internal class AppHostRpcTarget(
 
             // Compute health status
             var healthStatus = CustomResourceSnapshot.ComputeHealthStatus(resourceEvent.Snapshot.HealthReports, resourceEvent.Snapshot.State?.Text);
-            
+
             yield return new RpcResourceState
             {
                 Resource = resourceEvent.Resource.Name,
@@ -134,7 +134,7 @@ internal class AppHostRpcTarget(
         if (!StringUtils.TryGetUriFromDelimitedString(dashboardOptions.Value.DashboardUrl, ";", out var dashboardUri))
         {
             logger.LogWarning("Dashboard URL could not be parsed from dashboard options.");
-            throw new InvalidOperationException("Dashboard URL could not be parsed from dashboard options.");            
+            throw new InvalidOperationException("Dashboard URL could not be parsed from dashboard options.");
         }
 
         var codespacesUrlRewriter = serviceProvider.GetService<CodespacesUrlRewriter>();

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -119,7 +119,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
         }
 
         var registrationKeysToCheck = annotations.DistinctBy(a => a.Key).Select(a => a.Key).ToFrozenSet();
-        logger.LogDebug("Resource '{ResourceName}' health checks to monitor: {HeathCheckKeys}", resource.Name, string.Join(", ", registrationKeysToCheck));
+        logger.LogDebug("Resource '{ResourceName}' health checks to monitor: {HealthCheckKeys}", resource.Name, string.Join(", ", registrationKeysToCheck));
 
         var lastHealthCheckTimestamp = 0L;
         var lastDelayInterrupted = false;

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -65,7 +65,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                                     return;
                                 }
 
-                                logger.LogError(ex, "Unexpected error ended health monitoring for resource '{Resource}'.", resourceName);
+                                logger.LogError(ex, "Unexpected error ended health monitoring for resource '{ResourceName}'.", resourceName);
                             }
                         }, state.CancellationToken);
                     }
@@ -112,14 +112,14 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
             //       dynamically add health checks at runtime. If this changes then we
             //       would need to revisit this and scan for transitive health checks
             //       on a periodic basis (you wouldn't want to do it on every pass.
-            logger.LogDebug("Resource '{Resource}' has no health checks to monitor.", resource.Name);
+            logger.LogDebug("Resource '{ResourceName}' has no health checks to monitor.", resource.Name);
             FireResourceReadyEvent(resource, cancellationToken);
 
             return;
         }
 
         var registrationKeysToCheck = annotations.DistinctBy(a => a.Key).Select(a => a.Key).ToFrozenSet();
-        logger.LogDebug("Resource '{Resource}' health checks to monitor: {HeathCheckKeys}", resource.Name, string.Join(", ", registrationKeysToCheck));
+        logger.LogDebug("Resource '{ResourceName}' health checks to monitor: {HeathCheckKeys}", resource.Name, string.Join(", ", registrationKeysToCheck));
 
         var lastHealthCheckTimestamp = 0L;
         var lastDelayInterrupted = false;
@@ -156,7 +156,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                     report = new HealthReport(registrationKeysToCheck.ToDictionary(k => k, k => new HealthReportEntry(HealthStatus.Unhealthy, "Error calling HealthCheckService.", TimeSpan.Zero, ex, data: null)), TimeSpan.Zero);
                 }
 
-                logger.LogTrace("Health report status for '{Resource}' is {HealthReportStatus}.", resource.Name, report.Status);
+                logger.LogTrace("Health report status for '{ResourceName}' is {HealthReportStatus}.", resource.Name, report.Status);
 
                 if (report.Status == HealthStatus.Healthy)
                 {
@@ -176,7 +176,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
 
                 if (ContainsAnyHealthReportChange(report, currentEvent.Snapshot.HealthReports))
                 {
-                    logger.LogTrace("Health reports for '{Resource}' have changed. Publishing updated reports.", resource.Name);
+                    logger.LogTrace("Health reports for '{ResourceName}' have changed. Publishing updated reports.", resource.Name);
 
                     await resourceNotificationService.PublishUpdateAsync(resource, s =>
                     {
@@ -197,7 +197,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                 // cancellation token is signaled.
                 logger.LogTrace(
                     ex,
-                    "Health check monitoring loop for resource '{Resource}' observed exception but was ignored.",
+                    "Health check monitoring loop for resource '{ResourceName}' observed exception but was ignored.",
                     resource.Name
                     );
             }
@@ -210,7 +210,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                 ? HealthyHealthCheckInterval
                 : NonHealthyHealthCheckStepInterval * Math.Min(5, nonHealthyReportCount);
 
-            logger.LogTrace("Resource '{Resource}' health check monitoring loop starting delay of {DelayInterval}.", resource.Name, delayInterval);
+            logger.LogTrace("Resource '{ResourceName}' health check monitoring loop starting delay of {DelayInterval}.", resource.Name, delayInterval);
 
             lastDelayInterrupted = await state.DelayAsync(currentEvent, delayInterval, cancellationToken).ConfigureAwait(false);
         }
@@ -239,26 +239,26 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
 
     private void FireResourceReadyEvent(IResource resource, CancellationToken cancellationToken)
     {
-        logger.LogDebug("Resource '{Resource}' is ready.", resource.Name);
+        logger.LogDebug("Resource '{ResourceName}' is ready.", resource.Name);
 
         // We don't want to block the monitoring loop while we fire the event.
         _ = Task.Run(async () =>
         {
             var resourceReadyEvent = new ResourceReadyEvent(resource, services);
 
-            logger.LogDebug("Publishing ResourceReadyEvent for '{Resource}'.", resource.Name);
+            logger.LogDebug("Publishing ResourceReadyEvent for '{ResourceName}'.", resource.Name);
 
             // Execute the publish and store the task so that waiters can await it and observe the result.
             var task = eventing.PublishAsync(resourceReadyEvent, cancellationToken);
 
-            logger.LogDebug("Waiting for ResourceReadyEvent for '{Resource}'.", resource.Name);
+            logger.LogDebug("Waiting for ResourceReadyEvent for '{ResourceName}'.", resource.Name);
 
             // Suppress exceptions, we just want to make sure that the event is completed.
             await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 
-            logger.LogDebug("ResourceReadyEvent for '{Resource}' completed.", resource.Name);
+            logger.LogDebug("ResourceReadyEvent for '{ResourceName}' completed.", resource.Name);
 
-            logger.LogDebug("Publishing the result of ResourceReadyEvent for '{Resource}'.", resource.Name);
+            logger.LogDebug("Publishing the result of ResourceReadyEvent for '{ResourceName}'.", resource.Name);
 
             await resourceNotificationService.PublishUpdateAsync(resource, s => s with
             {
@@ -315,7 +315,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
             _resourceName = initialEvent.Resource.Name;
             LatestEvent = initialEvent;
 
-            _logger.LogDebug("Starting health monitoring for resource '{Resource}'.", _resourceName);
+            _logger.LogDebug("Starting health monitoring for resource '{ResourceName}'.", _resourceName);
         }
 
         // Used to cancel and exit the monitoring loop for a resource.
@@ -325,7 +325,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
 
         public void StopResourceMonitor()
         {
-            _logger.LogDebug("Stopping health monitoring for resource '{Resource}'.", _resourceName);
+            _logger.LogDebug("Stopping health monitoring for resource '{ResourceName}'.", _resourceName);
             _cts.Cancel();
         }
 
@@ -353,7 +353,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                 // The event might have changed before delay was called. Interrupt immediately if required.
                 if (currentEvent != null && ShouldInterrupt(currentEvent, LatestEvent))
                 {
-                    _logger.LogTrace("Health monitoring delay interrupted for resource '{Resource}'.", _resourceName);
+                    _logger.LogTrace("Health monitoring delay interrupted for resource '{ResourceName}'.", _resourceName);
                     return true;
                 }
                 _delayInterruptTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -35,7 +35,7 @@ internal sealed class ResourceContainerImageBuilder(
 {
     public async Task BuildImageAsync(IResource resource, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Building container image for resource {Resource}", resource.Name);
+        logger.LogInformation("Building container image for resource {ResourceName}", resource.Name);
 
         if (resource is ProjectResource)
         {


### PR DESCRIPTION
Standardizes logging resource placeholder names

Updates all logging statements to use a consistent placeholder name for resources, improving clarity and maintainability in log outputs. Ensures uniformity across components and reduces potential confusion when interpreting logs.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
