### PR TITLE
Use orchestrator container delay start feature for better `WithExplictStart` + `ContainerLifetime.Persistent` support

### DIFF
--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -65,6 +65,13 @@ internal sealed class ContainerSpec
     [JsonPropertyName("networks")]
     public List<ContainerNetworkConnection>? Networks { get; set; }
 
+    /// <summary>
+    /// Should this resource be started? If set to false, we will not attempt
+    /// to start the resource until Start is set to true (or null).
+    /// </summary>
+    [JsonPropertyName("start")]
+    public bool? Start { get; set; }
+
     // Should this resource be stopped?
     [JsonPropertyName("stop")]
     public bool? Stop { get; set; }

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -26,7 +26,7 @@ internal class ResourceSnapshotBuilder
         var environment = GetEnvironmentVariables(container.Status?.EffectiveEnv ?? container.Spec.Env, container.Spec.Env);
         var state = container.Status?.State;
 
-        if (container.Spec.Start == false && (state == null || state == ContainerState.Pending))
+        if (container.Spec.Start is false && (state == null || state == ContainerState.Pending))
         {
             state = KnownResourceStates.NotStarted;
         }

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -26,6 +26,11 @@ internal class ResourceSnapshotBuilder
         var environment = GetEnvironmentVariables(container.Status?.EffectiveEnv ?? container.Spec.Env, container.Spec.Env);
         var state = container.Status?.State;
 
+        if (container.Spec.Start == false && (state == null || state == ContainerState.Pending))
+        {
+            state = KnownResourceStates.NotStarted;
+        }
+
         var relationships = ImmutableArray<RelationshipSnapshot>.Empty;
 
         (ImmutableArray<string> Args, ImmutableArray<int>? ArgsAreSensitive, bool IsSensitive)? launchArguments = null;

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -330,8 +330,8 @@ public class DistributedApplicationTests
         if (firstRun)
         {
             // On start, one resource won't be started and the other is waiting on it.
-            notStartedResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.NotStarted).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-            dependentResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Waiting).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+            notStartedResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.NotStarted).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            dependentResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Waiting).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
 
             Assert.Collection(notStartedResourceEvent.Snapshot.Urls, u =>
             {
@@ -350,17 +350,17 @@ public class DistributedApplicationTests
             Assert.Contains("TestProject.ServiceB.csproj", dependentResourceEvent.Snapshot.Properties.Single(p => p.Name == "project.path").Value?.ToString());
 
             logger.LogInformation("Start explicit start resource.");
-            await orchestrator.StartResourceAsync(notStartedResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+            await orchestrator.StartResourceAsync(notStartedResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
         }
 
-        var runningResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        var runningResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
         Assert.Collection(runningResourceEvent.Snapshot.Urls, u =>
         {
             Assert.Equal("tcp://localhost:6379", u.Url);
         });
 
         // Dependent resource should now run.
-        var dependentRunningResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        var dependentRunningResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
         Assert.Collection(dependentRunningResourceEvent.Snapshot.Urls, u =>
         {
             Assert.Equal("http://localhost:5254", u.Url);
@@ -368,19 +368,19 @@ public class DistributedApplicationTests
         });
 
         logger.LogInformation("Stop resource.");
-        await orchestrator.StopResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-        await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Exited).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await orchestrator.StopResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+        await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Exited).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
 
         // Stop the continer if this isn't the first run otherwise it'll stay running
         if (firstRun)
         {
             logger.LogInformation("Start resource again");
-            await orchestrator.StartResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-            await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+            await orchestrator.StartResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
         }
 
-        await startTask.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-        await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await startTask.DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+        await app.StopAsync().DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -296,91 +296,92 @@ public class DistributedApplicationTests
         await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
+    [Fact]
     [RequiresDocker]
-    public async Task ExplicitStart_StartPersistentContainer(bool firstRun)
+    public async Task ExplicitStart_StartPersistentContainer()
     {
-        const string testName = "explicit-start-persistent-container";
-        using var testProgram = CreateTestProgram(testName, randomizePorts: false);
-        SetupXUnitLogging(testProgram.AppBuilder.Services);
-
-        var notStartedResourceName = $"{testName}-redis";
-        var dependentResourceName = $"{testName}-serviceb";
-
-        var containerBuilder = AddRedisContainer(testProgram.AppBuilder, notStartedResourceName)
-            .WithContainerName(notStartedResourceName)
-            .WithLifetime(ContainerLifetime.Persistent)
-            .WithEndpoint(port: 6379, targetPort: 6379, name: "tcp", env: "REDIS_PORT")
-            .WithExplicitStart();
-
-        containerBuilder.WithExplicitStart();
-        testProgram.ServiceBBuilder.WaitFor(containerBuilder);
-
-        using var app = testProgram.Build();
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        var orchestrator = app.Services.GetRequiredService<ApplicationOrchestrator>();
-        var logger = app.Services.GetRequiredService<ILogger<DistributedApplicationTests>>();
-
-        var startTask = app.StartAsync();
-
-        ResourceEvent? notStartedResourceEvent = null;
-        ResourceEvent? dependentResourceEvent = null;
-        if (firstRun)
+        foreach (var firstRun in new[] { true, false })
         {
-            // On start, one resource won't be started and the other is waiting on it.
-            notStartedResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.NotStarted).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-            dependentResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Waiting).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            const string testName = "explicit-start-persistent-container";
+            using var testProgram = CreateTestProgram(testName, randomizePorts: false);
+            SetupXUnitLogging(testProgram.AppBuilder.Services);
 
-            Assert.Collection(notStartedResourceEvent.Snapshot.Urls, u =>
+            var notStartedResourceName = $"{testName}-redis";
+            var dependentResourceName = $"{testName}-serviceb";
+
+            var containerBuilder = AddRedisContainer(testProgram.AppBuilder, notStartedResourceName)
+                .WithContainerName(notStartedResourceName)
+                .WithLifetime(ContainerLifetime.Persistent)
+                .WithEndpoint(port: 6379, targetPort: 6379, name: "tcp", env: "REDIS_PORT")
+                .WithExplicitStart();
+
+            containerBuilder.WithExplicitStart();
+            testProgram.ServiceBBuilder.WaitFor(containerBuilder);
+
+            using var app = testProgram.Build();
+            var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+            var orchestrator = app.Services.GetRequiredService<ApplicationOrchestrator>();
+            var logger = app.Services.GetRequiredService<ILogger<DistributedApplicationTests>>();
+
+            var startTask = app.StartAsync();
+
+            ResourceEvent? notStartedResourceEvent = null;
+            ResourceEvent? dependentResourceEvent = null;
+            if (firstRun)
+            {
+                // On start, one resource won't be started and the other is waiting on it.
+                notStartedResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.NotStarted).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+                dependentResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Waiting).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+
+                Assert.Collection(notStartedResourceEvent.Snapshot.Urls, u =>
+                {
+                    Assert.Equal("tcp://localhost:6379", u.Url);
+                    Assert.True(u.IsInactive);
+                });
+                Assert.Collection(dependentResourceEvent.Snapshot.Urls, u =>
+                {
+                    Assert.Equal("http://localhost:5254", u.Url);
+                    Assert.Equal("http", u.Name);
+                    Assert.True(u.IsInactive);
+                });
+
+                // Source should be populated on non-started resources.
+                Assert.Equal(RedisImageSource, notStartedResourceEvent.Snapshot.Properties.Single(p => p.Name == "container.image").Value?.ToString());
+                Assert.Contains("TestProject.ServiceB.csproj", dependentResourceEvent.Snapshot.Properties.Single(p => p.Name == "project.path").Value?.ToString());
+
+                logger.LogInformation("Start explicit start resource.");
+                await orchestrator.StartResourceAsync(notStartedResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            }
+
+            var runningResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            Assert.Collection(runningResourceEvent.Snapshot.Urls, u =>
             {
                 Assert.Equal("tcp://localhost:6379", u.Url);
-                Assert.True(u.IsInactive);
             });
-            Assert.Collection(dependentResourceEvent.Snapshot.Urls, u =>
+
+            // Dependent resource should now run.
+            var dependentRunningResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            Assert.Collection(dependentRunningResourceEvent.Snapshot.Urls, u =>
             {
                 Assert.Equal("http://localhost:5254", u.Url);
                 Assert.Equal("http", u.Name);
-                Assert.True(u.IsInactive);
             });
 
-            // Source should be populated on non-started resources.
-            Assert.Equal(RedisImageSource, notStartedResourceEvent.Snapshot.Properties.Single(p => p.Name == "container.image").Value?.ToString());
-            Assert.Contains("TestProject.ServiceB.csproj", dependentResourceEvent.Snapshot.Properties.Single(p => p.Name == "project.path").Value?.ToString());
+            logger.LogInformation("Stop resource.");
+            await orchestrator.StopResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Exited).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
 
-            logger.LogInformation("Start explicit start resource.");
-            await orchestrator.StartResourceAsync(notStartedResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            // Stop the continer if this isn't the first run otherwise it'll stay running
+            if (firstRun)
+            {
+                logger.LogInformation("Start resource again");
+                await orchestrator.StartResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+                await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            }
+
+            await startTask.DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
+            await app.StopAsync().DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
         }
-
-        var runningResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-        Assert.Collection(runningResourceEvent.Snapshot.Urls, u =>
-        {
-            Assert.Equal("tcp://localhost:6379", u.Url);
-        });
-
-        // Dependent resource should now run.
-        var dependentRunningResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-        Assert.Collection(dependentRunningResourceEvent.Snapshot.Urls, u =>
-        {
-            Assert.Equal("http://localhost:5254", u.Url);
-            Assert.Equal("http", u.Name);
-        });
-
-        logger.LogInformation("Stop resource.");
-        await orchestrator.StopResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-        await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Exited).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-
-        // Stop the continer if this isn't the first run otherwise it'll stay running
-        if (firstRun)
-        {
-            logger.LogInformation("Start resource again");
-            await orchestrator.StartResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-            await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-        }
-
-        await startTask.DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
-        await app.StopAsync().DefaultTimeout(TestConstants.ExtraLongTimeoutTimeSpan);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -296,6 +296,93 @@ public class DistributedApplicationTests
         await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [RequiresDocker]
+    public async Task ExplicitStart_StartPersistentContainer(bool firstRun)
+    {
+        const string testName = "explicit-start-persistent-container";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false);
+        SetupXUnitLogging(testProgram.AppBuilder.Services);
+
+        var notStartedResourceName = $"{testName}-redis";
+        var dependentResourceName = $"{testName}-serviceb";
+
+        var containerBuilder = AddRedisContainer(testProgram.AppBuilder, notStartedResourceName)
+            .WithContainerName(notStartedResourceName)
+            .WithLifetime(ContainerLifetime.Persistent)
+            .WithEndpoint(port: 6379, targetPort: 6379, name: "tcp", env: "REDIS_PORT")
+            .WithExplicitStart();
+
+        containerBuilder.WithExplicitStart();
+        testProgram.ServiceBBuilder.WaitFor(containerBuilder);
+
+        using var app = testProgram.Build();
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        var orchestrator = app.Services.GetRequiredService<ApplicationOrchestrator>();
+        var logger = app.Services.GetRequiredService<ILogger<DistributedApplicationTests>>();
+
+        var startTask = app.StartAsync();
+
+        ResourceEvent? notStartedResourceEvent = null;
+        ResourceEvent? dependentResourceEvent = null;
+        if (firstRun)
+        {
+            // On start, one resource won't be started and the other is waiting on it.
+            notStartedResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.NotStarted).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+            dependentResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Waiting).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+            Assert.Collection(notStartedResourceEvent.Snapshot.Urls, u =>
+            {
+                Assert.Equal("tcp://localhost:6379", u.Url);
+                Assert.True(u.IsInactive);
+            });
+            Assert.Collection(dependentResourceEvent.Snapshot.Urls, u =>
+            {
+                Assert.Equal("http://localhost:5254", u.Url);
+                Assert.Equal("http", u.Name);
+                Assert.True(u.IsInactive);
+            });
+
+            // Source should be populated on non-started resources.
+            Assert.Equal(RedisImageSource, notStartedResourceEvent.Snapshot.Properties.Single(p => p.Name == "container.image").Value?.ToString());
+            Assert.Contains("TestProject.ServiceB.csproj", dependentResourceEvent.Snapshot.Properties.Single(p => p.Name == "project.path").Value?.ToString());
+
+            logger.LogInformation("Start explicit start resource.");
+            await orchestrator.StartResourceAsync(notStartedResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        }
+
+        var runningResourceEvent = await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        Assert.Collection(runningResourceEvent.Snapshot.Urls, u =>
+        {
+            Assert.Equal("tcp://localhost:6379", u.Url);
+        });
+
+        // Dependent resource should now run.
+        var dependentRunningResourceEvent = await rns.WaitForResourceAsync(dependentResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        Assert.Collection(dependentRunningResourceEvent.Snapshot.Urls, u =>
+        {
+            Assert.Equal("http://localhost:5254", u.Url);
+            Assert.Equal("http", u.Name);
+        });
+
+        logger.LogInformation("Stop resource.");
+        await orchestrator.StopResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Exited).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        // Stop the continer if this isn't the first run otherwise it'll stay running
+        if (firstRun)
+        {
+            logger.LogInformation("Start resource again");
+            await orchestrator.StartResourceAsync(runningResourceEvent.ResourceId, CancellationToken.None).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+            await rns.WaitForResourceAsync(notStartedResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        }
+
+        await startTask.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+    }
+
     [Fact]
     public void RegisteredLifecycleHookIsExecutedWhenRunSynchronously()
     {


### PR DESCRIPTION
## Description

The orchestrator now supports explicitly marking a container resource as delayed start. This PR updates the explicit start behavior to create containers with delay start enabled (instead of delaying DCP resource creation until the user manually starts the container). This specifically allows us to better support persistent containers combined with explicit start.

If a container is marked as both persistent and delayed start, DCP will still check for an existing valid container and transition the resource to running if one is found, but won't create a new container if one isn't found.

Fixes #8073

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
