### PR TITLE
Fix ACA DataProtection

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
@@ -42,7 +42,7 @@ resource account_kv_outputs_name_kv_connectionstrings__account 'Microsoft.KeyVau
   parent: account_kv_outputs_name_kv
 }
 
-resource api 'Microsoft.App/containerApps@2024-03-01' = {
+resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: 'api'
   location: location
   properties: {
@@ -81,6 +81,11 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
           identity: infra_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: infra_outputs_azure_container_apps_environment_id
     template: {

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppContext.cs
@@ -84,11 +84,7 @@ internal sealed class ContainerAppContext(IResource resource, ContainerAppEnviro
 
         containerAppResource.EnvironmentId = containerAppIdParam;
 
-        var configuration = new ContainerAppConfiguration()
-        {
-            ActiveRevisionsMode = ContainerAppActiveRevisionsMode.Single,
-        };
-        containerAppResource.Configuration = configuration;
+        var configuration = containerAppResource.Configuration;
 
         AddIngress(configuration);
 
@@ -134,14 +130,20 @@ internal sealed class ContainerAppContext(IResource resource, ContainerAppEnviro
             Name = NormalizedContainerAppName
         };
 
+        var configuration = new ContainerAppConfiguration()
+        {
+            ActiveRevisionsMode = ContainerAppActiveRevisionsMode.Single,
+        };
+        containerApp.Configuration = configuration;
+
         // default autoConfigureDataProtection to true for .NET projects
         if (resource is ProjectResource)
         {
             containerApp.ResourceVersion = "2025-02-02-preview"; // currently only available in a preview version
 
             var value = new BicepValue<bool>(true);
-            ((IBicepValue)value).Self = new BicepValueReference(containerApp, "AutoConfigureDataProtection", ["properties", "runtime", "dotnet", "autoConfigureDataProtection"]);
-            containerApp.ProvisionableProperties["AutoConfigureDataProtection"] = value;
+            ((IBicepValue)value).Self = new BicepValueReference(configuration, "AutoConfigureDataProtection", ["runtime", "dotnet", "autoConfigureDataProtection"]);
+            configuration.ProvisionableProperties["AutoConfigureDataProtection"] = value;
         }
 
         return containerApp;

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
@@ -30,6 +30,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: env_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: env_outputs_azure_container_apps_environment_id
     template: {
@@ -63,11 +68,6 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#01.verified.bicep
@@ -30,6 +30,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: env_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: env_outputs_azure_container_apps_environment_id
     template: {
@@ -63,11 +68,6 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomWorkspace#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomWorkspace#01.verified.bicep
@@ -30,6 +30,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: env_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: env_outputs_azure_container_apps_environment_id
     template: {
@@ -63,11 +68,6 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectUsesTheTargetPortAsADefaultPortForFirstHttpEndpoint.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectUsesTheTargetPortAsADefaultPortForFirstHttpEndpoint.verified.bicep
@@ -30,6 +30,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: env_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: env_outputs_azure_container_apps_environment_id
     template: {
@@ -67,11 +72,6 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
@@ -82,6 +82,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: env_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: env_outputs_azure_container_apps_environment_id
     template: {
@@ -187,11 +192,6 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
@@ -82,6 +82,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: cae_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: cae_outputs_azure_container_apps_environment_id
     template: {
@@ -187,11 +192,6 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#00.verified.bicep
@@ -27,6 +27,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: env_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: env_outputs_azure_container_apps_environment_id
     template: {
@@ -56,11 +61,6 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingCosmosDB#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingCosmosDB#00.verified.bicep
@@ -29,6 +29,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: env_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: env_outputs_azure_container_apps_environment_id
     template: {
@@ -62,11 +67,6 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
@@ -29,6 +29,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: env_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: env_outputs_azure_container_apps_environment_id
     template: {
@@ -62,11 +67,6 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
@@ -27,6 +27,11 @@ resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: cae_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: cae_outputs_azure_container_apps_environment_id
     template: {
@@ -56,11 +61,6 @@ resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
@@ -27,6 +27,11 @@ resource myapp2 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: cae_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: cae_outputs_azure_container_apps_environment_id
     template: {
@@ -56,11 +61,6 @@ resource myapp2 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
@@ -27,6 +27,11 @@ resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: cae_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: cae_outputs_azure_container_apps_environment_id
     template: {
@@ -56,11 +61,6 @@ resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
@@ -27,6 +27,11 @@ resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
           identity: cae_outputs_azure_container_registry_managed_identity_id
         }
       ]
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
     }
     environmentId: cae_outputs_azure_container_apps_environment_id
     template: {
@@ -56,11 +61,6 @@ resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
       ]
       scale: {
         minReplicas: 1
-      }
-    }
-    runtime: {
-      dotnet: {
-        autoConfigureDataProtection: true
       }
     }
   }


### PR DESCRIPTION
#9777 put the setting in the wrong spot. Instead of going directly under "properties", the "runtime" node needs to go under "properties/configuration".

Fix #8005