### PR TITLE
Use default colors for prompts in CLI.

### DIFF
--- a/src/Aspire.Cli/Interaction/InteractionService.cs
+++ b/src/Aspire.Cli/Interaction/InteractionService.cs
@@ -21,7 +21,6 @@ internal class InteractionService : IInteractionService
     {
         return await _ansiConsole.Status()
             .Spinner(Spinner.Known.Dots3)
-            .SpinnerStyle(Style.Parse("purple"))
             .StartAsync(statusText, (context) => action());
     }
 
@@ -29,7 +28,6 @@ internal class InteractionService : IInteractionService
     {
         _ansiConsole.Status()
             .Spinner(Spinner.Known.Dots3)
-            .SpinnerStyle(Style.Parse("purple"))
             .Start(statusText, (context) => action());
     }
 
@@ -69,8 +67,7 @@ internal class InteractionService : IInteractionService
             .UseConverter(choiceFormatter)
             .AddChoices(choices)
             .PageSize(10)
-            .EnableSearch()
-            .HighlightStyle(Style.Parse("darkmagenta"));
+            .EnableSearch();
 
         return await _ansiConsole.PromptAsync(prompt, cancellationToken);
     }


### PR DESCRIPTION
Styling simplifications:

* Removed the `SpinnerStyle` configuration from both `ShowStatusAsync` and `ShowStatus` methods, which previously used the color "purple."

Selection prompt adjustments:

* Removed the `HighlightStyle` configuration (previously set to "darkmagenta") from the `PromptForSelectionAsync` method to streamline the prompt setup.

![image](https://github.com/user-attachments/assets/8197c8d9-28ce-4ce9-8032-e799a6fa0798)
