### PR TITLE
[release/9.3] Skip role assignment handling for emulators (#9705)

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -143,6 +143,12 @@ internal sealed class AzureResourcePreparer(
                         .ToLookup(a => a.Target);
                 foreach (var azureReference in azureReferences.OfType<AzureProvisioningResource>())
                 {
+                    if (azureReference.IsContainer())
+                    {
+                        // Skip emulators
+                        continue;
+                    }
+
                     var roleAssignments = azureReferencesWithRoleAssignments[azureReference];
                     if (roleAssignments.Any())
                     {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -134,6 +134,28 @@ public class AzureResourcePreparerTests
     }
 
     [Fact]
+    public async Task DoesNotApplyRoleAssignmentsInRunModeForEmulators()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        builder.AddAzureContainerAppEnvironment("env");
+
+        builder.AddBicepTemplateString("foo", "");
+
+        var dbsrv = builder.AddAzureSqlServer("dbsrv").RunAsContainer();
+        var db = dbsrv.AddDatabase("db");
+
+        var api = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithReference(db);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        // in RunMode, we skip applying the role assignments to a new 'dbsrv-roles' resource, since the storage is running as emulator.
+        Assert.DoesNotContain(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "dbsrv-roles");
+    }
+
+    [Fact]
     public async Task FindsAzureReferencesFromArguments()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);


### PR DESCRIPTION
- Updated `BuildRoleAssignmentAnnotations` to skip processing for container emulators.
- Added a new test `DoesNotApplyRoleAssignmentsInRunModeForEmulators` to verify that role assignments are not applied to emulator resources.

Fixes https://github.com/dotnet/aspire/issues/9422

## Customer Impact

Users are unable to F5 their application when they don't have Azure subscription information added, even though they are using the local emulator. We shouldn't require Azure subscription information when using emulators.

## Testing

Added new test. Plus manual.

## Risk

Low

## Regression?

Yes