### PR TITLE
Fix dashboard selecting resources with dashes in instance ids

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Channels;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Mvc;
+using OpenTelemetry.Resources;
 using Stress.ApiService;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,6 +16,10 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 
 builder.Services.AddOpenTelemetry()
+    .ConfigureResource(b =>
+    {
+        b.AddService(builder.Environment.ApplicationName);
+    })
     .WithTracing(tracing => tracing
         .AddSource(TraceCreator.ActivitySourceName, ProducerConsumer.ActivitySourceName)
         .AddSource("Services.Api"))

--- a/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
+++ b/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
@@ -32,7 +32,7 @@ public class ResourceTypeDetails : IEquatable<ResourceTypeDetails>
             return new ApplicationKey(ReplicaSetName, InstanceId: null);
         }
 
-        return ApplicationKey.Create(ReplicaSetName, InstanceId);
+        return ApplicationKey.Create(name: ReplicaSetName, instanceId: InstanceId);
     }
 
     public static ResourceTypeDetails CreateApplicationGrouping(string groupingName, bool isReplicaSet)

--- a/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
+++ b/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
@@ -27,12 +27,12 @@ public class ResourceTypeDetails : IEquatable<ResourceTypeDetails>
         {
             throw new InvalidOperationException($"Can't get ApplicationKey from resource type details '{ToString()}' because {nameof(ReplicaSetName)} is null.");
         }
-        if (InstanceId != null)
+        if (InstanceId is null)
         {
-            return ApplicationKey.Create(InstanceId);
+            return new ApplicationKey(ReplicaSetName, InstanceId: null);
         }
 
-        return new ApplicationKey(ReplicaSetName, InstanceId);
+        return ApplicationKey.Create(ReplicaSetName, InstanceId);
     }
 
     public static ResourceTypeDetails CreateApplicationGrouping(string groupingName, bool isReplicaSet)

--- a/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
@@ -20,6 +20,7 @@ public readonly record struct ApplicationKey(string Name, string? InstanceId) : 
 
         // Fall back to splitting based on a dash delimiter.
         // This could fail because there could be a dash in either the name or the instance id.
+        // At this point we're doing our best guess. It's better than throwing an error.
         var separator = instanceId.LastIndexOf('-');
         if (separator == -1)
         {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1082,7 +1082,7 @@ public sealed class TelemetryRepository : IDisposable
                     continue;
                 }
 
-                var appKey = ApplicationKey.Create(uninstrumentedPeer.Name);
+                var appKey = ApplicationKey.Create(uninstrumentedPeer.DisplayName, uninstrumentedPeer.Name);
                 var (app, _) = GetOrAddApplication(appKey, uninstrumentedPeer: true);
                 span.UninstrumentedPeer = app;
             }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1082,7 +1082,7 @@ public sealed class TelemetryRepository : IDisposable
                     continue;
                 }
 
-                var appKey = ApplicationKey.Create(uninstrumentedPeer.DisplayName, uninstrumentedPeer.Name);
+                var appKey = ApplicationKey.Create(name: uninstrumentedPeer.DisplayName, instanceId: uninstrumentedPeer.Name);
                 var (app, _) = GetOrAddApplication(appKey, uninstrumentedPeer: true);
                 span.UninstrumentedPeer = app;
             }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ApplicationKeyTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ApplicationKeyTests.cs
@@ -9,6 +9,20 @@ namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 public class ApplicationKeyTests
 {
     [Theory]
+    [InlineData("name", "instanceid", "instanceid", null)]
+    [InlineData("name-abc", "name-abc", "name", "abc")]
+    [InlineData("name", "name-abc-def", "name", "abc-def")]
+    public void Create_Success(string name, string instanceId, string expectedName, string? expectedInstanceId)
+    {
+        // Arrange & Act
+        var key = ApplicationKey.Create(name, instanceId);
+
+        // Assert
+        Assert.Equal(expectedName, key.Name);
+        Assert.Equal(expectedInstanceId, key.InstanceId);
+    }
+
+    [Theory]
     [InlineData("name", "instanceid", "name-instanceid")]
     [InlineData("name", "instanceid", "NAME-INSTANCEID")]
     [InlineData("name", "752e1688-ca3c-45da-b48b-b2163296ac91", "name-752e1688-ca3c-45da-b48b-b2163296ac91")]


### PR DESCRIPTION
## Description

A change in 9.3 caused resources with dashes in the instance id to not be correctly selected in the dashboard.

The problem is caused by splitting the name and instance id by using the dash. Splitting on a delimiter can never be reliabely correct because both parts could contain extra dashes.

The fix is to change code that creates an application key from a name to always use the source's name and instance id together. If the full instance id is `app-abc-def` then the name is `app` and the resolved instance id is `abc-def`.

Fixes https://github.com/dotnet/aspire/issues/9632

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
