### PR TITLE
[CI] Fail tests validation run if vscode extensions tests fail

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -257,23 +257,6 @@ jobs:
           --timeout ${{ inputs.testSessionTimeout }}
           ${{ inputs.extraTestArgs }}
 
-      # Save the result of the previous steps - success or failure
-      # in the form of a file result-success/result-failure -{name}.rst
-      - name: Store result - success
-        if: ${{ success() }}
-        run: touch result-success-${{ inputs.testShortName }}.rst
-      - name: Store result - failure
-        if: ${{ !success() }}
-        run: touch result-failed-${{ inputs.testShortName }}.rst
-
-      # Upload that result file to artifact named test-job-result-{name}
-      - name: Upload test result
-        if: always()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        with:
-          name: test-job-result-${{ inputs.testShortName }}-${{ inputs.os }}
-          path: result-*.rst
-
       - name: Dump docker info
         if: ${{ always() && inputs.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -178,7 +178,7 @@ jobs:
       requiresTestSdk: true
 
   endtoend_tests:
-    name: EndToEnd ${{ matrix.os }}
+    name: EndToEnd Linux
     uses: ./.github/workflows/run-tests.yml
     needs: build_packages
     with:
@@ -213,11 +213,21 @@ jobs:
         with:
           name: aspire-extension
           path: extension/out/aspire-extension.vsix
+
   results: # This job is used for branch protection. It ensures all the above tests passed
     if: ${{ always() && github.repository_owner == 'dotnet' }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [ integrations_test_lin, integrations_test_win, integrations_test_macos, templates_test_lin, templates_test_win, templates_test_macos, endtoend_tests, extension_tests_win ]
+    needs: [
+      endtoend_tests,
+      extension_tests_win,
+      integrations_test_lin,
+      integrations_test_macos,
+      integrations_test_win,
+      templates_test_lin,
+      templates_test_macos,
+      templates_test_win
+    ]
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -260,7 +260,7 @@ jobs:
           --combined
 
       - name: Fail if any dependency failed
-        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')) }}
         run: |
           echo "One or more dependent jobs failed."
           exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -260,7 +260,7 @@ jobs:
           --combined
 
       - name: Fail if any dependency failed
-        if: ${{ always() && contains(needs.*.result, 'failure') }}" = "true" }}
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: |
           echo "One or more dependent jobs failed."
           exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,13 +222,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      # get all the test-job-result* artifacts into a single directory
-      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
-        with:
-          pattern: test-job-result-*
-          merge-multiple: true
-          path: test-job-result
-
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           pattern: logs-*-ubuntu-latest
@@ -266,7 +259,8 @@ jobs:
           ${{ github.workspace }}/testresults
           --combined
 
-      # return success if zero result-failed-* files are found
-      - name: Compute result
+      - name: Fail if any dependency failed
+        if: ${{ always() && contains(needs.*.result, 'failure') }}" = "true" }}
         run: |
-          [ 0 -eq $(find test-job-result -name 'result-failed-*' | wc -l) ]
+          echo "One or more dependent jobs failed."
+          exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -270,6 +270,8 @@ jobs:
           --combined
 
       - name: Fail if any dependency failed
+        # 'skipped' can be when a transitive dependency fails and the dependent job gets 'skipped'.
+        # For example, one of setup_* jobs failing and the Integration test jobs getting 'skipped'
         if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')) }}
         run: |
           echo "One or more dependent jobs failed."


### PR DESCRIPTION
Instead of using special `test-job-result` files, use a simplified condition that checks the results of all the jobs and fails the run if any of them has failed. This simplifies the whole thing and automatically adds support for the vscode extensions job.

This also means that the number of artifacts produced is reduced by a lot.

Fixes https://github.com/dotnet/aspire/issues/9690
