### PR TITLE
Use a persistent container network if there are persistent container resources

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1219,11 +1219,9 @@ internal sealed class DcpExecutor : IDcpExecutor, IConsoleLogsService, IAsyncDis
             {
                 var usePersistentNetwork = containerResources.Any(cr => cr.ModelResource.GetContainerLifetimeType() == ContainerLifetime.Persistent);
 
-                var networkSuffix = usePersistentNetwork switch
-                {
-                    false => DcpNameGenerator.GetRandomNameSuffix(),
-                    _ => _nameGenerator.GetProjectHashSuffix(),
-                };
+                var networkSuffix = usePersistentNetwork ?
+                    DcpNameGenerator.GetRandomNameSuffix() :
+                    _nameGenerator.GetProjectHashSuffix();
 
                 var networkName = (string.IsNullOrWhiteSpace(networkSuffix), string.IsNullOrWhiteSpace(_options.Value.ResourceNameSuffix)) switch
                 {

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1217,8 +1217,28 @@ internal sealed class DcpExecutor : IDcpExecutor, IConsoleLogsService, IAsyncDis
             // Create a custom container network for Aspire if there are container resources
             if (containerResources.Any())
             {
+                var usePersistentNetwork = containerResources.Any(cr => cr.ModelResource.GetContainerLifetimeType() == ContainerLifetime.Persistent);
+
+                var networkSuffix = usePersistentNetwork switch
+                {
+                    false => DcpNameGenerator.GetRandomNameSuffix(),
+                    _ => _nameGenerator.GetProjectHashSuffix(),
+                };
+
+                var networkName = (string.IsNullOrWhiteSpace(networkSuffix), string.IsNullOrWhiteSpace(_options.Value.ResourceNameSuffix)) switch
+                {
+                    (true, true) => DefaultAspireNetworkName,
+                    (false, true) => $"{DefaultAspireNetworkName}-{networkSuffix}",
+                    (true, false) => $"{DefaultAspireNetworkName}-{_options.Value.ResourceNameSuffix}",
+                    (false, false) => $"{DefaultAspireNetworkName}-{networkSuffix}-{_options.Value.ResourceNameSuffix}"
+                };
+
+                var network = ContainerNetwork.Create(DefaultAspireNetworkName);
+                network.Spec.Persistent = usePersistentNetwork;
+                network.Spec.NetworkName = networkName;
+
                 // The network will be created with a unique postfix to avoid conflicts with other Aspire AppHost networks
-                tasks.Add(_kubernetesService.CreateAsync(ContainerNetwork.Create(DefaultAspireNetworkName), cancellationToken));
+                tasks.Add(_kubernetesService.CreateAsync(network, cancellationToken));
             }
 
             foreach (var cr in containerResources)

--- a/src/Aspire.Hosting/Dcp/DcpNameGenerator.cs
+++ b/src/Aspire.Hosting/Dcp/DcpNameGenerator.cs
@@ -65,8 +65,7 @@ internal sealed class DcpNameGenerator
         var nameSuffix = container.GetContainerLifetimeType() switch
         {
             ContainerLifetime.Session => GetRandomNameSuffix(),
-            // Compute a short hash of the content root path to differentiate between multiple AppHost projects with similar resource names
-            _ => _configuration["AppHost:Sha256"]!.Substring(0, RandomNameSuffixLength).ToLowerInvariant(),
+            _ => GetProjectHashSuffix(),
         };
 
         return (GetObjectNameForResource(container, _options.Value, nameSuffix), nameSuffix);
@@ -106,10 +105,17 @@ internal sealed class DcpNameGenerator
         return uniqueName;
     }
 
-    private static string GetRandomNameSuffix()
+    public static string GetRandomNameSuffix()
     {
         // RandomNameSuffixLength of lowercase characters
         var suffix = PasswordGenerator.Generate(RandomNameSuffixLength, true, false, false, false, RandomNameSuffixLength, 0, 0, 0);
+        return suffix;
+    }
+
+    public string GetProjectHashSuffix()
+    {
+        // Compute a short hash of the content root path to differentiate between multiple AppHost projects with similar resource names
+        var suffix = _configuration["AppHost:Sha256"]!.Substring(0, RandomNameSuffixLength).ToLowerInvariant();
         return suffix;
     }
 


### PR DESCRIPTION
## Description

This changes the internal container network Aspire creates to have a persistent lifetime if any container resources have a persistent lifetime. This will allow persistent containers to continue to communicate with each other even after the app host is shut down and the network will be re-used for all container networking when the app host is restarted.

This depends on an orchestrator update that has a few fixes for persistent networking and container resource cleanup.

The main reason we haven't done this previously is that Docker has a roughly 29 network limit by default and we wanted to be careful about leaving abandoned networks behind, but we've made some updates to the orchestrator to cleanup unused resources as part of startup (leftover Aspire networks without containers attached) and will only launch persistent networks for persistent container resources.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
