### PR TITLE
Update verify and remove AddTextExtension

### DIFF
--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -22,6 +22,6 @@
     <PackageVersion Include="Testcontainers.Milvus" Version="$(TestcontainersPackageVersion)" />
     <PackageVersion Include="Testcontainers.Oracle" Version="$(TestcontainersPackageVersion)" />
     <PackageVersion Include="Testcontainers" Version="$(TestcontainersPackageVersion)" />
-    <PackageVersion Include="Verify.XunitV3" Version="29.1.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="30.3.0" />
   </ItemGroup>
 </Project>

--- a/tests/Shared/TestModuleInitializer.cs
+++ b/tests/Shared/TestModuleInitializer.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.CompilerServices;
 using Aspire.TestUtilities;
-using EmptyFiles;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -12,13 +11,6 @@ sealed class TestModuleInitializer
     [ModuleInitializer]
     internal static void Setup()
     {
-        FileExtensions.AddTextExtension("bicep");
-        FileExtensions.AddTextExtension("json");
-        FileExtensions.AddTextExtension("yaml");
-        FileExtensions.AddTextExtension("yml");
-        FileExtensions.AddTextExtension("dockerfile");
-        FileExtensions.AddTextExtension("env");
-
         // Set the directory for all Verify calls in test projects
         var target = PlatformDetection.IsRunningOnHelix
             ? Path.Combine(Environment.GetEnvironmentVariable("HELIX_CORRELATION_PAYLOAD")!, "Snapshots")


### PR DESCRIPTION
## Description

 * Update Verify to 30.3.0. I assume you are using a restricted subset of package+version combos?? if so this may requires some updates to that list
 * new version of Verify adds `bicep`, `dockerfile`, and `env` as text extensions. since they are sensible defauls for other consumers of Verify
 * `json`, `yaml`, and `yml` were already text extensions


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
