### PR TITLE
Implementing Foundry Local as an emulator

### DIFF
--- a/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/AzureAIFoundryLocalModelResource.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/AzureAIFoundryLocalModelResource.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a local model resource for Azure AI Foundry.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="model">The model associated with the resource.</param>
+/// <param name="parent">The parent resource to which this model belongs.</param>
+public class AzureAIFoundryLocalModelResource(string name, string model, AzureAIFoundryLocalResource parent) : Resource(name), IResourceWithConnectionString
+{
+    /// <summary>
+    /// Gets the model associated with the resource.
+    /// </summary>
+    public string Model { get; } = model;
+
+    /// <summary>
+    /// Gets or sets the model ID.
+    /// </summary>
+    public string? ModelId { get; internal set; }
+
+    /// <summary>
+    /// Gets the parent resource to which this model belongs.
+    /// </summary>
+    internal AzureAIFoundryLocalResource Parent { get; } = parent;
+
+    /// <summary>
+    /// Gets the connection string expression for the resource.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent};ModelName={Model};ModelId={ModelId}");
+}

--- a/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/AzureAIFoundryLocalResource.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/AzureAIFoundryLocalResource.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a local Azure AI Foundry resource with endpoints and connection string capabilities.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+public class AzureAIFoundryLocalResource(string name) : Resource(name), IResourceWithEndpoints, IResourceWithConnectionString
+{
+    internal const string PrimaryEndpointName = "http";
+
+    private EndpointReference? _primaryEndpointReference;
+
+    /// <summary>
+    /// Gets the primary endpoint reference for the resource.
+    /// </summary>
+    public EndpointReference PrimaryEndpoint => _primaryEndpointReference ??= new(this, PrimaryEndpointName);
+
+    private readonly List<AzureAIFoundryLocalModelResource> _models = [];
+
+    /// <summary>
+    /// Gets the list of models associated with the resource.
+    /// </summary>
+    public IReadOnlyList<AzureAIFoundryLocalModelResource> Models => _models;
+
+    /// <summary>
+    /// Gets the connection string expression for the resource.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create(
+        $"Endpoint={PrimaryEndpoint.Property(EndpointProperty.Host)}"
+      );
+
+    /// <summary>
+    /// Adds a model resource to the list of models.
+    /// </summary>
+    /// <param name="modelResource">The model resource to add.</param>
+    internal void AddModel(AzureAIFoundryLocalModelResource modelResource) => _models.Add(modelResource);
+}

--- a/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/AzureAIFoundryLocalResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/AzureAIFoundryLocalResourceExtensions.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Azure;
+using Microsoft.AI.Foundry.Local;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Provides extension methods for configuring and managing Azure AI Foundry local resources.
+/// </summary>
+public static partial class AzureAIFoundryLocalResourceExtensions
+{
+    /// <summary>
+    /// Adds an Azure AI Foundry local resource to the distributed application builder.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <returns>A resource builder for the Azure AI Foundry local resource.</returns>
+    public static IResourceBuilder<AzureAIFoundryResource> RunAsFoundryLocal(this IResourceBuilder<AzureAIFoundryResource> builder, [ResourceName] string? name)
+    {
+        ArgumentNullException.ThrowIfNull(builder, nameof(builder));
+        ArgumentException.ThrowIfNullOrWhiteSpace(name, nameof(name));
+
+        if (builder.ApplicationBuilder.Resources.OfType<AzureAIFoundryLocalResource>().SingleOrDefault() is { } existingResource)
+        {
+            builder.ApplicationBuilder.CreateResourceBuilder(existingResource);
+            return builder;
+        }
+
+        builder.ApplicationBuilder.Services.AddSingleton<FoundryManager>();
+
+        AzureAIFoundryLocalResource resource = new(name);
+        var resourceBuilder = builder.ApplicationBuilder.AddResource(resource)
+            .WithHttpEndpoint(env: "PORT", isProxied: false, port: 6914, name: AzureAIFoundryLocalResource.PrimaryEndpointName)
+            .WithExternalHttpEndpoints()
+            .WithAIFoundryLocalDefaults()
+
+            // Ensure that when the DCP exits the Foundry Local service is stopped.
+            .EnsureResourceStops();
+
+        builder.ApplicationBuilder.Eventing.Subscribe<BeforeStartEvent>((@event, ct)
+            => Task.Run(async () =>
+            {
+                var rns = @event.Services.GetRequiredService<ResourceNotificationService>();
+                var manager = @event.Services.GetRequiredService<FoundryManager>();
+
+                await rns.PublishUpdateAsync(resource, state => state with
+                {
+                    State = new ResourceStateSnapshot(KnownResourceStates.Starting, KnownResourceStateStyles.Info)
+                }).ConfigureAwait(false);
+
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                try
+                {
+                    await manager.StartServiceAsync(cts.Token);
+                }
+                catch (TaskCanceledException)
+                {
+                    await manager.StartServiceAsync(ct);
+                }
+
+                if (manager.IsServiceRunning)
+                {
+                    if (resource.TryGetLastAnnotation<EndpointAnnotation>(out var endpoint))
+                    {
+                        endpoint.AllocatedEndpoint = new AllocatedEndpoint(
+                            new EndpointAnnotation(
+                                System.Net.Sockets.ProtocolType.Tcp, manager.Endpoint.Scheme, "http", "http", manager.Endpoint.Port, manager.Endpoint.Port, false, false), manager.Endpoint.ToString(), manager.Endpoint.Port);
+                    }
+
+                    await rns.PublishUpdateAsync(resource, state => state with
+                    {
+                        State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
+                    }).ConfigureAwait(false);
+                }
+
+            }, ct));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Ensures that the resource stops when the application is shutting down.
+    /// </summary>
+    /// <param name="resource">The resource builder for the Azure AI Foundry local resource.</param>
+    /// <returns>The updated resource builder.</returns>
+    private static IResourceBuilder<AzureAIFoundryLocalResource> EnsureResourceStops(this IResourceBuilder<AzureAIFoundryLocalResource> resource)
+    {
+        resource.ApplicationBuilder.Eventing.Subscribe<ResourceReadyEvent>(resource.Resource, static (@event, ct) =>
+        {
+            _ = Task.Run(async () =>
+            {
+                var rns = @event.Services.GetRequiredService<ResourceNotificationService>();
+                var manager = @event.Services.GetRequiredService<FoundryManager>();
+
+                await rns.WaitForResourceAsync(@event.Resource.Name, KnownResourceStates.Finished, ct).ConfigureAwait(false);
+
+                await manager.StopServiceAsync(ct);
+            }, ct);
+
+            return Task.CompletedTask;
+        });
+
+        return resource;
+    }
+
+    /// <summary>
+    /// Adds a model to the Azure AI Foundry local resource.
+    /// </summary>
+    /// <param name="builder">The resource builder for the Azure AI Foundry local resource.</param>
+    /// <param name="name">The name of the model resource.</param>
+    /// <param name="model">The model identifier.</param>
+    /// <returns>A resource builder for the Azure AI Foundry local model resource.</returns>
+    public static IResourceBuilder<AzureAIFoundryLocalModelResource> AddModel(this IResourceBuilder<AzureAIFoundryLocalResource> builder, [ResourceName] string name, string model)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(model, nameof(model));
+
+        var modelResource = new AzureAIFoundryLocalModelResource(name, model, builder.Resource);
+
+        builder.Resource.AddModel(modelResource);
+
+        builder.ApplicationBuilder.Eventing.Subscribe<ResourceReadyEvent>(builder.Resource, (@event, ct) =>
+        {
+            var rns = @event.Services.GetRequiredService<ResourceNotificationService>();
+            var loggerService = @event.Services.GetRequiredService<ResourceLoggerService>();
+            var logger = loggerService.GetLogger(modelResource);
+            var manager = @event.Services.GetRequiredService<FoundryManager>();
+
+            _ = Task.Run(async () =>
+            {
+                await rns.PublishUpdateAsync(modelResource, state => state with
+                {
+                    State = new ResourceStateSnapshot($"Downloading model {model}", KnownResourceStateStyles.Info),
+                    Properties = [.. state.Properties, new(CustomResourceKnownProperties.Source, model)]
+                }).ConfigureAwait(false);
+
+                var result = manager.DownloadModelWithProgressAsync(model, ct: ct) ?? throw new InvalidOperationException($"Failed to download model {model}.");
+
+                await foreach (var progress in result)
+                {
+                    if (progress.IsCompleted && progress.ModelInfo is not null)
+                    {
+                        var modelInfo = progress.ModelInfo;
+                        logger.LogInformation("Model {Model} downloaded successfully.", model);
+
+                        await rns.PublishUpdateAsync(modelResource, state => state with
+                        {
+                            State = new ResourceStateSnapshot("Loading model", KnownResourceStateStyles.Info)
+                        }).ConfigureAwait(false);
+
+                        _ = await manager.LoadModelAsync(modelInfo.ModelId, ct: ct);
+
+                        await rns.PublishUpdateAsync(modelResource, state => state with
+                        {
+                            State = new ResourceStateSnapshot(KnownResourceStates.Running, KnownResourceStateStyles.Success)
+                        }).ConfigureAwait(false);
+
+                        modelResource.ModelId = modelInfo.ModelId;
+                    }
+                    else if (progress.IsCompleted && !string.IsNullOrEmpty(progress.ErrorMessage))
+                    {
+                        logger.LogInformation("Failed to start {Model}. Error: {Error}", model, progress.ErrorMessage);
+                        await rns.PublishUpdateAsync(modelResource, state => state with
+                        {
+                            State = new ResourceStateSnapshot(KnownResourceStates.FailedToStart, KnownResourceStateStyles.Error)
+                        }).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await rns.PublishUpdateAsync(modelResource, state => state with
+                        {
+                            State = new ResourceStateSnapshot($"Downloading  model {model}: {progress.Percentage}%", KnownResourceStateStyles.Info)
+                        }).ConfigureAwait(false);
+                    }
+                }
+            }, ct);
+
+            return Task.CompletedTask;
+        });
+
+        var healthCheckKey = $"{name}_check";
+        builder.ApplicationBuilder.Services.AddHealthChecks()
+                .Add(new HealthCheckRegistration(
+                    healthCheckKey,
+                    sp => new ModelHealthCheck(model, sp.GetRequiredService<FoundryManager>()),
+                    failureStatus: default,
+                    tags: default,
+                    timeout: default
+                    ));
+
+        return builder.ApplicationBuilder
+            .AddResource(modelResource)
+            .WithParentRelationship(builder.Resource)
+            .WithHealthCheck(healthCheckKey);
+    }
+
+    /// <summary>
+    /// Configures the resource builder with default settings for Azure AI Foundry local resources.
+    /// </summary>
+    /// <param name="resource">The resource builder for the Azure AI Foundry local resource.</param>
+    /// <returns>The updated resource builder.</returns>
+    private static IResourceBuilder<AzureAIFoundryLocalResource> WithAIFoundryLocalDefaults(this IResourceBuilder<AzureAIFoundryLocalResource> resource)
+        => resource.WithHttpHealthCheck("/openai/status");
+}

--- a/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/AzureAIFoundryLocalResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/AzureAIFoundryLocalResourceExtensions.cs
@@ -50,7 +50,7 @@ public static partial class AzureAIFoundryLocalResourceExtensions
 
                 await rns.PublishUpdateAsync(resource, state => state with
                 {
-                    State = new ResourceStateSnapshot(KnownResourceStates.Starting, KnownResourceStateStyles.Info)
+                    State = KnownResourceStates.Starting
                 }).ConfigureAwait(false);
 
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));

--- a/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/ModelHealthCheck.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/FoundryLocal/ModelHealthCheck.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AI.Foundry.Local;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+internal class ModelHealthCheck(string model, FoundryManager manager) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        if (!manager.IsServiceRunning)
+        {
+            return HealthCheckResult.Unhealthy("Foundry Local not running");
+        }
+
+        var loadedModels = await manager.ListLoadedModelsAsync(cancellationToken);
+
+        if (!loadedModels.Any(lm => lm.Alias == model))
+        {
+            return HealthCheckResult.Unhealthy("Model has not been loaded.");
+        }
+
+        return HealthCheckResult.Healthy();
+    }
+}


### PR DESCRIPTION
Depends on the management SDK being published to NuGet.

All code added to a sub directory of the integration to make it easier to group/keep separate from the other part of the integration.
