### PR TITLE
Default to single resource on console logs and metrics pages

### DIFF
--- a/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/Program.cs
+++ b/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/Program.cs
@@ -16,9 +16,9 @@ builder.AddProject<Projects.ProxylessEndToEnd_ApiService>("api")
     })
     .WithReference(redis);
 
-builder.AddProject<Projects.ProxylessEndToEnd_ApiService>("api2", launchProfileName: null)
-    .WithHttpEndpoint(port: 13456)
-    .WithReference(redis);
+//builder.AddProject<Projects.ProxylessEndToEnd_ApiService>("api2", launchProfileName: null)
+//    .WithHttpEndpoint(port: 13456)
+//    .WithReference(redis);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/Program.cs
+++ b/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/Program.cs
@@ -16,9 +16,9 @@ builder.AddProject<Projects.ProxylessEndToEnd_ApiService>("api")
     })
     .WithReference(redis);
 
-//builder.AddProject<Projects.ProxylessEndToEnd_ApiService>("api2", launchProfileName: null)
-//    .WithHttpEndpoint(port: 13456)
-//    .WithReference(redis);
+builder.AddProject<Projects.ProxylessEndToEnd_ApiService>("api2", launchProfileName: null)
+    .WithHttpEndpoint(port: 13456)
+    .WithReference(redis);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -724,6 +724,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             }
             else if (TryGetSingleResource() is { } r)
             {
+                // If there is no app selected and there is only one application available, select it.
                 viewModel.SelectedResource = r;
                 return this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false);
             }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -62,8 +62,9 @@ public partial class ConsoleLogsTests : DashboardTestContext
 
         logger = Services.GetRequiredService<ILogger<ConsoleLogsTests>>();
 
-        var targetLocationTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         var navigationManager = Services.GetRequiredService<NavigationManager>();
+
+        var targetLocationTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         using var changeHandler = navigationManager.RegisterLocationChangingHandler(c =>
         {
             targetLocationTcs.SetResult(c.TargetLocation);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -39,6 +39,55 @@ public partial class ConsoleLogsTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task NoResourceName_SingleResource_RedirectToResource()
+    {
+        // Arrange
+        ILogger logger = null!;
+        var subscribedResourceNamesChannel = Channel.CreateUnbounded<string>();
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var testResource = ModelTestHelpers.CreateResource(appName: "test-resource", state: KnownResourceState.Running);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: name =>
+            {
+                logger.LogInformation($"Requesting logs for: {name}");
+                subscribedResourceNamesChannel.Writer.TryWrite(name);
+                return consoleLogsChannel;
+            },
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+
+        SetupConsoleLogsServices(dashboardClient);
+
+        logger = Services.GetRequiredService<ILogger<ConsoleLogsTests>>();
+
+        var targetLocationTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        using var changeHandler = navigationManager.RegisterLocationChangingHandler(c =>
+        {
+            targetLocationTcs.SetResult(c.TargetLocation);
+            return ValueTask.CompletedTask;
+        });
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        // Act 1
+        var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var instance = cut.Instance;
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
+
+        // Assert 1
+        Assert.Equal("/consolelogs/resource/test-resource", await targetLocationTcs.Task.DefaultTimeout());
+    }
+
+    [Fact]
     public async Task ResourceName_SubscribeOnLoadAndChange_SubscribeConsoleLogsOnce()
     {
         // Arrange


### PR DESCRIPTION
## Description

Replaces https://github.com/dotnet/aspire/pull/9745

Fixes https://github.com/dotnet/aspire/issues/9742.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
