### PR TITLE
bump version of azure.provisioning to 1.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AzureProvisiongVersion>1.0.0</AzureProvisiongVersion>
+    <AzureProvisionVersion>1.0.0</AzureProvisionVersion>
     <!-- The Npgsql version used when using Npgsql EF Core on net8. The major versions need to match between Npgsql and EF Core. -->
     <Npgsql8Version>8.0.6</Npgsql8Version>
   </PropertyGroup>
@@ -32,25 +32,25 @@
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.11.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.2.0" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppService" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.Redis" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.Search" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.SignalR" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.Sql" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.WebPubSub" Version="$(AzureProvisiongVersion)" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.0.1" />
+    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.AppService" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.Redis" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.Search" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.SignalR" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.Sql" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.WebPubSub" Version="$(AzureProvisionVersion)" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.4" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.2" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.9.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -146,7 +146,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
-    <PackageVersion Include="Azure.Core" Version="1.46.0" />
+    <PackageVersion Include="Azure.Core" Version="1.46.1" />
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AzureProvisionVersion>1.0.0</AzureProvisionVersion>
     <!-- The Npgsql version used when using Npgsql EF Core on net8. The major versions need to match between Npgsql and EF Core. -->
     <Npgsql8Version>8.0.6</Npgsql8Version>
   </PropertyGroup>
@@ -33,24 +32,24 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.2.0" />
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.Provisioning" Version="1.0.1" />
-    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppService" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.Redis" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.Search" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.SignalR" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.Sql" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="$(AzureProvisionVersion)" />
-    <PackageVersion Include="Azure.Provisioning.WebPubSub" Version="$(AzureProvisionVersion)" />
+    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.AppService" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.Redis" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.Search" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.SignalR" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.Sql" Version="1.0.0" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="1.0.1" />
+    <PackageVersion Include="Azure.Provisioning.WebPubSub" Version="1.0.0" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.4" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.2" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.9.1" />


### PR DESCRIPTION
## Description

This PR bumps the version of Azure.Provisioning and Azure.Provisioning.Storage to `1.0.1` which fixed a few bugs.

* https://github.com/Azure/azure-sdk-for-net/issues/48493
* https://github.com/Azure/azure-sdk-for-net/issues/48249
* https://github.com/Azure/azure-sdk-for-net/issues/49898

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
