### PR TITLE
Default ACA autoConfigureDataProtection to true for .NET projects

### DIFF
--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1523,4 +1523,16 @@ public class AzureContainerAppsTests
     {
         public string ValueExpression => "{customValue}";
     }
+
+    [Fact]
+    public void FailForNewContainerAppVersions()
+    {
+        var containerApp = new ContainerApp("app");
+
+        // In order to set autoConfigureDataProtection, we need to use a preview API ContainerApp version.
+        // This test fails on new default versions for ContainerApp so we check if autoConfigureDataProtection exists on the new Azure.Provisioning version.
+        // Also, we need to ensure the new default version isn't newer than the preview version used to set autoConfigureDataProtection because
+        // callers will get new APIs that may not work with the preview version we are using.
+        Assert.True(containerApp.ResourceVersion == "2024-03-01", "When we get a new ResourceVersion for ContainerApps, ensure the version used by ContainerAppContext.CreateContainerApp() still works correctly.");
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param api_containerport string
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -63,6 +63,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#01.verified.bicep
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param api_containerport string
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -63,6 +63,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomWorkspace#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomWorkspace#01.verified.bicep
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param api_containerport string
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -63,6 +63,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectUsesTheTargetPortAsADefaultPortForFirstHttpEndpoint.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectUsesTheTargetPortAsADefaultPortForFirstHttpEndpoint.verified.bicep
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param api_containerport string
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -67,6 +67,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
@@ -40,7 +40,7 @@ resource pg_kv_outputs_name_kv_connectionstrings__db 'Microsoft.KeyVault/vaults/
   parent: pg_kv_outputs_name_kv
 }
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -187,6 +187,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
@@ -40,7 +40,7 @@ resource pg_kv_outputs_name_kv_connectionstrings__db 'Microsoft.KeyVault/vaults/
   parent: pg_kv_outputs_name_kv
 }
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -187,6 +187,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#00.verified.bicep
@@ -15,7 +15,7 @@ param api_identity_outputs_id string
 
 param api_identity_outputs_clientid string
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -56,6 +56,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingCosmosDB#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingCosmosDB#00.verified.bicep
@@ -17,7 +17,7 @@ param cosmos_outputs_connectionstring string
 
 param api_identity_outputs_clientid string
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -62,6 +62,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
@@ -17,7 +17,7 @@ param redis_outputs_connectionstring string
 
 param api_identity_outputs_clientid string
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -62,6 +62,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
@@ -15,7 +15,7 @@ param myidentity_outputs_id string
 
 param myidentity_outputs_clientid string
 
-resource myapp 'Microsoft.App/containerApps@2024-03-01' = {
+resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'myapp'
   location: location
   properties: {
@@ -56,6 +56,11 @@ resource myapp 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
@@ -15,7 +15,7 @@ param myidentity_outputs_id string
 
 param myidentity_outputs_clientid string
 
-resource myapp2 'Microsoft.App/containerApps@2024-03-01' = {
+resource myapp2 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'myapp2'
   location: location
   properties: {
@@ -56,6 +56,11 @@ resource myapp2 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
@@ -15,7 +15,7 @@ param myidentity_outputs_id string
 
 param myidentity_outputs_clientid string
 
-resource myapp 'Microsoft.App/containerApps@2024-03-01' = {
+resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'myapp'
   location: location
   properties: {
@@ -56,6 +56,11 @@ resource myapp 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
@@ -15,7 +15,7 @@ param myidentity_outputs_id string
 
 param myidentity_outputs_clientid string
 
-resource myapp 'Microsoft.App/containerApps@2024-03-01' = {
+resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'myapp'
   location: location
   properties: {
@@ -56,6 +56,11 @@ resource myapp 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         minReplicas: 1
+      }
+    }
+    runtime: {
+      dotnet: {
+        autoConfigureDataProtection: true
       }
     }
   }


### PR DESCRIPTION
## Description

This ensures scaling up works correctly with Data Protection.

When azd owns generating the ContainerApp resource, it sets this property. See

* https://github.com/Azure/azure-dev/pull/3731
* https://github.com/Azure/azure-dev/pull/3929

However, when we generate the ContainerApp bicep, we are not setting this property.

Fix #8005

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
