### PR TITLE
Force SqlDatabase resource api version

### DIFF
--- a/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/sql1.module.bicep
+++ b/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/sql1.module.bicep
@@ -35,7 +35,7 @@ resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2
   parent: sql1
 }
 
-resource db1 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db1 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db1'
   location: location
   properties: {

--- a/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/sql2.module.bicep
+++ b/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/sql2.module.bicep
@@ -35,7 +35,7 @@ resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2
   parent: sql2
 }
 
-resource db2 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db2 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db2'
   location: location
   properties: {

--- a/playground/SqlServerScript/AppHost1/mysqlserver.module.bicep
+++ b/playground/SqlServerScript/AppHost1/mysqlserver.module.bicep
@@ -35,7 +35,7 @@ resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2
   parent: mysqlserver
 }
 
-resource todosdb 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource todosdb 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'todosdb'
   location: location
   properties: {

--- a/playground/bicep/BicepSample.AppHost/sql.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/sql.module.bicep
@@ -35,7 +35,7 @@ resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2
   parent: sql
 }
 
-resource db 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db'
   location: location
   properties: {

--- a/playground/cdk/CdkSample.AppHost/sql.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/sql.module.bicep
@@ -35,7 +35,7 @@ resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2
   parent: sql
 }
 
-resource sqldb 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource sqldb 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'sqldb'
   location: location
   properties: {

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -252,7 +252,11 @@ public static class AzureSqlExtensions
     private static SqlDatabase CreateAzureSQLDatabase(SqlServer sqlServer, string databaseKey, string databaseName)
     {
         var bicepIdentifier = Infrastructure.NormalizeBicepIdentifier(databaseKey);
-        var sqlDatabase = new SqlDatabase(bicepIdentifier)
+
+        // Force the api version to the one supporting the free SKU
+        // c.f. https://github.com/Azure/azure-sdk-for-net/issues/50281
+
+        var sqlDatabase = new SqlDatabase(bicepIdentifier, "2023-08-01")
         {
             Parent = sqlServer,
             Name = databaseName,

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AsAzureSqlDatabaseViaPublishMode.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AsAzureSqlDatabaseViaPublishMode.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource sqlServerAdminManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
@@ -35,7 +35,7 @@ resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2
   parent: sql
 }
 
-resource db 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'dbName'
   location: location
   parent: sql

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AsAzureSqlDatabaseViaRunMode.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureBicepResourceTests.AsAzureSqlDatabaseViaRunMode.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource sqlServerAdminManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
@@ -44,7 +44,7 @@ resource sqlFirewallRule_AllowAllIps 'Microsoft.Sql/servers/firewallRules@2021-1
   parent: sql
 }
 
-resource db 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'dbName'
   location: location
   parent: sql

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentWorksWithSqlServer.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentWorksWithSqlServer.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource sqlServerAdminManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
@@ -35,7 +35,7 @@ resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2
   parent: sql
 }
 
-resource db 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db'
   location: location
   parent: sql

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourceOptionsTests.AzureResourceOptionsCanBeConfigured#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureResourceOptionsTests.AzureResourceOptionsCanBeConfigured#01.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource sqlServerAdminManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
@@ -35,7 +35,7 @@ resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2
   parent: sql_server
 }
 
-resource evadexdb 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource evadexdb 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'evadexdb'
   location: location
   parent: sql_server

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlExtensionsTests.AddAzureSqlServer_publishMode=False_useAcaInfrastructure=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlExtensionsTests.AddAzureSqlServer_publishMode=False_useAcaInfrastructure=False.verified.bicep
@@ -44,7 +44,7 @@ resource sqlFirewallRule_AllowAllIps 'Microsoft.Sql/servers/firewallRules@2021-1
   parent: sql
 }
 
-resource db1 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db1 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db1'
   location: location
   properties: {
@@ -57,7 +57,7 @@ resource db1 'Microsoft.Sql/servers/databases@2021-11-01' = {
   parent: sql
 }
 
-resource db2 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db2 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db2Name'
   location: location
   properties: {
@@ -70,7 +70,7 @@ resource db2 'Microsoft.Sql/servers/databases@2021-11-01' = {
   parent: sql
 }
 
-resource db3 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db3 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db3Name'
   location: location
   parent: sql

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlExtensionsTests.AddAzureSqlServer_publishMode=False_useAcaInfrastructure=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlExtensionsTests.AddAzureSqlServer_publishMode=False_useAcaInfrastructure=True.verified.bicep
@@ -44,7 +44,7 @@ resource sqlFirewallRule_AllowAllIps 'Microsoft.Sql/servers/firewallRules@2021-1
   parent: sql
 }
 
-resource db1 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db1 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db1'
   location: location
   properties: {
@@ -57,7 +57,7 @@ resource db1 'Microsoft.Sql/servers/databases@2021-11-01' = {
   parent: sql
 }
 
-resource db2 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db2 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db2Name'
   location: location
   properties: {
@@ -70,7 +70,7 @@ resource db2 'Microsoft.Sql/servers/databases@2021-11-01' = {
   parent: sql
 }
 
-resource db3 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db3 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db3Name'
   location: location
   parent: sql

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlExtensionsTests.AddAzureSqlServer_publishMode=True_useAcaInfrastructure=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlExtensionsTests.AddAzureSqlServer_publishMode=True_useAcaInfrastructure=False.verified.bicep
@@ -35,7 +35,7 @@ resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2
   parent: sql
 }
 
-resource db1 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db1 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db1'
   location: location
   properties: {
@@ -48,7 +48,7 @@ resource db1 'Microsoft.Sql/servers/databases@2021-11-01' = {
   parent: sql
 }
 
-resource db2 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db2 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db2Name'
   location: location
   properties: {
@@ -61,7 +61,7 @@ resource db2 'Microsoft.Sql/servers/databases@2021-11-01' = {
   parent: sql
 }
 
-resource db3 'Microsoft.Sql/servers/databases@2021-11-01' = {
+resource db3 'Microsoft.Sql/servers/databases@2023-08-01' = {
   name: 'db3Name'
   location: location
   parent: sql


### PR DESCRIPTION
## Description

Currently used SqlDatabase API version doesn't support the properties required to use the FREE SKU.

Fixes #9499

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
