### PR TITLE
change 2->8 cores for copilot setup build

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,7 +6,7 @@ on: workflow_dispatch
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: ubuntu-latest
+    runs-on: 16-core-ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,7 +6,7 @@ on: workflow_dispatch
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: 16-core-ubuntu-latest
+    runs-on: 8-core-ubuntu-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
Similar to https://github.com/dotnet/aspnetcore/pull/62206

Takes setup time for each copilot iteration down from 4min->2min at nominal cost. 16 c ore isn't worth it.

experimental data: https://github.com/dotnet/aspire/actions/workflows/copilot-setup-steps.yml