### PR TITLE
Implement `IDistributedApplicationResourceEvent` on `ResourceEndpointsAllocatedEvent`

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceEndpointsAllocatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceEndpointsAllocatedEvent.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <remarks>
 /// Any resources that customize their URLs via a <see cref="ResourceUrlsCallbackAnnotation"/> will have their callbacks invoked during this event.
 /// </remarks>
-public class ResourceEndpointsAllocatedEvent(IResource resource, IServiceProvider services) : IDistributedApplicationEvent
+public class ResourceEndpointsAllocatedEvent(IResource resource, IServiceProvider services) : IDistributedApplicationResourceEvent 
 {
     /// <inheritdoc />
     public IResource Resource { get; } = resource;


### PR DESCRIPTION
## Description

`ResourceEndpointsAllocatedEvent` is meant to represent endpoints being allocated for a specific resource, so it ought to implement `IDistributedApplicationResourceEvent` rather than `IDistributedApplicationEvent`

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
