### PR TITLE
Add a counter to Stress app

### DIFF
--- a/playground/Stress/Stress.TelemetryService/CounterMetrics.cs
+++ b/playground/Stress/Stress.TelemetryService/CounterMetrics.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Metrics;
+
+namespace Stress.TelemetryService;
+
+public class CounterMetrics(ILogger<CounterMetrics> logger, IMeterFactory meterFactory) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Starting CounterMetrics");
+
+        var meter = meterFactory.Create("CounterMetrics");
+        var counter = meter.CreateCounter<int>(
+            name: "run.done.new.count",
+            description: "Count of new done run",
+            unit: "count");
+
+        for (var i = 0; i < 1000000; i++)
+        {
+            counter.Add(1);
+            await Task.Delay(20, cancellationToken);
+        }
+    }
+}

--- a/playground/Stress/Stress.TelemetryService/Program.cs
+++ b/playground/Stress/Stress.TelemetryService/Program.cs
@@ -6,6 +6,7 @@ using Stress.TelemetryService;
 var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddHostedService<TelemetryStresser>();
 builder.Services.AddHostedService<GaugeMetrics>();
+builder.Services.AddHostedService<CounterMetrics>();
 
 builder.AddServiceDefaults();
 builder.Logging.SetMinimumLevel(LogLevel.Trace);
@@ -14,6 +15,7 @@ builder.Services.AddOpenTelemetry()
     .WithMetrics(metrics =>
     {
         metrics.AddMeter("GaugeMetrics");
+        metrics.AddMeter("CounterMetrics");
     });
 
 var app = builder.Build();


### PR DESCRIPTION
## Description

While investigating #9251, I ntoiced we were missing a counter in the stress playground app.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
