### PR TITLE
Quarantine Aspire.Cli.Tests.Projects.ProjectLocatorTests.UseOrFindAppHostProjectFilePromptsWhenMultipleFilesFound

### DIFF
--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Aspire.TestUtilities;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -106,6 +107,7 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9652")]
     public async Task UseOrFindAppHostProjectFilePromptsWhenMultipleFilesFound()
     {
         var logger = NullLogger<ProjectLocator>.Instance;
@@ -162,7 +164,7 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     {
         var logger = NullLogger<ProjectLocator>.Instance;
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        
+
         var runner = new TestDotNetCliRunner();
         var interactionService = new TestInteractionService();
 

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -174,6 +174,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     [InlineData(403, false)]
     [InlineData(404, false)]
     [InlineData(500, false)]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9670")]
     [Theory]
     public async Task WithHttpCommand_ResultsInExpectedResultForStatusCode(int statusCode, bool expectSuccess)
     {


### PR DESCRIPTION
Issue: https://github.com/dotnet/aspire/issues/9652

Also, Quarantined WithHttpCommandTests.WithHttpCommand_ResultsInExpectedResultForStatusCode - https://github.com/dotnet/aspire/issues/9670
