### PR TITLE
Add Kubernetes publisher Workload and Resource extension points

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -28,20 +28,8 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
     internal List<PersistentVolumeClaim> PersistentVolumeClaims { get; } = [];
 
     /// <summary>
-    /// Gets or sets the Kubernetes <see cref="Deployment"/> associated with this resource.
     /// </summary>
-    /// <remarks>
-    /// <see cref="KubernetesResource"/> instances can be associated with either a <see cref="StatefulSet"/> or a <see cref="Deployment"/> resource.
-    /// </remarks>
-    public Deployment? Deployment { get; set; }
-
-    /// <summary>
-    /// Gets or sets the Kubernetes <see cref="StatefulSet"/> associated with this resource.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="KubernetesResource"/> instances can be associated with either a <see cref="StatefulSet"/> or a <see cref="Deployment"/> resource.
-    /// </remarks>
-    public StatefulSet? StatefulSet { get; set; }
+    public Workload? Workload { get; set; }
 
     /// <summary>
     /// Gets or sets the Kubernetes ConfigMap associated with this resource.
@@ -69,14 +57,11 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
 
     internal IEnumerable<BaseKubernetesResource> GetTemplatedResources()
     {
-        if (Deployment is not null)
+        if (Workload is not null)
         {
-            yield return Deployment;
+            yield return Workload;
         }
-        if (StatefulSet is not null)
-        {
-            yield return StatefulSet;
-        }
+
         if (ConfigMap is not null)
         {
             yield return ConfigMap;
@@ -128,11 +113,11 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
     {
         if (resource is IResourceWithConnectionString)
         {
-            StatefulSet = resource.ToStatefulSet(this);
+            Workload = resource.ToStatefulSet(this);
             return;
         }
 
-        Deployment = resource.ToDeployment(this);
+        Workload = resource.ToDeployment(this);
     }
 
     internal string GetContainerImageName(IResource resourceInstance)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -47,6 +47,7 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
     public Service? Service { get; set; }
 
     /// <summary>
+    /// Additional resources that are part of this Kubernetes service.
     /// </summary>
     public List<BaseKubernetesResource> Resources { get; } = [];
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -59,6 +59,10 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
     public Service? Service { get; set; }
 
     /// <summary>
+    /// </summary>
+    public List<BaseKubernetesResource> Resources { get; } = [];
+
+    /// <summary>
     /// Gets the resource that is the target of this Kubernetes service.
     /// </summary>
     internal IResource TargetResource => resource;
@@ -94,6 +98,11 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
         foreach (var volumeClaim in PersistentVolumeClaims)
         {
             yield return volumeClaim;
+        }
+
+        foreach (var resource in Resources)
+        {
+            yield return resource;
         }
     }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -49,7 +49,7 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
     /// <summary>
     /// Additional resources that are part of this Kubernetes service.
     /// </summary>
-    public List<BaseKubernetesResource> Resources { get; } = [];
+    public List<BaseKubernetesResource> AdditionalResources { get; } = [];
 
     /// <summary>
     /// Gets the resource that is the target of this Kubernetes service.
@@ -86,7 +86,7 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
             yield return volumeClaim;
         }
 
-        foreach (var resource in Resources)
+        foreach (var resource in AdditionalResources)
         {
             yield return resource;
         }

--- a/src/Aspire.Hosting.Kubernetes/Resources/DeploymentV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/DeploymentV1.cs
@@ -31,8 +31,5 @@ public sealed class Deployment() : Workload("apps/v1", "Deployment")
     /// <summary>
     /// Gets the pod template specification for the Deployment.
     /// </summary>
-    public override PodTemplateSpecV1 GetPodTemplate()
-    {
-        return Spec.Template;
-    }
+    public override PodTemplateSpecV1 PodTemplate => Spec.Template;
 }

--- a/src/Aspire.Hosting.Kubernetes/Resources/DeploymentV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/DeploymentV1.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Kubernetes.Resources;
 /// It uses the "apps/v1" API version and the resource kind "Deployment".
 /// </remarks>
 [YamlSerializable]
-public sealed class Deployment() : BaseKubernetesResource("apps/v1", "Deployment")
+public sealed class Deployment() : Workload("apps/v1", "Deployment")
 {
     /// <summary>
     /// Gets or sets the specification of the Kubernetes Deployment resource.
@@ -27,4 +27,12 @@ public sealed class Deployment() : BaseKubernetesResource("apps/v1", "Deployment
     /// </remarks>
     [YamlMember(Alias = "spec")]
     public DeploymentSpecV1 Spec { get; set; } = new();
+
+    /// <summary>
+    /// Gets the pod template specification for the Deployment.
+    /// </summary>
+    public override PodTemplateSpecV1 GetPodTemplate()
+    {
+        return Spec.Template;
+    }
 }

--- a/src/Aspire.Hosting.Kubernetes/Resources/StatefulSetV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/StatefulSetV1.cs
@@ -22,7 +22,7 @@ namespace Aspire.Hosting.Kubernetes.Resources;
 /// for use with Kubernetes manifests.
 /// </example>
 [YamlSerializable]
-public sealed class StatefulSet() : BaseKubernetesResource("apps/v1", "StatefulSet")
+public sealed class StatefulSet() : Workload("apps/v1", "StatefulSet")
 {
     /// <summary>
     /// Gets or sets the specification of the Kubernetes StatefulSet resource.
@@ -36,4 +36,12 @@ public sealed class StatefulSet() : BaseKubernetesResource("apps/v1", "StatefulS
     /// </remarks>
     [YamlMember(Alias = "spec")]
     public StatefulSetSpecV1 Spec { get; set; } = new();
+
+    /// <summary>
+    /// Gets the pod template specification for the StatefulSet.
+    /// </summary>
+    public override PodTemplateSpecV1 GetPodTemplate()
+    {
+        return Spec.Template;
+    }
 }

--- a/src/Aspire.Hosting.Kubernetes/Resources/StatefulSetV1.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/StatefulSetV1.cs
@@ -40,8 +40,5 @@ public sealed class StatefulSet() : Workload("apps/v1", "StatefulSet")
     /// <summary>
     /// Gets the pod template specification for the StatefulSet.
     /// </summary>
-    public override PodTemplateSpecV1 GetPodTemplate()
-    {
-        return Spec.Template;
-    }
+    public override PodTemplateSpecV1 PodTemplate => Spec.Template;
 }

--- a/src/Aspire.Hosting.Kubernetes/Resources/Workload.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/Workload.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Kubernetes.Resources;
+
+/// <summary>
+/// 
+/// </summary>
+public abstract class Workload(string apiVersion, string kind) : BaseKubernetesResource(apiVersion, kind)
+{
+    /// <summary>
+    /// Gets the pod template specification for the workload.
+    /// </summary>
+    public abstract PodTemplateSpecV1 GetPodTemplate();
+}

--- a/src/Aspire.Hosting.Kubernetes/Resources/Workload.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/Workload.cs
@@ -4,12 +4,12 @@
 namespace Aspire.Hosting.Kubernetes.Resources;
 
 /// <summary>
-/// 
+/// The base class for Kubernetes workload resources, such as StatefulSets and Deployments.
 /// </summary>
 public abstract class Workload(string apiVersion, string kind) : BaseKubernetesResource(apiVersion, kind)
 {
     /// <summary>
-    /// Gets the pod template specification for the workload.
+    /// Gets the pod template for the workload.
     /// </summary>
     public abstract PodTemplateSpecV1 GetPodTemplate();
 }

--- a/src/Aspire.Hosting.Kubernetes/Resources/Workload.cs
+++ b/src/Aspire.Hosting.Kubernetes/Resources/Workload.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using YamlDotNet.Serialization;
+
 namespace Aspire.Hosting.Kubernetes.Resources;
 
 /// <summary>
@@ -11,5 +13,6 @@ public abstract class Workload(string apiVersion, string kind) : BaseKubernetesR
     /// <summary>
     /// Gets the pod template for the workload.
     /// </summary>
-    public abstract PodTemplateSpecV1 GetPodTemplate();
+    [YamlIgnore]
+    public abstract PodTemplateSpecV1 PodTemplate { get; }
 }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Kubernetes.Resources;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
@@ -47,11 +48,11 @@ public class KubernetesPublisherTests()
             "Chart.yaml",
             "values.yaml",
             "templates/project1/deployment.yaml",
-            "templates/project1/configmap.yaml",
+            "templates/project1/config.yaml",
             "templates/myapp/deployment.yaml",
             "templates/myapp/service.yaml",
-            "templates/myapp/configmap.yaml",
-            "templates/myapp/secret.yaml"
+            "templates/myapp/config.yaml",
+            "templates/myapp/secrets.yaml"
         };
 
         SettingsTask settingsTask = default!;
@@ -102,6 +103,55 @@ public class KubernetesPublisherTests()
         var content = await File.ReadAllTextAsync(deploymentPath);
 
         await Verify(content, "yaml");
+    }
+
+    [Fact]
+    public async Task PublishAsync_GeneratesAdditionalResourcesInChart()
+    {
+        using var tempDir = new TempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, "default", outputPath: tempDir.Path);
+
+        builder.AddKubernetesEnvironment("env");
+
+        // Add a container to the application
+        var api = builder.AddContainer("myapp", "mcr.microsoft.com/dotnet/aspnet:8.0")
+            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
+            .WithHttpEndpoint(targetPort: 8080)
+            .PublishAsKubernetesService(resource => {
+                resource.Resources.Add(new Secret { Metadata = { Name = "mycustomresource"} });
+        });
+
+        builder.AddProject<TestProject>("project1", launchProfileName: null)
+            .WithReference(api.GetEndpoint("http"));
+
+        var app = builder.Build();
+
+        app.Run();
+
+        // Assert
+        var expectedFiles = new[]
+        {
+            "templates/myapp/mycustomresource.yaml"
+        };
+
+        SettingsTask settingsTask = default!;
+
+        foreach (var expectedFile in expectedFiles)
+        {
+            var filePath = Path.Combine(tempDir.Path, expectedFile);
+            var fileExtension = Path.GetExtension(filePath)[1..];
+
+            if (settingsTask is null)
+            {
+                settingsTask = Verify(File.ReadAllText(filePath), fileExtension);
+            }
+            else
+            {
+                settingsTask = settingsTask.AppendContentAsFile(File.ReadAllText(filePath), fileExtension);
+            }
+        }
+
+        await settingsTask;
     }
 
     private sealed class TestProject : IProjectMetadata

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -90,7 +90,7 @@ public class KubernetesPublisherTests()
             .WithEnvironment("ORIGINAL_ENV", "value")
             .PublishAsKubernetesService(serviceResource =>
             {
-                serviceResource.Workload!.GetPodTemplate().Spec.Containers[0].ImagePullPolicy = "Always";
+                serviceResource.Workload!.PodTemplate.Spec.Containers[0].ImagePullPolicy = "Always";
                 (serviceResource.Workload as Deployment)!.Spec.RevisionHistoryLimit = 5;
             });
 
@@ -120,7 +120,7 @@ public class KubernetesPublisherTests()
             .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
             .WithHttpEndpoint(targetPort: 8080)
             .PublishAsKubernetesService(serviceResource => {
-                serviceResource.Resources.Add(new TestCustomResource { Metadata = { Name = "myapp-mycustomresource"}, CustomProperty = "custom" });
+                serviceResource.AdditionalResources.Add(new TestCustomResource { Metadata = { Name = "myapp-mycustomresource"}, CustomProperty = "custom" });
         });
 
         builder.AddProject<TestProject>("project1", launchProfileName: null)

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -89,7 +89,8 @@ public class KubernetesPublisherTests()
             .WithEnvironment("ORIGINAL_ENV", "value")
             .PublishAsKubernetesService(serviceResource =>
             {
-                serviceResource.Deployment!.Spec.RevisionHistoryLimit = 5;
+                serviceResource.Workload!.GetPodTemplate().Spec.Containers[0].ImagePullPolicy = "Always";
+                (serviceResource.Workload as Deployment)!.Spec.RevisionHistoryLimit = 5;
             });
 
         var app = builder.Build();
@@ -117,8 +118,8 @@ public class KubernetesPublisherTests()
         var api = builder.AddContainer("myapp", "mcr.microsoft.com/dotnet/aspnet:8.0")
             .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
             .WithHttpEndpoint(targetPort: 8080)
-            .PublishAsKubernetesService(resource => {
-                resource.Resources.Add(new Secret { Metadata = { Name = "mycustomresource"} });
+            .PublishAsKubernetesService(serviceResource => {
+                serviceResource.Resources.Add(new Secret { Metadata = { Name = "mycustomresource"} });
         });
 
         builder.AddProject<TestProject>("project1", launchProfileName: null)

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Kubernetes.Resources;
 using Aspire.Hosting.Utils;
+using YamlDotNet.Serialization;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
 
@@ -119,7 +120,7 @@ public class KubernetesPublisherTests()
             .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
             .WithHttpEndpoint(targetPort: 8080)
             .PublishAsKubernetesService(serviceResource => {
-                serviceResource.Resources.Add(new Secret { Metadata = { Name = "mycustomresource"} });
+                serviceResource.Resources.Add(new TestCustomResource { Metadata = { Name = "myapp-mycustomresource"}, CustomProperty = "custom" });
         });
 
         builder.AddProject<TestProject>("project1", launchProfileName: null)
@@ -153,6 +154,12 @@ public class KubernetesPublisherTests()
         }
 
         await settingsTask;
+    }
+
+    private sealed class TestCustomResource() : BaseKubernetesResource("custom/v1", "Custom")
+    {
+        [YamlMember(Alias = "custom")]
+        public string CustomProperty { get; set; } = "";
     }
 
     private sealed class TestProject : IProjectMetadata

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#00.verified.yaml
@@ -1,0 +1,11 @@
+apiVersion: "v2"
+name: "aspire"
+version: "0.1.0"
+kubeVersion: ">= 1.18.0-0"
+description: "Aspire Helm Chart"
+type: "application"
+keywords:
+  - "aspire"
+  - "kubernetes"
+appVersion: "0.1.0"
+deprecated: false

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#01.verified.yaml
@@ -1,0 +1,12 @@
+parameters:
+  project1:
+    project1_image: "project1:latest"
+secrets: {}
+config:
+  myapp:
+    ASPNETCORE_ENVIRONMENT: "Development"
+  project1:
+    OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "true"
+    OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
+    OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "in_memory"
+    services__myapp__http__0: "http://myapp:8080"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#02.verified.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: "argoproj.io/v1alpha1"
+kind: "Rollout"
+metadata:
+  name: "myapp-rollout"
+  labels:
+    app: "aspire"
+    component: "myapp"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: "aspire"
+        component: "myapp"
+    spec:
+      containers:
+        - image: "mcr.microsoft.com/dotnet/aspnet:8.0"
+          name: "myapp"
+          envFrom:
+            - configMapRef:
+                name: "myapp-config"
+          ports:
+            - name: "http"
+              protocol: "TCP"
+              containerPort: "8080"
+          imagePullPolicy: "IfNotPresent"
+  selector:
+    matchLabels:
+      app: "aspire"
+      component: "myapp"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#03.verified.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "myapp-service"
+spec:
+  type: "ClusterIP"
+  selector:
+    app: "aspire"
+    component: "myapp"
+  ports:
+    - name: "http"
+      protocol: "TCP"
+      port: "8080"
+      targetPort: "8080"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#04.verified.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "myapp-config"
+  labels:
+    app: "aspire"
+    component: "myapp"
+data:
+  ASPNETCORE_ENVIRONMENT: "{{ .Values.config.myapp.ASPNETCORE_ENVIRONMENT }}"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#05.verified.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: "keda.sh/v1alpha1"
+kind: "ScaledObject"
+metadata:
+  name: "myapp-scaler"
+spec:
+  scaleTargetRef:
+    name: "myapp-rollout"
+    kind: "Rollout"
+  minReplicaCount: 1
+  maxReplicaCount: 3

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesAdditionalResourcesInChart.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesAdditionalResourcesInChart.verified.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: "v1"
+kind: "Secret"
+metadata:
+  name: "mycustomresource"
+type: "Opaque"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesAdditionalResourcesInChart.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesAdditionalResourcesInChart.verified.yaml
@@ -1,6 +1,6 @@
 ---
-apiVersion: "v1"
-kind: "Secret"
+apiVersion: "custom/v1"
+kind: "Custom"
 metadata:
-  name: "mycustomresource"
-type: "Opaque"
+  name: "myapp-mycustomresource"
+custom: "custom"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesAdditionalResourcesInChart.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesAdditionalResourcesInChart.verified.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: "custom/v1"
-kind: "Custom"
-metadata:
-  name: "myapp-mycustomresource"
-custom: "custom"


### PR DESCRIPTION
## Description

Introduced KubernetesResource.Workload to replace Deployment and StatefulSet. This allows future support for additional workload types, like CronJob, Job, etc. or allows extending with custom workload types like ArgoRollouts.

Introduced KubernetesResource.Resources, allowing adding additional BaseKubernetesResource objects. This allows more flexibility in adding multiple secrets, configmaps, etc. and also allows adding custom resource types to a service.

Improvements as discussed in issue https://github.com/dotnet/aspire/issues/830#issuecomment-2853744988

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
