### PR TITLE
Support hierarchical partition keys for Azure Cosmos

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
@@ -10,7 +10,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 builder.AddAzureCosmosDatabase("db")
     .AddKeyedContainer("entries")
-    .AddKeyedContainer("users");
+    .AddKeyedContainer("users")
+    .AddKeyedContainer("user-todo");
 builder.AddCosmosDbContext<TestCosmosContext>("db", configureDbContextOptions =>
 {
     configureDbContextOptions.RequestTimeout = TimeSpan.FromSeconds(120);
@@ -58,6 +59,17 @@ app.MapGet("/users", async ([FromKeyedServices("users")] Container container) =>
     return await AddAndGetStatus(container, newEntry);
 });
 
+app.MapGet("/user-todo", async ([FromKeyedServices("user-todo")] Container container) =>
+{
+    var newEntry = new UserTodo
+    {
+        Id = Guid.NewGuid(),
+        UserId = Guid.NewGuid().ToString(),
+        Task = "Sample task"
+    };
+    return await AddAndGetStatus(container, newEntry);
+});
+
 app.MapGet("/ef", async (TestCosmosContext context) =>
 {
     await context.Database.EnsureCreatedAsync();
@@ -80,6 +92,15 @@ public class Entry
 {
     [JsonProperty("id")]
     public string? Id { get; set; }
+}
+
+public class UserTodo
+{
+    [JsonProperty("id")]
+    public required Guid Id { get; set; }
+    [JsonProperty("userId")]
+    public required string UserId { get; set; }
+    public required string Task { get; set; }
 }
 
 public class TestCosmosContext(DbContextOptions<TestCosmosContext> options) : DbContext(options)

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -5,17 +5,19 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var cosmos = builder.AddAzureCosmosDB("cosmos")
-                .RunAsPreviewEmulator(e => e.WithDataExplorer());
+var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
 
 var db = cosmos.AddCosmosDatabase("db");
 var entries = db.AddContainer("entries", "/id", "staging-entries");
-db.AddContainer("users", "/id");
+var users = db.AddContainer("users", "/id");
+var userToDo = db.AddContainer("user-todo", ["/userId", "/id"], "UserTodo");
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()
        .WithReference(db).WaitFor(db)
-       .WithReference(entries).WaitFor(entries);
+       .WithReference(users).WaitFor(users)
+       .WithReference(entries).WaitFor(entries)
+       .WithReference(userToDo).WaitFor(userToDo);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/aspire-manifest.json
@@ -18,6 +18,10 @@
       "type": "value.v0",
       "connectionString": "AccountEndpoint={cosmos.outputs.connectionString};Database=db;Container=users"
     },
+    "user-todo": {
+      "type": "value.v0",
+      "connectionString": "AccountEndpoint={cosmos.outputs.connectionString};Database=db;Container=UserTodo"
+    },
     "api": {
       "type": "project.v0",
       "path": "../CosmosEndToEnd.ApiService/CosmosEndToEnd.ApiService.csproj",

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
@@ -66,6 +66,23 @@ resource users 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@20
   parent: db
 }
 
+resource user_todo 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
+  name: 'UserTodo'
+  location: location
+  properties: {
+    resource: {
+      id: 'UserTodo'
+      partitionKey: {
+        paths: [
+          '/userId'
+          '/id'
+        ]
+      }
+    }
+  }
+  parent: db
+}
+
 output connectionString string = cosmos.properties.documentEndpoint
 
 output name string = cosmos.name

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -27,6 +27,30 @@ public class AzureCosmosDBContainerResource(string name, string containerName, s
     /// </summary>
     public string PartitionKeyPath { get; set; } = ThrowIfNullOrEmpty(partitionKeyPath);
 
+    private IReadOnlyList<string>? _partitionKeyPaths;
+
+    /// <summary>
+    /// Gets or sets the hierarchical partition keys.
+    /// </summary>
+    public IReadOnlyList<string>? PartitionKeyPaths
+    {
+        get => _partitionKeyPaths;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            if (value.Count == 0)
+            {
+                throw new ArgumentException("At least one partition key path should be provided.", nameof(value));
+            }
+            if (value.Any(string.IsNullOrEmpty))
+            {
+                throw new ArgumentException("Partition key paths cannot contain null or empty strings.", nameof(value));
+            }
+
+            _partitionKeyPaths = value;
+        }
+    }
+
     /// <summary>
     /// Gets the parent Azure Cosmos DB database resource.
     /// </summary>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -22,17 +22,21 @@ public class AzureCosmosDBContainerResource(string name, string containerName, s
     /// </summary>
     public string ContainerName { get; set; } = ThrowIfNullOrEmpty(containerName);
 
+    private IReadOnlyList<string> _partitionKeyPaths = [ThrowIfNullOrEmpty(partitionKeyPath)];
+
     /// <summary>
     /// Gets or sets the partition key path.
     /// </summary>
-    public string PartitionKeyPath { get; set; } = ThrowIfNullOrEmpty(partitionKeyPath);
-
-    private IReadOnlyList<string>? _partitionKeyPaths;
+    public string PartitionKeyPath
+    {
+        get => _partitionKeyPaths[0];
+        set => _partitionKeyPaths = [ThrowIfNullOrEmpty(value)];
+    }
 
     /// <summary>
     /// Gets or sets the hierarchical partition keys.
     /// </summary>
-    public IReadOnlyList<string>? PartitionKeyPaths
+    public IReadOnlyList<string> PartitionKeyPaths
     {
         get => _partitionKeyPaths;
         set

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -36,7 +36,7 @@ public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<Azur
             throw new ArgumentException("Partition key paths cannot contain null or empty strings.", nameof(partitionKeyPaths));
         }
 
-        _partitionKeyPaths = partitionKeyPathsArray;
+        PartitionKeyPaths = partitionKeyPathsArray;
         Parent = parent ?? throw new ArgumentNullException(nameof(parent));
     }
 
@@ -56,39 +56,20 @@ public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<Azur
     /// </summary>
     public string ContainerName { get; set; }
 
-    private IReadOnlyList<string> _partitionKeyPaths;
-
     /// <summary>
     /// Gets or sets the partition key path.
     /// </summary>
     [Obsolete($"Use {nameof(PartitionKeyPaths)} instead.")]
     public string PartitionKeyPath
     {
-        get => _partitionKeyPaths[0];
-        set => _partitionKeyPaths = [ThrowIfNullOrEmpty(value)];
+        get => PartitionKeyPaths[0];
+        set => PartitionKeyPaths = [ThrowIfNullOrEmpty(value)];
     }
 
     /// <summary>
     /// Gets or sets the hierarchical partition keys.
     /// </summary>
-    public IReadOnlyList<string> PartitionKeyPaths
-    {
-        get => _partitionKeyPaths;
-        init
-        {
-            ArgumentNullException.ThrowIfNull(value);
-            if (value.Count == 0)
-            {
-                throw new ArgumentException("At least one partition key path should be provided.", nameof(value));
-            }
-            if (value.Any(string.IsNullOrEmpty))
-            {
-                throw new ArgumentException("Partition key paths cannot contain null or empty strings.", nameof(value));
-            }
-
-            _partitionKeyPaths = value;
-        }
-    }
+    public IReadOnlyList<string> PartitionKeyPaths { get; private set; }
 
     /// <summary>
     /// Gets the parent Azure Cosmos DB database resource.

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -119,8 +119,16 @@ public static class AzureCosmosExtensions
                     var containerProperties = new ContainerProperties
                     {
                         Id = container.ContainerName,
-                        PartitionKeyPaths = container.PartitionKeyPaths
                     };
+
+                    if (container.PartitionKeyPaths.Count == 1)
+                    {
+                        containerProperties.PartitionKeyPath = container.PartitionKeyPath;
+                    }
+                    else
+                    {
+                        containerProperties.PartitionKeyPaths = container.PartitionKeyPaths;
+                    }
 
                     await db.CreateContainerIfNotExistsAsync(containerProperties, cancellationToken: ct).ConfigureAwait(false);
                 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -116,24 +116,13 @@ public static class AzureCosmosExtensions
 
                 foreach (var container in database.Containers)
                 {
-                    if (container.PartitionKeyPaths is null)
+                    var containerProperties = new ContainerProperties
                     {
-                        await db.CreateContainerIfNotExistsAsync(
-                                container.ContainerName,
-                                container.PartitionKeyPath,
-                                cancellationToken: ct)
-                            .ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        var containerProperties = new ContainerProperties
-                        {
-                            Id = container.ContainerName,
-                            PartitionKeyPaths = container.PartitionKeyPaths
-                        };
+                        Id = container.ContainerName,
+                        PartitionKeyPaths = container.PartitionKeyPaths
+                    };
 
-                        await db.CreateContainerIfNotExistsAsync(containerProperties, cancellationToken: ct).ConfigureAwait(false);
-                    }
+                    await db.CreateContainerIfNotExistsAsync(containerProperties, cancellationToken: ct).ConfigureAwait(false);
                 }
             }
         });
@@ -496,9 +485,7 @@ public static class AzureCosmosExtensions
                     Resource = new CosmosDBSqlContainerResourceInfo()
                     {
                         ContainerName = container.ContainerName,
-                        PartitionKey = container.PartitionKeyPaths is null
-                        ? new CosmosDBContainerPartitionKey { Paths = [container.PartitionKeyPath] }
-                        : new CosmosDBContainerPartitionKey { Paths = [.. container.PartitionKeyPaths] }
+                        PartitionKey = new CosmosDBContainerPartitionKey { Paths = [.. container.PartitionKeyPaths] }
                     }
                 };
                 infrastructure.Add(cosmosContainer);

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -279,7 +279,7 @@ public static class AzureCosmosExtensions
         // Use the resource name as the container name if it's not provided
         containerName ??= name;
 
-        var container = new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, builder.Resource);
+        var container = new AzureCosmosDBContainerResource(name, containerName, [partitionKeyPath], builder.Resource);
         builder.Resource.Containers.Add(container);
 
         return builder.ApplicationBuilder.AddResource(container);
@@ -312,10 +312,7 @@ public static class AzureCosmosExtensions
         // Use the resource name as the container name if it's not provided
         containerName ??= name;
 
-        var container = new AzureCosmosDBContainerResource(name, containerName, partitionKeyPathsArray[0], builder.Resource)
-        {
-            PartitionKeyPaths = partitionKeyPathsArray
-        };
+        var container = new AzureCosmosDBContainerResource(name, containerName, partitionKeyPaths, builder.Resource);
 
         builder.Resource.Containers.Add(container);
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -116,7 +116,24 @@ public static class AzureCosmosExtensions
 
                 foreach (var container in database.Containers)
                 {
-                    await db.CreateContainerIfNotExistsAsync(container.ContainerName, container.PartitionKeyPath, cancellationToken: ct).ConfigureAwait(false);
+                    if (container.PartitionKeyPaths is null)
+                    {
+                        await db.CreateContainerIfNotExistsAsync(
+                                container.ContainerName,
+                                container.PartitionKeyPath,
+                                cancellationToken: ct)
+                            .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        var containerProperties = new ContainerProperties
+                        {
+                            Id = container.ContainerName,
+                            PartitionKeyPaths = container.PartitionKeyPaths
+                        };
+
+                        await db.CreateContainerIfNotExistsAsync(containerProperties, cancellationToken: ct).ConfigureAwait(false);
+                    }
                 }
             }
         });
@@ -274,6 +291,43 @@ public static class AzureCosmosExtensions
         containerName ??= name;
 
         var container = new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, builder.Resource);
+        builder.Resource.Containers.Add(container);
+
+        return builder.ApplicationBuilder.AddResource(container);
+    }
+
+    /// <summary>
+    /// Adds a container to the associated Cosmos DB database resource with hierarchical partition keys.
+    /// </summary>
+    /// <param name="builder">CosmosDBDatabase resource builder.</param>
+    /// <param name="name">Name of container resource.</param>
+    /// <param name="partitionKeyPaths">Hierarchical partition key paths for the container.</param>
+    /// <param name="containerName">The name of the container. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureCosmosDBContainerResource> AddContainer(this IResourceBuilder<AzureCosmosDBDatabaseResource> builder, [ResourceName] string name, IEnumerable<string> partitionKeyPaths, string? containerName = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(partitionKeyPaths);
+        var partitionKeyPathsArray = partitionKeyPaths.ToArray();
+        if (partitionKeyPathsArray.Length == 0)
+        {
+            throw new ArgumentException("At least one partition key path should be provided.", nameof(partitionKeyPaths));
+        }
+
+        if (partitionKeyPathsArray.Any(string.IsNullOrEmpty))
+        {
+            throw new ArgumentException("Partition key paths cannot contain null or empty strings.", nameof(partitionKeyPaths));
+        }
+
+        // Use the resource name as the container name if it's not provided
+        containerName ??= name;
+
+        var container = new AzureCosmosDBContainerResource(name, containerName, partitionKeyPathsArray[0], builder.Resource)
+        {
+            PartitionKeyPaths = partitionKeyPathsArray
+        };
+
         builder.Resource.Containers.Add(container);
 
         return builder.ApplicationBuilder.AddResource(container);
@@ -442,7 +496,9 @@ public static class AzureCosmosExtensions
                     Resource = new CosmosDBSqlContainerResourceInfo()
                     {
                         ContainerName = container.ContainerName,
-                        PartitionKey = new CosmosDBContainerPartitionKey { Paths = [container.PartitionKeyPath] }
+                        PartitionKey = container.PartitionKeyPaths is null
+                        ? new CosmosDBContainerPartitionKey { Paths = [container.PartitionKeyPath] }
+                        : new CosmosDBContainerPartitionKey { Paths = [.. container.PartitionKeyPaths] }
                     }
                 };
                 infrastructure.Add(cosmosContainer);

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -119,16 +119,8 @@ public static class AzureCosmosExtensions
                     var containerProperties = new ContainerProperties
                     {
                         Id = container.ContainerName,
+                        PartitionKeyPaths = container.PartitionKeyPaths
                     };
-
-                    if (container.PartitionKeyPaths.Count == 1)
-                    {
-                        containerProperties.PartitionKeyPath = container.PartitionKeyPath;
-                    }
-                    else
-                    {
-                        containerProperties.PartitionKeyPaths = container.PartitionKeyPaths;
-                    }
 
                     await db.CreateContainerIfNotExistsAsync(containerProperties, cancellationToken: ct).ConfigureAwait(false);
                 }

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
@@ -83,6 +83,68 @@ public class CosmosDBPublicApiTests
         Assert.Equal(nameof(parent), exception.ParamName);
     }
 
+    [Fact]
+    public void AzureCosmosDBContainerResourcePartitionKeyPathsSetterShouldThrowWhenPathsIsNull()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddAzureCosmosDB("cosmos");
+        const string name = "cosmos";
+        const string containerName = "db";
+        const string partitionKeyPath = "data";
+        IReadOnlyList<string> partitionKeyPaths = null!;
+        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
+
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent)
+        {
+            PartitionKeyPaths = partitionKeyPaths
+        };
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void AzureCosmosDBContainerResourcePartitionKeyPathsSetterShouldThrowWhenPathsIsEmpty()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddAzureCosmosDB("cosmos");
+        const string name = "cosmos";
+        const string containerName = "db";
+        const string partitionKeyPath = "data";
+        IReadOnlyList<string> partitionKeyPaths = [];
+        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
+
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent)
+        {
+            PartitionKeyPaths = partitionKeyPaths
+        };
+
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AzureCosmosDBContainerResourcePartitionKeyPathsSetterShouldThrowWhenPathsContainsNullOrEmpty(bool isNull)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddAzureCosmosDB("cosmos");
+        const string name = "cosmos";
+        const string containerName = "db";
+        const string partitionKeyPath = "data";
+        IReadOnlyList<string> partitionKeyPaths = [isNull ? null! : string.Empty];
+        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
+
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent)
+        {
+            PartitionKeyPaths = partitionKeyPaths
+        };
+
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal("value", exception.ParamName);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -368,6 +430,44 @@ public class CosmosDBPublicApiTests
             ? Assert.Throws<ArgumentNullException>(action)
             : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(partitionKeyPath), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddContainerShouldThrowWhenHierarchicalPartitionKeyIsNull()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var cosmos = builder.AddAzureCosmosDB("cosmos").AddCosmosDatabase("cosmos-db");
+        const string name = "cosmos";
+        IEnumerable<string>? partitionKeyPaths = null;
+        var action = () => cosmos.AddContainer(name, partitionKeyPaths!);
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(partitionKeyPaths), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddContainerShouldThrowWhenHierarchicalPartitionKeyIsEmpty()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var cosmos = builder.AddAzureCosmosDB("cosmos").AddCosmosDatabase("cosmos-db");
+        const string name = "cosmos";
+        string[] partitionKeyPaths = [];
+        var action = () => cosmos.AddContainer(name, partitionKeyPaths);
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(partitionKeyPaths), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AddContainerShouldThrowWhenHierarchicalPartitionKeyContainsEmptyOrNull(bool isNull)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var cosmos = builder.AddAzureCosmosDB("cosmos").AddCosmosDatabase("cosmos-db");
+        const string name = "cosmos";
+        string[] partitionKeyPaths = [isNull ? null! : string.Empty];
+        var action = () => cosmos.AddContainer(name, partitionKeyPaths);
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(partitionKeyPaths), exception.ParamName);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
@@ -114,6 +114,56 @@ public class CosmosDBPublicApiTests
     }
 
     [Fact]
+    public void HierarchicalPartitionCtorAzureCosmosDBContainerResourceShouldThrowWhenPartitionKeyPathsIsNull()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddAzureCosmosDB("cosmos");
+        const string name = "cosmos";
+        const string containerName = "db";
+        IEnumerable<string> partitionKeyPaths = null!;
+        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
+
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPaths, parent);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(partitionKeyPaths), exception.ParamName);
+    }
+
+    [Fact]
+    public void HierarchicalPartitionCtorAzureCosmosDBContainerResourceShouldThrowWhenPartitionKeyPathsIsEmpty()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddAzureCosmosDB("cosmos");
+        const string name = "cosmos";
+        const string containerName = "db";
+        IEnumerable<string> partitionKeyPaths = [];
+        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
+
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPaths, parent);
+
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(partitionKeyPaths), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void HierarchicalPartitionCtorAzureCosmosDBContainerResourceShouldThrowWhenPartitionKeyPathsContainEmptyOrNull(bool isNull)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddAzureCosmosDB("cosmos");
+        const string name = "cosmos";
+        const string containerName = "db";
+        IEnumerable<string> partitionKeyPaths = [isNull ? null! : string.Empty];
+        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
+
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPaths, parent);
+
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(partitionKeyPaths), exception.ParamName);
+    }
+
+    [Fact]
     public void CtorAzureCosmosDBContainerResourceShouldThrowWhenParentIsNull()
     {
         const string name = "cosmos";

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
@@ -21,7 +21,29 @@ public class CosmosDBPublicApiTests
         const string partitionKeyPath = "data";
         var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void HierarchicalPartitionCtorAzureCosmosDBContainerResourceShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddAzureCosmosDB("cosmos");
+        var name = isNull ? null! : string.Empty;
+        const string containerName = "db";
+        const string partitionKeyPath = "data";
+        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
+
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, [partitionKeyPath], parent);
 
         var exception = isNull
             ? Assert.Throws<ArgumentNullException>(action)
@@ -41,7 +63,29 @@ public class CosmosDBPublicApiTests
         const string partitionKeyPath = "data";
         var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(containerName), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void HierarchicalPartitionCtorAzureCosmosDBContainerResourceShouldThrowWhenContainerNameIsNullOrEmpty(bool isNull)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddAzureCosmosDB("cosmos");
+        const string name = "cosmos";
+        var containerName = isNull ? null! : string.Empty;
+        const string partitionKeyPath = "data";
+        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
+
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, [partitionKeyPath], parent);
 
         var exception = isNull
             ? Assert.Throws<ArgumentNullException>(action)
@@ -61,12 +105,12 @@ public class CosmosDBPublicApiTests
         var partitionKeyPath = isNull ? null! : string.Empty;
         var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent);
+#pragma warning restore CS0618 // Type or member is obsolete
 
-        var exception = isNull
-            ? Assert.Throws<ArgumentNullException>(action)
-            : Assert.Throws<ArgumentException>(action);
-        Assert.Equal(nameof(partitionKeyPath), exception.ParamName);
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal("partitionKeyPaths", exception.ParamName);
     }
 
     [Fact]
@@ -77,14 +121,30 @@ public class CosmosDBPublicApiTests
         const string partitionKeyPath = "data";
         AzureCosmosDBDatabaseResource parent = null!;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(parent), exception.ParamName);
     }
 
     [Fact]
-    public void AzureCosmosDBContainerResourcePartitionKeyPathsSetterShouldThrowWhenPathsIsNull()
+    public void HierarchicalPartitionCtorAzureCosmosDBContainerResourceShouldThrowWhenParentIsNull()
+    {
+        const string name = "cosmos";
+        const string containerName = "db";
+        const string partitionKeyPath = "data";
+        AzureCosmosDBDatabaseResource parent = null!;
+
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, [partitionKeyPath], parent);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(parent), exception.ParamName);
+    }
+
+    [Fact]
+    public void AzureCosmosDBContainerResourcePartitionKeyPathsInitializerShouldThrowWhenPathsIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var resource = builder.AddAzureCosmosDB("cosmos");
@@ -94,7 +154,7 @@ public class CosmosDBPublicApiTests
         IReadOnlyList<string> partitionKeyPaths = null!;
         var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
 
-        var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent)
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, [partitionKeyPath], parent)
         {
             PartitionKeyPaths = partitionKeyPaths
         };
@@ -114,7 +174,7 @@ public class CosmosDBPublicApiTests
         IReadOnlyList<string> partitionKeyPaths = [];
         var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
 
-        var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent)
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, [partitionKeyPath], parent)
         {
             PartitionKeyPaths = partitionKeyPaths
         };
@@ -126,17 +186,17 @@ public class CosmosDBPublicApiTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public void AzureCosmosDBContainerResourcePartitionKeyPathsSetterShouldThrowWhenPathsContainsNullOrEmpty(bool isNull)
+    public void AzureCosmosDBContainerResourcePartitionKeyPathsInitializerShouldThrowWhenPathsContainsNullOrEmpty(bool isNull)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var resource = builder.AddAzureCosmosDB("cosmos");
         const string name = "cosmos";
         const string containerName = "db";
-        const string partitionKeyPath = "data";
-        IReadOnlyList<string> partitionKeyPaths = [isNull ? null! : string.Empty];
+        string[] validPartitionKeyPaths = ["/test"];
+        string[] partitionKeyPaths = [isNull ? null! : string.Empty];
         var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
 
-        var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent)
+        var action = () => new AzureCosmosDBContainerResource(name, containerName, validPartitionKeyPaths, parent)
         {
             PartitionKeyPaths = partitionKeyPaths
         };

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
@@ -143,68 +143,6 @@ public class CosmosDBPublicApiTests
         Assert.Equal(nameof(parent), exception.ParamName);
     }
 
-    [Fact]
-    public void AzureCosmosDBContainerResourcePartitionKeyPathsInitializerShouldThrowWhenPathsIsNull()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create();
-        var resource = builder.AddAzureCosmosDB("cosmos");
-        const string name = "cosmos";
-        const string containerName = "db";
-        const string partitionKeyPath = "data";
-        IReadOnlyList<string> partitionKeyPaths = null!;
-        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
-
-        var action = () => new AzureCosmosDBContainerResource(name, containerName, [partitionKeyPath], parent)
-        {
-            PartitionKeyPaths = partitionKeyPaths
-        };
-
-        var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal("value", exception.ParamName);
-    }
-
-    [Fact]
-    public void AzureCosmosDBContainerResourcePartitionKeyPathsSetterShouldThrowWhenPathsIsEmpty()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create();
-        var resource = builder.AddAzureCosmosDB("cosmos");
-        const string name = "cosmos";
-        const string containerName = "db";
-        const string partitionKeyPath = "data";
-        IReadOnlyList<string> partitionKeyPaths = [];
-        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
-
-        var action = () => new AzureCosmosDBContainerResource(name, containerName, [partitionKeyPath], parent)
-        {
-            PartitionKeyPaths = partitionKeyPaths
-        };
-
-        var exception = Assert.Throws<ArgumentException>(action);
-        Assert.Equal("value", exception.ParamName);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void AzureCosmosDBContainerResourcePartitionKeyPathsInitializerShouldThrowWhenPathsContainsNullOrEmpty(bool isNull)
-    {
-        using var builder = TestDistributedApplicationBuilder.Create();
-        var resource = builder.AddAzureCosmosDB("cosmos");
-        const string name = "cosmos";
-        const string containerName = "db";
-        string[] validPartitionKeyPaths = ["/test"];
-        string[] partitionKeyPaths = [isNull ? null! : string.Empty];
-        var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
-
-        var action = () => new AzureCosmosDBContainerResource(name, containerName, validPartitionKeyPaths, parent)
-        {
-            PartitionKeyPaths = partitionKeyPaths
-        };
-
-        var exception = Assert.Throws<ArgumentException>(action);
-        Assert.Equal("value", exception.ParamName);
-    }
-
     [Theory]
     [InlineData(false)]
     [InlineData(true)]


### PR DESCRIPTION
## Description

Support hierarchical partition keys for Azure Cosmos and make both `AzureInfrastructure` and emulator respect the hierarchical partition keys.

As @davidfowl suggested, this won't introduce any break changes. ~A `nullable` property which is `PartitionKeyPaths` has been introduced, and~ when initializes a new instance of the `AzureCosmosDBContainerResource`, the first key will be used as the required parameter.

Similar with the Azure Cosmos SDK, only the `PartitionKeyPaths` will provide the partition key info.

~The way to determine whether to use hierarchical partition keys to create the container is to check whether `PartitionKeyPaths` is `null`.~

If there are further tests need to be added, let me know😊. Another thing I'm not sure is whether we should check the partition keys count, it should be <= 3.

Fixes #9462 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
