### PR TITLE
Add definitions for new log streaming options

### DIFF
--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Utils;
@@ -48,12 +48,30 @@ internal interface IKubernetesService
         string? namespaceParameter = null,
         CancellationToken cancellationToken = default)
         where T : CustomResource;
+
+    /// <summary>
+    /// Returns a log stream for the specified resource.
+    /// </summary>
+    /// <param name="obj">The resource to get the log stream for.</param>
+    /// <param name="logStreamType">The type of log stream to retrieve ("stdout", "stderr", "startup_stdout", or "startup_stderr", see <see cref="Aspire.Hosting.Dcp.Model.Logs"/>).</param>
+    /// <param name="cancellationToken">The cancellation token for the stream retrieval operation (does not affect the returned stream).</param>
+    /// <param name="follow">If true, the log stream will be followed until the resource is deleted or the stream is disposed of.</param>
+    /// <param name="timestamps">If true, timestamps (RFC3339) will be included in the log stream.</param>
+    /// <param name="lineNumbers">If true, line numbers will be included in the log stream.</param>
+    /// <param name="limit">If specified, limits the number of log linets returned. Cannot be used with "follow".</param>
+    /// <param name="tail">If specified, limits the response to at most N existing, NEWEST log lines. If "follow" is true, new log lines that appear after the log stream was created do not count against the limit, and will be streamed until the client closes the stream.</param>
+    /// <param name="skip">If specified, skips the first N log lines in the result set. Cannot be used together with "tail".</param>
     Task<Stream> GetLogStreamAsync<T>(
         T obj,
         string logStreamType,
+        CancellationToken cancellationToken = default,
         bool? follow = true,
         bool? timestamps = false,
-        CancellationToken cancellationToken = default) where T : CustomResource;
+        bool? lineNumbers = false,
+        long? limit = null,
+        long? tail = null,
+        long? skip = null
+    ) where T : CustomResource;
     Task StopServerAsync(string resourceCleanup = ResourceCleanup.Full, CancellationToken cancellation = default);
     Task CleanupResourcesAsync(CancellationToken cancellationToken = default);
 }
@@ -281,18 +299,38 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
     public Task<Stream> GetLogStreamAsync<T>(
         T obj,
         string logStreamType,
+        CancellationToken cancellationToken = default,
         bool? follow = true,
         bool? timestamps = false,
-        CancellationToken cancellationToken = default) where T : CustomResource
+        bool? lineNumbers = false,
+        long? limit = null,
+        long? tail = null,
+        long? skip = null) where T : CustomResource
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         var resourceType = GetResourceFor<T>();
 
-        ImmutableArray<(string name, string value)>? queryParams = [
+        List<(string name, string value)> queryParams = [
             (name: "follow", value: follow == true ? "true": "false"),
             (name: "timestamps", value: timestamps == true ? "true" : "false"),
-            (name: "source", value: logStreamType)
+            (name: "source", value: logStreamType),
+            (name: "line_numbers", value: lineNumbers == true ? "true" : "false"),
         ];
+        if (limit.HasValue)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(limit.Value, 1, nameof(limit));
+            queryParams.Add((name: "limit", value: limit.Value.ToString(CultureInfo.InvariantCulture)));
+        }
+        if (tail.HasValue)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(tail.Value, 1, nameof(limit));
+            queryParams.Add((name: "tail", value: tail.Value.ToString(CultureInfo.InvariantCulture)));
+        }
+        if (skip.HasValue)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(skip.Value, 1, nameof(skip));
+            queryParams.Add((name: "skip", value: skip.Value.ToString(CultureInfo.InvariantCulture)));
+        }
 
         return ExecuteWithRetry(
             DcpApiOperationType.GetLogSubresource,
@@ -469,7 +507,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
             })
             .AddRetry(new RetryStrategyOptions()
             {
-                ShouldHandle = new PredicateBuilder().Handle<Exception>(isRetryable),
+                ShouldHandle = new PredicateBuilder().Handle(isRetryable),
                 BackoffType = DelayBackoffType.Exponential,
                 MaxRetryAttempts = int.MaxValue,
                 Delay = s_initialRetryDelay,

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -323,7 +323,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         }
         if (tail.HasValue)
         {
-            ArgumentOutOfRangeException.ThrowIfLessThan(tail.Value, 1, nameof(limit));
+            ArgumentOutOfRangeException.ThrowIfLessThan(tail.Value, 1, nameof(tail));
             queryParams.Add((name: "tail", value: tail.Value.ToString(CultureInfo.InvariantCulture)));
         }
         if (skip.HasValue)

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -456,6 +456,5 @@ internal static class Logs
     public const string StreamTypeStartupStdErr = "startup_stderr";
     public const string StreamTypeStdOut = "stdout";
     public const string StreamTypeStdErr = "stderr";
-    public const string StreamTypeAll = "all";
     public const string SubResourceName = "log";
 }

--- a/src/Aspire.Hosting/Dcp/ResourceLogSource.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceLogSource.cs
@@ -34,8 +34,8 @@ internal sealed class ResourceLogSource<TResource>(
 
         var streamTasks = new List<Task>();
 
-        var startupStderrStream = await kubernetesService.GetLogStreamAsync(resource, Logs.StreamTypeStartupStdErr, follow: follow, timestamps: true, cancellationToken).ConfigureAwait(false);
-        var startupStdoutStream = await kubernetesService.GetLogStreamAsync(resource, Logs.StreamTypeStartupStdOut, follow: follow, timestamps: true, cancellationToken).ConfigureAwait(false);
+        var startupStderrStream = await kubernetesService.GetLogStreamAsync(resource, Logs.StreamTypeStartupStdErr, cancellationToken, follow: follow, timestamps: true).ConfigureAwait(false);
+        var startupStdoutStream = await kubernetesService.GetLogStreamAsync(resource, Logs.StreamTypeStartupStdOut, cancellationToken, follow: follow, timestamps: true).ConfigureAwait(false);
 
         var startupStdoutStreamTask = Task.Run(() => StreamLogsAsync(startupStdoutStream, isError: false), cancellationToken);
         streamTasks.Add(startupStdoutStreamTask);
@@ -43,8 +43,8 @@ internal sealed class ResourceLogSource<TResource>(
         var startupStderrStreamTask = Task.Run(() => StreamLogsAsync(startupStderrStream, isError: false), cancellationToken);
         streamTasks.Add(startupStderrStreamTask);
 
-        var stdoutStream = await kubernetesService.GetLogStreamAsync(resource, Logs.StreamTypeStdOut, follow: follow, timestamps: true, cancellationToken).ConfigureAwait(false);
-        var stderrStream = await kubernetesService.GetLogStreamAsync(resource, Logs.StreamTypeStdErr, follow: follow, timestamps: true, cancellationToken).ConfigureAwait(false);
+        var stdoutStream = await kubernetesService.GetLogStreamAsync(resource, Logs.StreamTypeStdOut, cancellationToken, follow: follow, timestamps: true).ConfigureAwait(false);
+        var stderrStream = await kubernetesService.GetLogStreamAsync(resource, Logs.StreamTypeStdErr, cancellationToken, follow: follow, timestamps: true).ConfigureAwait(false);
 
         var stdoutStreamTask = Task.Run(() => StreamLogsAsync(stdoutStream, isError: false), cancellationToken);
         streamTasks.Add(stdoutStreamTask);

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -162,7 +162,17 @@ internal sealed class TestKubernetesService : IKubernetesService
         }
     }
 
-    public Task<Stream> GetLogStreamAsync<T>(T obj, string logStreamType, bool? follow = true, bool? timestamps = false, CancellationToken cancellationToken = default) where T : CustomResource
+    public Task<Stream> GetLogStreamAsync<T>(
+        T obj,
+        string logStreamType,
+        CancellationToken cancellationToken = default,
+        bool? follow = true,
+        bool? timestamps = false,
+        bool? lineNumbers = false,
+        long? limit = null,
+        long? tail = null,
+        long? skip = null
+    ) where T : CustomResource
     {
         return Task.FromResult(_startStream(obj, logStreamType));
     }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1206,7 +1206,7 @@ public class DistributedApplicationTests
         // It is not intended to verify the functionality of all possible option combinations.
 
         const string testName = "log-stream-options-work";
-        using var testProgram = CreateTestProgram(testName, randomizePorts: false);
+        using var testProgram = CreateTestProgram(testName);
         SetupXUnitLogging(testProgram.AppBuilder.Services);
 
         await using var app = testProgram.Build();

--- a/tests/testproject/TestProject.WorkerA/Worker.cs
+++ b/tests/testproject/TestProject.WorkerA/Worker.cs
@@ -14,12 +14,17 @@ public class Worker : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        long item = 1;
+
         while (!stoppingToken.IsCancellationRequested)
         {
             if (_logger.IsEnabled(LogLevel.Information))
             {
                 _logger.LogInformation("Worker running at: {Time}", DateTimeOffset.Now);
             }
+
+            System.Console.WriteLine($"Worker A: processing item {item++}...");
+
             await Task.Delay(1000, stoppingToken);
         }
     }


### PR DESCRIPTION
## Description

DCP 0.15 added new log streaming options that enable log paging. This PR adds the corresponding API definitions to Aspire app model.

This is meant to enable fixing https://github.com/dotnet/aspire/issues/6281

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
