### PR TITLE
Use ProcessSpec for invoking dotnet publish

### DIFF
--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -229,7 +229,7 @@ internal sealed class PublishCommand : BaseCommand
             {
                 // If we have an error or all tasks are complete then we can stop
                 // processing the publishing activities.
-                return false;
+                return lastActivityUpdateLookup.All(kvp => !kvp.Value.IsError);
             }
         }
 

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -228,7 +228,7 @@ internal sealed class PublishCommand : BaseCommand
             if (lastActivityUpdateLookup.Any(kvp => kvp.Value.IsError) || lastActivityUpdateLookup.All(kvp => kvp.Value.IsComplete))
             {
                 // If we have an error or all tasks are complete then we can stop
-                // processing the publishing activities.
+                // processing the publishing activities. Return true if there are no errors.
                 return lastActivityUpdateLookup.All(kvp => !kvp.Value.IsError);
             }
         }


### PR DESCRIPTION
This should fix apparent hangs when doing `aspire publish`. The root issue was that when the process stdout buffer filled up the process would stop. This resolves that issue by reading out of that buffer as lines are written and piping them to stdout.

We already do this for `docker build` but hadn't yet done it to `dotnet publish`.

Fixes: #9233