### PR TITLE
[release/9.3] Initialize telemetry context in UpdateTelemetryProperties if not already initialized

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -37,6 +37,9 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
 
+    [Inject]
+    public required ILogger<ResourceDetails> Logger { get; init; }
+
     private bool IsSpecOnlyToggleDisabled => !Resource.Environment.All(i => !i.FromSpec) && !GetResourceProperties(ordered: false).Any(static vm => vm.KnownProperty is null);
 
     // NOTE Excludes URLs as they don't expose sensitive items (and enumerating URLs is non-trivial)
@@ -159,8 +162,8 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
 
     protected override void OnInitialized()
     {
-        (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlStringsLoc);
         TelemetryContextProvider.Initialize(TelemetryContext);
+        (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlStringsLoc);
     }
 
     private IEnumerable<ResourceDetailRelationshipViewModel> GetRelationships()
@@ -279,7 +282,7 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
     {
         TelemetryContext.UpdateTelemetryProperties([
             new ComponentTelemetryProperty(TelemetryPropertyKeys.ResourceType, new AspireTelemetryProperty(TelemetryPropertyValues.GetResourceTypeTelemetryValue(Resource.ResourceType)))
-        ]);
+        ], Logger);
     }
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -126,6 +126,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
     protected override async Task OnInitializedAsync()
     {
+        TelemetryContextProvider.Initialize(TelemetryContext);
         _resourceSubscriptionToken = _resourceSubscriptionCts.Token;
         _logEntries = new(Options.Value.Frontend.MaxConsoleLogCount);
         _noSelection = new() { Id = null, Name = ControlsStringsLoc[nameof(ControlsStrings.LabelNone)] };
@@ -171,8 +172,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             Logger.LogWarning(ex, "Load timeout while waiting for resource {ResourceName}.", ResourceName);
             PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLogsNotYetAvailable)];
         }
-
-        TelemetryContextProvider.Initialize(TelemetryContext);
 
         async Task TrackResourceSnapshotsAsync()
         {
@@ -743,6 +742,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     {
         TelemetryContext.UpdateTelemetryProperties([
             new ComponentTelemetryProperty(TelemetryPropertyKeys.ConsoleLogsShowTimestamp, new AspireTelemetryProperty(_showTimestamp, AspireTelemetryPropertyType.UserSetting))
-        ]);
+        ], Logger);
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/Error.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Error.razor.cs
@@ -9,6 +9,9 @@ namespace Aspire.Dashboard.Components.Pages;
 
 public partial class Error : IComponentWithTelemetry, IDisposable
 {
+    [Inject]
+    public required ILogger<Error> Logger { get; init; }
+
     [CascadingParameter]
     private HttpContext? HttpContext { get; set; }
 
@@ -17,8 +20,8 @@ public partial class Error : IComponentWithTelemetry, IDisposable
 
     protected override void OnInitialized()
     {
-        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
         TelemetryContextProvider.Initialize(TelemetryContext);
+        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
     }
 
     [Inject]
@@ -36,7 +39,7 @@ public partial class Error : IComponentWithTelemetry, IDisposable
     {
         TelemetryContext.UpdateTelemetryProperties([
             new ComponentTelemetryProperty(TelemetryPropertyKeys.ErrorRequestId, new AspireTelemetryProperty(RequestId ?? string.Empty)),
-        ]);
+        ], Logger);
     }
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Pages/Login.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor.cs
@@ -41,6 +41,8 @@ public partial class Login : IAsyncDisposable, IComponentWithTelemetry
 
     protected override async Task OnInitializedAsync()
     {
+        TelemetryContextProvider.Initialize(TelemetryContext);
+
         // Create EditContext before awaiting. This is required to prevent an await in OnInitializedAsync
         // triggering parameters being set on EditForm before EditContext is created.
         // If that happens then EditForm errors that it requires an EditContext.
@@ -60,8 +62,6 @@ public partial class Login : IAsyncDisposable, IComponentWithTelemetry
                 return;
             }
         }
-
-        TelemetryContextProvider.Initialize(TelemetryContext);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -78,6 +78,8 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
 
     protected override void OnInitialized()
     {
+        TelemetryContextProvider.Initialize(TelemetryContext);
+
         _durations = new List<SelectViewModel<TimeSpan>>
         {
             new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastOneMinute)], Id = TimeSpan.FromMinutes(1) },
@@ -109,8 +111,6 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
             UpdateApplications();
             StateHasChanged();
         }));
-
-        TelemetryContextProvider.Initialize(TelemetryContext);
     }
 
     protected override async Task OnParametersSetAsync()
@@ -335,6 +335,6 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
             new ComponentTelemetryProperty(TelemetryPropertyKeys.MetricsInstrumentsCount, new AspireTelemetryProperty((PageViewModel.Instruments?.Count ?? -1).ToString(CultureInfo.InvariantCulture), AspireTelemetryPropertyType.Metric)),
             new ComponentTelemetryProperty(TelemetryPropertyKeys.MetricsSelectedDuration, new AspireTelemetryProperty(PageViewModel.SelectedDuration.Id.ToString(), AspireTelemetryPropertyType.UserSetting)),
             new ComponentTelemetryProperty(TelemetryPropertyKeys.MetricsSelectedView, new AspireTelemetryProperty(PageViewModel.SelectedViewKind?.ToString() ?? string.Empty, AspireTelemetryPropertyType.UserSetting))
-        ]);
+        ], Logger);
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -56,6 +56,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     public required IOptionsMonitor<DashboardOptions> DashboardOptions { get; init; }
     [Inject]
     public required ComponentTelemetryContextProvider TelemetryContextProvider { get; init; }
+    [Inject]
+    public required ILogger<Resources> Logger { get; init; }
 
     public string BasePath => DashboardUrls.ResourcesBasePath;
     public string SessionStorageKey => BrowserStorageKeys.ResourcesPageState;
@@ -160,6 +162,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     protected override async Task OnInitializedAsync()
     {
+        TelemetryContextProvider.Initialize(TelemetryContext);
         (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlsStringsLoc);
 
         _gridColumns = [
@@ -214,7 +217,6 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             }
         });
 
-        TelemetryContextProvider.Initialize(TelemetryContext);
         _isLoading = false;
 
         async Task SubscribeResourcesAsync()
@@ -868,6 +870,6 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             new(TelemetryPropertyKeys.ResourceTypes, new AspireTelemetryProperty(_resourceByName.Values.Select(r => TelemetryPropertyValues.GetResourceTypeTelemetryValue(r.ResourceType)).OrderBy(t => t).ToList()))
         };
 
-        TelemetryContext.UpdateTelemetryProperties(properties.ToArray());
+        TelemetryContext.UpdateTelemetryProperties(properties.ToArray(), Logger);
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -148,6 +148,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     protected override void OnInitialized()
     {
+        TelemetryContextProvider.Initialize(TelemetryContext);
         (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlsStringsLoc);
 
         _gridColumns = [
@@ -203,8 +204,6 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             UpdateApplications();
             StateHasChanged();
         }));
-
-        TelemetryContextProvider.Initialize(TelemetryContext);
     }
 
     protected override async Task OnParametersSetAsync()
@@ -497,6 +496,6 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         TelemetryContext.UpdateTelemetryProperties([
             new ComponentTelemetryProperty(TelemetryPropertyKeys.StructuredLogsSelectedLogLevel, new AspireTelemetryProperty(PageViewModel.SelectedLogLevel.Id?.ToString() ?? string.Empty, AspireTelemetryPropertyType.UserSetting)),
             new ComponentTelemetryProperty(TelemetryPropertyKeys.StructuredLogsFilterCount, new AspireTelemetryProperty(ViewModel.Filters.Count.ToString(CultureInfo.InvariantCulture), AspireTelemetryPropertyType.Metric))
-        ]);
+        ], Logger);
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -65,6 +65,8 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
     protected override void OnInitialized()
     {
+        TelemetryContextProvider.Initialize(TelemetryContext);
+
         _gridColumns = [
             new GridColumn(Name: NameColumn, DesktopWidth: "4fr", MobileWidth: "4fr"),
             new GridColumn(Name: TicksColumn, DesktopWidth: "12fr", MobileWidth: "12fr"),
@@ -80,8 +82,6 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
                 await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
             }));
         }
-
-        TelemetryContextProvider.Initialize(TelemetryContext);
     }
 
     // Internal to be used in unit tests

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -149,6 +149,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
 
     protected override void OnInitialized()
     {
+        TelemetryContextProvider.Initialize(TelemetryContext);
         (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlsStringsLoc);
 
         _gridColumns = [
@@ -168,8 +169,6 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
             UpdateApplications();
             StateHasChanged();
         }));
-
-        TelemetryContextProvider.Initialize(TelemetryContext);
     }
 
     protected override async Task OnParametersSetAsync()

--- a/tests/Aspire.Dashboard.Tests/Telemetry/ComponentTelemetryContextTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Telemetry/ComponentTelemetryContextTests.cs
@@ -19,6 +19,7 @@ public class ComponentTelemetryContextTests
         var telemetryContextProvider = new ComponentTelemetryContextProvider(telemetryService);
         telemetryContextProvider.SetBrowserUserAgent("mozilla");
         await telemetryService.InitializeAsync();
+        var logger = NullLogger<ComponentTelemetryContextTests>.Instance;
 
         telemetryContextProvider.Initialize(telemetryContext);
         for (var i = 0; i < telemetryService.GetDefaultProperties().Count; i++)
@@ -35,18 +36,18 @@ public class ComponentTelemetryContextTests
 
         OperationContext? parametersUpdateOperation;
 
-        telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("Value"))]);
+        telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("Value"))], logger);
         Assert.Equal(3, telemetryContext.Properties.Count);
         Assert.True(telemetrySender.ContextChannel.Reader.TryRead(out parametersUpdateOperation));
         Assert.Equal("/telemetry/operation - $aspire/dashboard/component/paramsSet", parametersUpdateOperation.Name);
         Assert.Single(parametersUpdateOperation.Properties);
 
         // If value didn't change, we shouldn't post again
-        telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("Value"))]);
+        telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("Value"))], logger);
         Assert.Equal(3, telemetryContext.Properties.Count);
         Assert.False(telemetrySender.ContextChannel.Reader.TryRead(out parametersUpdateOperation));
 
-        telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("NewValue"))]);
+        telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("NewValue"))], logger);
         Assert.Equal(3, telemetryContext.Properties.Count);
         Assert.True(telemetrySender.ContextChannel.Reader.TryRead(out parametersUpdateOperation));
 
@@ -64,11 +65,12 @@ public class ComponentTelemetryContextTests
         var telemetryContextProvider = new ComponentTelemetryContextProvider(telemetryService);
         telemetryContextProvider.SetBrowserUserAgent("mozilla");
         await telemetryService.InitializeAsync();
+        var logger = NullLogger<ComponentTelemetryContextTests>.Instance;
 
         telemetryContextProvider.Initialize(telemetryContext);
         Assert.False(telemetrySender.ContextChannel.Reader.TryRead(out _));
 
-        telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("Value"))]);
+        telemetryContext.UpdateTelemetryProperties([new ComponentTelemetryProperty("Test", new AspireTelemetryProperty("Value"))], logger);
         Assert.Equal(3, telemetryContext.Properties.Count);
         Assert.False(telemetrySender.ContextChannel.Reader.TryRead(out _));
 


### PR DESCRIPTION
## Customer Impact

Race between initializing telemetry for a component can cause a dashboard error: https://github.com/dotnet/aspire/issues/9559

The fixes in the PR:

- Ensure telemetry is initialized at the start of `OnInitializedAsync`. This means it will always been initialized when parameters are updated.
- Log a warning instead of throwing an error if not initialized.

## Testing

Manual

## Risk

Low

## Regression?

Telemetry is new in 9.3. But it causes errors on existing pages that previously worked.