### PR TITLE
Speed up/robustify copilot setup step

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,11 @@
 * Always use `is null` or `is not null` instead of `== null` or `!= null`.
 * Trust the C# null annotations and don't add null checks when the type system says a value cannot be null.
 
+### Building
+
+* Follow the instructions in the repo to build.
+* If temporarily introducing warnings during a refactoring, you can add the flag `/p:TreatWarningsAsErrors=false` to your build command to prevent the build from failing. However before you finish your work, you must strive to fix any warnings as well.
+
 ### Testing
 
 * We use xUnit SDK v3 with Microsoft.Testing.Platform (https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@
 
 (1) Build from the root with `build.sh`.
 (2) If that produces errors, fix those errors and build again. Repeat until the build is successful.
-(3) To then run tests, use a command similar to this `dotnet test tests/Aspire.Seq.Tests/Aspire.Seq.Tests.csproj` (using the path to whatever projects are applicable to the change).
+(3) To then run tests, use a command similar to this `dotnet.sh test tests/Aspire.Seq.Tests/Aspire.Seq.Tests.csproj` (using the path to whatever projects are applicable to the change).
 
 ## Quarantined tests
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,6 @@ jobs:
         env:
           # prevent GitInfo errors
           CI: false
-        run: ./build.sh /p:PrepareForHelix=true
+        # a full build is too slow; also do not fail on errors, continue so that
+        # copilot can attempt to recover
+        run: ./build.sh -restore || true

--- a/playground/AspireEventHub/EventHubsApi/EventHubsApi.csproj
+++ b/playground/AspireEventHub/EventHubsApi/EventHubsApi.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>10988975-8943-45bd-8598-a455ff9dd597</UserSecretsId>
   </PropertyGroup>
-
+TYPOE TO BREAK BUILD
   <ItemGroup>
     <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.EventHubs" />
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />

--- a/playground/AspireEventHub/EventHubsApi/EventHubsApi.csproj
+++ b/playground/AspireEventHub/EventHubsApi/EventHubsApi.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>10988975-8943-45bd-8598-a455ff9dd597</UserSecretsId>
   </PropertyGroup>
-TYPOE TO BREAK BUILD
+
   <ItemGroup>
     <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.EventHubs" />
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />


### PR DESCRIPTION
## Description

1. Speed up copilot iterations by changing build to restore. NOTE: we will need to open up parts of the firewall to get tests to run. Will find this out in use.
1. Make copilot setup never fail on a build error. This avoids the problem where copilot introduces a build error, finishes, then cannot be restarted to fix it.
1. Ensure that copilot knows how to build successfully with warnings temporarily (it should know this anyway) to potentially help it do refactorings that temporarily introduce warnings.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
