### PR TITLE
Fix two common dashboard errors

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -838,7 +838,6 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     {
         _resourcesInteropReference?.Dispose();
         _watchTaskCancellationTokenSource.Cancel();
-        _watchTaskCancellationTokenSource.Dispose();
         _logsSubscription?.Dispose();
         TelemetryContext.Dispose();
 


### PR DESCRIPTION
## Description

Partially addresses https://github.com/dotnet/aspire/issues/9537

> at System.Threading.CancellationTokenSource.get_Token()    at Aspire.Dashboard.Components.Pages.Resources.<OnInitializedAsync>g__SubscribeResourcesAsync|135_2() in /_/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs:line 244    at Aspire.Dashboard.Components.Pages.Resources.OnInitializedAsync() in /_/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs:line 224    at Microsoft.AspNetCore.Components.ComponentBase.RunInitAndSetParametersAsync()    at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle, ComponentState owningComponentState)


Error above is fixed by not disposing CTS.

> at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, CancellationToken cancellationToken, Object[] args)    at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, Object[] args)    at Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(IJSRuntime jsRuntime, String identifier, Object[] args)    at Aspire.Dashboard.Components.Resize.BrowserDimensionWatcher.OnAfterRenderAsync(Boolean firstRender) in /_/src/Aspire.Dashboard/Components/Resize/BrowserDimensionWatcher.cs:line 51    at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle, ComponentState owningComponentState)

Errror above is fixed by catching `Microsoft.JSInterop.JSDisconnectedException`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
