### PR TITLE
Allow scheme to be specified when configuring Azurite

### DIFF
--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageEmulatorConnectionString.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageEmulatorConnectionString.cs
@@ -32,7 +32,7 @@ internal static class AzureStorageEmulatorConnectionString
 
         static void AppendEndpointExpression(ReferenceExpressionBuilder builder, string key, EndpointReference endpoint)
         {
-            builder.Append($"{key}=http://{endpoint.Property(EndpointProperty.IPV4Host)}:{endpoint.Property(EndpointProperty.Port)}/devstoreaccount1;");
+            builder.Append($"{key}={endpoint.Property(EndpointProperty.Scheme)}://{endpoint.Property(EndpointProperty.IPV4Host)}:{endpoint.Property(EndpointProperty.Port)}/devstoreaccount1;");
         }
     }
 }

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -121,9 +121,9 @@ public static class AzureStorageExtensions
             return builder;
         }
 
-        builder.WithEndpoint(name: "blob", targetPort: 10000)
-               .WithEndpoint(name: "queue", targetPort: 10001)
-               .WithEndpoint(name: "table", targetPort: 10002)
+        builder.WithHttpEndpoint(name: "blob", targetPort: 10000)
+               .WithHttpEndpoint(name: "queue", targetPort: 10001)
+               .WithHttpEndpoint(name: "table", targetPort: 10002)
                .WithAnnotation(new ContainerImageAnnotation
                {
                    Registry = StorageEmulatorContainerImageTags.Registry,

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -322,6 +322,7 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
 
         string Resolve(string? qs, string name, int port) =>
             qs!.Replace("{storage.bindings." + name + ".host}", "127.0.0.1")
+               .Replace("{storage.bindings." + name + ".scheme}", "http")
                .Replace("{storage.bindings." + name + ".port}", port.ToString());
 
         Assert.Equal(Resolve(blobqs, "blob", 10000), await ((IResourceWithConnectionString)blob.Resource).GetConnectionStringAsync());


### PR DESCRIPTION
## Description

Part of the work involved for #9381

Currently `http` is hardcoded when Aspire is configured to use Azurite. This change moves that into default configuration and allows it to be customised.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes (existing tests updated)
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
