### PR TITLE
[tests] Quarantine failing Garnet tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,7 @@
 * Do not emit "Act", "Arrange" or "Assert" comments.
 * We do not use any mocking framework at the moment.
 * Copy existing style in nearby files for test method names and capitalization.
+* Flaky tests can be quarantined with the `QuarantinedTest` attribute, with a corresponding github issue. These tests are then skipped in the regular tests run. Instead they are run in the Outerloop tests workflow.
 
 ## Running tests
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@
 * Do not emit "Act", "Arrange" or "Assert" comments.
 * We do not use any mocking framework at the moment.
 * Copy existing style in nearby files for test method names and capitalization.
-* Flaky tests can be quarantined with the `QuarantinedTest` attribute, with a corresponding github issue. These tests are then skipped in the regular tests run. Instead they are run in the Outerloop tests workflow.
+* Flaky tests can be quarantined with the `QuarantinedTest` attribute, with a corresponding GitHub issue. These tests are then skipped in the regular tests run. Instead they are run in the Outerloop tests workflow.
 
 ## Running tests
 

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -17,6 +17,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
     [RequiresDocker]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9483")]
     public async Task VerifyWaitForOnGarnetBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -55,6 +56,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9484")]
     public async Task VerifyGarnetResource()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));


### PR DESCRIPTION
- **Quarantine GarnetFunctionalTests.VerifyWaitForOnGarnetBlocksDependentResources (9483) and VerifyGarnetResource (9484)**
- **copilot-instructions: Add information about quarantined tests**
