### PR TITLE
CosmosDB: Add the 'EnableServerless' capability to accounts

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -320,6 +320,17 @@ public static class AzureCosmosExtensions
     }
 
     /// <summary>
+    /// Configures the Azure Cosmos DB resource to be deployed use the default SKU provided by Azure.
+    /// </summary>
+    /// <param name="builder">The builder for the Azure Cosmos DB resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureCosmosDBResource> WithDefaultAzureSku(this IResourceBuilder<AzureCosmosDBResource> builder)
+    {
+        builder.Resource.UseDefaultAzureSku = true;
+        return builder;
+    }
+
+    /// <summary>
     /// Configures the Azure Cosmos DB preview emulator to expose the Data Explorer endpoint.
     /// </summary>
     /// <param name="builder">Builder for the Cosmos emulator container</param>
@@ -440,7 +451,7 @@ public static class AzureCosmosExtensions
             (infrastructure) => new CosmosDBAccount(infrastructure.AspireResource.GetBicepIdentifier())
             {
                 Kind = CosmosDBAccountKind.GlobalDocumentDB,
-                Capabilities =
+                Capabilities = azureResource.UseDefaultAzureSku ? [] : new BicepList<CosmosDBAccountCapability>
                 {
                     new CosmosDBAccountCapability { Name = CosmosConstants.EnableServerlessCapability }
                 },

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -440,6 +440,10 @@ public static class AzureCosmosExtensions
             (infrastructure) => new CosmosDBAccount(infrastructure.AspireResource.GetBicepIdentifier())
             {
                 Kind = CosmosDBAccountKind.GlobalDocumentDB,
+                Capabilities =
+                {
+                    new CosmosDBAccountCapability { Name = CosmosConstants.EnableServerlessCapability }
+                },
                 ConsistencyPolicy = new ConsistencyPolicy()
                 {
                     DefaultConsistencyLevel = DefaultConsistencyLevel.Session

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -42,7 +42,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     /// account is created as a serverless account. If true, it will use the default Azure Cosmos DB SKU, which is
     /// typically a provisioned throughput account.
     /// </summary>
-    public bool UseDefaultAzureSku {  get; set; } // Default to false
+    internal bool UseDefaultAzureSku {  get; set; } // Default to false
 
     /// <summary>
     /// Gets the "connectionString" secret reference from the key vault associated with this resource.

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -38,6 +38,13 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     public BicepOutputReference ConnectionStringOutput => new("connectionString", this);
 
     /// <summary>
+    /// Whether or not to use the default Azure Cosmos DB SKU. By default, this is set to false, and the Cosmos DB
+    /// account is created as a serverless account. If true, it will use the default Azure Cosmos DB SKU, which is
+    /// typically a provisioned throughput account.
+    /// </summary>
+    public bool UseDefaultAzureSku {  get; set; } // Default to false
+
+    /// <summary>
     /// Gets the "connectionString" secret reference from the key vault associated with this resource.
     ///
     /// This is set when access key authentication is used. The connection string is stored in a secret in the Azure Key Vault.

--- a/src/Shared/Cosmos/CosmosConstants.cs
+++ b/src/Shared/Cosmos/CosmosConstants.cs
@@ -16,4 +16,9 @@ internal static class CosmosConstants
     /// See <a href="https://learn.microsoft.com/azure/cosmos-db/emulator#authentication"></a>
     /// </summary>
     internal const string EmulatorAccountKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+
+    /// <summary>
+    /// Gets the well-known and documented capability value used to enable serverless mode for Azure Cosmos DB accounts.
+    /// </summary>
+    internal const string EnableServerlessCapability = "EnableServerless";
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -512,7 +512,18 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         Assert.Equal("cosmos", cosmos.Resource.Name);
         Assert.Equal("mycosmosconnectionstring", await connectionStringResource.GetConnectionStringAsync());
     }
-    
+
+    [Fact]
+    public async Task AddAzureCosmosDBViaPublishMode_WithDefaultAzureSku()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+            .WithDefaultAzureSku();
+
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(cosmos.Resource);
+        await Verify(manifest.BicepText, extension: "bicep");
+    }
+
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
     private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_NoAccessKeyAuthentication.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_NoAccessKeyAuthentication.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
@@ -9,6 +9,11 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
       {
         locationName: location
         failoverPriority: 0
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
       }
     ]
     consistencyPolicy: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_NoAccessKeyAuthentication.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_NoAccessKeyAuthentication.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param mykeyvault_outputs_name string

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param mykeyvault_outputs_name string
@@ -11,6 +11,11 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
       {
         locationName: location
         failoverPriority: 0
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
       }
     ]
     consistencyPolicy: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cosmos_kv_outputs_name string

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cosmos_kv_outputs_name string
@@ -11,6 +11,11 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
       {
         locationName: location
         failoverPriority: 0
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
       }
     ]
     consistencyPolicy: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithDefaultAzureSku.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithDefaultAzureSku.verified.bicep
@@ -1,0 +1,28 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
+  name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
+  location: location
+  properties: {
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+      }
+    ]
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    databaseAccountOfferType: 'Standard'
+    disableLocalAuth: true
+  }
+  kind: 'GlobalDocumentDB'
+  tags: {
+    'aspire-resource-name': 'cosmos'
+  }
+}
+
+output connectionString string = cosmos.properties.documentEndpoint
+
+output name string = cosmos.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_NoAccessKeyAuthentication.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_NoAccessKeyAuthentication.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
@@ -9,6 +9,11 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
       {
         locationName: location
         failoverPriority: 0
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
       }
     ]
     consistencyPolicy: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_NoAccessKeyAuthentication.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_NoAccessKeyAuthentication.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param mykeyvault_outputs_name string

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param mykeyvault_outputs_name string
@@ -11,6 +11,11 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
       {
         locationName: location
         failoverPriority: 0
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
       }
     ]
     consistencyPolicy: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cosmos_kv_outputs_name string

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cosmos_kv_outputs_name string
@@ -11,6 +11,11 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
       {
         locationName: location
         failoverPriority: 0
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
       }
     ]
     consistencyPolicy: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDB_useAcaInfrastructure=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDB_useAcaInfrastructure=False.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
@@ -9,6 +9,11 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
       {
         locationName: location
         failoverPriority: 0
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
       }
     ]
     consistencyPolicy: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDB_useAcaInfrastructure=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDB_useAcaInfrastructure=False.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDB_useAcaInfrastructure=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDB_useAcaInfrastructure=True.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
@@ -9,6 +9,11 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
       {
         locationName: location
         failoverPriority: 0
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
       }
     ]
     consistencyPolicy: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDB_useAcaInfrastructure=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDB_useAcaInfrastructure=True.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cosmos_kv_outputs_name string

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cosmos_kv_outputs_name string
@@ -11,6 +11,11 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
       {
         locationName: location
         failoverPriority: 0
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
       }
     ]
     consistencyPolicy: {


### PR DESCRIPTION
## Description

Change Azure Cosmos DB accounts to be created with the "EnableServerless" capability.  This is the recommended path for dev/test type scenarios, since it scales to zero when idle. See https://learn.microsoft.com/en-us/azure/cosmos-db/serverless for more details about it.

Fixes #8854 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
