### PR TITLE
Cleanup error handling conditions for ACA compute environment

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppContainerExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppContainerExtensions.cs
@@ -42,6 +42,8 @@ public static class AzureContainerAppContainerExtensions
             return container;
         }
 
+        container.ApplicationBuilder.AddAzureContainerAppsInfrastructureCore();
+
         container.WithAnnotation(new AzureContainerAppCustomizationAnnotation(configure));
 
         return container;

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExecutableExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExecutableExtensions.cs
@@ -42,6 +42,8 @@ public static class AzureContainerAppExecutableExtensions
             return executable;
         }
 
+        executable.ApplicationBuilder.AddAzureContainerAppsInfrastructureCore();
+
         return executable.WithAnnotation(new AzureContainerAppCustomizationAnnotation(configure));
     }
 }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -31,7 +31,7 @@ public static class AzureContainerAppExtensions
     public static IDistributedApplicationBuilder AddAzureContainerAppsInfrastructure(this IDistributedApplicationBuilder builder) =>
         AddAzureContainerAppsInfrastructureCore(builder);
 
-    private static IDistributedApplicationBuilder AddAzureContainerAppsInfrastructureCore(this IDistributedApplicationBuilder builder)
+    internal static IDistributedApplicationBuilder AddAzureContainerAppsInfrastructureCore(this IDistributedApplicationBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -56,15 +56,6 @@ public static class AzureContainerAppExtensions
     public static IResourceBuilder<AzureContainerAppEnvironmentResource> AddAzureContainerAppEnvironment(this IDistributedApplicationBuilder builder, string name)
     {
         builder.AddAzureContainerAppsInfrastructureCore();
-
-        // Only support one temporarily until we can support multiple environments
-        // and allowing each container app to be explicit about which environment it uses
-        var existingContainerAppEnvResource = builder.Resources.OfType<AzureContainerAppEnvironmentResource>().FirstOrDefault();
-
-        if (existingContainerAppEnvResource != null)
-        {
-            throw new NotSupportedException($"Only one container app environment is supported at this time. Found: {existingContainerAppEnvResource.Name}");
-        }
 
         var containerAppEnvResource = new AzureContainerAppEnvironmentResource(name, static infra =>
         {

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppProjectExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppProjectExtensions.cs
@@ -42,6 +42,8 @@ public static class AzureContainerAppProjectExtensions
             return project;
         }
 
+        project.ApplicationBuilder.AddAzureContainerAppsInfrastructureCore();
+
         project.WithAnnotation(new AzureContainerAppCustomizationAnnotation(configure));
 
         return project;

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -51,10 +51,10 @@ internal sealed class AzureContainerAppsInfrastructure(
             }
         }
 
-        EnsurePublishAsAcaAnnoationsMatch(appModel, hasAcaEnvironments: caes.Length > 0);
+        EnsurePublishAsAcaAnnotationsMatch(appModel, hasAcaEnvironments: caes.Length > 0);
     }
 
-    private static void EnsurePublishAsAcaAnnoationsMatch(DistributedApplicationModel appModel, bool hasAcaEnvironments)
+    private static void EnsurePublishAsAcaAnnotationsMatch(DistributedApplicationModel appModel, bool hasAcaEnvironments)
     {
         foreach (var r in appModel.GetComputeResources())
         {

--- a/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModelExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModelExtensions.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Provides extension methods on the <see cref="DistributedApplicationModel"/> class.
+/// </summary>
+public static class DistributedApplicationModelExtensions
+{
+    /// <summary>
+    /// Returns the compute resources from the <see cref="DistributedApplicationModel"/>.
+    /// Compute resources are those that are either containers or project resources, and are not marked to be ignored by the manifest publishing callback annotation.
+    /// </summary>
+    /// <param name="model">The distributed application model to extract compute resources from.</param>
+    /// <returns>An enumerable of compute <see cref="IResource"/> in the model.</returns>
+    public static IEnumerable<IResource> GetComputeResources(this DistributedApplicationModel model)
+    {
+        foreach (var r in model.Resources)
+        {
+            if (r.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var lastAnnotation) && lastAnnotation == ManifestPublishingCallbackAnnotation.Ignore)
+            {
+                continue;
+            }
+
+            if (!r.IsContainer() && r is not ProjectResource)
+            {
+                continue;
+            }
+
+            yield return r;
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1541,25 +1541,6 @@ public class AzureContainerAppsTests
     }
 
     [Fact]
-    public async Task PublishAsAzureContainerApp_ThrowsIfWrongEnvironment()
-    {
-        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-
-        var acaEnv = builder.AddAzureContainerAppEnvironment("acaEnv");
-        var appServiceEnv = builder.AddAzureAppServiceEnvironment("appServiceEnv");
-
-        builder.AddContainer("api1", "myimage")
-            .PublishAsAzureContainerApp((_, _) => { })
-            .WithComputeEnvironment(appServiceEnv);
-
-        using var app = builder.Build();
-
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => ExecuteBeforeStartHooksAsync(app, default));
-
-        Assert.Contains("it is not associated with an Azure Container App Environment", ex.Message);
-    }
-
-    [Fact]
     public async Task MultipleAzureContainerAppEnvironmentsSupported()
     {
         using var tempDir = new TempDirectory();

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleAzureContainerAppEnvironmentsSupported.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleAzureContainerAppEnvironmentsSupported.verified.json
@@ -1,0 +1,43 @@
+﻿{
+  "$schema": "https://json.schemastore.org/aspire-8.0.json",
+  "resources": {
+    "env1": {
+      "type": "azure.bicep.v0",
+      "path": "env1.module.bicep",
+      "params": {
+        "userPrincipalId": ""
+      }
+    },
+    "env2": {
+      "type": "azure.bicep.v0",
+      "path": "env2.module.bicep",
+      "params": {
+        "userPrincipalId": ""
+      }
+    },
+    "api1": {
+      "type": "container.v1",
+      "image": "myimage:latest",
+      "deployment": {
+        "type": "azure.bicep.v0",
+        "path": "api1.module.bicep",
+        "params": {
+          "env1_outputs_azure_container_apps_environment_default_domain": "{env1.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+          "env1_outputs_azure_container_apps_environment_id": "{env1.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+        }
+      }
+    },
+    "api2": {
+      "type": "container.v1",
+      "image": "myimage:latest",
+      "deployment": {
+        "type": "azure.bicep.v0",
+        "path": "api2.module.bicep",
+        "params": {
+          "env2_outputs_azure_container_apps_environment_default_domain": "{env2.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+          "env2_outputs_azure_container_apps_environment_id": "{env2.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+        }
+      }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationModelExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationModelExtensionsTests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class DistributedApplicationModelExtensionsTests
+{
+    [Fact]
+    public void GetComputeResources_Returns_Containers_And_Projects_Excludes_Ignored()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var container1 = builder.AddContainer("container1", "image");
+        var container2 = builder.AddContainer("container2", "image");
+        var project = builder.AddProject<Projects.ServiceA>("ServiceA");
+
+        var ignored = builder.AddContainer("container3", "image")
+            .ExcludeFromManifest();
+
+        var notACompute = builder.AddExecutable("notACompute", "path/to/executable", ".");
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var result = appModel.GetComputeResources().ToList();
+
+        Assert.Collection(result,
+            item => Assert.Equal(container1.Resource, item),
+            item => Assert.Equal(container2.Resource, item),
+            item => Assert.Equal(project.Resource, item));
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
@@ -137,6 +137,8 @@ public class SchemaTests
 
                 { "VanillaProjectBasedContainerApp", (IDistributedApplicationBuilder builder) =>
                     {
+                        builder.AddAzureContainerAppEnvironment("env");
+
                         builder.AddProject<Projects.ServiceA>("project")
                                .PublishAsAzureContainerApp((_, _) => { });
 
@@ -145,6 +147,8 @@ public class SchemaTests
 
                 { "CustomizedProjectBasedContainerApp", (IDistributedApplicationBuilder builder) =>
                     {
+                        builder.AddAzureContainerAppEnvironment("env");
+
                         var minReplicas = builder.AddParameter("minReplicas");
 
                         builder.AddProject<Projects.ServiceA>("project")
@@ -158,6 +162,8 @@ public class SchemaTests
 
                 { "VanillaContainerBasedContainerApp", (IDistributedApplicationBuilder builder) =>
                     {
+                        builder.AddAzureContainerAppEnvironment("env");
+
                         builder.AddContainer("mycontainer", "myimage")
                                .PublishAsAzureContainerApp((_, _) => { });
 
@@ -166,6 +172,8 @@ public class SchemaTests
 
                 { "CustomizedContainerBasedContainerApp", (IDistributedApplicationBuilder builder) =>
                     {
+                        builder.AddAzureContainerAppEnvironment("env");
+
                         var minReplicas = builder.AddParameter("minReplicas");
 
                         builder.AddContainer("mycontainer", "myimage")


### PR DESCRIPTION
## Description

1. When calling PublishAsAzureContainerApp and there are no ACA compute environments, throw. Also throw if the environment is wrong.
2. Support multiple ACA environments

Contributes to #9532

Will do the other 3 compute environments separately after we agree upon a pattern.

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected. **Need to do the same for the other 3 compute environments**
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
