### PR TITLE
Improve/Fix hierarchical partition keys for Azure Cosmos

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
@@ -45,7 +45,6 @@ resource entries 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@
           '/id'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }
@@ -63,7 +62,6 @@ resource users 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@20
           '/id'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
@@ -44,6 +44,8 @@ resource entries 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@
         paths: [
           '/id'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }
@@ -60,6 +62,8 @@ resource users 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@20
         paths: [
           '/id'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }
@@ -77,6 +81,8 @@ resource user_todo 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
           '/userId'
           '/id'
         ]
+        kind: 'MultiHash'
+        version: 2
       }
     }
   }

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -55,6 +55,11 @@ public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<Azur
     }
 
     /// <summary>
+    /// Gets the container properties for this azure cosmos db container resource.
+    /// </summary>
+    public ContainerProperties ContainerProperties { get; private init; }
+
+    /// <summary>
     /// Gets or sets the container name.
     /// </summary>
     public string ContainerName
@@ -62,11 +67,6 @@ public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<Azur
         get => ContainerProperties.Id;
         set => ContainerProperties.Id = value;
     }
-
-    /// <summary>
-    /// Gets the container properties for this azure cosmos db container resouce.
-    /// </summary>
-    public ContainerProperties ContainerProperties { get; private init; }
 
     /// <summary>
     /// Gets or sets the partition key path.

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -479,10 +479,15 @@ public static class AzureCosmosExtensions
                         {
                             Paths = [.. container.PartitionKeyPaths],
                             Kind = container.PartitionKeyPaths.Count > 1 ? CosmosDBPartitionKind.MultiHash : CosmosDBPartitionKind.Hash,
-                            Version = (int)PartitionKeyDefinitionVersion.V2
                         }
                     }
                 };
+
+                if (container.ContainerProperties.PartitionKeyDefinitionVersion is { } version)
+                {
+                    cosmosContainer.Resource.PartitionKey.Version = (int)version;
+                }
+
                 infrastructure.Add(cosmosContainer);
             }
         }

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -116,11 +116,7 @@ public static class AzureCosmosExtensions
 
                 foreach (var container in database.Containers)
                 {
-                    var containerProperties = new ContainerProperties
-                    {
-                        Id = container.ContainerName,
-                        PartitionKeyPaths = container.PartitionKeyPaths
-                    };
+                    var containerProperties = container.ContainerProperties;
 
                     await db.CreateContainerIfNotExistsAsync(containerProperties, cancellationToken: ct).ConfigureAwait(false);
                 }
@@ -279,7 +275,7 @@ public static class AzureCosmosExtensions
         // Use the resource name as the container name if it's not provided
         containerName ??= name;
 
-        var container = new AzureCosmosDBContainerResource(name, containerName, [partitionKeyPath], builder.Resource);
+        var container = new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, builder.Resource);
         builder.Resource.Containers.Add(container);
 
         return builder.ApplicationBuilder.AddResource(container);
@@ -479,7 +475,12 @@ public static class AzureCosmosExtensions
                     Resource = new CosmosDBSqlContainerResourceInfo()
                     {
                         ContainerName = container.ContainerName,
-                        PartitionKey = new CosmosDBContainerPartitionKey { Paths = [.. container.PartitionKeyPaths] }
+                        PartitionKey = new CosmosDBContainerPartitionKey
+                        {
+                            Paths = [.. container.PartitionKeyPaths],
+                            Kind = container.PartitionKeyPaths.Count > 1 ? CosmosDBPartitionKind.MultiHash : CosmosDBPartitionKind.Hash,
+                            Version = (int)PartitionKeyDefinitionVersion.V2
+                        }
                     }
                 };
                 infrastructure.Add(cosmosContainer);

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/CosmosDBPublicApiTests.cs
@@ -21,9 +21,7 @@ public class CosmosDBPublicApiTests
         const string partitionKeyPath = "data";
         var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
 
-#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent);
-#pragma warning restore CS0618 // Type or member is obsolete
 
         var exception = isNull
             ? Assert.Throws<ArgumentNullException>(action)
@@ -63,9 +61,7 @@ public class CosmosDBPublicApiTests
         const string partitionKeyPath = "data";
         var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
 
-#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent);
-#pragma warning restore CS0618 // Type or member is obsolete
 
         var exception = isNull
             ? Assert.Throws<ArgumentNullException>(action)
@@ -105,12 +101,12 @@ public class CosmosDBPublicApiTests
         var partitionKeyPath = isNull ? null! : string.Empty;
         var parent = new AzureCosmosDBDatabaseResource("database", "cosmos-db", resource.Resource);
 
-#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent);
-#pragma warning restore CS0618 // Type or member is obsolete
 
-        var exception = Assert.Throws<ArgumentException>(action);
-        Assert.Equal("partitionKeyPaths", exception.ParamName);
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(partitionKeyPath), exception.ParamName);
     }
 
     [Fact]
@@ -171,9 +167,7 @@ public class CosmosDBPublicApiTests
         const string partitionKeyPath = "data";
         AzureCosmosDBDatabaseResource parent = null!;
 
-#pragma warning disable CS0618 // Type or member is obsolete
         var action = () => new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, parent);
-#pragma warning restore CS0618 // Type or member is obsolete
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(parent), exception.ParamName);

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_NoAccessKeyAuthentication.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_NoAccessKeyAuthentication.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
@@ -44,6 +44,8 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
         paths: [
           'mypartitionkeypath'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_NoAccessKeyAuthentication.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_NoAccessKeyAuthentication.verified.bicep
@@ -45,7 +45,6 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
           'mypartitionkeypath'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -47,7 +47,6 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
           'mypartitionkeypath'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param mykeyvault_outputs_name string
@@ -46,6 +46,8 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
         paths: [
           'mypartitionkeypath'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -47,7 +47,6 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
           'mypartitionkeypath'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaPublishMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cosmos_kv_outputs_name string
@@ -46,6 +46,8 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
         paths: [
           'mypartitionkeypath'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_NoAccessKeyAuthentication.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_NoAccessKeyAuthentication.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
@@ -44,6 +44,8 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
         paths: [
           'mypartitionkeypath'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_NoAccessKeyAuthentication.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_NoAccessKeyAuthentication.verified.bicep
@@ -45,7 +45,6 @@ resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/contain
           'mypartitionkeypath'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param mykeyvault_outputs_name string
@@ -46,6 +46,8 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
         paths: [
           'mypartitionkeypath'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=mykeyvault.verified.bicep
@@ -47,7 +47,6 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
           'mypartitionkeypath'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cosmos_kv_outputs_name string
@@ -46,6 +46,8 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
         paths: [
           'mypartitionkeypath'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDBViaRunMode_WithAccessKeyAuthentication_kvName=null.verified.bicep
@@ -47,7 +47,6 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
           'mypartitionkeypath'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cosmos_kv_outputs_name string
@@ -46,6 +46,8 @@ resource container1 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containe
         paths: [
           'id'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureCosmosDBExtensionsTests.AddAzureCosmosDatabase_WorksWithAccessKeyAuth_ChildResources.verified.bicep
@@ -47,7 +47,6 @@ resource container1 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containe
           'id'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroup.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroup.verified.bicep
@@ -29,7 +29,6 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
           '/id'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroup.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroup.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param existingResourceName string
@@ -28,6 +28,8 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
         paths: [
           '/id'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroupAccessKey.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroupAccessKey.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param existingResourceName string
@@ -30,6 +30,8 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
         paths: [
           '/id'
         ]
+        kind: 'Hash'
+        version: 2
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroupAccessKey.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureCosmosDBWithResourceGroupAccessKey.verified.bicep
@@ -31,7 +31,6 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
           '/id'
         ]
         kind: 'Hash'
-        version: 2
       }
     }
   }


### PR DESCRIPTION
## Description

1. Fix hierarchical partition keys provisioning.
2. Use `ContainerProperties` from Azure Cosmos SDK to hold the properties, so that we can reuse the logic.
3. We obsolete single key before, but if we follow the SDK way, we don't need to obsolete them.

Fixes #9462

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
