### PR TITLE
Remove a few auto injected known parameters

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -310,7 +310,7 @@ public static class AzureContainerAppExtensions
                 Value = containerAppEnvironment.Id
             });
 
-            // Required or azd to output the dashboard URL
+            // Required for azd to output the dashboard URL
             infra.Add(new ProvisioningOutput("AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN", typeof(string))
             {
                 Value = containerAppEnvironment.DefaultDomain

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -277,26 +277,13 @@ public static class AzureContainerAppExtensions
                 }
             }
 
-            infra.Add(new ProvisioningOutput("MANAGED_IDENTITY_NAME", typeof(string))
-            {
-                Value = identity.Name
-            });
-
-            infra.Add(new ProvisioningOutput("MANAGED_IDENTITY_PRINCIPAL_ID", typeof(string))
-            {
-                Value = identity.PrincipalId
-            });
-
+            // Exposed so that callers reference the LA workspace in other bicep modules
             infra.Add(new ProvisioningOutput("AZURE_LOG_ANALYTICS_WORKSPACE_NAME", typeof(string))
             {
                 Value = laWorkspace.Name
             });
 
-            infra.Add(new ProvisioningOutput("AZURE_LOG_ANALYTICS_WORKSPACE_ID", typeof(string))
-            {
-                Value = laWorkspace.Id
-            });
-
+            // Required by the IContaineRegistry interface
             infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_NAME", typeof(string))
             {
                 Value = containerRegistry.Name
@@ -307,6 +294,7 @@ public static class AzureContainerAppExtensions
                 Value = containerRegistry.LoginServer
             });
 
+            // Required by the IAzureContainerRegistry interface
             infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID", typeof(string))
             {
                 Value = identity.Id
@@ -322,6 +310,7 @@ public static class AzureContainerAppExtensions
                 Value = containerAppEnvironment.Id
             });
 
+            // Required or azd to output the dashboard URL
             infra.Add(new ProvisioningOutput("AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN", typeof(string))
             {
                 Value = containerAppEnvironment.DefaultDomain

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -283,6 +283,11 @@ public static class AzureContainerAppExtensions
                 Value = laWorkspace.Name
             });
 
+            infra.Add(new ProvisioningOutput("AZURE_LOG_ANALYTICS_WORKSPACE_ID", typeof(string))
+            {
+                Value = laWorkspace.Id
+            });
+
             // Required by the IContaineRegistry interface
             infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_NAME", typeof(string))
             {

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -73,35 +73,5 @@ internal sealed class AzureContainerAppsInfrastructure(
                 ComputeEnvironment = environment
             });
         }
-
-        static void SetKnownParameterValue(AzureBicepResource r, string key, Func<AzureBicepResource, object> factory)
-        {
-            if (r.Parameters.TryGetValue(key, out var existingValue) && existingValue is null)
-            {
-                var value = factory(r);
-
-                r.Parameters[key] = value;
-            }
-        }
-
-        // Resolve the known parameters for the container app environment
-        foreach (var r in appModel.Resources.OfType<AzureBicepResource>())
-        {
-            // HACK: This forces parameters to be resolved for any AzureProvisioningResource
-            r.GetBicepTemplateFile();
-
-            // This will throw an exception if there's no value specified, in this new mode, we don't no longer support
-            // automagic secret key vault references.
-            SetKnownParameterValue(r, AzureBicepResource.KnownParameters.KeyVaultName, _ => throw new NotSupportedException("Automatic Key vault generation is not supported in this environment. Please create a key vault resource directly."));
-
-            // Set the known parameters for the container app environment
-            SetKnownParameterValue(r, AzureBicepResource.KnownParameters.PrincipalId, _ => environment.PrincipalId);
-            SetKnownParameterValue(r, AzureBicepResource.KnownParameters.PrincipalType, _ => "ServicePrincipal");
-            SetKnownParameterValue(r, AzureBicepResource.KnownParameters.PrincipalName, _ => environment.PrincipalName);
-            SetKnownParameterValue(r, AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, _ => environment.LogAnalyticsWorkspaceId);
-
-            SetKnownParameterValue(r, "containerAppEnvironmentId", _ => environment.ContainerAppEnvironmentId);
-            SetKnownParameterValue(r, "containerAppEnvironmentName", _ => environment.ContainerAppEnvironmentName);
-        }
     }
 }

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -73,11 +73,11 @@ public static class AzureApplicationInsightsExtensions
                     if (logAnalyticsWorkspace != null)
                     {
                         // If someone provides a workspace via the extension method we should use it.
-                        appInsights.WorkspaceResourceId = logAnalyticsWorkspace.Resource.WorkspaceId.AsProvisioningParameter(infrastructure, AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId);
+                        appInsights.WorkspaceResourceId = logAnalyticsWorkspace.Resource.WorkspaceId.AsProvisioningParameter(infrastructure);
                     }
-                    else if (builder.ExecutionContext.IsRunMode)
+                    else
                     {
-                        // ... otherwise if we are in run mode, the provisioner expects us to create one ourselves.
+                        // ... otherwise create one ourselves.
                         var autoInjectedLogAnalyticsWorkspaceName = $"law_{appInsights.BicepIdentifier}";
                         var autoInjectedLogAnalyticsWorkspace = new OperationalInsightsWorkspace(autoInjectedLogAnalyticsWorkspaceName)
                         {
@@ -93,20 +93,12 @@ public static class AzureApplicationInsightsExtensions
                         // side and the CDK side so that AZD can fill the value in with the one it generates.
                         appInsights.WorkspaceResourceId = autoInjectedLogAnalyticsWorkspace.Id;
                     }
-                    else
-                    {
-                        // If the user does not supply a log analytics workspace of their own, and we are in publish mode
-                        // then we want AZD to provide one to us.
-                        var logAnalyticsWorkspaceParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, typeof(string));
-                        infrastructure.Add(logAnalyticsWorkspaceParameter);
-                        appInsights.WorkspaceResourceId = logAnalyticsWorkspaceParameter;
-                    }
 
                     return appInsights;
                 });
 
             infrastructure.Add(new ProvisioningOutput("appInsightsConnectionString", typeof(string)) { Value = appInsights.ConnectionString });
-            
+
             // Add name output for the resource to externalize role assignments
             infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = appInsights.Name });
         };

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -119,22 +119,6 @@ public static class AzureApplicationInsightsExtensions
     }
 
     /// <summary>
-    /// Configures the Application Insights resource to use an existing Log Analytics Workspace via a Bicep output reference.
-    /// </summary>
-    /// <param name="builder">The resource builder for <see cref="AzureApplicationInsightsResource"/>.</param>
-    /// <param name="workspaceId">The <see cref="BicepOutputReference"/> for the Log Analytics Workspace resource id.</param>
-    /// <returns>The <see cref="IResourceBuilder{AzureApplicationInsightsResource}"/> for chaining.</returns>
-    public static IResourceBuilder<AzureApplicationInsightsResource> WithLogAnalyticsWorkspaceId(
-        this IResourceBuilder<AzureApplicationInsightsResource> builder,
-        BicepOutputReference workspaceId)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(workspaceId);
-
-        return builder.WithAnnotation(new LogAnalyticsWorkspaceReferenceAnnotation(workspaceId));
-    }
-
-    /// <summary>
     /// Configures the Application Insights resource to use an existing Log Analytics Workspace via a <see cref="BicepOutputReference"/>.
     /// </summary>
     /// <param name="builder">The resource builder for <see cref="AzureApplicationInsightsResource"/>.</param>
@@ -144,7 +128,7 @@ public static class AzureApplicationInsightsExtensions
         this IResourceBuilder<AzureApplicationInsightsResource> builder,
         BicepOutputReference workspaceId)
     {
-        return builder.WithLogAnalyticsWorkspaceId(workspaceId);
+        return builder.WithAnnotation(new LogAnalyticsWorkspaceReferenceAnnotation(workspaceId));
     }
 
     /// <summary>
@@ -157,7 +141,7 @@ public static class AzureApplicationInsightsExtensions
         this IResourceBuilder<AzureApplicationInsightsResource> builder,
         IResourceBuilder<AzureLogAnalyticsWorkspaceResource> logAnalyticsWorkspace)
     {
-        return builder.WithLogAnalyticsWorkspaceId(logAnalyticsWorkspace.Resource.WorkspaceId);
+        return builder.WithLogAnalyticsWorkspace(logAnalyticsWorkspace.Resource.WorkspaceId);
     }
 
     // REVIEW: This isn't strongly typed, but it allows us to pass the workspaceId as a BicepOutputReference

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -413,10 +413,7 @@ public static class AzureCosmosExtensions
         ArgumentNullException.ThrowIfNull(builder);
 
         var azureResource = builder.Resource;
-        azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecret(
-            $"connectionstrings--{azureResource.Name}");
-
-        builder.WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, keyVaultBuilder.Resource.NameOutputReference);
+        azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecret($"connectionstrings--{azureResource.Name}");
 
         // remove role assignment annotations when using access key authentication so an empty roles bicep module isn't generated
         var roleAssignmentAnnotations = azureResource.Annotations.OfType<DefaultRoleAssignmentsAnnotation>().ToArray();
@@ -491,8 +488,7 @@ public static class AzureCosmosExtensions
 
         if (azureResource.UseAccessKeyAuthentication)
         {
-            var kvNameParam = new ProvisioningParameter(AzureBicepResource.KnownParameters.KeyVaultName, typeof(string));
-            infrastructure.Add(kvNameParam);
+            var kvNameParam = azureResource.ConnectionStringSecretOutput.Resource.NameOutputReference.AsProvisioningParameter(infrastructure);
 
             var keyVault = KeyVaultService.FromExisting("keyVault");
             keyVault.Name = kvNameParam;

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -339,8 +339,6 @@ public static class AzurePostgresExtensions
 
         azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecret($"connectionstrings--{builder.Resource.Name}");
 
-        builder.WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, keyVaultBuilder.Resource.NameOutputReference);
-
         // If someone already called RunAsContainer - we need to reset the username/password parameters on the InnerResource
         var containerResource = azureResource.InnerResource;
         if (containerResource is not null)
@@ -439,8 +437,7 @@ public static class AzurePostgresExtensions
             var administratorLoginPassword = new ProvisioningParameter("administratorLoginPassword", typeof(string)) { IsSecure = true };
             infrastructure.Add(administratorLoginPassword);
 
-            var kvNameParam = new ProvisioningParameter("keyVaultName", typeof(string));
-            infrastructure.Add(kvNameParam);
+            var kvNameParam = azureResource.ConnectionStringSecretOutput.Resource.NameOutputReference.AsProvisioningParameter(infrastructure);
 
             var keyVault = KeyVaultService.FromExisting("keyVault");
             keyVault.Name = kvNameParam;

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -229,7 +229,6 @@ public static class AzureRedisExtensions
 
         var azureResource = builder.Resource;
         azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecret($"connectionstrings--{azureResource.Name}");
-        builder.WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, keyVaultBuilder.Resource.NameOutputReference);
 
         // remove role assignment annotations when using access key authentication so an empty roles bicep module isn't generated
         var roleAssignmentAnnotations = azureResource.Annotations.OfType<DefaultRoleAssignmentsAnnotation>().ToArray();
@@ -271,8 +270,7 @@ public static class AzureRedisExtensions
         var redisResource = (AzureRedisCacheResource)infrastructure.AspireResource;
         if (redisResource.UseAccessKeyAuthentication)
         {
-            var kvNameParam = new ProvisioningParameter(AzureBicepResource.KnownParameters.KeyVaultName, typeof(string));
-            infrastructure.Add(kvNameParam);
+            var kvNameParam = redisResource.ConnectionStringSecretOutput.Resource.NameOutputReference.AsProvisioningParameter(infrastructure);
 
             var keyVault = KeyVaultService.FromExisting("keyVault");
             keyVault.Name = kvNameParam;

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -255,6 +255,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
         /// <summary>
         /// The name of the key vault resource used to store secret outputs.
         /// </summary>
+        [Obsolete("KnownParameters.KeyVaultName is deprecated. Use an AzureKeyVaultResource instead.")]
         public static readonly string KeyVaultName = KeyVaultNameConst;
 
         /// <summary>
@@ -265,6 +266,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
         /// <summary>
         /// The resource id of the log analytics workspace.
         /// </summary>
+        [Obsolete("KnownParameters.LogAnalyticsWorkspaceId is deprecated. Use an AzureLogAnalyticsWorkspaceResource instead.")]
         public static readonly string LogAnalyticsWorkspaceId = LogAnalyticsWorkspaceIdConst;
 
         internal static bool IsKnownParameterName(string name) =>

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -339,12 +339,6 @@ internal sealed class BicepProvisioner(
             resource.Parameters[AzureBicepResource.KnownParameters.PrincipalType] = "User";
         }
 
-        if (resource.Parameters.TryGetValue(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, out var logAnalyticsWorkspaceId) && logAnalyticsWorkspaceId is null)
-        {
-            // We don't have a log analytics workspace for environments so we will just let the bicep file create one
-            resource.Parameters.Remove(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId);
-        }
-
         // Always specify the location
         resource.Parameters[AzureBicepResource.KnownParameters.Location] = context.Location.Name;
     }
@@ -454,9 +448,7 @@ internal sealed class BicepProvisioner(
         AzureBicepResource.KnownParameters.PrincipalName,
         AzureBicepResource.KnownParameters.PrincipalId,
         AzureBicepResource.KnownParameters.PrincipalType,
-        AzureBicepResource.KnownParameters.KeyVaultName,
         AzureBicepResource.KnownParameters.Location,
-        AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId,
     ];
 
     // Converts the parameters to a JSON object compatible with the ARM template

--- a/tests/Aspire.Hosting.Azure.Tests/AzureApplicationInsightsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureApplicationInsightsExtensionsTests.cs
@@ -107,7 +107,7 @@ public class AzureApplicationInsightsExtensionsTests
         var env = builder.AddAzureContainerAppEnvironment("aca");
 
         var appInsights = builder.AddAzureApplicationInsights("appInsights")
-                                 .WithLogAnalyticsWorkspaceId(env.GetOutput("AZURE_LOG_ANALYTICS_WORKSPACE_ID"));
+                                 .WithLogAnalyticsWorkspace(env.GetOutput("AZURE_LOG_ANALYTICS_WORKSPACE_ID"));
 
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(appInsights.Resource);
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -182,13 +182,11 @@ public class AzureBicepProvisionerTests
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
-                       .WithParameter("name", "david")
-                       .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName);
+                       .WithParameter("name", "david");
 
         // Simulate the case where a known parameter has a value
         var bicep1 = builder.AddBicepTemplateString("bicep1", "param name string")
                        .WithParameter("name", "david")
-                       .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, "blah")
                        .WithParameter(AzureBicepResource.KnownParameters.PrincipalId, "id")
                        .WithParameter(AzureBicepResource.KnownParameters.Location, "tomorrow")
                        .WithParameter(AzureBicepResource.KnownParameters.PrincipalType, "type");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -351,24 +351,10 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
             return Task.FromResult<string?>(value);
         };
 
-        var manifest = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
+        var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
-        var expectedManifest = $$"""
-                               {
-                                 "type": "azure.bicep.v0",
-                                 "connectionString": "{{{kvName}}.secrets.connectionstrings--cosmos}",
-                                 "path": "cosmos.module.bicep",
-                                 "params": {
-                                   "keyVaultName": "{{{kvName}}.outputs.name}"
-                                 }
-                               }
-                               """;
-        var m = manifest.ManifestNode.ToString();
-        output.WriteLine(m);
-
-        Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
-
-        await Verify(manifest.BicepText, extension: "bicep");
+        await Verify(bicep, extension: "bicep")
+            .AppendContentAsFile(manifest.ToString(), "json");
 
         Assert.NotNull(callbackDatabases);
         Assert.Collection(
@@ -469,25 +455,10 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
             return Task.FromResult<string?>(value);
         };
 
-        var manifest = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
+        var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
 
-        var expectedManifest = $$"""
-                               {
-                                 "type": "azure.bicep.v0",
-                                 "connectionString": "{{{kvName}}.secrets.connectionstrings--cosmos}",
-                                 "path": "cosmos.module.bicep",
-                                 "params": {
-                                   "keyVaultName": "{{{kvName}}.outputs.name}"
-                                 }
-                               }
-                               """;
-
-        var m = manifest.ManifestNode.ToString();
-
-        output.WriteLine(m);
-        Assert.Equal(expectedManifest, m);
-
-        await Verify(manifest.BicepText, extension: "bicep");
+        await Verify(bicep, extension: "bicep")
+            .AppendContentAsFile(manifest.ToString(), "json");
 
         Assert.NotNull(callbackDatabases);
         Assert.Collection(

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -72,8 +72,6 @@ public class AzureRedisExtensionsTests
 
         if (kvName is null)
         {
-            kvName = "redis-cache-kv";
-
             redis.WithAccessKeyAuthentication();
         }
         else

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -10,7 +10,7 @@ using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;
 
-public class AzureRedisExtensionsTests(ITestOutputHelper output)
+public class AzureRedisExtensionsTests
 {
     /// <summary>
     /// Test both with and without ACA infrastructure because the role assignments
@@ -81,23 +81,10 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
             redis.WithAccessKeyAuthentication(builder.AddAzureKeyVault(kvName));
         }
 
-        var manifest = await AzureManifestUtils.GetManifestWithBicep(redis.Resource);
+        var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(redis.Resource);
 
-        var expectedManifest = $$"""
-            {
-              "type": "azure.bicep.v0",
-              "connectionString": "{{{kvName}}.secrets.connectionstrings--redis-cache}",
-              "path": "redis-cache.module.bicep",
-              "params": {
-                "keyVaultName": "{{{kvName}}.outputs.name}"
-              }
-            }
-            """;
-        var m = manifest.ManifestNode.ToString();
-        output.WriteLine(m);
-        Assert.Equal(expectedManifest, m);
-
-        await Verify(manifest.BicepText, extension: "bicep");
+        await Verify(bicep, extension: "bicep")
+                  .AppendContentAsFile(manifest.ToString(), "json");
 
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.AddApplicationInsightsWithExplicitLawArgumentDoesntGetDefaultParameter.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.AddApplicationInsightsWithExplicitLawArgumentDoesntGetDefaultParameter.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{appInsights.outputs.appInsightsConnectionString}",
+  "path": "appInsights.module.bicep",
+  "params": {
+    "mylaw_outputs_loganalyticsworkspaceid": "{mylaw.outputs.logAnalyticsWorkspaceId}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.AddApplicationInsightsWithoutExplicitLawGetsGeneratedLaw.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.AddApplicationInsightsWithoutExplicitLawGetsGeneratedLaw.verified.bicep
@@ -5,7 +5,18 @@ param applicationType string = 'web'
 
 param kind string = 'web'
 
-param mylaw_outputs_loganalyticsworkspaceid string
+resource law_appInsights 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: take('lawappInsights-${uniqueString(resourceGroup().id)}', 63)
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+  tags: {
+    'aspire-resource-name': 'law_appInsights'
+  }
+}
 
 resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   name: take('appInsights-${uniqueString(resourceGroup().id)}', 260)
@@ -13,7 +24,7 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   location: location
   properties: {
     Application_Type: applicationType
-    WorkspaceResourceId: mylaw_outputs_loganalyticsworkspaceid
+    WorkspaceResourceId: law_appInsights.id
   }
   tags: {
     'aspire-resource-name': 'appInsights'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.AddApplicationInsightsWithoutExplicitLawGetsGeneratedLaw.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.AddApplicationInsightsWithoutExplicitLawGetsGeneratedLaw.verified.json
@@ -1,0 +1,5 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{appInsights.outputs.appInsightsConnectionString}",
+  "path": "appInsights.module.bicep"
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.WithLogAnalyticsWorkspaceId_UsesProvidedWorkspaceId_VerifyBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.WithLogAnalyticsWorkspaceId_UsesProvidedWorkspaceId_VerifyBicep.verified.bicep
@@ -1,0 +1,25 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param applicationType string = 'web'
+
+param kind string = 'web'
+
+param aca_outputs_azure_log_analytics_workspace_id string
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: take('appInsights-${uniqueString(resourceGroup().id)}', 260)
+  kind: kind
+  location: location
+  properties: {
+    Application_Type: applicationType
+    WorkspaceResourceId: aca_outputs_azure_log_analytics_workspace_id
+  }
+  tags: {
+    'aspire-resource-name': 'appInsights'
+  }
+}
+
+output appInsightsConnectionString string = appInsights.properties.ConnectionString
+
+output name string = appInsights.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.WithLogAnalyticsWorkspaceId_UsesProvidedWorkspaceId_VerifyBicep.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.WithLogAnalyticsWorkspaceId_UsesProvidedWorkspaceId_VerifyBicep.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{appInsights.outputs.appInsightsConnectionString}",
+  "path": "appInsights.module.bicep",
+  "params": {
+    "aca_outputs_azure_log_analytics_workspace_id": "{aca.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.WithLogAnalyticsWorkspace_UsesWorkspaceResourceId_VerifyBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.WithLogAnalyticsWorkspace_UsesWorkspaceResourceId_VerifyBicep.verified.bicep
@@ -1,0 +1,25 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param applicationType string = 'web'
+
+param kind string = 'web'
+
+param law_outputs_loganalyticsworkspaceid string
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: take('appInsights-${uniqueString(resourceGroup().id)}', 260)
+  kind: kind
+  location: location
+  properties: {
+    Application_Type: applicationType
+    WorkspaceResourceId: law_outputs_loganalyticsworkspaceid
+  }
+  tags: {
+    'aspire-resource-name': 'appInsights'
+  }
+}
+
+output appInsightsConnectionString string = appInsights.properties.ConnectionString
+
+output name string = appInsights.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.WithLogAnalyticsWorkspace_UsesWorkspaceResourceId_VerifyBicep.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureApplicationInsightsExtensionsTests.WithLogAnalyticsWorkspace_UsesWorkspaceResourceId_VerifyBicep.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{appInsights.outputs.appInsightsConnectionString}",
+  "path": "appInsights.module.bicep",
+  "params": {
+    "law_outputs_loganalyticsworkspaceid": "{law.outputs.logAnalyticsWorkspaceId}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
@@ -114,6 +114,8 @@ output volumes_cache_0 string = managedStorage_volumes_cache_0.name
 
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = env_law.name
 
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
+
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
@@ -112,13 +112,7 @@ resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/stora
 
 output volumes_cache_0 string = managedStorage_volumes_cache_0.name
 
-output MANAGED_IDENTITY_NAME string = env_mi.name
-
-output MANAGED_IDENTITY_PRINCIPAL_ID string = env_mi.properties.principalId
-
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = env_law.name
-
-output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
 
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
@@ -114,13 +114,7 @@ resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/stora
 
 output volumes_cache_0 string = managedStorage_volumes_cache_0.name
 
-output MANAGED_IDENTITY_NAME string = 'mi-${resourceToken}'
-
-output MANAGED_IDENTITY_PRINCIPAL_ID string = env_mi.properties.principalId
-
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = 'law-${resourceToken}'
-
-output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
 
 output AZURE_CONTAINER_REGISTRY_NAME string = replace('acr-${resourceToken}', '-', '')
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
@@ -116,6 +116,8 @@ output volumes_cache_0 string = managedStorage_volumes_cache_0.name
 
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = 'law-${resourceToken}'
 
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
+
 output AZURE_CONTAINER_REGISTRY_NAME string = replace('acr-${resourceToken}', '-', '')
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanReferenceContainerAppEnvironment.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanReferenceContainerAppEnvironment.verified.bicep
@@ -1,0 +1,10 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_apps_environment_name string
+
+resource env 'Microsoft.App/managedEnvironments@2024-03-01' existing = {
+  name: env_outputs_azure_container_apps_environment_name
+}
+
+output id string = env.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanReferenceContainerAppEnvironment.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanReferenceContainerAppEnvironment.verified.json
@@ -1,0 +1,7 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "infra.module.bicep",
+  "params": {
+    "env_outputs_azure_container_apps_environment_name": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_NAME}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#00.verified.bicep
@@ -67,13 +67,7 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: env
 }
 
-output MANAGED_IDENTITY_NAME string = env_mi.name
-
-output MANAGED_IDENTITY_PRINCIPAL_ID string = env_mi.properties.principalId
-
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = env_law.name
-
-output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
 
 output AZURE_CONTAINER_REGISTRY_NAME string = customregistry_outputs_name
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#00.verified.bicep
@@ -69,6 +69,8 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
 
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = env_law.name
 
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
+
 output AZURE_CONTAINER_REGISTRY_NAME string = customregistry_outputs_name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = customregistry.properties.loginServer

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param keyVaultName string
+param mykeyvault_outputs_name string
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
   name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
@@ -53,7 +53,7 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: mykeyvault_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{mykeyvault.secrets.connectionstrings--cosmos}",
+  "path": "cosmos.module.bicep",
+  "params": {
+    "mykeyvault_outputs_name": "{mykeyvault.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param keyVaultName string
+param cosmos_kv_outputs_name string
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
   name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
@@ -53,7 +53,7 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: cosmos_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{cosmos-kv.secrets.connectionstrings--cosmos}",
+  "path": "cosmos.module.bicep",
+  "params": {
+    "cosmos_kv_outputs_name": "{cosmos-kv.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param keyVaultName string
+param mykeyvault_outputs_name string
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
   name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
@@ -53,7 +53,7 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: mykeyvault_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{mykeyvault.secrets.connectionstrings--cosmos}",
+  "path": "cosmos.module.bicep",
+  "params": {
+    "mykeyvault_outputs_name": "{mykeyvault.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param keyVaultName string
+param cosmos_kv_outputs_name string
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
   name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
@@ -53,7 +53,7 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: cosmos_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{cosmos-kv.secrets.connectionstrings--cosmos}",
+  "path": "cosmos.module.bicep",
+  "params": {
+    "cosmos_kv_outputs_name": "{cosmos-kv.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param keyVaultName string
+param cosmos_kv_outputs_name string
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
   name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
@@ -53,7 +53,7 @@ resource container1 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containe
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: cosmos_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#01.verified.bicep
@@ -72,6 +72,8 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
 
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = env_law.name
 
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
+
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#01.verified.bicep
@@ -70,13 +70,7 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
   parent: env
 }
 
-output MANAGED_IDENTITY_NAME string = env_mi.name
-
-output MANAGED_IDENTITY_PRINCIPAL_ID string = env_mi.properties.principalId
-
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = env_law.name
-
-output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = env_law.id
 
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=False_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=False_kvName=mykeyvault.verified.bicep
@@ -6,7 +6,7 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
-param keyVaultName string
+param mykeyvault_outputs_name string
 
 resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
@@ -64,7 +64,7 @@ resource db1 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = 
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: mykeyvault_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=False_kvName=mykeyvault.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=False_kvName=mykeyvault.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{mykeyvault.secrets.connectionstrings--postgres-data}",
+  "path": "postgres-data.module.bicep",
+  "params": {
+    "administratorLogin": "{postgres-data-username.value}",
+    "administratorLoginPassword": "{postgres-data-password.value}",
+    "mykeyvault_outputs_name": "{mykeyvault.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=False_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=False_kvName=null.verified.bicep
@@ -6,7 +6,7 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
-param keyVaultName string
+param postgres_data_kv_outputs_name string
 
 resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
@@ -64,7 +64,7 @@ resource db1 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = 
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: postgres_data_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=False_kvName=null.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=False_kvName=null.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{postgres-data-kv.secrets.connectionstrings--postgres-data}",
+  "path": "postgres-data.module.bicep",
+  "params": {
+    "administratorLogin": "{postgres-data-username.value}",
+    "administratorLoginPassword": "{postgres-data-password.value}",
+    "postgres_data_kv_outputs_name": "{postgres-data-kv.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=True_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=True_kvName=mykeyvault.verified.bicep
@@ -6,7 +6,7 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
-param keyVaultName string
+param mykeyvault_outputs_name string
 
 resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
@@ -64,7 +64,7 @@ resource db1 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = 
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: mykeyvault_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=True_kvName=mykeyvault.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=True_kvName=mykeyvault.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{mykeyvault.secrets.connectionstrings--postgres-data}",
+  "path": "postgres-data.module.bicep",
+  "params": {
+    "administratorLogin": "{postgres-data-username.value}",
+    "administratorLoginPassword": "{password.value}",
+    "mykeyvault_outputs_name": "{mykeyvault.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=True_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=True_kvName=null.verified.bicep
@@ -6,7 +6,7 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
-param keyVaultName string
+param postgres_data_kv_outputs_name string
 
 resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
@@ -64,7 +64,7 @@ resource db1 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = 
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: postgres_data_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=True_kvName=null.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=False_specifyPassword=True_kvName=null.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{postgres-data-kv.secrets.connectionstrings--postgres-data}",
+  "path": "postgres-data.module.bicep",
+  "params": {
+    "administratorLogin": "{postgres-data-username.value}",
+    "administratorLoginPassword": "{password.value}",
+    "postgres_data_kv_outputs_name": "{postgres-data-kv.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=False_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=False_kvName=mykeyvault.verified.bicep
@@ -6,7 +6,7 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
-param keyVaultName string
+param mykeyvault_outputs_name string
 
 resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
@@ -64,7 +64,7 @@ resource db1 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = 
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: mykeyvault_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=False_kvName=mykeyvault.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=False_kvName=mykeyvault.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{mykeyvault.secrets.connectionstrings--postgres-data}",
+  "path": "postgres-data.module.bicep",
+  "params": {
+    "administratorLogin": "{user.value}",
+    "administratorLoginPassword": "{postgres-data-password.value}",
+    "mykeyvault_outputs_name": "{mykeyvault.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=False_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=False_kvName=null.verified.bicep
@@ -6,7 +6,7 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
-param keyVaultName string
+param postgres_data_kv_outputs_name string
 
 resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
@@ -64,7 +64,7 @@ resource db1 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = 
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: postgres_data_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=False_kvName=null.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=False_kvName=null.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{postgres-data-kv.secrets.connectionstrings--postgres-data}",
+  "path": "postgres-data.module.bicep",
+  "params": {
+    "administratorLogin": "{user.value}",
+    "administratorLoginPassword": "{postgres-data-password.value}",
+    "postgres_data_kv_outputs_name": "{postgres-data-kv.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=True_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=True_kvName=mykeyvault.verified.bicep
@@ -6,7 +6,7 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
-param keyVaultName string
+param mykeyvault_outputs_name string
 
 resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
@@ -64,7 +64,7 @@ resource db1 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = 
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: mykeyvault_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=True_kvName=mykeyvault.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=True_kvName=mykeyvault.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{mykeyvault.secrets.connectionstrings--postgres-data}",
+  "path": "postgres-data.module.bicep",
+  "params": {
+    "administratorLogin": "{user.value}",
+    "administratorLoginPassword": "{password.value}",
+    "mykeyvault_outputs_name": "{mykeyvault.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=True_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=True_kvName=null.verified.bicep
@@ -6,7 +6,7 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
-param keyVaultName string
+param postgres_data_kv_outputs_name string
 
 resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
@@ -64,7 +64,7 @@ resource db1 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = 
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: postgres_data_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=True_kvName=null.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePostgresExtensionsTests.AddAzurePostgresWithPasswordAuth_specifyUserName=True_specifyPassword=True_kvName=null.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{postgres-data-kv.secrets.connectionstrings--postgres-data}",
+  "path": "postgres-data.module.bicep",
+  "params": {
+    "administratorLogin": "{user.value}",
+    "administratorLoginPassword": "{password.value}",
+    "postgres_data_kv_outputs_name": "{postgres-data-kv.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureRedisExtensionsTests.AddAzureRedisWithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureRedisExtensionsTests.AddAzureRedisWithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param keyVaultName string
+param mykeyvault_outputs_name string
 
 resource redis_cache 'Microsoft.Cache/redis@2024-03-01' = {
   name: take('rediscache-${uniqueString(resourceGroup().id)}', 63)
@@ -21,7 +21,7 @@ resource redis_cache 'Microsoft.Cache/redis@2024-03-01' = {
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: mykeyvault_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureRedisExtensionsTests.AddAzureRedisWithAccessKeyAuthentication_kvName=mykeyvault.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureRedisExtensionsTests.AddAzureRedisWithAccessKeyAuthentication_kvName=mykeyvault.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{mykeyvault.secrets.connectionstrings--redis-cache}",
+  "path": "redis-cache.module.bicep",
+  "params": {
+    "mykeyvault_outputs_name": "{mykeyvault.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureRedisExtensionsTests.AddAzureRedisWithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureRedisExtensionsTests.AddAzureRedisWithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param keyVaultName string
+param redis_cache_kv_outputs_name string
 
 resource redis_cache 'Microsoft.Cache/redis@2024-03-01' = {
   name: take('rediscache-${uniqueString(resourceGroup().id)}', 63)
@@ -21,7 +21,7 @@ resource redis_cache 'Microsoft.Cache/redis@2024-03-01' = {
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: redis_cache_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureRedisExtensionsTests.AddAzureRedisWithAccessKeyAuthentication_kvName=null.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureRedisExtensionsTests.AddAzureRedisWithAccessKeyAuthentication_kvName=null.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "connectionString": "{redis-cache-kv.secrets.connectionstrings--redis-cache}",
+  "path": "redis-cache.module.bicep",
+  "params": {
+    "redis_cache_kv_outputs_name": "{redis-cache-kv.outputs.name}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroupAccessKey.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroupAccessKey.verified.bicep
@@ -3,7 +3,7 @@ param location string = resourceGroup().location
 
 param existingResourceName string
 
-param keyVaultName string
+param cosmos_kv_outputs_name string
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' existing = {
   name: existingResourceName
@@ -37,7 +37,7 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: cosmos_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroupAccessKey.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroupAccessKey.verified.json
@@ -3,8 +3,8 @@
   "connectionString": "{cosmos-kv.secrets.connectionstrings--cosmos}",
   "path": "cosmos.module.bicep",
   "params": {
-    "keyVaultName": "{cosmos-kv.outputs.name}",
-    "existingResourceName": "{existingResourceName.value}"
+    "existingResourceName": "{existingResourceName.value}",
+    "cosmos_kv_outputs_name": "{cosmos-kv.outputs.name}"
   },
   "scope": {
     "resourceGroup": "{existingResourceGroupName.value}"

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureRedisWithResouceGroupAndAccessKeyAuth.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureRedisWithResouceGroupAndAccessKeyAuth.verified.bicep
@@ -1,14 +1,14 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param keyVaultName string
+param redis_kv_outputs_name string
 
 resource redis 'Microsoft.Cache/redis@2024-03-01' existing = {
   name: 'existingResourceName'
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: redis_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureRedisWithResouceGroupAndAccessKeyAuth.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureRedisWithResouceGroupAndAccessKeyAuth.verified.json
@@ -3,7 +3,7 @@
   "connectionString": "{redis-kv.secrets.connectionstrings--redis}",
   "path": "redis.module.bicep",
   "params": {
-    "keyVaultName": "{redis-kv.outputs.name}"
+    "redis_kv_outputs_name": "{redis-kv.outputs.name}"
   },
   "scope": {
     "resourceGroup": "existingResourceGroupName"

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingPostgresSqlWithResourceGroupWithPasswordAuth.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingPostgresSqlWithResourceGroupWithPasswordAuth.verified.bicep
@@ -8,7 +8,7 @@ param administratorLogin string
 @secure()
 param administratorLoginPassword string
 
-param keyVaultName string
+param postgressql_kv_outputs_name string
 
 resource postgresSql 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' existing = {
   name: existingResourceName
@@ -24,7 +24,7 @@ resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flex
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
+  name: postgressql_kv_outputs_name
 }
 
 resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingPostgresSqlWithResourceGroupWithPasswordAuth.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingPostgresSqlWithResourceGroupWithPasswordAuth.verified.json
@@ -5,8 +5,8 @@
   "params": {
     "administratorLogin": "{existingUserName.value}",
     "administratorLoginPassword": "{existingPassword.value}",
-    "keyVaultName": "{postgresSql-kv.outputs.name}",
-    "existingResourceName": "{existingResourceName.value}"
+    "existingResourceName": "{existingResourceName.value}",
+    "postgressql_kv_outputs_name": "{postgresSql-kv.outputs.name}"
   },
   "scope": {
     "resourceGroup": "{existingResourceGroupName.value}"


### PR DESCRIPTION
This is a follow up to https://github.com/dotnet/aspire/pull/9500

## Description

- Removed injection of container app properties into other azure resources. Since we now support multiple compute environment, this pattern no longer makes sense when we have the entire resource graph modeled.
- Obsoleted keyvault and log analytics workspace known parameters.
- The AppInsightsResource will auto create LA workspace if not specified.
- Added WithLogAnalyticsWorkspace to associate an AppInsightsResource with a LA workspace. 
- Exposing NameOutputReference on AzureContainerAppEnvironmentResource to make it easier to reference it.
- Updated tests

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
