### PR TITLE
Fix Blob Container Connection String Format Exception

### DIFF
--- a/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Program.cs
+++ b/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Program.cs
@@ -3,10 +3,11 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureStorage("storage").RunAsEmulator(container =>
-{
-    container.WithDataBindMount();
-});
+var storage = builder.AddAzureStorage("storage");
+//.RunAsEmulator(container =>
+//{
+//    container.WithDataBindMount();
+//});
 
 var blobs = storage.AddBlobs("blobs");
 blobs.AddBlobContainer("mycontainer1", blobContainerName: "test-container-1");
@@ -14,10 +15,11 @@ blobs.AddBlobContainer("mycontainer2", blobContainerName: "test-container-2");
 
 var queues = storage.AddQueues("queues");
 
-var storage2 = builder.AddAzureStorage("storage2").RunAsEmulator(container =>
-{
-    container.WithDataBindMount();
-});
+var storage2 = builder.AddAzureStorage("storage2");
+//    .RunAsEmulator(container =>
+//{
+//    container.WithDataBindMount();
+//});
 var blobs2 = storage2.AddBlobs("blobs2");
 var blobContainer2 = blobs2.AddBlobContainer("foocontainer", blobContainerName: "foo-container");
 

--- a/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Program.cs
+++ b/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Program.cs
@@ -3,11 +3,10 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureStorage("storage");
-//.RunAsEmulator(container =>
-//{
-//    container.WithDataBindMount();
-//});
+var storage = builder.AddAzureStorage("storage").RunAsEmulator(container =>
+{
+    container.WithDataBindMount();
+});
 
 var blobs = storage.AddBlobs("blobs");
 blobs.AddBlobContainer("mycontainer1", blobContainerName: "test-container-1");
@@ -15,11 +14,10 @@ blobs.AddBlobContainer("mycontainer2", blobContainerName: "test-container-2");
 
 var queues = storage.AddQueues("queues");
 
-var storage2 = builder.AddAzureStorage("storage2");
-//    .RunAsEmulator(container =>
-//{
-//    container.WithDataBindMount();
-//});
+var storage2 = builder.AddAzureStorage("storage2").RunAsEmulator(container =>
+{
+    container.WithDataBindMount();
+});
 var blobs2 = storage2.AddBlobs("blobs2");
 var blobContainer2 = blobs2.AddBlobContainer("foocontainer", blobContainerName: "foo-container");
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageResource.cs
@@ -45,10 +45,7 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
             builder.Append($"Endpoint={ConnectionStringExpression}");
         }
 
-        if (!string.IsNullOrEmpty(blobContainerName))
-        {
-            builder.Append($";ContainerName={blobContainerName}");
-        }
+        builder.Append($";ContainerName={blobContainerName}");
 
         return builder.Build();
     }

--- a/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageResource.cs
@@ -16,10 +16,6 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
     IResourceWithParent<AzureStorageResource>,
     IResourceWithAzureFunctionsConfig
 {
-    // NOTE: if ever these contants are changed, the AzureBlobStorageContainerSettings in Aspire.Azure.Storage.Blobs class should be updated as well.
-    private const string Endpoint = nameof(Endpoint);
-    private const string ContainerName = nameof(ContainerName);
-
     /// <summary>
     /// Gets the parent AzureStorageResource of this AzureBlobStorageResource.
     /// </summary>
@@ -39,11 +35,19 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
         }
 
         ReferenceExpressionBuilder builder = new();
-        builder.Append($"{Endpoint}=\"{ConnectionStringExpression}\";");
+
+        if (Parent.IsEmulator)
+        {
+            builder.AppendFormatted(ConnectionStringExpression);
+        }
+        else
+        {
+            builder.Append($"Endpoint={ConnectionStringExpression}");
+        }
 
         if (!string.IsNullOrEmpty(blobContainerName))
         {
-            builder.Append($"{ContainerName}={blobContainerName};");
+            builder.Append($";ContainerName={blobContainerName}");
         }
 
         return builder.Build();

--- a/src/Components/Aspire.Azure.Storage.Blobs/AzureBlobStorageContainerSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AzureBlobStorageContainerSettings.cs
@@ -28,9 +28,10 @@ public sealed partial class AzureBlobStorageContainerSettings : AzureStorageBlob
         const string ContainerName = nameof(ContainerName);
 
         DbConnectionStringBuilder builder = new() { ConnectionString = connectionString };
-        if (builder.TryGetValue(Endpoint, out var endpoint) && builder.TryGetValue(ContainerName, out var containerName))
+        if (builder.TryGetValue(Endpoint, out var endpoint) && endpoint is string endpointValue && builder.TryGetValue(ContainerName, out var containerName))
         {
-            ConnectionString = endpoint.ToString();
+            // endpoint can be a URI (azure deployment) or key/value pairs (emulator)
+            base.ParseConnectionStringInternal(endpointValue);
             BlobContainerName = containerName.ToString();
         }
     }

--- a/src/Components/Aspire.Azure.Storage.Blobs/AzureBlobStorageContainerSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AzureBlobStorageContainerSettings.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data.Common;
+using System.Text.RegularExpressions;
 using Aspire.Azure.Common;
 
 namespace Aspire.Azure.Storage.Blobs;
@@ -11,6 +12,9 @@ namespace Aspire.Azure.Storage.Blobs;
 /// </summary>
 public sealed partial class AzureBlobStorageContainerSettings : AzureStorageBlobsSettings, IConnectionStringSettings
 {
+    [GeneratedRegex(@"(?i)ContainerName\s*=\s*([^;]+);?", RegexOptions.IgnoreCase)]
+    private static partial Regex ContainerNameRegex();
+
     /// <summary>
     ///  Gets or sets the name of the blob container.
     /// </summary>
@@ -23,16 +27,31 @@ public sealed partial class AzureBlobStorageContainerSettings : AzureStorageBlob
             return;
         }
 
-        // NOTE: if ever these contants are changed, the AzureBlobStorageResource in Aspire.Hosting.Azure.Storage class should be updated as well.
-        const string Endpoint = nameof(Endpoint);
-        const string ContainerName = nameof(ContainerName);
-
         DbConnectionStringBuilder builder = new() { ConnectionString = connectionString };
-        if (builder.TryGetValue(Endpoint, out var endpoint) && endpoint is string endpointValue && builder.TryGetValue(ContainerName, out var containerName))
+
+        if (builder.TryGetValue("ContainerName", out var containerName))
         {
-            // endpoint can be a URI (azure deployment) or key/value pairs (emulator)
-            base.ParseConnectionStringInternal(endpointValue);
-            BlobContainerName = containerName.ToString();
+            BlobContainerName = containerName?.ToString();
+
+            // Remove the ContainerName property from the connection string as BlobServiceClient would fail to parse it.
+            connectionString = ContainerNameRegex().Replace(connectionString, "");
+
+            // NB: we can't remove ContainerName by using the DbConnectionStringBuilder as it would escape the AccountKey value
+            // when the connection string is built and BlobServiceClient doesn't support escape sequences. 
+        }
+
+        // Connection string built from a URI? e.g., Endpoint=https://{account_name}.blob.core.windows.net;ContainerName=...;
+        if (builder.TryGetValue("Endpoint", out var endpoint) && endpoint is string)
+        {
+            if (Uri.TryCreate(endpoint.ToString(), UriKind.Absolute, out var uri))
+            {
+                ServiceUri = uri;
+            }
+        }
+        else
+        {
+            // Otherwise preserve the existing connection string
+            ConnectionString = connectionString;
         }
     }
 }

--- a/src/Components/Aspire.Azure.Storage.Blobs/AzureStorageBlobsSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AzureStorageBlobsSettings.cs
@@ -52,21 +52,18 @@ public class AzureStorageBlobsSettings : IConnectionStringSettings
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {
-        ParseConnectionStringInternal(connectionString);
-    }
-
-    internal virtual void ParseConnectionStringInternal(string? connectionString)
-    {
-        if (!string.IsNullOrEmpty(connectionString))
+        if (string.IsNullOrEmpty(connectionString))
         {
-            if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
-            {
-                ServiceUri = uri;
-            }
-            else
-            {
-                ConnectionString = connectionString;
-            }
+            return;
+        }
+
+        if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
+        {
+            ServiceUri = uri;
+        }
+        else
+        {
+            ConnectionString = connectionString;
         }
     }
 }

--- a/src/Components/Aspire.Azure.Storage.Blobs/AzureStorageBlobsSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AzureStorageBlobsSettings.cs
@@ -52,6 +52,11 @@ public class AzureStorageBlobsSettings : IConnectionStringSettings
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {
+        ParseConnectionStringInternal(connectionString);
+    }
+
+    internal virtual void ParseConnectionStringInternal(string? connectionString)
+    {
         if (!string.IsNullOrEmpty(connectionString))
         {
             if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))

--- a/tests/Aspire.Azure.Storage.Blobs.Tests/AzureBlobStorageContainerSettingsTests.cs
+++ b/tests/Aspire.Azure.Storage.Blobs.Tests/AzureBlobStorageContainerSettingsTests.cs
@@ -11,26 +11,6 @@ public class AzureBlobStorageContainerSettingsTests
 {
     private const string EmulatorConnectionString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1";
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData(";")]
-    [InlineData("Endpoint=https://example.blob.core.windows.net;")]
-    [InlineData("ContainerName=my-container;")]
-    [InlineData("Endpoint=https://example.blob.core.windows.net;ExtraParam=value;")]
-    public void ParseConnectionString_invalid_input(string? connectionString)
-    {
-        // Both Endpoint and ContainerName are required in a blob resource connection string.
-
-        var settings = new AzureBlobStorageContainerSettings();
-
-        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
-
-        Assert.Null(settings.ConnectionString);
-        Assert.Null(settings.ServiceUri);
-        Assert.Null(settings.BlobContainerName);
-    }
-
     [Fact]
     public void ParseConnectionString_invalid_input_results_in_AE()
     {
@@ -57,29 +37,29 @@ public class AzureBlobStorageContainerSettingsTests
     }
 
     [Theory]
-    [InlineData($"Endpoint=\"{EmulatorConnectionString}\";ContainerName=my-container")]
-    [InlineData($"Endpoint=\"{EmulatorConnectionString}\";ContainerName=\"my-container\"")]
+    [InlineData($"{EmulatorConnectionString};ContainerName=my-container")]
+    [InlineData($"{EmulatorConnectionString};ContainerName=\"my-container\"")]
     public void ParseConnectionString_With_ConnectionString(string connectionString)
     {
         var settings = new AzureBlobStorageContainerSettings();
 
         ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
 
-        Assert.Equal(EmulatorConnectionString, settings.ConnectionString);
+        Assert.Contains(EmulatorConnectionString, settings.ConnectionString, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ContainerName", settings.ConnectionString, StringComparison.OrdinalIgnoreCase);
         Assert.Equal("my-container", settings.BlobContainerName);
         Assert.Null(settings.ServiceUri);
     }
 
     [Theory]
     [InlineData($"Endpoint=not-a-uri;ContainerName=my-container")]
-    [InlineData($"Endpoint=\"not-a-uri\";ContainerName=my-container")]
     public void ParseConnectionString_With_NotAUri(string connectionString)
     {
         var settings = new AzureBlobStorageContainerSettings();
 
         ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
 
-        Assert.Equal("not-a-uri", settings.ConnectionString);
+        Assert.True(string.IsNullOrEmpty(settings.ConnectionString));
         Assert.Equal("my-container", settings.BlobContainerName);
         Assert.Null(settings.ServiceUri);
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -232,10 +232,15 @@ public class AzureStorageExtensionsTests
         var blobContainer = blobs.AddBlobContainer(name: "myContainer", blobContainerName);
 
         string? blobConnectionString = await ((IResourceWithConnectionString)blobs.Resource).GetConnectionStringAsync();
+        string? blobContainerConnectionString = await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync();
 
         Assert.NotNull(blobConnectionString);
         Assert.Contains(blobConnectionString, await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
         Assert.Contains($"ContainerName={blobContainerName}", await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
+
+        Assert.NotNull(blobContainerConnectionString);
+        Assert.DoesNotContain($"ContainerName", await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
+        Assert.DoesNotContain(blobContainerName, await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -235,12 +235,8 @@ public class AzureStorageExtensionsTests
         string? blobContainerConnectionString = await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync();
 
         Assert.NotNull(blobConnectionString);
-        Assert.Contains(blobConnectionString, await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
-        Assert.Contains($"ContainerName={blobContainerName}", await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
-
-        Assert.NotNull(blobContainerConnectionString);
-        Assert.DoesNotContain($"ContainerName", await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
-        Assert.DoesNotContain(blobContainerName, await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
+        Assert.Contains(blobConnectionString, blobContainerConnectionString);
+        Assert.Contains($"ContainerName={blobContainerName}", blobContainerConnectionString);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -231,10 +231,11 @@ public class AzureStorageExtensionsTests
         var blobs = storage.AddBlobs("blob");
         var blobContainer = blobs.AddBlobContainer(name: "myContainer", blobContainerName);
 
-        string? blobConntionString = await ((IResourceWithConnectionString)blobs.Resource).GetConnectionStringAsync();
-        string expected = $"Endpoint=\"{blobConntionString}\";ContainerName={blobContainerName};";
+        string? blobConnectionString = await ((IResourceWithConnectionString)blobs.Resource).GetConnectionStringAsync();
 
-        Assert.Equal(expected, await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
+        Assert.NotNull(blobConnectionString);
+        Assert.Contains(blobConnectionString, await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
+        Assert.Contains($"ContainerName={blobContainerName}", await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
     }
 
     [Fact]
@@ -252,7 +253,7 @@ public class AzureStorageExtensionsTests
         var blobContainer = blobs.AddBlobContainer(name: "myContainer", blobContainerName);
 
         string? blobsConnectionString = await ((IResourceWithConnectionString)blobs.Resource).GetConnectionStringAsync();
-        string expected = $"Endpoint=\"{blobsConnectionString}\";ContainerName={blobContainerName};";
+        string expected = $"Endpoint={blobsConnectionString};ContainerName={blobContainerName}";
 
         Assert.Equal(expected, await ((IResourceWithConnectionString)blobContainer.Resource).GetConnectionStringAsync());
     }
@@ -266,7 +267,7 @@ public class AzureStorageExtensionsTests
         var blobs = storage.AddBlobs("blob");
         var blobContainer = blobs.AddBlobContainer(name: "myContainer");
 
-        Assert.Equal("Endpoint=\"{storage.outputs.blobEndpoint}\";ContainerName=myContainer;", blobContainer.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("Endpoint={storage.outputs.blobEndpoint};ContainerName=myContainer", blobContainer.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

The `AzureBlobStorageContainerSettings` specialized class is preventing the distinction between `ConnectionString` and `ServiceUri` from happening. In the case of Azure deployment it would then assign a service uri to the `ConnectionString` property and the wrong client constructor was invoked.

Fixes #9454

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
