### PR TITLE
Menu button concurrency fix

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -31,7 +31,7 @@ public partial class AspireMenu : FluentComponentBase
     public EventCallback<bool> OpenChanged { get; set; }
 
     [Parameter]
-    public required IList<MenuButtonItem> Items { get; set; }
+    public required IReadOnlyList<MenuButtonItem> Items { get; set; }
 
     public async Task CloseAsync()
     {

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -12,7 +12,7 @@
     };
 }
 
-<FluentButton Id="@MenuButtonId" Title="@Title" Appearance="@ButtonAppearance" IconStart="@IconStart" @onclick="ToggleMenu" Disabled="@(!Items.Where(i => !i.IsDivider).Any())" AdditionalAttributes="@additionalButtonAttributes" Class="@ButtonClass">
+<FluentButton Id="@MenuButtonId" Title="@Title" Appearance="@ButtonAppearance" IconStart="@IconStart" @onclick="ToggleMenu" Disabled="@_disabled" AdditionalAttributes="@additionalButtonAttributes" Class="@ButtonClass">
     @if (string.IsNullOrWhiteSpace(Text))
     {
         <FluentIcon Value="@_icon" Color="@IconColor" />
@@ -28,4 +28,4 @@
     }
 </FluentButton>
 
-<AspireMenu Anchor="@MenuButtonId" @bind-Open="@_visible" Items="Items" />
+<AspireMenu Anchor="@MenuButtonId" @bind-Open="@_visible" Items="_items" />

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -15,7 +15,7 @@ public partial class AspireMenuButton : FluentComponentBase
 
     private bool _visible;
     private Icon? _icon;
-    private IReadOnlyList<MenuButtonItem> _items = [];
+    private MenuButtonItem[] _items = [];
     private bool _disabled;
 
     [Parameter]
@@ -54,8 +54,10 @@ public partial class AspireMenuButton : FluentComponentBase
 
         if (Items != null && !_items.SequenceEqual(Items))
         {
-            _items = Items.ToList();
-            _disabled = !_items.Where(i => !i.IsDivider).Any();
+            _items = Items.ToArray();
+
+            // Disabled if there are no actionable items
+            _disabled = !_items.Any(i => !i.IsDivider);
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -15,6 +15,8 @@ public partial class AspireMenuButton : FluentComponentBase
 
     private bool _visible;
     private Icon? _icon;
+    private IReadOnlyList<MenuButtonItem> _items = [];
+    private bool _disabled;
 
     [Parameter]
     public string? Text { get; set; }
@@ -49,6 +51,12 @@ public partial class AspireMenuButton : FluentComponentBase
     protected override void OnParametersSet()
     {
         _icon = Icon ?? s_defaultIcon;
+
+        if (Items != null && !_items.SequenceEqual(Items))
+        {
+            _items = Items.ToList();
+            _disabled = !_items.Where(i => !i.IsDivider).Any();
+        }
     }
 
     private void ToggleMenu()

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -33,27 +33,27 @@
 
             @if (PageViewModel.SelectedResource is { } selectedResource)
             {
-                if (_highlightedCommands.Count > 0)
+                if (_highlightedCommands.Count > 0 || _resourceMenuItems.Count > 0)
                 {
                     <span style="margin-left: 10px;">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsResourceActions)]</span>
+                }
 
-                    @foreach (var command in _highlightedCommands)
-                    {
-                        <FluentButton Appearance="Appearance.Lightweight"
-                                      Title="@(!string.IsNullOrEmpty(command.GetDisplayDescription(CommandsLoc)) ? command.GetDisplayDescription(CommandsLoc) : command.GetDisplayName(CommandsLoc))"
-                                      Disabled="@(command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(selectedResource.Name, command.Name))"
-                                      OnClick="@(() => ExecuteResourceCommandAsync(command))"
-                                      Class="highlighted-command">
-                            @if (!string.IsNullOrEmpty(command.IconName) && IconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) is { } icon)
-                            {
-                                <FluentIcon Value="@icon" Width="16px" />
-                            }
-                            else
-                            {
-                                @command.GetDisplayName(CommandsLoc)
-                            }
-                        </FluentButton>
-                    }
+                @foreach (var command in _highlightedCommands)
+                {
+                    <FluentButton Appearance="Appearance.Lightweight"
+                                  Title="@(!string.IsNullOrEmpty(command.GetDisplayDescription(CommandsLoc)) ? command.GetDisplayDescription(CommandsLoc) : command.GetDisplayName(CommandsLoc))"
+                                  Disabled="@(command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(selectedResource.Name, command.Name))"
+                                  OnClick="@(() => ExecuteResourceCommandAsync(command))"
+                                  Class="highlighted-command">
+                        @if (!string.IsNullOrEmpty(command.IconName) && IconResolver.ResolveIconName(command.IconName, IconSize.Size16, command.IconVariant) is { } icon)
+                        {
+                            <FluentIcon Value="@icon" Width="16px" />
+                        }
+                        else
+                        {
+                            @command.GetDisplayName(CommandsLoc)
+                        }
+                    </FluentButton>
                 }
 
                 if (_resourceMenuItems.Count > 0)


### PR DESCRIPTION
## Description

A rare error if menu buttons are updated while render is in progress:
```
at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.WhereListIterator`1.MoveNext()
   at System.Linq.Enumerable.<Any>g__WithEnumerator|36_0[TSource](IEnumerable`1 source)
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source)
   at Aspire.Dashboard.Components.AspireMenuButton.BuildRenderTree(RenderTreeBuilder __builder) in /_/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor:line 7
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.RenderIntoBatch(RenderBatchBuilder batchBuilder, RenderFragment renderFragment, Exception& renderFragmentException)
```

Fix is to take a copy of menu items when parameters update and avoid enumerating during render.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
