### PR TITLE
Use custom ConnectionStringBuilder when mutating connection strings

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
+++ b/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="..\Shared\Cosmos\CosmosConstants.cs" Link="Shared\CosmosConstants.cs" />
     <Compile Include="..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
+    <Compile Include="..\Shared\StableConnectionStringBuilder.cs" Link="Shared\StableConnectionStringBuilder.cs" />
     <Compile Include="..\Shared\KnownUrls.cs" Link="KnownUrls.cs" />
   </ItemGroup>
 

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/Aspire.Azure.Messaging.EventHubs.csproj
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/Aspire.Azure.Messaging.EventHubs.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+    <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="StableConnectionStringBuilder.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/AzureMessagingEventHubsSettings.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/AzureMessagingEventHubsSettings.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Data.Common;
 using Aspire.Azure.Common;
 
 using Azure.Core;
@@ -110,10 +109,7 @@ public abstract class AzureMessagingEventHubsSettings : IConnectionStringSetting
                 return;
             }
 
-            var connectionBuilder = new DbConnectionStringBuilder()
-            {
-                ConnectionString = connectionString
-            };
+            var connectionBuilder = new StableConnectionStringBuilder(connectionString);
 
             // Note: Strip out the ConsumerGroup and EntityPath from the connection string in order
             // to tell if we are left with just Endpoint.
@@ -132,7 +128,7 @@ public abstract class AzureMessagingEventHubsSettings : IConnectionStringSetting
                 connectionBuilder.Remove("EntityPath");
             }
 
-            if (connectionBuilder.Count == 1 &&
+            if (connectionBuilder.Count() == 1 &&
                 connectionBuilder.TryGetValue("Endpoint", out var endpoint))
             {
                 // if all that's left is Endpoint, it is a fully qualified namespace

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/Aspire.Azure.Messaging.ServiceBus.csproj
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/Aspire.Azure.Messaging.ServiceBus.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+    <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="StableConnectionStringBuilder.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,6 +24,10 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Azure.Messaging.ServiceBus.Tests" />
   </ItemGroup>
   
 </Project>

--- a/src/Components/Aspire.Azure.Messaging.WebPubSub/Aspire.Azure.Messaging.WebPubSub.csproj
+++ b/src/Components/Aspire.Azure.Messaging.WebPubSub/Aspire.Azure.Messaging.WebPubSub.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+    <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="StableConnectionStringBuilder.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Messaging.WebPubSub/AzureMessagingWebPubSubSettings.cs
+++ b/src/Components/Aspire.Azure.Messaging.WebPubSub/AzureMessagingWebPubSubSettings.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Data.Common;
 using Aspire.Azure.Common;
 using Azure.Core;
 
@@ -65,10 +64,7 @@ public sealed class AzureMessagingWebPubSubSettings : IConnectionStringSettings
                 return;
             }
 
-            var connectionBuilder = new DbConnectionStringBuilder()
-            {
-                ConnectionString = connectionString
-            };
+            var connectionBuilder = new StableConnectionStringBuilder(connectionString);
 
             if (connectionBuilder.TryGetValue("Hub", out var entityPath))
             {
@@ -76,7 +72,7 @@ public sealed class AzureMessagingWebPubSubSettings : IConnectionStringSettings
                 connectionBuilder.Remove("Hub");
             }
 
-            if (connectionBuilder.Count == 1 &&
+            if (connectionBuilder.Count() == 1 &&
                 connectionBuilder.TryGetValue("Endpoint", out var endpoint))
             {
                 Endpoint = new Uri(endpoint.ToString()!);

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\..\Shared\Cosmos\CosmosConstants.cs" Link="Shared\CosmosConstants.cs" />
     <Compile Include="..\..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
+    <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="Shared\StableConnectionStringBuilder.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\..\Shared\Cosmos\CosmosConstants.cs" Link="Shared\CosmosConstants.cs" />
     <Compile Include="..\..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
+    <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="Shared\StableConnectionStringBuilder.cs" />
     <Compile Include="..\Common\EntityFrameworkUtils.cs" Link="EntityFrameworkUtils.cs" />
   </ItemGroup>
   

--- a/src/Shared/Cosmos/CosmosUtils.cs
+++ b/src/Shared/Cosmos/CosmosUtils.cs
@@ -42,10 +42,7 @@ internal static class CosmosUtils
             return new CosmosConnectionInfo(accountEndpoint, null);
         }
 
-        var connectionBuilder = new DbConnectionStringBuilder()
-        {
-            ConnectionString = connectionString
-        };
+        var connectionBuilder = new StableConnectionStringBuilder(connectionString);
 
         // Strip out the database and container from the connection string in order
         // to tell if we are left with just AccountEndpoint.
@@ -61,7 +58,7 @@ internal static class CosmosUtils
 
         // if we are only left with the AccountEndpoint, then we set the AccountEndpoint and
         // not the connection string and include the database and container names.
-        if (connectionBuilder.Count == 1 &&
+        if (connectionBuilder.Count() == 1 &&
             connectionBuilder.TryGetValue("AccountEndpoint", out var accountEndpointValue) &&
             Uri.TryCreate(accountEndpointValue.ToString(), UriKind.Absolute, out accountEndpoint))
         {

--- a/src/Shared/StableConnectionStringBuilder.cs
+++ b/src/Shared/StableConnectionStringBuilder.cs
@@ -1,0 +1,286 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Text;
+
+namespace Aspire;
+
+/// <summary>
+/// Parses and manages connection strings in the form: Key1=Value1;Key2=Value2;...
+/// Preserves the exact placement of empty segments and semicolons.
+/// </summary>
+internal sealed class StableConnectionStringBuilder : IEnumerable<KeyValuePair<string, string>>
+{
+    private string _connectionString;
+    private readonly List<ConnectionStringSegment> _segments;
+
+    /// <summary>
+    /// The current connection string, always up-to-date.
+    /// </summary>
+    public string ConnectionString
+    {
+        get => _connectionString;
+        private set => _connectionString = value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StableConnectionStringBuilder"/> class.
+    /// </summary>
+    /// <param name="connectionString">The connection string to parse.</param>
+    public StableConnectionStringBuilder(string connectionString)
+    {
+        ArgumentNullException.ThrowIfNull(connectionString);
+        _connectionString = connectionString;
+        _segments = ParseSegments(_connectionString);
+    }
+
+    /// <summary>
+    /// Tries to parse the given connection string into a StableConnectionStringBuilder.
+    /// Returns true if parsing succeeds, false otherwise.
+    /// </summary>
+    public static bool TryParse(string connectionString, out StableConnectionStringBuilder? builder)
+    {
+        try
+        {
+            builder = new StableConnectionStringBuilder(connectionString);
+            return true;
+        }
+        catch
+        {
+            builder = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the value associated with the specified key (case-insensitive).
+    /// Returns an empty string if the value is empty, and null if the key does not exist.
+    /// Setting a value to null removes the key/value pair and its following semicolon.
+    /// </summary>
+    public string? this[string key]
+    {
+        get
+        {
+            var idx = FindKeyIndex(key);
+            if (idx >= 0)
+            {
+                return _segments[idx].Value;
+            }
+            return null;
+        }
+        set
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+            key = key.Trim();
+
+            var idx = FindKeyIndex(key);
+            if (idx >= 0)
+            {
+                if (value is null)
+                {
+                    RemoveKeyAndSemicolon(idx);
+                }
+                else
+                {
+                    UpdateValue(idx, value);
+                }
+            }
+            else
+            {
+                if (value is null)
+                {
+                    return;
+                }
+                AddKey(key, value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes the specified key and its following semicolon (if present) from the connection string.
+    /// Returns true if the key was found and removed; otherwise, false.
+    /// </summary>
+    public bool Remove(string key)
+    {
+        var idx = FindKeyIndex(key);
+        if (idx >= 0 && _segments[idx].Key != null)
+        {
+            RemoveKeyAndSemicolon(idx);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to get the value associated with the specified key (case-insensitive).
+    /// </summary>
+    public bool TryGetValue(string key, out string value)
+    {
+        var idx = FindKeyIndex(key);
+        if (idx >= 0 && _segments[idx].Key != null)
+        {
+            value = _segments[idx].Value ?? string.Empty;
+            return true;
+        }
+        value = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the connection string in the original order, preserving empty segments and semicolons.
+    /// </summary>
+    public override string ToString() => ConnectionString;
+
+    IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator()
+    {
+        foreach (var seg in _segments)
+        {
+            if (seg != ConnectionStringSegment.SemiColon)
+            {
+                yield return new KeyValuePair<string, string>(seg.Key, seg.Value ?? string.Empty);
+            }
+        }
+    }
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<KeyValuePair<string, string>>)this).GetEnumerator();
+
+    private static List<ConnectionStringSegment> ParseSegments(string connectionString)
+    {
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            return [];
+        }
+
+        var segments = new List<ConnectionStringSegment>();
+
+        var parts = connectionString.Split(';');
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var part = parts[i];
+
+            if (i > 0)
+            {
+                segments.Add(ConnectionStringSegment.SemiColon);
+            }
+
+            var keyAndValue = part.Split('=', 2);
+            if (keyAndValue.Length > 1)
+            {
+                var key = keyAndValue[0].Trim();
+                var value = keyAndValue[1].Trim();
+
+                if (string.IsNullOrEmpty(key))
+                {
+                    // If the key is empty, treat this as an invalid segment
+                    throw new ArgumentException($"Invalid segment in connection string: '{part}'", nameof(connectionString));
+                }
+                else if (segments.Any(s => s.Key != null && string.Equals(s.Key, key, StringComparison.OrdinalIgnoreCase)))
+                {
+                    // If a key already exists, throw an exception
+                    throw new ArgumentException($"Duplicate key in connection string: '{key}'", nameof(connectionString));
+                }
+                else
+                {
+                    // Value can be empty
+                    segments.Add(new ConnectionStringSegment(key, value ?? string.Empty));
+                }
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(part))
+                {
+                    // A segment without an equal sign is considered invalid
+                    throw new ArgumentException($"Invalid segment in connection string: '{part}'", nameof(connectionString));
+                }
+            }
+        }
+
+        return segments;
+    }
+
+    private void UpdateConnectionString()
+    {
+        var sb = new StringBuilder();
+        foreach (var segment in _segments)
+        {
+            if (segment == ConnectionStringSegment.SemiColon)
+            {
+                sb.Append(';');
+            }
+            else
+            {
+                sb.Append(segment.Key);
+                sb.Append('=');
+                sb.Append(segment.Value ?? string.Empty);
+            }
+        }
+        _connectionString = sb.ToString();
+    }
+
+    private int FindKeyIndex(string key)
+    {
+        for (var i = 0; i < _segments.Count; i++)
+        {
+            if (_segments[i].Key != null && string.Equals(_segments[i].Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void UpdateValue(int idx, string value)
+    {
+        var seg = _segments[idx];
+        seg.Value = value;
+        UpdateConnectionString();
+    }
+
+    private void RemoveKeyAndSemicolon(int idx)
+    {
+        _segments.RemoveAt(idx);
+
+        // If there is a following semicolon , remove it as well
+        if (idx < _segments.Count)
+        {
+            if (_segments[idx] == ConnectionStringSegment.SemiColon)
+            {
+                _segments.RemoveAt(idx);
+            }
+        }
+
+        UpdateConnectionString();
+    }
+
+    private void AddKey(string key, string value)
+    {
+        if (_segments.Count > 0 && _segments[^1] != ConnectionStringSegment.SemiColon)
+        {
+            // If the last segment is not a semicolon, add one before adding the new key
+            _segments.Add(ConnectionStringSegment.SemiColon);
+        }
+
+        _segments.Add(new ConnectionStringSegment(key, value));
+
+        _segments.Add(ConnectionStringSegment.SemiColon);
+
+        UpdateConnectionString();
+    }
+
+    private sealed class ConnectionStringSegment
+    {
+        public static readonly ConnectionStringSegment SemiColon = new(null!, null!);
+
+        public string Key { get; set; }
+
+        public string Value { get; set; }
+
+        public ConnectionStringSegment(string key, string value)
+        {
+            Key = key;
+            Value = value;
+        }
+    }
+}

--- a/src/Shared/StableConnectionStringBuilder.cs
+++ b/src/Shared/StableConnectionStringBuilder.cs
@@ -3,14 +3,19 @@
 
 using System.Collections;
 using System.Text;
-using Microsoft.Identity.Client;
 
 namespace Aspire;
 
 /// <summary>
 /// Parses and manages connection strings in the form: Key1=Value1;Key2=Value2;...
-/// Preserves the exact placement of empty segments and semicolons.
+/// Preserves the exact placement of empty segments and semicolons. It also preserves
+/// spaces and case in keys and values.
 /// </summary>
+/// <remarks>
+/// This connection string builder should be used when you need to maintain the exact format of a connection string
+/// while adding or removing keys and values. When only parsing/reading connection string it is recommended to use
+/// <see cref="System.Data.Common.DbConnectionStringBuilder"/> as it handles escaping too.
+/// </remarks>
 internal sealed class StableConnectionStringBuilder : IEnumerable<KeyValuePair<string, string>>
 {
     private string _connectionString;

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AzureMessagingServiceBusSettingsTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AzureMessagingServiceBusSettingsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Azure.Common;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
@@ -18,5 +19,70 @@ public class AzureMessagingServiceBusSettingsTests
     private static void EnsureTracingIsEnabledWhenAzureSwitchIsSet(bool expectedValue)
     {
         Assert.Equal(expectedValue, new AzureMessagingServiceBusSettings().DisableTracing);
+    }
+
+    [Theory]
+    [InlineData("Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=keyvalue")]
+    public void ParseConnectionString_PreservesOriginalFormatWhenNoEntityPath(string connectionString)
+    {
+        // Regression test for issue #9448: Ensure connection string format is preserved exactly
+        // when no EntityPath is present. This tests the fix that prevents DbConnectionStringBuilder
+        // from normalizing the connection string (converting to lowercase, adding quotes, etc.)
+        var settings = new AzureMessagingServiceBusSettings();
+
+        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
+
+        Assert.Equal(connectionString, settings.ConnectionString);
+        Assert.Null(settings.QueueOrTopicName);
+        Assert.Null(settings.SubscriptionName);
+    }
+
+    [Theory]
+    [InlineData("Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=keyvalue;EntityPath=myqueue",
+                "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=keyvalue;",
+                "myqueue", null)]
+    public void ParseConnectionString_PreservesOriginalFormatWhenEntityPathPresent(string connectionString, string expectedConnectionString, string expectedQueueOrTopic, string? expectedSubscription)
+    {
+        // Regression test for issue #9448: Ensure connection string format is preserved exactly
+        // when EntityPath is present, but EntityPath is removed. This is the key fix - we extract
+        // the EntityPath value for parsing but preserve the original connection string format.
+        var settings = new AzureMessagingServiceBusSettings();
+
+        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
+
+        Assert.Equal(expectedConnectionString, settings.ConnectionString);
+        Assert.Equal(expectedQueueOrTopic, settings.QueueOrTopicName);
+        Assert.Equal(expectedSubscription, settings.SubscriptionName);
+    }
+
+    [Theory]
+    [InlineData("Endpoint=sb://test.servicebus.windows.net/;EntityPath=myqueue")]
+    [InlineData("Endpoint=sb://test.servicebus.windows.net/")]
+    public void ParseConnectionString_SetsFullyQualifiedNamespaceWhenOnlyEndpointRemains(string connectionString)
+    {
+        // Test the case where after removing EntityPath (or when no EntityPath), only Endpoint remains,
+        // so we should set FullyQualifiedNamespace instead of ConnectionString
+        var settings = new AzureMessagingServiceBusSettings();
+
+        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
+
+        Assert.Equal("test.servicebus.windows.net", settings.FullyQualifiedNamespace);
+        Assert.Null(settings.ConnectionString);
+    }
+
+    [Theory]
+    [InlineData("Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=key=;EntityPath=mytopic/Subscriptions/mysub",
+                "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=key=;",
+                "mytopic", "mysub")]
+    public void ParseConnectionString_ParsesTopicAndSubscriptionFromEntityPath(string connectionString, string expectedConnectionString, string expectedTopic, string expectedSubscription)
+    {
+        // Test parsing topic and subscription from EntityPath format: "mytopic/Subscriptions/mysub"
+        var settings = new AzureMessagingServiceBusSettings();
+
+        ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
+
+        Assert.Equal(expectedConnectionString, settings.ConnectionString);
+        Assert.Equal(expectedTopic, settings.QueueOrTopicName);
+        Assert.Equal(expectedSubscription, settings.SubscriptionName);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="$(TestsSharedDir)DistributedApplicationTestingBuilderExtensions.cs" Link="shared/DistributedApplicationTestingBuilderExtensions.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.PostgreSQL\PostgresContainerImageTags.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.Redis\RedisContainerImageTags.cs" />
+    <Compile Include="$(RepoRoot)src\Shared\StableConnectionStringBuilder.cs" Link="shared/StableConnectionStringBuilder.cs" />
 
     <Compile Include="$(RepoRoot)tests\Aspire.Hosting.Testing.Tests\DistributedApplicationHttpClientExtensionsForTests.cs" />
   </ItemGroup>

--- a/tests/Aspire.Hosting.Tests/StableConnectionStringBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/StableConnectionStringBuilderTests.cs
@@ -1,0 +1,241 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class StableConnectionStringBuilderTests
+{
+    [Fact]
+    public void Parses_ConnectionString_And_Preserves_Order()
+    {
+        var cs = "Key1=Value1;Key2=Value2;Key3=Value3";
+        var builder = new StableConnectionStringBuilder(cs);
+
+        Assert.Equal("Value1", builder["Key1"]);
+        Assert.Equal("Value2", builder["Key2"]);
+        Assert.Equal("Value3", builder["Key3"]);
+        Assert.Equal(cs, builder.ToString());
+    }
+
+    [Fact]
+    public void Parses_ConnectionString_With_Base64()
+    {
+        var cs = "Key1=ABC=;Key2=ABC==;Key3===";
+        var builder = new StableConnectionStringBuilder(cs);
+
+        Assert.Equal("ABC=", builder["Key1"]);
+        Assert.Equal("ABC==", builder["Key2"]);
+        Assert.Equal("==", builder["Key3"]);
+    }
+
+    [Fact]
+    public void Indexer_Can_Set_And_Add_Values()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2");
+        builder["B"] = "22";
+        builder["C"] = "3";
+
+        Assert.Equal("1", builder["A"]);
+        Assert.Equal("22", builder["B"]);
+        Assert.Equal("3", builder["C"]);
+        Assert.Equal("A=1;B=22;C=3;", builder.ToString());
+    }
+
+    [Fact]
+    public void TryGetValue_Is_CaseInsensitive_And_Does_Not_Change_Key_Case()
+    {
+        var builder = new StableConnectionStringBuilder("Foo=Bar");
+        Assert.True(builder.TryGetValue("foo", out var value));
+        Assert.Equal("Bar", value);
+        builder["FOO"] = "Baz";
+        Assert.Equal("Baz", builder["foo"]);
+        Assert.Equal("Foo=Baz", builder.ToString());
+    }
+
+    [Fact]
+    public void Adding_New_Key_Preserves_Order()
+    {
+        var builder = new StableConnectionStringBuilder("X=1;Y=2");
+        builder["Z"] = "3";
+        Assert.Equal("X=1;Y=2;Z=3;", builder.ToString());
+    }
+
+    [Fact]
+    public void Indexer_Returns_Empty_String_For_Empty_Value_And_Null_For_Missing_Key()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=;C=3");
+
+        // Key exists, value is empty
+        Assert.Equal(string.Empty, builder["B"]);
+
+        // Key exists, value is not empty
+        Assert.Equal("1", builder["A"]);
+        Assert.Equal("3", builder["C"]);
+
+        // Key does not exist
+        Assert.Null(builder["D"]);
+    }
+
+    [Fact]
+    public void Indexer_Removes_Key_When_Setting_Value_To_Null()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2;C=3");
+        builder["B"] = null;
+
+        // Key "B" should be removed
+        Assert.Null(builder["B"]);
+        Assert.Equal("A=1;C=3", builder.ToString());
+
+        // Setting a non-existent key to null should not throw and should not add the key
+        builder["D"] = null;
+        Assert.Null(builder["D"]);
+        Assert.Equal("A=1;C=3", builder.ToString());
+    }
+
+    [Fact]
+    public void Successive_Semicolons_Are_Preserved_When_Serializing()
+    {
+        var original = "A=1;;B=2;;;C=3;";
+        var builder = new StableConnectionStringBuilder(original);
+
+        // The ToString() result should preserve the original placement of successive semicolons
+        Assert.Equal(original, builder.ToString());
+    }
+
+    [Theory]
+    [InlineData("Key1=Value1;Key2=Value2")]
+    [InlineData("Key1=Value1;Key2=Value2;")]
+    [InlineData("Key1=Value1;Key2=Value2;;")]
+    [InlineData("Key1=Value1;Key2=Value2;;;")]
+    public void ToString_PreservesMultipleTrailingSemicolons(string connectionString)
+    {
+        var builder = new StableConnectionStringBuilder(connectionString);
+        Assert.Equal(connectionString, builder.ToString());
+    }
+
+    [Fact]
+    public void Removing_Key_Removes_Trailing_Semicolon()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2;");
+        builder["B"] = null;
+        Assert.Equal("A=1;", builder.ToString());
+    }
+
+    [Fact]
+    public void Removing_Last_Key_Removes_Only_One_Trailing_Semicolon()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2;");
+        builder["B"] = null;
+        Assert.Equal("A=1;", builder.ToString());
+    }
+
+    [Fact]
+    public void Removing_Middle_Key_Removes_Only_Its_Semicolon()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2;;C=3;");
+        builder["B"] = null;
+        Assert.Equal("A=1;;C=3;", builder.ToString());
+    }
+
+    [Theory]
+    [InlineData("A=1;B=2;A=3")]
+    [InlineData("A=1;B=2;a=3")]
+    [InlineData("A=1;A=2;A=3")]
+    [InlineData("A=1;A=2;B=3")]
+    [InlineData("A=1;A=2;B=3;b=3;")]
+    public void Throws_On_Duplicate_Keys(string connectionString)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+        {
+            var builder = new StableConnectionStringBuilder(connectionString);
+        });
+        Assert.Contains("Duplicate key", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("A=1;B;C=2")]
+    [InlineData("B;A=1;C=2")]
+    [InlineData("A=1;C=2;B")]
+    public void Throws_On_Invalid_Segment(string connectionString)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+        {
+            var builder = new StableConnectionStringBuilder(connectionString);
+        });
+        Assert.Contains("Invalid segment", ex.Message);
+    }
+
+    [Fact]
+    public void Remove_Removes_Key_And_Semicolon()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2;C=3;");
+        var result = builder.Remove("B");
+        Assert.True(result);
+        Assert.Equal("A=1;C=3;", builder.ToString());
+        Assert.Null(builder["B"]);
+    }
+
+    [Fact]
+    public void Remove_Returns_False_If_Key_Not_Found()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2;C=3;");
+        var result = builder.Remove("X");
+        Assert.False(result);
+        Assert.Equal("A=1;B=2;C=3;", builder.ToString());
+    }
+
+    [Fact]
+    public void Remove_Removes_Only_One_Semicolon()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2;;C=3;");
+        builder.Remove("B");
+        Assert.Equal("A=1;;C=3;", builder.ToString());
+    }
+
+    [Fact]
+    public void Remove_Last_Key_Removes_Only_One_Trailing_Semicolon()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2;");
+        builder.Remove("B");
+        Assert.Equal("A=1;", builder.ToString());
+    }
+
+    [Fact]
+    public void IEnumerable_Enumerates_KeyValuePairs_In_Order()
+    {
+        var builder = new StableConnectionStringBuilder("A=1;B=2;C=3;");
+        var expected = new[]
+        {
+            new KeyValuePair<string, string>("A", "1"),
+            new KeyValuePair<string, string>("B", "2"),
+            new KeyValuePair<string, string>("C", "3"),
+        };
+
+        var actual = builder.ToList();
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TryParse_Returns_True_For_Valid_ConnectionString()
+    {
+        var valid = "A=1;B=2;C=3";
+        var result = StableConnectionStringBuilder.TryParse(valid, out var builder);
+        Assert.True(result);
+        Assert.NotNull(builder);
+        Assert.Equal("1", builder!["A"]);
+        Assert.Equal("2", builder!["B"]);
+        Assert.Equal("3", builder!["C"]);
+    }
+
+    [Fact]
+    public void TryParse_Returns_False_For_Invalid_ConnectionString()
+    {
+        var invalid = "A=1;B;C=3";
+        var result = StableConnectionStringBuilder.TryParse(invalid, out var builder);
+        Assert.False(result);
+        Assert.Null(builder);
+    }
+}


### PR DESCRIPTION
## Description

Preserves existing connection string format when altering them.

Fixes #9448

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
