### PR TITLE
Add support for DeployCommand and DeployingCallbackAnnotation

### DIFF
--- a/src/Aspire.Cli/Commands/DeployCommand.cs
+++ b/src/Aspire.Cli/Commands/DeployCommand.cs
@@ -1,0 +1,197 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Diagnostics;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
+using Aspire.Hosting;
+
+namespace Aspire.Cli.Commands;
+
+internal sealed class DeployCommand : BaseCommand
+{
+    private readonly ActivitySource _activitySource = new ActivitySource(nameof(DeployCommand));
+    private readonly IDotNetCliRunner _runner;
+    private readonly IInteractionService _interactionService;
+    private readonly IProjectLocator _projectLocator;
+
+    public DeployCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator)
+        : base("deploy", "Deploy an Aspire app host project to the supported targets.")
+    {
+        ArgumentNullException.ThrowIfNull(runner);
+        ArgumentNullException.ThrowIfNull(interactionService);
+        ArgumentNullException.ThrowIfNull(projectLocator);
+
+        _runner = runner;
+        _interactionService = interactionService;
+        _projectLocator = projectLocator;
+
+        var projectOption = new Option<FileInfo?>("--project");
+        projectOption.Description = "The path to the Aspire app host project file.";
+        Options.Add(projectOption);
+
+        var outputPathOption = new Option<string?>("--output-path", "-o");
+        outputPathOption.Description = "The output path for deployment artifacts.";
+        outputPathOption.DefaultValueFactory = (result) => Path.Combine(Environment.CurrentDirectory, "deploy");
+        Options.Add(outputPathOption);
+
+        // In deploy commands we forward all unrecognized tokens through to the underlying deployment tooling
+        TreatUnmatchedTokensAsErrors = false;
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var buildOutputCollector = new OutputCollector();
+        var deployOutputCollector = new OutputCollector();
+
+        (bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
+
+        try
+        {
+            using var activity = _activitySource.StartActivity();
+
+            var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
+            var effectiveAppHostProjectFile = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, cancellationToken);
+
+            if (effectiveAppHostProjectFile is null)
+            {
+                return ExitCodeConstants.FailedToFindProject;
+            }
+
+            var outputPath = parseResult.GetValue<string?>("--output-path") ?? Path.Combine(Environment.CurrentDirectory, "deploy");
+
+            var fullyQualifiedOutputPath = Path.GetFullPath(outputPath);
+
+            // Check app host compatibility
+            appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, _interactionService, effectiveAppHostProjectFile, cancellationToken);
+
+            if (!appHostCompatibilityCheck?.IsCompatibleAppHost ?? throw new InvalidOperationException("IsCompatibleAppHost is null"))
+            {
+                return ExitCodeConstants.AppHostIncompatible;
+            }
+
+            // Build the project
+            var buildOptions = new DotNetCliRunnerInvocationOptions
+            {
+                StandardOutputCallback = buildOutputCollector.AppendOutput,
+                StandardErrorCallback = buildOutputCollector.AppendError,
+            };
+
+            var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, buildOptions, cancellationToken);
+
+            if (buildExitCode != 0)
+            {
+                _interactionService.DisplayLines(buildOutputCollector.GetLines());
+                _interactionService.DisplayError("The project could not be built. For more information run with --debug switch.");
+                return ExitCodeConstants.FailedToBuildArtifacts;
+            }
+
+            var env = new Dictionary<string, string>();
+
+            var waitForDebugger = parseResult.GetValue<bool?>("--wait-for-debugger") ?? false;
+            if (waitForDebugger)
+            {
+                env[KnownConfigNames.WaitForDebugger] = "true";
+            }
+
+            var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
+
+            var deployRunOptions = new DotNetCliRunnerInvocationOptions
+            {
+                StandardOutputCallback = deployOutputCollector.AppendOutput,
+                StandardErrorCallback = deployOutputCollector.AppendError,
+                NoLaunchProfile = true
+            };
+
+            var unmatchedTokens = parseResult.UnmatchedTokens.ToArray();
+
+            var pendingRun = _runner.RunAsync(
+                effectiveAppHostProjectFile,
+                false,
+                true,
+                ["--operation", "publish", "--publisher", "default", "--output-path", fullyQualifiedOutputPath, "--deploy", "true", .. unmatchedTokens],
+                env,
+                backchannelCompletionSource,
+                deployRunOptions,
+                cancellationToken);
+
+            // If we use the --wait-for-debugger option we print out the process ID
+            if (waitForDebugger)
+            {
+                _interactionService.DisplayMessage("bug", "Waiting for debugger to attach to app host process");
+            }
+
+            var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
+
+            // Reuse the Publishing activities activity source for the backchannel
+            var deploymentActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
+
+            var debugMode = parseResult.GetValue<bool?>("--debug") ?? false;
+
+            var noFailuresReported = debugMode switch
+            {
+                true => await PublishCommand.ProcessPublishingActivitiesAsync(deploymentActivities, cancellationToken),
+                false => await PublishCommand.ProcessAndDisplayPublishingActivitiesAsync(deploymentActivities, cancellationToken),
+            };
+
+            await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
+            var exitCode = await pendingRun;
+
+            if (exitCode == 0)
+            {
+                _interactionService.DisplaySuccess($"Successfully deployed. Artifacts available at: {fullyQualifiedOutputPath}");
+                return ExitCodeConstants.Success;
+            }
+
+            _interactionService.DisplayLines(deployOutputCollector.GetLines());
+            _interactionService.DisplayError($"Deployment failed with exit code {exitCode}. For more information run with --debug switch.");
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+        catch (OperationCanceledException)
+        {
+            _interactionService.DisplayError("The deployment was canceled.");
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+        catch (ProjectLocatorException ex) when (ex.Message == "Project file is not an Aspire app host project.")
+        {
+            _interactionService.DisplayError("The specified project file is not an Aspire app host project.");
+            return ExitCodeConstants.FailedToFindProject;
+        }
+        catch (ProjectLocatorException ex) when (ex.Message == "Project file does not exist.")
+        {
+            _interactionService.DisplayError("The --project option specified a project that does not exist.");
+            return ExitCodeConstants.FailedToFindProject;
+        }
+        catch (ProjectLocatorException ex) when (ex.Message.Contains("Multiple project files found."))
+        {
+            _interactionService.DisplayError("The --project option was not specified and multiple app host project files were detected.");
+            return ExitCodeConstants.FailedToFindProject;
+        }
+        catch (ProjectLocatorException ex) when (ex.Message.Contains("No project file"))
+        {
+            _interactionService.DisplayError("The project argument was not specified and no *.csproj files were detected.");
+            return ExitCodeConstants.FailedToFindProject;
+        }
+        catch (AppHostIncompatibleException ex)
+        {
+            return _interactionService.DisplayIncompatibleVersionError(
+                ex,
+                appHostCompatibilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
+                );
+        }
+        catch (FailedToConnectBackchannelConnection ex)
+        {
+            _interactionService.DisplayError($"An error occurred while connecting to the app host. The app host possibly crashed before it was available: {ex.Message}");
+            _interactionService.DisplayLines(deployOutputCollector.GetLines());
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+        catch (Exception ex)
+        {
+            _interactionService.DisplayError($"An unexpected error occurred: {ex.Message}");
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+    }
+}

--- a/src/Aspire.Cli/Commands/DeployCommand.cs
+++ b/src/Aspire.Cli/Commands/DeployCommand.cs
@@ -1,197 +1,31 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.Diagnostics;
-using Aspire.Cli.Backchannel;
+using System.CommandLine.Parsing;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
-using Aspire.Cli.Utils;
-using Aspire.Hosting;
 
 namespace Aspire.Cli.Commands;
 
-internal sealed class DeployCommand : BaseCommand
+internal sealed class DeployCommand : PublishCommandBase
 {
-    private readonly ActivitySource _activitySource = new ActivitySource(nameof(DeployCommand));
-    private readonly IDotNetCliRunner _runner;
-    private readonly IInteractionService _interactionService;
-    private readonly IProjectLocator _projectLocator;
-
     public DeployCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator)
-        : base("deploy", "Deploy an Aspire app host project to the supported targets.")
+        : base("deploy", "Deploy an Aspire app host project to its supported deployment targets.", runner, interactionService, projectLocator)
     {
-        ArgumentNullException.ThrowIfNull(runner);
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(projectLocator);
-
-        _runner = runner;
-        _interactionService = interactionService;
-        _projectLocator = projectLocator;
-
-        var projectOption = new Option<FileInfo?>("--project");
-        projectOption.Description = "The path to the Aspire app host project file.";
-        Options.Add(projectOption);
-
-        var outputPathOption = new Option<string?>("--output-path", "-o");
-        outputPathOption.Description = "The output path for deployment artifacts.";
-        outputPathOption.DefaultValueFactory = (result) => Path.Combine(Environment.CurrentDirectory, "deploy");
-        Options.Add(outputPathOption);
-
-        // In deploy commands we forward all unrecognized tokens through to the underlying deployment tooling
-        TreatUnmatchedTokensAsErrors = false;
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        var buildOutputCollector = new OutputCollector();
-        var deployOutputCollector = new OutputCollector();
+    protected override string GetOutputPathDescription() => "The output path for deployment artifacts.";
 
-        (bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
+    protected override string GetDefaultOutputPath(ArgumentResult result) => Path.Combine(Environment.CurrentDirectory, "deploy");
 
-        try
-        {
-            using var activity = _activitySource.StartActivity();
+    protected override string[] GetRunArguments(string fullyQualifiedOutputPath, string[] unmatchedTokens) =>
+        ["--operation", "publish", "--publisher", "default", "--output-path", fullyQualifiedOutputPath, "--deploy", "true", ..unmatchedTokens];
 
-            var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
-            var effectiveAppHostProjectFile = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, cancellationToken);
+    protected override string GetSuccessMessage(string fullyQualifiedOutputPath) => $"Successfully deployed. Artifacts available at: {fullyQualifiedOutputPath}";
 
-            if (effectiveAppHostProjectFile is null)
-            {
-                return ExitCodeConstants.FailedToFindProject;
-            }
+    protected override string GetFailureMessage(int exitCode) => $"Deployment failed with exit code {exitCode}. For more information run with --debug switch.";
 
-            var outputPath = parseResult.GetValue<string?>("--output-path") ?? Path.Combine(Environment.CurrentDirectory, "deploy");
+    protected override string GetCanceledMessage() => "The deployment was canceled.";
 
-            var fullyQualifiedOutputPath = Path.GetFullPath(outputPath);
-
-            // Check app host compatibility
-            appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, _interactionService, effectiveAppHostProjectFile, cancellationToken);
-
-            if (!appHostCompatibilityCheck?.IsCompatibleAppHost ?? throw new InvalidOperationException("IsCompatibleAppHost is null"))
-            {
-                return ExitCodeConstants.AppHostIncompatible;
-            }
-
-            // Build the project
-            var buildOptions = new DotNetCliRunnerInvocationOptions
-            {
-                StandardOutputCallback = buildOutputCollector.AppendOutput,
-                StandardErrorCallback = buildOutputCollector.AppendError,
-            };
-
-            var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, buildOptions, cancellationToken);
-
-            if (buildExitCode != 0)
-            {
-                _interactionService.DisplayLines(buildOutputCollector.GetLines());
-                _interactionService.DisplayError("The project could not be built. For more information run with --debug switch.");
-                return ExitCodeConstants.FailedToBuildArtifacts;
-            }
-
-            var env = new Dictionary<string, string>();
-
-            var waitForDebugger = parseResult.GetValue<bool?>("--wait-for-debugger") ?? false;
-            if (waitForDebugger)
-            {
-                env[KnownConfigNames.WaitForDebugger] = "true";
-            }
-
-            var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
-
-            var deployRunOptions = new DotNetCliRunnerInvocationOptions
-            {
-                StandardOutputCallback = deployOutputCollector.AppendOutput,
-                StandardErrorCallback = deployOutputCollector.AppendError,
-                NoLaunchProfile = true
-            };
-
-            var unmatchedTokens = parseResult.UnmatchedTokens.ToArray();
-
-            var pendingRun = _runner.RunAsync(
-                effectiveAppHostProjectFile,
-                false,
-                true,
-                ["--operation", "publish", "--publisher", "default", "--output-path", fullyQualifiedOutputPath, "--deploy", "true", .. unmatchedTokens],
-                env,
-                backchannelCompletionSource,
-                deployRunOptions,
-                cancellationToken);
-
-            // If we use the --wait-for-debugger option we print out the process ID
-            if (waitForDebugger)
-            {
-                _interactionService.DisplayMessage("bug", "Waiting for debugger to attach to app host process");
-            }
-
-            var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
-
-            // Reuse the Publishing activities activity source for the backchannel
-            var deploymentActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
-
-            var debugMode = parseResult.GetValue<bool?>("--debug") ?? false;
-
-            var noFailuresReported = debugMode switch
-            {
-                true => await PublishCommand.ProcessPublishingActivitiesAsync(deploymentActivities, cancellationToken),
-                false => await PublishCommand.ProcessAndDisplayPublishingActivitiesAsync(deploymentActivities, cancellationToken),
-            };
-
-            await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
-            var exitCode = await pendingRun;
-
-            if (exitCode == 0)
-            {
-                _interactionService.DisplaySuccess($"Successfully deployed. Artifacts available at: {fullyQualifiedOutputPath}");
-                return ExitCodeConstants.Success;
-            }
-
-            _interactionService.DisplayLines(deployOutputCollector.GetLines());
-            _interactionService.DisplayError($"Deployment failed with exit code {exitCode}. For more information run with --debug switch.");
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-        catch (OperationCanceledException)
-        {
-            _interactionService.DisplayError("The deployment was canceled.");
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-        catch (ProjectLocatorException ex) when (ex.Message == "Project file is not an Aspire app host project.")
-        {
-            _interactionService.DisplayError("The specified project file is not an Aspire app host project.");
-            return ExitCodeConstants.FailedToFindProject;
-        }
-        catch (ProjectLocatorException ex) when (ex.Message == "Project file does not exist.")
-        {
-            _interactionService.DisplayError("The --project option specified a project that does not exist.");
-            return ExitCodeConstants.FailedToFindProject;
-        }
-        catch (ProjectLocatorException ex) when (ex.Message.Contains("Multiple project files found."))
-        {
-            _interactionService.DisplayError("The --project option was not specified and multiple app host project files were detected.");
-            return ExitCodeConstants.FailedToFindProject;
-        }
-        catch (ProjectLocatorException ex) when (ex.Message.Contains("No project file"))
-        {
-            _interactionService.DisplayError("The project argument was not specified and no *.csproj files were detected.");
-            return ExitCodeConstants.FailedToFindProject;
-        }
-        catch (AppHostIncompatibleException ex)
-        {
-            return _interactionService.DisplayIncompatibleVersionError(
-                ex,
-                appHostCompatibilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
-                );
-        }
-        catch (FailedToConnectBackchannelConnection ex)
-        {
-            _interactionService.DisplayError($"An error occurred while connecting to the app host. The app host possibly crashed before it was available: {ex.Message}");
-            _interactionService.DisplayLines(deployOutputCollector.GetLines());
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-        catch (Exception ex)
-        {
-            _interactionService.DisplayError($"An unexpected error occurred: {ex.Message}");
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-    }
+    protected override string GetProgressMessage() => "Generating artifacts...";
 }

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -1,14 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.CommandLine;
-using System.Diagnostics;
-using Aspire.Cli.Backchannel;
+using System.CommandLine.Parsing;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
-using Aspire.Cli.Utils;
-using Aspire.Hosting;
-using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
 
@@ -30,248 +25,29 @@ internal class PublishCommandPrompter(IInteractionService interactionService) : 
     }
 }
 
-internal sealed class PublishCommand : BaseCommand
+internal sealed class PublishCommand : PublishCommandBase
 {
-    private readonly ActivitySource _activitySource = new ActivitySource(nameof(PublishCommand));
-    private readonly IDotNetCliRunner _runner;
-    private readonly IInteractionService _interactionService;
-    private readonly IProjectLocator _projectLocator;
     private readonly IPublishCommandPrompter _prompter;
 
     public PublishCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, IPublishCommandPrompter prompter)
-        : base("publish", "Generates deployment artifacts for an Aspire app host project.")
+        : base("publish", "Generates deployment artifacts for an Aspire app host project.", runner, interactionService, projectLocator)
     {
-        ArgumentNullException.ThrowIfNull(runner);
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(projectLocator);
         ArgumentNullException.ThrowIfNull(prompter);
-
-        _runner = runner;
-        _interactionService = interactionService;
-        _projectLocator = projectLocator;
         _prompter = prompter;
-
-        var projectOption = new Option<FileInfo?>("--project");
-        projectOption.Description = "The path to the Aspire app host project file.";
-        Options.Add(projectOption);
-
-        var outputPath = new Option<string>("--output-path", "-o");
-        outputPath.Description = "The output path for the generated artifacts.";
-        outputPath.DefaultValueFactory = (result) => Path.Combine(Environment.CurrentDirectory);
-        Options.Add(outputPath);
-
-        // In the `aspire publish` and run commands we forward all unrecognized tokens
-        // through to `dotnet run` when we launch the app host.
-        TreatUnmatchedTokensAsErrors = false;
     }
 
-    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        var buildOutputCollector = new OutputCollector();
-        var publishOutputCollector = new OutputCollector();
+    protected override string GetOutputPathDescription() => "The output path for the generated artifacts.";
 
-        (bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
+    protected override string GetDefaultOutputPath(ArgumentResult result) => Path.Combine(Environment.CurrentDirectory);
 
-        try
-        {
-            using var activity = _activitySource.StartActivity();
+    protected override string[] GetRunArguments(string fullyQualifiedOutputPath, string[] unmatchedTokens) =>
+        ["--operation", "publish", "--publisher", "default", "--output-path", fullyQualifiedOutputPath, ..unmatchedTokens];
 
-            var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
-            var effectiveAppHostProjectFile = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, cancellationToken);
+    protected override string GetSuccessMessage(string fullyQualifiedOutputPath) => $"Successfully published artifacts to: {fullyQualifiedOutputPath}";
 
-            if (effectiveAppHostProjectFile is null)
-            {
-                return ExitCodeConstants.FailedToFindProject;
-            }
+    protected override string GetFailureMessage(int exitCode) => $"Publishing artifacts failed with exit code {exitCode}. For more information run with --debug switch.";
 
-            var env = new Dictionary<string, string>();
+    protected override string GetCanceledMessage() => "The operation was canceled.";
 
-            var waitForDebugger = parseResult.GetValue<bool?>("--wait-for-debugger") ?? false;
-            if (waitForDebugger)
-            {
-                env[KnownConfigNames.WaitForDebugger] = "true";
-            }
-
-            appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, _interactionService, effectiveAppHostProjectFile, cancellationToken);
-
-            if (!appHostCompatibilityCheck?.IsCompatibleAppHost ?? throw new InvalidOperationException("IsCompatibleAppHost is null"))
-            {
-                return ExitCodeConstants.AppHostIncompatible;
-            }
-
-            var buildOptions = new DotNetCliRunnerInvocationOptions
-            {
-                StandardOutputCallback = buildOutputCollector.AppendOutput,
-                StandardErrorCallback = buildOutputCollector.AppendError,
-            };
-
-            var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, buildOptions, cancellationToken);
-
-            if (buildExitCode != 0)
-            {
-                _interactionService.DisplayLines(buildOutputCollector.GetLines());
-                _interactionService.DisplayError("The project could not be built. For more information run with --debug switch.");
-                return ExitCodeConstants.FailedToBuildArtifacts;
-            }
-
-            var outputPath = parseResult.GetValue<string>("--output-path");
-            var fullyQualifiedOutputPath = Path.GetFullPath(outputPath ?? ".");
-
-            _interactionService.DisplayMessage($"hammer_and_wrench", $"Generating artifacts...");
-            
-            var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
-
-            var publishRunOptions = new DotNetCliRunnerInvocationOptions
-            {
-                StandardOutputCallback = publishOutputCollector.AppendOutput,
-                StandardErrorCallback = publishOutputCollector.AppendError,
-                NoLaunchProfile = true
-            };
-
-            var unmatchedTokens = parseResult.UnmatchedTokens.ToArray();
-
-            var pendingRun = _runner.RunAsync(
-                effectiveAppHostProjectFile,
-                false,
-                true,
-                ["--operation", "publish", "--publisher", "default", "--output-path", fullyQualifiedOutputPath, ..unmatchedTokens],
-                env,
-                backchannelCompletionSource,
-                publishRunOptions,
-                cancellationToken);
-
-            // If we use the --wait-for-debugger option we print out the process ID
-            // of the apphost so that the user can attach to it.
-            if (waitForDebugger)
-            {
-                _interactionService.DisplayMessage("bug", $"Waiting for debugger to attach to app host process");
-            }
-
-            var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
-            var publishingActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
-
-            var debugMode = parseResult.GetValue<bool?>("--debug") ?? false;
-
-            var noFailuresReported = debugMode switch {
-                true => await ProcessPublishingActivitiesAsync(publishingActivities, cancellationToken),
-                false => await ProcessAndDisplayPublishingActivitiesAsync(publishingActivities, cancellationToken),
-            };
-
-            await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
-            var exitCode = await pendingRun;
-
-            if (exitCode == 0 && noFailuresReported)
-            {
-                _interactionService.DisplaySuccess($"Successfully published artifacts to: {fullyQualifiedOutputPath}");
-                return ExitCodeConstants.Success;
-            }
-
-            _interactionService.DisplayLines(publishOutputCollector.GetLines());
-            _interactionService.DisplayError($"Publishing artifacts failed with exit code {exitCode}. For more information run with --debug switch.");
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-        catch (OperationCanceledException)
-        {
-            _interactionService.DisplayError("The operation was canceled.");
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-        catch (ProjectLocatorException ex) when (ex.Message == "Project file is not an Aspire app host project.")
-        {
-            _interactionService.DisplayError("The specified project file is not an Aspire app host project.");
-            return ExitCodeConstants.FailedToFindProject;
-        }
-        catch (ProjectLocatorException ex) when (ex.Message == "Project file does not exist.")
-        {
-            _interactionService.DisplayError("The --project option specified a project that does not exist.");
-            return ExitCodeConstants.FailedToFindProject;
-        }
-        catch (ProjectLocatorException ex) when (ex.Message.Contains("Multiple project files found."))
-        {
-            _interactionService.DisplayError("The --project option was not specified and multiple app host project files were detected.");
-            return ExitCodeConstants.FailedToFindProject;
-        }
-        catch (ProjectLocatorException ex) when (ex.Message.Contains("No project file"))
-        {
-            _interactionService.DisplayError("The project argument was not specified and no *.csproj files were detected.");
-            return ExitCodeConstants.FailedToFindProject;
-        }
-        catch (AppHostIncompatibleException ex)
-        {
-            return _interactionService.DisplayIncompatibleVersionError(
-                ex,
-                appHostCompatibilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
-                );
-        }
-        catch (FailedToConnectBackchannelConnection ex)
-        {
-            _interactionService.DisplayError($"An error occurred while connecting to the app host. The app host possibly crashed before it was available: {ex.Message}");
-            _interactionService.DisplayLines(publishOutputCollector.GetLines());
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-        catch (Exception ex)
-        {
-            _interactionService.DisplayError($"An unexpected error occurred: {ex.Message}");
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-    }
-
-    public static async Task<bool> ProcessPublishingActivitiesAsync(IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> publishingActivities, CancellationToken cancellationToken)
-    {
-        var lastActivityUpdateLookup = new Dictionary<string, (string Id, string StatusText, bool IsComplete, bool IsError)>();
-        await foreach (var publishingActivity in publishingActivities.WithCancellation(cancellationToken))
-        {
-            lastActivityUpdateLookup[publishingActivity.Id] = publishingActivity;
-
-            if (lastActivityUpdateLookup.Any(kvp => kvp.Value.IsError) || lastActivityUpdateLookup.All(kvp => kvp.Value.IsComplete))
-            {
-                // If we have an error or all tasks are complete then we can stop
-                // processing the publishing activities. Return true if there are no errors.
-                return lastActivityUpdateLookup.All(kvp => !kvp.Value.IsError);
-            }
-        }
-
-        return true;
-    }
-
-    public static async Task<bool> ProcessAndDisplayPublishingActivitiesAsync(IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> publishingActivities, CancellationToken cancellationToken)
-    {
-        return await AnsiConsole.Progress()
-            .AutoRefresh(true)
-            .Columns(
-                new TaskDescriptionColumn() { Alignment = Justify.Left },
-                new ProgressBarColumn() { Width = 10 },
-                new ElapsedTimeColumn())
-            .StartAsync<bool>(async context => {
-
-                var progressTasks = new Dictionary<string, ProgressTask>();
-
-                await foreach (var publishingActivity in publishingActivities.WithCancellation(cancellationToken))
-                {
-                    if (!progressTasks.TryGetValue(publishingActivity.Id, out var progressTask))
-                    {
-                        progressTask = context.AddTask(publishingActivity.Id);
-                        progressTask.StartTask();
-                        progressTask.IsIndeterminate();
-                        progressTasks.Add(publishingActivity.Id, progressTask);
-                    }
-
-                    progressTask.Description = $":play_button:  {publishingActivity.StatusText}";
-
-                    if (publishingActivity.IsComplete && !publishingActivity.IsError)
-                    {
-                        progressTask.Description = $":check_mark:  {publishingActivity.StatusText}";
-                        progressTask.Value = 100;
-                        progressTask.StopTask();
-                    }
-                    else if (publishingActivity.IsError)
-                    {
-                        progressTask.Description = $"[red bold]:cross_mark:  {publishingActivity.StatusText}[/]";
-                        progressTask.Value = 0;
-                        return false;
-                    }
-                }
-                
-                return true;
-            });
-    }
+    protected override string GetProgressMessage() => "Generating artifacts...";
 }

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -1,0 +1,266 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Diagnostics;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
+using Aspire.Hosting;
+using Spectre.Console;
+
+namespace Aspire.Cli.Commands;
+
+internal abstract class PublishCommandBase : BaseCommand
+{
+    private readonly ActivitySource _activitySource;
+    protected readonly IDotNetCliRunner _runner;
+    protected readonly IInteractionService _interactionService;
+    protected readonly IProjectLocator _projectLocator;
+
+    protected PublishCommandBase(string name, string description, IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator)
+        : base(name, description)
+    {
+        ArgumentNullException.ThrowIfNull(runner);
+        ArgumentNullException.ThrowIfNull(interactionService);
+        ArgumentNullException.ThrowIfNull(projectLocator);
+
+        _activitySource = new ActivitySource(GetType().Name);
+        _runner = runner;
+        _interactionService = interactionService;
+        _projectLocator = projectLocator;
+
+        var projectOption = new Option<FileInfo?>("--project");
+        projectOption.Description = "The path to the Aspire app host project file.";
+        Options.Add(projectOption);
+
+        var outputPath = new Option<string>("--output-path", "-o");
+        outputPath.Description = GetOutputPathDescription();
+        outputPath.DefaultValueFactory = GetDefaultOutputPath;
+        Options.Add(outputPath);
+
+        // In the publish and deploy commands we forward all unrecognized tokens
+        // through to the underlying tooling when we launch the app host.
+        TreatUnmatchedTokensAsErrors = false;
+    }
+
+    protected abstract string GetOutputPathDescription();
+    protected abstract string GetDefaultOutputPath(ArgumentResult result);
+    protected abstract string[] GetRunArguments(string fullyQualifiedOutputPath, string[] unmatchedTokens);
+    protected abstract string GetSuccessMessage(string fullyQualifiedOutputPath);
+    protected abstract string GetFailureMessage(int exitCode);
+    protected abstract string GetCanceledMessage();
+    protected abstract string GetProgressMessage();
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var buildOutputCollector = new OutputCollector();
+        var operationOutputCollector = new OutputCollector();
+
+        (bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingSdkVersion)? appHostCompatibilityCheck = null;
+
+        try
+        {
+            using var activity = _activitySource.StartActivity();
+
+            var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
+            var effectiveAppHostProjectFile = await _projectLocator.UseOrFindAppHostProjectFileAsync(passedAppHostProjectFile, cancellationToken);
+
+            if (effectiveAppHostProjectFile is null)
+            {
+                return ExitCodeConstants.FailedToFindProject;
+            }
+
+            var env = new Dictionary<string, string>();
+
+            var waitForDebugger = parseResult.GetValue<bool?>("--wait-for-debugger") ?? false;
+            if (waitForDebugger)
+            {
+                env[KnownConfigNames.WaitForDebugger] = "true";
+            }
+
+            appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, _interactionService, effectiveAppHostProjectFile, cancellationToken);
+
+            if (!appHostCompatibilityCheck?.IsCompatibleAppHost ?? throw new InvalidOperationException("IsCompatibleAppHost is null"))
+            {
+                return ExitCodeConstants.AppHostIncompatible;
+            }
+
+            var buildOptions = new DotNetCliRunnerInvocationOptions
+            {
+                StandardOutputCallback = buildOutputCollector.AppendOutput,
+                StandardErrorCallback = buildOutputCollector.AppendError,
+            };
+
+            var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostProjectFile, buildOptions, cancellationToken);
+
+            if (buildExitCode != 0)
+            {
+                _interactionService.DisplayLines(buildOutputCollector.GetLines());
+                _interactionService.DisplayError("The project could not be built. For more information run with --debug switch.");
+                return ExitCodeConstants.FailedToBuildArtifacts;
+            }
+
+            var outputPath = parseResult.GetValue<string>("--output-path");
+            var fullyQualifiedOutputPath = Path.GetFullPath(outputPath ?? ".");
+
+            _interactionService.DisplayMessage($"hammer_and_wrench", GetProgressMessage());
+
+            var backchannelCompletionSource = new TaskCompletionSource<IAppHostBackchannel>();
+
+            var operationRunOptions = new DotNetCliRunnerInvocationOptions
+            {
+                StandardOutputCallback = operationOutputCollector.AppendOutput,
+                StandardErrorCallback = operationOutputCollector.AppendError,
+                NoLaunchProfile = true
+            };
+
+            var unmatchedTokens = parseResult.UnmatchedTokens.ToArray();
+
+            var pendingRun = _runner.RunAsync(
+                effectiveAppHostProjectFile,
+                false,
+                true,
+                GetRunArguments(fullyQualifiedOutputPath, unmatchedTokens),
+                env,
+                backchannelCompletionSource,
+                operationRunOptions,
+                cancellationToken);
+
+            // If we use the --wait-for-debugger option we print out the process ID
+            // of the apphost so that the user can attach to it.
+            if (waitForDebugger)
+            {
+                _interactionService.DisplayMessage("bug", $"Waiting for debugger to attach to app host process");
+            }
+
+            var backchannel = await backchannelCompletionSource.Task.ConfigureAwait(false);
+            var publishingActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
+
+            var debugMode = parseResult.GetValue<bool?>("--debug") ?? false;
+
+            var noFailuresReported = debugMode switch {
+                true => await ProcessPublishingActivitiesAsync(publishingActivities, cancellationToken),
+                false => await ProcessAndDisplayPublishingActivitiesAsync(publishingActivities, cancellationToken),
+            };
+
+            await backchannel.RequestStopAsync(cancellationToken).ConfigureAwait(false);
+            var exitCode = await pendingRun;
+
+            if (exitCode == 0 && noFailuresReported)
+            {
+                _interactionService.DisplaySuccess(GetSuccessMessage(fullyQualifiedOutputPath));
+                return ExitCodeConstants.Success;
+            }
+
+            _interactionService.DisplayLines(operationOutputCollector.GetLines());
+            _interactionService.DisplayError(GetFailureMessage(exitCode));
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+        catch (OperationCanceledException)
+        {
+            _interactionService.DisplayError(GetCanceledMessage());
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+        catch (ProjectLocatorException ex) when (ex.Message == "Project file is not an Aspire app host project.")
+        {
+            _interactionService.DisplayError("The specified project file is not an Aspire app host project.");
+            return ExitCodeConstants.FailedToFindProject;
+        }
+        catch (ProjectLocatorException ex) when (ex.Message == "Project file does not exist.")
+        {
+            _interactionService.DisplayError("The --project option specified a project that does not exist.");
+            return ExitCodeConstants.FailedToFindProject;
+        }
+        catch (ProjectLocatorException ex) when (ex.Message.Contains("Multiple project files found."))
+        {
+            _interactionService.DisplayError("The --project option was not specified and multiple app host project files were detected.");
+            return ExitCodeConstants.FailedToFindProject;
+        }
+        catch (ProjectLocatorException ex) when (ex.Message.Contains("No project file"))
+        {
+            _interactionService.DisplayError("The project argument was not specified and no *.csproj files were detected.");
+            return ExitCodeConstants.FailedToFindProject;
+        }
+        catch (AppHostIncompatibleException ex)
+        {
+            return _interactionService.DisplayIncompatibleVersionError(
+                ex,
+                appHostCompatibilityCheck?.AspireHostingSdkVersion ?? throw new InvalidOperationException("AspireHostingSdkVersion is null")
+                );
+        }
+        catch (FailedToConnectBackchannelConnection ex)
+        {
+            _interactionService.DisplayError($"An error occurred while connecting to the app host. The app host possibly crashed before it was available: {ex.Message}");
+            _interactionService.DisplayLines(operationOutputCollector.GetLines());
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+        catch (Exception ex)
+        {
+            _interactionService.DisplayError($"An unexpected error occurred: {ex.Message}");
+            return ExitCodeConstants.FailedToBuildArtifacts;
+        }
+    }
+
+    public static async Task<bool> ProcessPublishingActivitiesAsync(IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> publishingActivities, CancellationToken cancellationToken)
+    {
+        var lastActivityUpdateLookup = new Dictionary<string, (string Id, string StatusText, bool IsComplete, bool IsError)>();
+        await foreach (var publishingActivity in publishingActivities.WithCancellation(cancellationToken))
+        {
+            lastActivityUpdateLookup[publishingActivity.Id] = publishingActivity;
+
+            if (lastActivityUpdateLookup.Any(kvp => kvp.Value.IsError) || lastActivityUpdateLookup.All(kvp => kvp.Value.IsComplete))
+            {
+                // If we have an error or all tasks are complete then we can stop
+                // processing the publishing activities. Return true if there are no errors.
+                return lastActivityUpdateLookup.All(kvp => !kvp.Value.IsError);
+            }
+        }
+
+        return true;
+    }
+
+    public static async Task<bool> ProcessAndDisplayPublishingActivitiesAsync(IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> publishingActivities, CancellationToken cancellationToken)
+    {
+        return await AnsiConsole.Progress()
+            .AutoRefresh(true)
+            .Columns(
+                new TaskDescriptionColumn() { Alignment = Justify.Left },
+                new ProgressBarColumn() { Width = 10 },
+                new ElapsedTimeColumn())
+            .StartAsync<bool>(async context => {
+
+                var progressTasks = new Dictionary<string, ProgressTask>();
+
+                await foreach (var publishingActivity in publishingActivities.WithCancellation(cancellationToken))
+                {
+                    if (!progressTasks.TryGetValue(publishingActivity.Id, out var progressTask))
+                    {
+                        progressTask = context.AddTask(publishingActivity.Id);
+                        progressTask.StartTask();
+                        progressTask.IsIndeterminate();
+                        progressTasks.Add(publishingActivity.Id, progressTask);
+                    }
+
+                    progressTask.Description = $":play_button:  {publishingActivity.StatusText}";
+
+                    if (publishingActivity.IsComplete && !publishingActivity.IsError)
+                    {
+                        progressTask.Description = $":check_mark:  {publishingActivity.StatusText}";
+                        progressTask.Value = 100;
+                        progressTask.StopTask();
+                    }
+                    else if (publishingActivity.IsError)
+                    {
+                        progressTask.Description = $"[red bold]:cross_mark:  {publishingActivity.StatusText}[/]";
+                        progressTask.Value = 0;
+                        return false;
+                    }
+                }
+
+                return true;
+            });
+    }
+}

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -17,7 +17,7 @@ internal sealed class RootCommand : BaseRootCommand
 {
     private readonly IInteractionService _interactionService;
 
-    public RootCommand(NewCommand newCommand, RunCommand runCommand, AddCommand addCommand, PublishCommand publishCommand, ConfigCommand configCommand, IInteractionService interactionService)
+    public RootCommand(NewCommand newCommand, RunCommand runCommand, AddCommand addCommand, PublishCommand publishCommand, DeployCommand deployCommand, ConfigCommand configCommand, IInteractionService interactionService)
         : base("The Aspire CLI can be used to create, run, and publish Aspire-based applications.")
     {
         ArgumentNullException.ThrowIfNull(newCommand);
@@ -25,15 +25,16 @@ internal sealed class RootCommand : BaseRootCommand
         ArgumentNullException.ThrowIfNull(addCommand);
         ArgumentNullException.ThrowIfNull(publishCommand);
         ArgumentNullException.ThrowIfNull(configCommand);
+        ArgumentNullException.ThrowIfNull(deployCommand);
         ArgumentNullException.ThrowIfNull(interactionService);
-        
+
         _interactionService = interactionService;
 
         var debugOption = new Option<bool>("--debug", "-d");
         debugOption.Description = "Enable debug logging to the console.";
         debugOption.Recursive = true;
         Options.Add(debugOption);
-        
+
         var waitForDebuggerOption = new Option<bool>("--wait-for-debugger");
         waitForDebuggerOption.Description = "Wait for a debugger to attach before executing the command.";
         waitForDebuggerOption.Recursive = true;
@@ -45,8 +46,9 @@ internal sealed class RootCommand : BaseRootCommand
         cliWaitForDebuggerOption.Hidden = true;
         cliWaitForDebuggerOption.DefaultValueFactory = (result) => false;
 
-        #if DEBUG
-        cliWaitForDebuggerOption.Validators.Add((result) => {
+#if DEBUG
+        cliWaitForDebuggerOption.Validators.Add((result) =>
+        {
 
             var waitForDebugger = result.GetValueOrDefault<bool>();
 
@@ -54,7 +56,8 @@ internal sealed class RootCommand : BaseRootCommand
             {
                 _interactionService.ShowStatus(
                     $":bug:  Waiting for debugger to attach to CLI process ID: {Environment.ProcessId}",
-                    () => {
+                    () =>
+                    {
                         while (!Debugger.IsAttached)
                         {
                             Thread.Sleep(1000);
@@ -62,7 +65,7 @@ internal sealed class RootCommand : BaseRootCommand
                     });
             }
         });
-        #endif
+#endif
 
         Options.Add(waitForDebuggerOption);
         Options.Add(cliWaitForDebuggerOption);
@@ -72,5 +75,6 @@ internal sealed class RootCommand : BaseRootCommand
         Subcommands.Add(addCommand);
         Subcommands.Add(publishCommand);
         Subcommands.Add(configCommand);
+        Subcommands.Add(deployCommand);
     }
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -70,7 +70,8 @@ public class Program
                     nameof(NewCommand),
                     nameof(RunCommand),
                     nameof(AddCommand),
-                    nameof(PublishCommand)
+                    nameof(PublishCommand),
+                    nameof(DeployCommand)
                     );
 
                 tracing.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("aspire-cli"));
@@ -119,6 +120,7 @@ public class Program
         builder.Services.AddTransient<AddCommand>();
         builder.Services.AddTransient<PublishCommand>();
         builder.Services.AddTransient<ConfigCommand>();
+        builder.Services.AddTransient<DeployCommand>();
         builder.Services.AddTransient<RootCommand>();
 
         var app = builder.Build();
@@ -171,7 +173,7 @@ public class Program
         var rootCommand = app.Services.GetRequiredService<RootCommand>();
         var config = new CommandLineConfiguration(rootCommand);
         config.EnableDefaultExceptionHandler = true;
-        
+
         using var activity = s_activitySource.StartActivity();
         var exitCode = await config.InvokeAsync(args);
 

--- a/src/Aspire.Hosting/ApplicationModel/DeployingCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DeployingCallbackAnnotation.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a default deploying callback annotation for a distributed application model.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="DeployingCallbackAnnotation"/> class.
+/// </remarks>
+/// <param name="callback">The deploying callback.</param>
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class DeployingCallbackAnnotation(Func<DeployingContext, Task> callback) : IResourceAnnotation
+{
+    /// <summary>
+    /// The deploying callback.
+    /// </summary>
+    public Func<DeployingContext, Task> Callback { get; } = callback ?? throw new ArgumentNullException(nameof(callback));
+}

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -480,6 +480,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             { "--operation", "AppHost:Operation" },
             { "--publisher", "Publishing:Publisher" },
             { "--output-path", "Publishing:OutputPath" },
+            { "--deploy", "Publishing:Deploy" },
             { "--dcp-cli-path", "DcpPublisher:CliPath" },
             { "--dcp-container-runtime", "DcpPublisher:ContainerRuntime" },
             { "--dcp-dependency-check-timeout", "DcpPublisher:DependencyCheckTimeout" },

--- a/src/Aspire.Hosting/Publishing/DeployingContext.cs
+++ b/src/Aspire.Hosting/Publishing/DeployingContext.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Provides contextual information and services for the deploying process of a distributed application.
+/// </summary>
+/// <param name="model">The distributed application model to be deployed.</param>
+/// <param name="executionContext">The execution context for the distributed application.</param>
+/// <param name="serviceProvider">The service provider for dependency resolution.</param>
+/// <param name="logger">The logger for deploying operations.</param>
+/// <param name="cancellationToken">The cancellation token for the deploying operation.</param>
+/// <param name="outputPath">The output path for deployment artifacts.</param>
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class DeployingContext(
+    DistributedApplicationModel model,
+    DistributedApplicationExecutionContext executionContext,
+    IServiceProvider serviceProvider,
+    ILogger logger,
+    CancellationToken cancellationToken,
+    string outputPath)
+{
+    /// <summary>
+    /// Gets the distributed application model to be deployed.
+    /// </summary>
+    public DistributedApplicationModel Model { get; } = model;
+
+    /// <summary>
+    /// Gets the execution context for the distributed application.
+    /// </summary>
+    public DistributedApplicationExecutionContext ExecutionContext { get; } = executionContext;
+
+    /// <summary>
+    /// Gets the service provider for dependency resolution.
+    /// </summary>
+    public IServiceProvider Services { get; } = serviceProvider;
+
+    /// <summary>
+    /// Gets the logger for deploying operations.
+    /// </summary>
+    public ILogger Logger { get; } = logger;
+
+    /// <summary>
+    /// Gets the cancellation token for the deploying operation.
+    /// </summary>
+    public CancellationToken CancellationToken { get; } = cancellationToken;
+
+    /// <summary>
+    /// Gets the output path for deployment artifacts.
+    /// </summary>
+    public string OutputPath { get; } = outputPath;
+
+    /// <summary>
+    /// Invokes deploying callbacks for each resource in the provided distributed application model.
+    /// </summary>
+    /// <param name="model">The distributed application model whose resources will be processed.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    internal async Task WriteModelAsync(DistributedApplicationModel model)
+    {
+        foreach (var resource in model.Resources)
+        {
+            if (resource.TryGetLastAnnotation<DeployingCallbackAnnotation>(out var annotation))
+            {
+                await annotation.Callback(this).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Aspire.Hosting/Publishing/PublishingOptions.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Hosting.Publishing;
 
 /// <summary>
@@ -26,5 +28,6 @@ public class PublishingOptions
     /// <summary>
     /// Gets or sets a value indicating whether the application should be deployed after publishing.
     /// </summary>
+    [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public bool Deploy { get; set; }
 }

--- a/src/Aspire.Hosting/Publishing/PublishingOptions.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingOptions.cs
@@ -17,9 +17,14 @@ public class PublishingOptions
     /// Gets or sets the name of the publisher responsible for publishing the application.
     /// </summary>
     public string? Publisher { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the path to the directory where the published output will be written.
     /// </summary>
     public string? OutputPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the application should be deployed after publishing.
+    /// </summary>
+    public bool Deploy { get; set; }
 }

--- a/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
@@ -1,0 +1,262 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Commands;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Tests.TestServices;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class DeployCommandTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task DeployCommandWithHelpArgumentReturnsZero()
+    {
+        var services = CliTestHelper.CreateServiceCollection(outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("deploy --help");
+
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task DeployCommandFailsWithInvalidProjectFile()
+    {
+        // Arrange
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (1, false, null); // Simulate failure to retrieve app host information
+                    }
+                };
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        // Act
+        var result = command.Parse("deploy --project invalid.csproj");
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+
+        // Assert
+        Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode); // Ensure the command fails
+    }
+
+    [Fact]
+    public async Task DeployCommandFailsWhenAppHostIsNotCompatible()
+    {
+        // Arrange
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (0, false, "9.0.0"); // Simulate an incompatible app host
+                    }
+                };
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        // Act
+        var result = command.Parse("deploy --project valid.csproj");
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+
+        // Assert
+        Assert.Equal(ExitCodeConstants.AppHostIncompatible, exitCode); // Ensure the command fails
+    }
+
+    [Fact]
+    public async Task DeployCommandFailsWhenAppHostBuildFails()
+    {
+        // Arrange
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    BuildAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return 1; // Simulate a build failure
+                    }
+                };
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        // Act
+        var result = command.Parse("deploy --project valid.csproj");
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+
+        // Assert
+        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode); // Ensure the command fails
+    }
+
+    [Fact]
+    public async Task DeployCommandSucceedsEndToEnd()
+    {
+        // Arrange
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    // Simulate a successful build
+                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+
+                    // Simulate a successful app host information retrieval
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                    {
+                        return (0, true, VersionHelper.GetDefaultTemplateVersion()); // Compatible app host with backchannel support
+                    },
+
+                    // Simulate apphost running successfully and establishing a backchannel
+                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    {
+                        Assert.True(options.NoLaunchProfile);
+
+                        // Verify that the --deploy flag is included in the arguments
+                        Assert.Contains("--deploy", args);
+
+                        var deployModeCompleted = new TaskCompletionSource();
+                        var backchannel = new TestAppHostBackchannel
+                        {
+                            RequestStopAsyncCalled = deployModeCompleted
+                        };
+                        backchannelCompletionSource?.SetResult(backchannel);
+                        await deployModeCompleted.Task;
+                        return 0; // Simulate successful run
+                    }
+                };
+
+                return runner;
+            };
+
+            options.PublishCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestDeployCommandPrompter(interactionService);
+                return prompter;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        // Act
+        var result = command.Parse("deploy");
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+
+        // Assert
+        Assert.Equal(0, exitCode); // Ensure the command succeeds
+    }
+
+    [Fact]
+    public async Task DeployCommandIncludesDeployFlagInArguments()
+    {
+        // Arrange
+        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner
+                {
+                    // Simulate a successful build
+                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+
+                    // Simulate a successful app host information retrieval
+                    GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
+                        {
+                            return (0, true, VersionHelper.GetDefaultTemplateVersion());
+                        },
+
+                    // Simulate apphost running and verify --deploy flag is passed
+                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                        {
+                            // This is the key assertion - the deploy command should pass --deploy to the app host
+                            Assert.Contains("--deploy", args);
+                            Assert.Contains("--operation", args);
+                            Assert.Contains("publish", args);
+                            Assert.Contains("--publisher", args);
+                            Assert.Contains("default", args);
+
+                            var deployModeCompleted = new TaskCompletionSource();
+                            var backchannel = new TestAppHostBackchannel
+                            {
+                                RequestStopAsyncCalled = deployModeCompleted
+                            };
+                            backchannelCompletionSource?.SetResult(backchannel);
+                            await deployModeCompleted.Task;
+                            return 0;
+                        }
+                };
+
+                return runner;
+            };
+
+            options.PublishCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestDeployCommandPrompter(interactionService);
+                return prompter;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        // Act
+        var result = command.Parse("deploy --output-path /tmp/test");
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+
+        // Assert
+        Assert.Equal(0, exitCode);
+    }
+}
+
+internal sealed class TestDeployCommandPrompter(IInteractionService interactionService) : PublishCommandPrompter(interactionService)
+{
+    public Func<IEnumerable<string>, string>? PromptForPublisherCallback { get; set; }
+
+    public override Task<string> PromptForPublisherAsync(IEnumerable<string> publishers, CancellationToken cancellationToken)
+    {
+        return PromptForPublisherCallback switch
+        {
+            { } callback => Task.FromResult(callback(publishers)),
+            _ => Task.FromResult(publishers.First()) // Default to the first publisher if no callback is provided.
+        };
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
@@ -16,7 +16,9 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task DeployCommandWithHelpArgumentReturnsZero()
     {
-        var services = CliTestHelper.CreateServiceCollection(outputHelper);
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
         var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
@@ -29,8 +31,10 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task DeployCommandFailsWithInvalidProjectFile()
     {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
         // Arrange
-        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.DotNetCliRunnerFactory = (sp) =>
             {
@@ -59,8 +63,10 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task DeployCommandFailsWhenAppHostIsNotCompatible()
     {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
         // Arrange
-        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
 
@@ -91,8 +97,10 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task DeployCommandFailsWhenAppHostBuildFails()
     {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
         // Arrange
-        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
 
@@ -123,8 +131,10 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task DeployCommandSucceedsEndToEnd()
     {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
         // Arrange
-        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
 
@@ -185,8 +195,10 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task DeployCommandIncludesDeployFlagInArguments()
     {
+        using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
         // Arrange
-        var services = CliTestHelper.CreateServiceCollection(outputHelper, options =>
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -57,6 +57,7 @@ internal static class CliTestHelper
         services.AddTransient<NewCommand>();
         services.AddTransient<RunCommand>();
         services.AddTransient<AddCommand>();
+        services.AddTransient<DeployCommand>();
         services.AddTransient<PublishCommand>();
         services.AddTransient<ConfigCommand>();
         services.AddTransient(options.AppHostBackchannelFactory);

--- a/tests/Aspire.Hosting.Tests/PublishingTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishingTests.cs
@@ -3,7 +3,10 @@
 
 #pragma warning disable ASPIREPUBLISHERS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -34,5 +37,208 @@ public class PublishingTests
         app.Run();
 
         Assert.True(publishedCalled, "Publishing callback was not called.");
+    }
+
+    [Fact]
+    public void PublishWithDeployFalseDoesNotCallDeployingCallback()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default");
+
+        // Explicitly set Deploy to false
+        builder.Configuration["Publishing:Deploy"] = "false";
+
+        var publishingCalled = false;
+        var deployingCalled = false;
+
+        builder.AddContainer("cache", "redis")
+               .WithPublishingCallback(context =>
+                {
+                    publishingCalled = true;
+                    return Task.CompletedTask;
+                })
+               .WithAnnotation(new DeployingCallbackAnnotation(context =>
+                {
+                    deployingCalled = true;
+                    return Task.CompletedTask;
+                }));
+
+        using var app = builder.Build();
+        app.Run();
+
+        Assert.True(publishingCalled, "Publishing callback was not called.");
+        Assert.False(deployingCalled, "Deploying callback should not be called when Deploy is false.");
+    }
+
+    [Fact]
+    public void PublishWithDeployTrueCallsDeployingCallback()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default");
+
+        // Explicitly set Deploy to true
+        builder.Configuration["Publishing:Deploy"] = "true";
+
+        var publishingCalled = false;
+        var deployingCalled = false;
+
+        builder.AddContainer("cache", "redis")
+               .WithPublishingCallback(context =>
+                {
+                    Assert.NotNull(context);
+                    Assert.NotNull(context.Services);
+                    Assert.True(context.CancellationToken.CanBeCanceled);
+                    Assert.Equal(DistributedApplicationOperation.Publish, context.ExecutionContext.Operation);
+                    Assert.Equal("default", context.ExecutionContext.PublisherName);
+                    Assert.True(Path.IsPathFullyQualified(context.OutputPath));
+                    publishingCalled = true;
+                    return Task.CompletedTask;
+                })
+               .WithAnnotation(new DeployingCallbackAnnotation(context =>
+                {
+                    Assert.NotNull(context);
+                    Assert.NotNull(context.Services);
+                    Assert.True(context.CancellationToken.CanBeCanceled);
+                    Assert.Equal(DistributedApplicationOperation.Publish, context.ExecutionContext.Operation);
+                    Assert.Equal("default", context.ExecutionContext.PublisherName);
+                    Assert.True(Path.IsPathFullyQualified(context.OutputPath));
+                    deployingCalled = true;
+                    return Task.CompletedTask;
+                }));
+
+        using var app = builder.Build();
+        app.Run();
+
+        Assert.True(publishingCalled, "Publishing callback was not called.");
+        Assert.True(deployingCalled, "Deploying callback was not called when Deploy is true.");
+    }
+
+    [Fact]
+    public void DeployingCallbacksAreCalledAfterPublishingCallbacks()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default");
+
+        // Explicitly set Deploy to true
+        builder.Configuration["Publishing:Deploy"] = "true";
+
+        var callOrder = new List<string>();
+
+        builder.AddContainer("cache", "redis")
+               .WithPublishingCallback(context =>
+                {
+                    callOrder.Add("publishing");
+                    return Task.CompletedTask;
+                })
+               .WithAnnotation(new DeployingCallbackAnnotation(context =>
+                {
+                    callOrder.Add("deploying");
+                    return Task.CompletedTask;
+                }));
+
+        using var app = builder.Build();
+        app.Run();
+
+        Assert.Equal(2, callOrder.Count);
+        Assert.Equal("publishing", callOrder[0]);
+        Assert.Equal("deploying", callOrder[1]);
+    }
+
+    [Fact]
+    public void MultipleResourcesWithDeployingCallbacks()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default");
+
+        // Explicitly set Deploy to true
+        builder.Configuration["Publishing:Deploy"] = "true";
+
+        var deployingCallbacks = new List<string>();
+
+        builder.AddContainer("cache", "redis")
+               .WithAnnotation(new DeployingCallbackAnnotation(context =>
+                {
+                    deployingCallbacks.Add("cache");
+                    return Task.CompletedTask;
+                }));
+
+        builder.AddContainer("db", "postgres")
+               .WithAnnotation(new DeployingCallbackAnnotation(context =>
+                {
+                    deployingCallbacks.Add("db");
+                    return Task.CompletedTask;
+                }));
+
+        using var app = builder.Build();
+        app.Run();
+
+        Assert.Equal(2, deployingCallbacks.Count);
+        Assert.Contains("cache", deployingCallbacks);
+        Assert.Contains("db", deployingCallbacks);
+    }
+
+    [Fact]
+    public void DeployingCallbackReceivesCorrectContext()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default");
+
+        // Explicitly set Deploy to true
+        builder.Configuration["Publishing:Deploy"] = "true";
+
+        var contextValidated = false;
+
+        builder.AddContainer("cache", "redis")
+               .WithAnnotation(new DeployingCallbackAnnotation(context =>
+                {
+                    // Validate all properties of the DeployingContext
+                    Assert.NotNull(context);
+                    Assert.NotNull(context.Model);
+                    Assert.NotNull(context.Services);
+                    Assert.NotNull(context.Logger);
+                    Assert.True(context.CancellationToken.CanBeCanceled);
+                    Assert.Equal(DistributedApplicationOperation.Publish, context.ExecutionContext.Operation);
+                    Assert.Equal("default", context.ExecutionContext.PublisherName);
+                    Assert.True(Path.IsPathFullyQualified(context.OutputPath));
+
+                    // Verify the model contains our resource
+                    Assert.Single(context.Model.Resources);
+                    Assert.Equal("cache", context.Model.Resources.Single().Name);
+
+                    contextValidated = true;
+                    return Task.CompletedTask;
+                }));
+
+        using var app = builder.Build();
+        app.Run();
+
+        Assert.True(contextValidated, "DeployingContext validation failed.");
+    }
+
+    [Fact]
+    public void PublishingOptionsDeployPropertyDefaultsToFalse()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default");
+        using var app = builder.Build();
+
+        var publishingOptions = app.Services.GetRequiredService<IOptions<PublishingOptions>>();
+        Assert.False(publishingOptions.Value.Deploy, "Deploy should default to false.");
+    }
+
+    [Fact]
+    public void PublishingOptionsDeployPropertyCanBeSetToTrue()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default");
+        builder.Configuration["Publishing:Deploy"] = "true";
+        using var app = builder.Build();
+
+        var publishingOptions = app.Services.GetRequiredService<IOptions<PublishingOptions>>();
+        Assert.True(publishingOptions.Value.Deploy, "Deploy should be true when configured.");
+    }
+
+    [Fact]
+    public void PublishingOptionsDeployPropertyCanBeSetViaCommandLine()
+    {
+        var args = new[] { "--publisher", "default", "--output-path", "./", "--deploy", "true" };
+        using var builder = TestDistributedApplicationBuilder.Create(args);
+        using var app = builder.Build();
+
+        var publishingOptions = app.Services.GetRequiredService<IOptions<PublishingOptions>>();
+        Assert.True(publishingOptions.Value.Deploy, "Deploy should be true when set via command line.");
     }
 }


### PR DESCRIPTION
This PR adds a full deployment layer to .NET Aspire: a new aspire deploy CLI command funnels through the existing publish pipeline, a Deploy boolean is added to PublishingOptions, and the Publisher.PublishAsync now invokes DeployingCallbackAnnotation handlers via the new DeployingContext once publishing succeed.

With this model, a resource can register its publish and deploy behavior as follows:

```csharp
public MyResource(string name) : base(name)
{
    Annotations.Add(new PublishingCallbackAnnotation(PublishAsync));
    Annotations.Add(new DeployCallbackAnnotation(DeployAsync));
}
```

Contributes towards https://github.com/dotnet/aspire/issues/8913.

Some things to note about the behavior implemented here:

- Currently, all the `DeployingCallbackAnnotations` are executed in order-of-appearance _after_ all the `PublishingCallbackAnnotation`s have been executed. We might choose to change this behavior in the future so that for each resource, the publishing then callback annotation are run one after the other.
- Only one `DeployingCallbackAnnotation` is respected per resource. Multiple annotations can be provided in the application model on different resources. We can restrict the total number of deployers registered in the app model if we wanted to.
- The `aspire deploy` command currently redirects to `aspire publish --deploy true` but we can choose to model this differently in the future.
- The new `DeployingContext` shares the same properties as the `PublishingContext` at the moment. These might diverge in the future so I created a separate context for now to make the distinction clearer.
- The new APIs are experimental. The new command should be behind a feature flag as well once that change is in.