### PR TITLE
Fix error CSS

### DIFF
--- a/playground/keycloak/Keycloak.Web/Components/Layout/MainLayout.razor.css
+++ b/playground/keycloak/Keycloak.Web/Components/Layout/MainLayout.razor.css
@@ -93,5 +93,4 @@ main {
         position: absolute;
         right: 0.75rem;
         top: 0.5rem;
-        text-decoration: none;
     }

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -219,7 +219,3 @@
     top: 0.5rem;
     text-decoration: none;
 }
-
-#blazor-error-ui .reload {
-    color: var(--error-ui-accent-foreground-color);
-}

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -1,32 +1,4 @@
 @media (min-width: 768px) {
-    #blazor-error-ui {
-        background: var(--highlight-bg);
-        bottom: 0;
-        box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
-        display: none;
-        left: 0;
-        padding: 0.6rem 1.25rem 0.7rem 1.25rem;
-        position: fixed;
-        width: 100%;
-        z-index: 1000;
-        color: var(--error-ui-foreground-color);
-    }
-
-    #blazor-error-ui a {
-        color: var(--error-ui-accent-foreground-color);
-    }
-
-    #blazor-error-ui .dismiss {
-        cursor: pointer;
-        position: absolute;
-        right: 0.75rem;
-        top: 0.5rem;
-    }
-
-    #blazor-error-ui .reload {
-        color: var(--error-ui-accent-foreground-color);
-    }
-
     ::deep.layout {
         height: 100vh;
         width: 100vw;
@@ -103,34 +75,6 @@
 }
 
 @media (max-width: 768px) {
-    #blazor-error-ui {
-        background: var(--highlight-bg);
-        bottom: 0;
-        box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
-        display: none;
-        left: 0;
-        padding: 0.6rem 1.25rem 0.7rem 1.25rem;
-        position: fixed;
-        width: 100%;
-        z-index: 1000;
-        color: var(--error-ui-foreground-color);
-    }
-
-    #blazor-error-ui a {
-        color: var(--error-ui-accent-foreground-color);
-    }
-
-    #blazor-error-ui .dismiss {
-        cursor: pointer;
-        position: absolute;
-        right: 0.75rem;
-        top: 0.5rem;
-    }
-
-    #blazor-error-ui .reload {
-        color: var(--error-ui-accent-foreground-color);
-    }
-
     ::deep.layout {
         height: 100vh;
         width: 100vw;
@@ -249,4 +193,33 @@
 
 ::deep.layout > header > .header-gutters > .header-button-selected:not(:hover)::part(control) {
     background-color: var(--neutral-layer-floating) !important;
+}
+
+#blazor-error-ui {
+    background: var(--highlight-bg);
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+    color: var(--error-ui-foreground-color);
+}
+
+#blazor-error-ui a {
+    color: var(--error-ui-accent-foreground-color);
+}
+
+#blazor-error-ui .dismiss {
+    cursor: pointer;
+    position: absolute;
+    right: 0.75rem;
+    top: 0.5rem;
+    text-decoration: none;
+}
+
+#blazor-error-ui .reload {
+    color: var(--error-ui-accent-foreground-color);
 }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -281,12 +281,6 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 }
             });
         }
-
-        if (DateTime.Now != DateTime.MinValue)
-        {
-            await Task.Delay(1000);
-            throw new InvalidOperationException("Test");
-        }
     }
 
     private bool UpdateFromResource(ResourceViewModel resource)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -281,6 +281,12 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 }
             });
         }
+
+        if (DateTime.Now != DateTime.MinValue)
+        {
+            await Task.Delay(1000);
+            throw new InvalidOperationException("Test");
+        }
     }
 
     private bool UpdateFromResource(ResourceViewModel resource)


### PR DESCRIPTION
In https://github.com/dotnet/aspire/pull/9733 I put a CSS change into a playground app by mistake. Move to right location.

Also, there is no reason error CSS needs to be duplicated in page size rules. The CSS is the same for both.