### PR TITLE
Style dashboard blazor reconnect modal

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/ReconnectModal.razor
+++ b/src/Aspire.Dashboard/Components/Layout/ReconnectModal.razor
@@ -16,8 +16,10 @@
         <p class="components-reconnect-failed-visible">
             @((MarkupString)Loc[nameof(Layout.ReconnectFailedText)].Value)
         </p>
-        <button id="components-reconnect-button" class="components-reconnect-failed-visible">
-            @Loc[nameof(Layout.ReconnectRetryButtonText)]
-        </button>
+        <div class="components-reconnect-failed-visible">
+            <FluentButton Id="components-reconnect-button" Appearance="Appearance.Accent">
+                @Loc[nameof(Layout.ReconnectRetryButtonText)]
+            </FluentButton>
+        </div>
     </div>
 </dialog>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -146,40 +146,15 @@ h1 {
     margin-bottom: 0.5rem;
 }
 
-#components-reconnect-modal :is(h5, p) {
-    color: var(--error-ui-foreground-color);
-}
-
-#components-reconnect-modal a {
-    color: var(--error-ui-accent-foreground-color);
-}
-
 #components-reconnect-modal {
-    /* avoid making modal take the entire screen dimensions */
-    inset: unset !important;
+    background-color: var(--neutral-layer-floating) !important;
+}
 
-    /* force modal to be compact, centered, slightly padded, and towards the top - media queries below adjust the width and height of the modal for
-     mobile and desktop screens
-    */
-    top: 5% !important;
-    padding: 2px;
-
-    /* add a slight shadow */
-    box-shadow: 2px 2px 2px var(--neutral-fill-secondary-rest);
-
-    /* avoid modal being see-through */
-    opacity: 1 !important;
-
-    /* ensure sufficient contrast between all elements in the modal and its background */
-    background-color: var(--reconnection-ui-bg) !important;
+.components-rejoining-animation div {
+    border-color: var(--accent-fill-active) !important;
 }
 
 @media (max-width: 768px) {
-    #components-reconnect-modal {
-         left: 15% !important;
-         right: 15% !important;
-    }
-
     fluent-toolbar[orientation=horizontal].main-toolbar {
         padding-left: calc(var(--design-unit) * 2px);
         padding-right: calc(var(--design-unit) * 2px);
@@ -201,11 +176,6 @@ h1 {
 }
 
 @media (min-width: 768px) {
-    #components-reconnect-modal {
-        left: 30% !important;
-        right: 30% !important;
-    }
-
     fluent-toolbar[orientation=horizontal].main-toolbar {
         padding-left: calc(var(--design-unit) * 4.5px);
         padding-right: calc(var(--design-unit) * 2px);


### PR DESCRIPTION
## Description

https://github.com/dotnet/aspire/pull/9733 updated the dashboard to use .NET 10 Blazor bootstrap JS. The newer JS file displays a new reconnect dialog. It uses its own style and introduces some colors/UI that doesn't match what other parts of Aspire UI use.

This PR styles the dialog to use Aspire colors and removes old CSS. Supports light and dark themes.

![dashboard-reconnect](https://github.com/user-attachments/assets/104cfa4d-d149-4584-875b-9a0825c458b9)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
