### PR TITLE
Make verify tool accessible to the coding agent

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,14 @@ Note that tests for a project can be executed without first building from the ro
 
 Example: `[QuarantinedTest("..issue url..")]`
 
+## Snapshot Testing with Verify
+
+* We use the Verify library (Verify.XunitV3) for snapshot testing in several test projects.
+* Snapshot files are stored in `Snapshots` directories within test projects.
+* When tests that use snapshot testing are updated and generate new output, the snapshots need to be accepted.
+* Use `dotnet verify accept -y` to accept all pending snapshot changes after running tests.
+* The verify tool is available globally as part of the copilot setup.
+
 ## Editing resources
 
 The `*.Designer.cs` files are in the repo, but are intended to match same named `*.resx` files. If you add/remove/change resources in a resx, make the matching changes in the `*.Designer.cs` file that matches that resx.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-        # Include PrepareForHelix to maximise what is downloaded here
       - name: Build solution
         env:
           # prevent GitInfo errors
@@ -24,3 +23,7 @@ jobs:
         # a full build is too slow; also do not fail on errors, continue so that
         # copilot can attempt to recover
         run: ./build.sh -restore || true
+
+      # Install verify tool for snapshot testing
+      - name: Install verify tool
+        run: ./dotnet.sh tool install --global Verify.Tool --version 0.6.0 || true

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,3 +27,8 @@ jobs:
       # Install verify tool for snapshot testing
       - name: Install verify tool
         run: ./dotnet.sh tool install --global Verify.Tool --version 0.6.0 || true
+
+      - name: Setup PATH
+        run:
+          echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+          echo "$PWD/.dotnet/" >> $GITHUB_PATH


### PR DESCRIPTION
- **Make verify tool accessible to the coding agent**
- **Add dotnet and tools to PATH**

This was reverted in #9775 because it failed with:
```
Run dotnet tool install --global Verify.Tool --version 0.6.0
The command could not be loaded, possibly because:
  * You intended to execute a .NET application:
      The application 'tool' does not exist.
  * You intended to execute a .NET SDK command:
      A compatible .NET SDK was not found.

Requested SDK version: 9.0.200
global.json file: /home/runner/work/aspire/aspire/global.json

Installed SDKs:

Install the [9.0.200] .NET SDK or update [/home/runner/work/aspire/aspire/global.json] to match an installed SDK.

Learn about SDK resolution:
https://aka.ms/dotnet/sdk-not-found
8.0.116 [/usr/lib/dotnet/sdk]
```
