### PR TITLE
Update the WithInitFiles implementations to use bind mounts in publish mode

### DIFF
--- a/playground/keycloak/Keycloak.AppHost/aspire-manifest.json
+++ b/playground/keycloak/Keycloak.AppHost/aspire-manifest.json
@@ -8,6 +8,13 @@
         "start",
         "--import-realm"
       ],
+      "bindMounts": [
+        {
+          "source": "../realms",
+          "target": "/opt/keycloak/data/import",
+          "readOnly": true
+        }
+      ],
       "volumes": [
         {
           "name": "keycloak.apphost-28dd42043c-keycloak-data",

--- a/src/Aspire.Hosting.Keycloak/KeycloakContainerImageTags.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakContainerImageTags.cs
@@ -13,5 +13,11 @@ internal static class KeycloakContainerImageTags
 
     /// <remarks>26.2</remarks>
     public const string Tag = "26.2";
+
+    // <remarks>1000</remarks>>
+    public const int ContainerUser = 1000;
+
+    // <remarks>1000</remarks>
+    public const int ContainerGroup = 1000;
 }
 

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -192,7 +192,6 @@ public static class KeycloakResourceBuilderExtensions
         return builder.WithContainerFiles(
             KeycloakImportDirectory,
             importFullPath,
-            defaultOwner: KeycloakContainerImageTags.ContainerUser,
-            defaultGroup: KeycloakContainerImageTags.ContainerGroup);
+            defaultOwner: KeycloakContainerImageTags.ContainerUser);
     }
 }

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -241,9 +241,16 @@ public static class MongoDBBuilderExtensions
 
         var importFullPath = Path.GetFullPath(source, builder.ApplicationBuilder.AppHostDirectory);
 
-        return builder.WithContainerFiles(
-            initPath,
-            ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            return builder.WithContainerFiles(
+                initPath,
+                ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
+        }
+        else
+        {
+            return builder.WithBindMount(importFullPath, initPath, true);
+        }
     }
 
     private static void ConfigureMongoExpressContainer(EnvironmentCallbackContext context, MongoDBServerResource resource)

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -241,16 +241,7 @@ public static class MongoDBBuilderExtensions
 
         var importFullPath = Path.GetFullPath(source, builder.ApplicationBuilder.AppHostDirectory);
 
-        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
-        {
-            return builder.WithContainerFiles(
-                initPath,
-                ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
-        }
-        else
-        {
-            return builder.WithBindMount(importFullPath, initPath, true);
-        }
+        return builder.WithContainerFiles(initPath, importFullPath);
     }
 
     private static void ConfigureMongoExpressContainer(EnvironmentCallbackContext context, MongoDBServerResource resource)

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -343,9 +343,16 @@ public static class MySqlBuilderExtensions
 
         var importFullPath = Path.GetFullPath(source, builder.ApplicationBuilder.AppHostDirectory);
 
-        return builder.WithContainerFiles(
-            initPath,
-            ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            return builder.WithContainerFiles(
+                    initPath,
+                    ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
+        }
+        else
+        {
+            return builder.WithBindMount(importFullPath, initPath, true);
+        }
     }
 
     private static string WritePhpMyAdminConfiguration(IEnumerable<MySqlServerResource> mySqlInstances)

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -343,16 +343,7 @@ public static class MySqlBuilderExtensions
 
         var importFullPath = Path.GetFullPath(source, builder.ApplicationBuilder.AppHostDirectory);
 
-        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
-        {
-            return builder.WithContainerFiles(
-                    initPath,
-                    ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
-        }
-        else
-        {
-            return builder.WithBindMount(importFullPath, initPath, true);
-        }
+        return builder.WithContainerFiles(initPath, importFullPath);
     }
 
     private static string WritePhpMyAdminConfiguration(IEnumerable<MySqlServerResource> mySqlInstances)

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -145,9 +145,16 @@ public static class OracleDatabaseBuilderExtensions
 
         var importFullPath = Path.GetFullPath(source, builder.ApplicationBuilder.AppHostDirectory);
 
-        return builder.WithContainerFiles(
-            initPath,
-            ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            return builder.WithContainerFiles(
+                initPath,
+                ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
+        }
+        else
+        {
+            return builder.WithBindMount(importFullPath, initPath, true);
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -145,16 +145,7 @@ public static class OracleDatabaseBuilderExtensions
 
         var importFullPath = Path.GetFullPath(source, builder.ApplicationBuilder.AppHostDirectory);
 
-        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
-        {
-            return builder.WithContainerFiles(
-                initPath,
-                ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
-        }
-        else
-        {
-            return builder.WithBindMount(importFullPath, initPath, true);
-        }
+        return builder.WithContainerFiles(initPath, importFullPath);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -420,16 +420,7 @@ public static class PostgresBuilderExtensions
 
         var importFullPath = Path.GetFullPath(source, builder.ApplicationBuilder.AppHostDirectory);
 
-        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
-        {
-            return builder.WithContainerFiles(
-                initPath,
-                ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
-        }
-        else
-        {
-            return builder.WithBindMount(importFullPath, initPath, true);
-        }
+        return builder.WithContainerFiles(initPath, importFullPath);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -420,9 +420,16 @@ public static class PostgresBuilderExtensions
 
         var importFullPath = Path.GetFullPath(source, builder.ApplicationBuilder.AppHostDirectory);
 
-        return builder.WithContainerFiles(
-            initPath,
-            ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            return builder.WithContainerFiles(
+                initPath,
+                ContainerDirectory.GetFileSystemItemsFromPath(importFullPath));
+        }
+        else
+        {
+            return builder.WithBindMount(importFullPath, initPath, true);
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -857,6 +857,11 @@ public static class ContainerResourceBuilderExtensions
 
         var sourceFullPath = Path.GetFullPath(sourcePath, builder.ApplicationBuilder.AppHostDirectory);
 
+        if (!Directory.Exists(sourceFullPath) && !File.Exists(sourceFullPath))
+        {
+            throw new InvalidOperationException($"The source path '{sourceFullPath}' does not exist. Ensure the path is correct and accessible.");
+        }
+
         if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
         {
             // In run mode, use copied files as they allow us to configure permissions and ownership and support

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
@@ -167,10 +167,7 @@ public class KeycloakPublicApiTests
 
         var entries = await containerAnnotation.Callback(new() { Model = keycloakResource, ServiceProvider = app.Services }, CancellationToken.None);
 
-        Assert.Equal("/opt/keycloak/data", containerAnnotation.DestinationPath);
-        var importDirectory = Assert.IsType<ContainerDirectory>(entries.First());
-        Assert.Equal("import", importDirectory.Name);
-        Assert.Empty(importDirectory.Entries);
+        Assert.Equal("/opt/keycloak/data/import", containerAnnotation.DestinationPath);
     }
 
     [Fact]
@@ -197,10 +194,8 @@ public class KeycloakPublicApiTests
 
         var entries = await containerAnnotation.Callback(new() { Model = keycloakResource, ServiceProvider = app.Services }, CancellationToken.None);
 
-        Assert.Equal("/opt/keycloak/data", containerAnnotation.DestinationPath);
-        var importDirectory = Assert.IsType<ContainerDirectory>(entries.First());
-        Assert.Equal("import", importDirectory.Name);
-        var realmFile = Assert.IsType<ContainerFile>(Assert.Single(importDirectory.Entries));
+        Assert.Equal("/opt/keycloak/data/import", containerAnnotation.DestinationPath);
+        var realmFile = Assert.IsType<ContainerFile>(Assert.Single(entries));
         Assert.Equal(file, realmFile.Name);
         Assert.Equal(filePath, realmFile.SourcePath);
     }

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -404,10 +404,11 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
 
             var mySqlDbName = "db1";
 
-            var mysql = builder.AddMySql("mysql").WithEnvironment("MYSQL_DATABASE", mySqlDbName);
-            var db = mysql.AddDatabase(mySqlDbName);
+            var mysql = builder.AddMySql("mysql")
+                               .WithEnvironment("MYSQL_DATABASE", mySqlDbName)
+                               .WithInitFiles(initFilesPath);
 
-            mysql.WithInitFiles(initFilesPath);
+            var db = mysql.AddDatabase(mySqlDbName);
 
             using var app = builder.Build();
 

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -468,11 +468,11 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
                 .CreateWithTestContainerRegistry(testOutputHelper);
 
             var postgresDbName = "db1";
-            var postgres = builder.AddPostgres("pg").WithEnvironment("POSTGRES_DB", postgresDbName);
+            var postgres = builder.AddPostgres("pg")
+                                  .WithEnvironment("POSTGRES_DB", postgresDbName)
+                                  .WithInitFiles(initFilesPath);
 
             var db = postgres.AddDatabase(postgresDbName);
-
-            postgres.WithInitFiles(initFilesPath);
 
             using var app = builder.Build();
 


### PR DESCRIPTION
## Description

The new WIthContainerFiles API uses `cp` to copy files. This gives much better control over ownership and permissions for files within the container, but it isn't well supported in publish mode. This PR updates the various `WithInitFiles` methods to detect whether we're in run mode or publish mode and use WithBindMount for publish.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
