### PR TITLE
Remove dependencies on AfterEndpointsAllocatedEvent

### DIFF
--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -109,19 +109,16 @@ public static class KafkaBuilderExtensions
                 .WithHttpEndpoint(targetPort: KafkaUIPort)
                 .ExcludeFromManifest();
 
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(kafkaUi, (e, ct) =>
             {
                 var kafkaResources = builder.ApplicationBuilder.Resources.OfType<KafkaServerResource>();
 
                 int i = 0;
                 foreach (var kafkaResource in kafkaResources)
                 {
-                    if (kafkaResource.InternalEndpoint.IsAllocated)
-                    {
-                        var endpoint = kafkaResource.InternalEndpoint;
-                        int index = i;
-                        kafkaUiBuilder.WithEnvironment(context => ConfigureKafkaUIContainer(context, endpoint, index));
-                    }
+                    var endpoint = kafkaResource.InternalEndpoint;
+                    int index = i;
+                    kafkaUiBuilder.WithEnvironment(context => ConfigureKafkaUIContainer(context, endpoint, index));
 
                     i++;
                 }

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -205,7 +205,7 @@ public static class MySqlBuilderExtensions
                                                 .WithHttpEndpoint(targetPort: 80, name: "http")
                                                 .ExcludeFromManifest();
 
-        builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+        builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(phpMyAdminContainer, (e, ct) =>
         {
             var mySqlInstances = builder.ApplicationBuilder.Resources.OfType<MySqlServerResource>();
 

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -64,7 +64,7 @@ public static class RedisBuilderExtensions
 
         // StackExchange.Redis doesn't support passwords with commas.
         // See https://github.com/StackExchange/StackExchange.Redis/issues/680 and
-        // https://github.com/Azure/azure-dev/issues/4848 
+        // https://github.com/Azure/azure-dev/issues/4848
         var passwordParameter = password?.Resource ?? ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, $"{name}-password", special: false);
 
         var redis = new RedisResource(name, passwordParameter);
@@ -158,7 +158,7 @@ public static class RedisBuilderExtensions
                                       .WithHttpEndpoint(targetPort: 8081, name: "http")
                                       .ExcludeFromManifest();
 
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(resource, (e, ct) =>
             {
                 var redisInstances = builder.ApplicationBuilder.Resources.OfType<RedisResource>();
 
@@ -172,17 +172,14 @@ public static class RedisBuilderExtensions
 
                 foreach (var redisInstance in redisInstances)
                 {
-                    if (redisInstance.PrimaryEndpoint.IsAllocated)
+                    // Redis Commander assumes Redis is being accessed over a default Aspire container network and hardcodes the resource address
+                    // This will need to be refactored once updated service discovery APIs are available
+                    var hostString = $"{(hostsVariableBuilder.Length > 0 ? "," : string.Empty)}{redisInstance.Name}:{redisInstance.Name}:{redisInstance.PrimaryEndpoint.TargetPort}:0";
+                    if (redisInstance.PasswordParameter is not null)
                     {
-                        // Redis Commander assumes Redis is being accessed over a default Aspire container network and hardcodes the resource address
-                        // This will need to be refactored once updated service discovery APIs are available
-                        var hostString = $"{(hostsVariableBuilder.Length > 0 ? "," : string.Empty)}{redisInstance.Name}:{redisInstance.Name}:{redisInstance.PrimaryEndpoint.TargetPort}:0";
-                        if (redisInstance.PasswordParameter is not null)
-                        {
-                            hostString += $":{redisInstance.PasswordParameter.Value}";
-                        }
-                        hostsVariableBuilder.Append(hostString);
+                        hostString += $":{redisInstance.PasswordParameter.Value}";
                     }
+                    hostsVariableBuilder.Append(hostString);
                 }
 
                 resourceBuilder.WithEnvironment("REDIS_HOSTS", hostsVariableBuilder.ToString());

--- a/src/Aspire.Hosting/ApplicationModel/AfterEndpointsAllocatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AfterEndpointsAllocatedEvent.cs
@@ -26,7 +26,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </code>
 /// </example>
 /// </remarks>
-[Obsolete("The AfterEndpointsAllocatedEvent is deprecated and will be removed in a future version. Use the resource specific events BeforResourceStartedEvent or ResourceEndpointsAllocatedEvent instead depending on your needs.")]
+[Obsolete("The AfterEndpointsAllocatedEvent is deprecated and will be removed in a future version. Use the resource specific events BeforeResourceStartedEvent or ResourceEndpointsAllocatedEvent instead depending on your needs.")]
 public class AfterEndpointsAllocatedEvent(IServiceProvider services, DistributedApplicationModel model) : IDistributedApplicationEvent
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/AfterEndpointsAllocatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AfterEndpointsAllocatedEvent.cs
@@ -26,6 +26,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </code>
 /// </example>
 /// </remarks>
+[Obsolete("The AfterEndpointsAllocatedEvent is deprecated and will be removed in a future version. Use the resource specific events BeforResourceStartedEvent or ResourceEndpointsAllocatedEvent instead depending on your needs.")]
 public class AfterEndpointsAllocatedEvent(IServiceProvider services, DistributedApplicationModel model) : IDistributedApplicationEvent
 {
     /// <summary>

--- a/src/Aspire.Hosting/Lifecycle/IDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Lifecycle/IDistributedApplicationLifecycleHook.cs
@@ -27,6 +27,7 @@ public interface IDistributedApplicationLifecycleHook
     /// <param name="appModel">The distributed application model.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+
     Task AfterEndpointsAllocatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;

--- a/src/Aspire.Hosting/Lifecycle/IDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Lifecycle/IDistributedApplicationLifecycleHook.cs
@@ -27,7 +27,6 @@ public interface IDistributedApplicationLifecycleHook
     /// <param name="appModel">The distributed application model.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-
     Task AfterEndpointsAllocatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -94,18 +94,17 @@ internal sealed class ApplicationOrchestrator
 
     private async Task OnEndpointsAllocated(OnEndpointsAllocatedContext context)
     {
-        // TODO: Remove once we support async endpoint allocation
+#pragma warning disable CS0618 // Type or member is obsolete
         var afterEndpointsAllocatedEvent = new AfterEndpointsAllocatedEvent(_serviceProvider, _model);
+#pragma warning restore CS0618 // Type or member is obsolete
         await _eventing.PublishAsync(afterEndpointsAllocatedEvent, context.CancellationToken).ConfigureAwait(false);
 
         foreach (var lifecycleHook in _lifecycleHooks)
         {
-            // TODO: Replace this once async endpoint allocation is supported
             await lifecycleHook.AfterEndpointsAllocatedAsync(_model, context.CancellationToken).ConfigureAwait(false);
         }
 
         // Fire the endpoints allocated event for all resources.
-        // TODO: Fire these events asynchronously once an endpoint is actually allocated
         foreach (var resource in _model.Resources)
         {
             await _eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(resource, _serviceProvider), EventDispatchBehavior.NonBlockingConcurrent, context.CancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1312,7 +1312,7 @@ public static class ResourceBuilderExtensions
 
         var endpointName = endpoint.EndpointName;
 
-        builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((@event, ct) =>
+        builder.ApplicationBuilder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>(builder.Resource, (@event, ct) =>
         {
             if (!endpoint.Exists)
             {

--- a/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
@@ -239,9 +239,9 @@ public class AddMySqlTests
         // Add fake allocated endpoints.
         mysql.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var myAdmin = builder.Resources.Single(r => r.Name.Equals("phpmyadmin"));
+
+        await builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(myAdmin, app.Services));
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(myAdmin, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
@@ -271,9 +271,9 @@ public class AddMySqlTests
         using var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var myAdmin = builder.Resources.Single(r => r.Name.Equals("phpmyadmin"));
+        builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(myAdmin, app.Services));
+
         var volume = myAdmin.Annotations.OfType<ContainerMountAnnotation>().Single();
 
         using var stream = File.OpenRead(volume.Source!);

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -369,16 +369,13 @@ public class AddPostgresTests
     }
 
     [Fact]
-    public async Task WithPgAdminAddsContainer()
+    public void WithPgAdminAddsContainer()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.AddPostgres("mypostgres").WithPgAdmin(pga => pga.WithHostPort(8081));
 
         using var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-
-        // The mount annotation is added in the AfterEndpointsAllocatedEvent.
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
 
         var container = builder.Resources.Single(r => r.Name == "pgadmin");
         var createFile = container.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
@@ -468,8 +465,6 @@ public class AddPostgresTests
 
         using var app = builder.Build();
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var pgadmin = builder.Resources.Single(r => r.Name.Equals("pgadmin"));
 
         var createServers = pgadmin.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();
@@ -530,8 +525,6 @@ public class AddPostgresTests
 
         using var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
 
         var pgweb = builder.Resources.Single(r => r.Name.Equals("pgweb"));
         var createBookmarks = pgweb.Annotations.OfType<ContainerFileSystemCallbackAnnotation>().Single();

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -227,8 +227,10 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var qdrant = builder.AddQdrant("qdrant");
 
+        var qdrantResource = builder.Resources.Single(r => r.Name.Equals("qdrant"));
+
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        builder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+        builder.Eventing.Subscribe<ConnectionStringAvailableEvent>(qdrantResource, (e, ct) =>
         {
             tcs.SetResult();
             return Task.CompletedTask;

--- a/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
@@ -300,8 +300,6 @@ public class AddRedisTests
         redis1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
         redis2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5002));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var redisInsight = Assert.Single(builder.Resources.OfType<RedisInsightResource>());
         var envs = await redisInsight.GetEnvironmentVariableValuesAsync();
 
@@ -490,9 +488,9 @@ public class AddRedisTests
         // Add fake allocated endpoints.
         redis.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var commander = builder.Resources.Single(r => r.Name.Equals("rediscommander"));
+
+        await builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(commander, app.Services));
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             commander,
@@ -514,9 +512,9 @@ public class AddRedisTests
         // Add fake allocated endpoints.
         redis.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var commander = builder.Resources.Single(r => r.Name.Equals("rediscommander"));
+
+        await builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(commander, app.Services));
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(commander);
 
@@ -535,9 +533,9 @@ public class AddRedisTests
         redis1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
         redis2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5002, "host2"));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var commander = builder.Resources.Single(r => r.Name.Equals("rediscommander"));
+
+        await builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(commander, app.Services));
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             commander,

--- a/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
+++ b/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
@@ -238,6 +238,7 @@ public class DistributedApplicationBuilderEventingTests
             beforeStartEventFired.Set();
             return Task.CompletedTask;
         });
+#pragma warning disable CS0618 // Type or member is obsolete
         builder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
         {
             Assert.NotNull(e.Services);
@@ -245,6 +246,7 @@ public class DistributedApplicationBuilderEventingTests
             afterEndpointsAllocatedEventFired.Set();
             return Task.CompletedTask;
         });
+#pragma warning restore CS0618 // Type or member is obsolete
         builder.Eventing.Subscribe<AfterResourcesCreatedEvent>((e, ct) =>
         {
             Assert.NotNull(e.Services);

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -53,7 +53,7 @@ public class WithUrlsTests
             .WithUrls(c => called = true);
 
         var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+        builder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>(projectA.Resource, (e, ct) =>
         {
             // Should not be called at this point
             Assert.False(called);


### PR DESCRIPTION
## Description

In order to support proxyless persistent containers by default (and dynamic endpoint allocation in general), the `AfterEndpointsAllocatedEvent` is going to need to be deprecated. The current eventing model assumes that all endpoinst are allocated before any resources are created, but to properly support persistent containers, we'll have to break that assumption. This means that some endpoints may not become fully allocated until after resource creation starts.

This PR marks `AfterEndpointsAllocatedEvent` as `[Obsolete]` with instructions to use the resource specific `BeforeResourceStartedEvent` or `ResourceEndpointsAllocatedEvent` events as appropriate. Additionally it replaces all internal usage of `AfterEndpointsAllocatedEvent` with one of the two previous events.

The one remaining scenario that will need to be reworked is the `AfterEndpointsAllocatedAsync` callback in `IDistributedApplicationLifecycleHook`. The only internal usage is in `DevcontainerPortForwardingLifecycleHook`, but that will likely need to be rewritten to be event based too. 

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected. (possible work for `IDistributedApplicationLifecycleHook` usage)
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
