### PR TITLE
Disable local auth on Azure EventHubs and WebPubSub

### DIFF
--- a/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
+++ b/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
@@ -6,6 +6,9 @@ param sku string = 'Standard'
 resource eventhubns 'Microsoft.EventHub/namespaces@2024-01-01' = {
   name: take('eventhubns-${uniqueString(resourceGroup().id)}', 256)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
   }

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/eventhubs.module.bicep
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/eventhubs.module.bicep
@@ -6,6 +6,9 @@ param sku string = 'Standard'
 resource eventhubs 'Microsoft.EventHub/namespaces@2024-01-01' = {
   name: take('eventhubs-${uniqueString(resourceGroup().id)}', 256)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
   }

--- a/playground/webpubsub/WebPubSub.AppHost/wps1.module.bicep
+++ b/playground/webpubsub/WebPubSub.AppHost/wps1.module.bicep
@@ -10,6 +10,9 @@ param ChatForAspire_url_0 string
 resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
     capacity: capacity

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -61,6 +61,7 @@ public static class AzureEventHubsExtensions
 
                     var resource = new AzureProvisioning.EventHubsNamespace(infrastructure.AspireResource.GetBicepIdentifier())
                     {
+                        DisableLocalAuth = true,
                         Sku = new AzureProvisioning.EventHubsSku()
                         {
                             Name = skuParameter

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -63,6 +63,7 @@ public static class AzureWebPubSubExtensions
 
                     var service = new WebPubSubService(infrastructure.AspireResource.GetBicepIdentifier())
                     {
+                        IsLocalAuthDisabled = true,
                         Sku = new BillingInfoSku()
                         {
                             Name = skuParameter,

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEventHubsExtensionsTests.CanSetHubAndConsumerGroupName#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEventHubsExtensionsTests.CanSetHubAndConsumerGroupName#00.verified.bicep
@@ -6,6 +6,9 @@ param sku string = 'Standard'
 resource eh 'Microsoft.EventHub/namespaces@2024-01-01' = {
   name: take('eh-${uniqueString(resourceGroup().id)}', 256)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
   }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddAzureWebPubSubHubSettings.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddAzureWebPubSubHubSettings.verified.bicep
@@ -14,6 +14,9 @@ param hub2_url_2 string
 resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
     capacity: capacity

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddAzureWebPubSubHubWithEventHandlerExpressionWorks.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddAzureWebPubSubHubWithEventHandlerExpressionWorks.verified.bicep
@@ -10,6 +10,9 @@ param abc_url_0 string
 resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
     capacity: capacity

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddAzureWebPubSubHubWorks.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddAzureWebPubSubHubWorks.verified.bicep
@@ -8,6 +8,9 @@ param capacity int = 1
 resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
     capacity: capacity

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddAzureWebPubSubWithParameters.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddAzureWebPubSubWithParameters.verified.bicep
@@ -8,6 +8,9 @@ param capacity int = 1
 resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
     capacity: capacity

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddDefaultAzureWebPubSub.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddDefaultAzureWebPubSub.verified.bicep
@@ -8,6 +8,9 @@ param capacity int = 1
 resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
     capacity: capacity

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddWebPubSubWithHubConfigure.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.AddWebPubSubWithHubConfigure.verified.bicep
@@ -8,6 +8,9 @@ param capacity int = 1
 resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
     capacity: capacity

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.ConfigureConstructOverridesAddEventHandler.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureWebPubSubExtensionsTests.ConfigureConstructOverridesAddEventHandler.verified.bicep
@@ -8,6 +8,9 @@ param capacity int = 1
 resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
   location: location
+  properties: {
+    disableLocalAuth: true
+  }
   sku: {
     name: sku
     capacity: capacity


### PR DESCRIPTION
## Description

These integrations are using managed identity by default and can have local auth disabled without changing the application.

I've opened issues for the remaining integrations that I wasn't able to validate easily:

* #9796
* #9797 
* #9798 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates): [[Breaking change]: Local auth is disabled by default on Azure resources (dotnet/docs-aspire#3723)](https://github.com/dotnet/docs-aspire/issues/3723)
