### PR TITLE
Add connection string to resource details

### DIFF
--- a/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
+++ b/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
@@ -26,7 +26,8 @@ public sealed class KnownPropertyLookup : IKnownPropertyLookup
             new(KnownProperties.Resource.StartTime, loc => loc[nameof(ResourcesDetailsStartTimeProperty)]),
             new(KnownProperties.Resource.StopTime, loc => loc[nameof(ResourcesDetailsStopTimeProperty)]),
             new(KnownProperties.Resource.ExitCode, loc => loc[nameof(ResourcesDetailsExitCodeProperty)]),
-            new(KnownProperties.Resource.HealthState, loc => loc[nameof(ResourcesDetailsHealthStateProperty)])
+            new(KnownProperties.Resource.HealthState, loc => loc[nameof(ResourcesDetailsHealthStateProperty)]),
+            new(KnownProperties.Resource.ConnectionString, loc => loc[nameof(ResourcesDetailsConnectionStringProperty)])
         ];
 
         _projectProperties =

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -281,6 +281,9 @@ public sealed class DisplayedResourcePropertyViewModel : IPropertyGridItem
     string? IPropertyGridItem.Value => _displayValue.Value;
     object IPropertyGridItem.Key => _key;
 
+    bool IPropertyGridItem.IsValueSensitive => _propertyViewModel.IsValueSensitive;
+    bool IPropertyGridItem.IsValueMasked { get => _propertyViewModel.IsValueMasked; set => _propertyViewModel.IsValueMasked = value; }
+
     public DisplayedResourcePropertyViewModel(ResourcePropertyViewModel propertyViewModel, IStringLocalizer<Resources.Resources> loc, BrowserTimeProvider browserTimeProvider)
     {
         _propertyViewModel = propertyViewModel;

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -145,7 +145,8 @@ partial class Resource
                 value: ValidateNotNull(property.Value),
                 isValueSensitive: property.IsSensitive,
                 knownProperty: knownProperty,
-                priority: priority);
+                priority: priority)
+            { IsValueMasked = property.IsSensitive };
 
             if (builder.ContainsKey(propertyViewModel.Name))
             {

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -86,7 +86,6 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceActionStructuredLogsText", resourceCulture);
             }
         }
-
         
         /// <summary>
         ///   Looks up a localized string similar to Traces.
@@ -141,8 +140,6 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourceCommandToastViewLogs", resourceCulture);
             }
         }
-
-
         
         /// <summary>
         ///   Looks up a localized string similar to View console logs.
@@ -186,6 +183,15 @@ namespace Aspire.Dashboard.Resources {
         public static string ResourcesChangeViewOptions {
             get {
                 return ResourceManager.GetString("ResourcesChangeViewOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Connection string.
+        /// </summary>
+        public static string ResourcesDetailsConnectionStringProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsConnectionStringProperty", resourceCulture);
             }
         }
         
@@ -341,8 +347,6 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesDetailsStopTimeProperty", resourceCulture);
             }
         }
-
-
         
         /// <summary>
         ///   Looks up a localized string similar to Has filters.
@@ -397,7 +401,6 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ResourcesHideTypes", resourceCulture);
             }
         }
-
         
         /// <summary>
         ///   Looks up a localized string similar to No resources found.

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -225,6 +225,9 @@
   <data name="ResourcesDetailsHealthStateProperty" xml:space="preserve">
     <value>Health state</value>
   </data>
+  <data name="ResourcesDetailsConnectionStringProperty" xml:space="preserve">
+    <value>Connection string</value>
+  </data>
   <data name="ResourcesDetailsStopTimeProperty" xml:space="preserve">
     <value>Stop time</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Zobrazit možnosti</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argumenty kontejneru</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Optionen anzeigen</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Containerargumente</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Ver opciones</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argumentos de contenedor</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Afficher les options</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Arguments de conteneur</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Opzioni di visualizzazione</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argomenti contenitore</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -72,6 +72,11 @@
         <target state="translated">表示オプション</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">コンテナー引数</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -72,6 +72,11 @@
         <target state="translated">보기 옵션</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">컨테이너 인수</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Wyświetl opcje</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argumenty kontenera</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Exibir opções</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Argumentos de contêiner</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Просмотреть параметры</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Аргументы контейнера</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Seçenekleri görüntüle</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">Kapsayıcı bağımsız değişkenleri</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -72,6 +72,11 @@
         <target state="translated">查看选项</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">容器参数</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -72,6 +72,11 @@
         <target state="translated">檢視選項</target>
         <note>An icon allowing the user to expand or collapse all child resources.</note>
       </trans-unit>
+      <trans-unit id="ResourcesDetailsConnectionStringProperty">
+        <source>Connection string</source>
+        <target state="new">Connection string</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerArgumentsProperty">
         <source>Container arguments</source>
         <target state="translated">容器引數</target>

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceKnownProperties.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceKnownProperties.cs
@@ -14,4 +14,9 @@ public static class CustomResourceKnownProperties
     /// The source of the resource
     /// </summary>
     public static string Source { get; } = KnownProperties.Resource.Source;
+
+    /// <summary>
+    /// The connection string of the resource
+    /// </summary>
+    public static string ConnectionString { get; } = KnownProperties.Resource.ConnectionString;
 }

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -384,6 +384,51 @@ public class ApplicationOrchestratorTests
         Assert.True(grandChildConnectionStringAvailable);
     }
 
+    [Fact]
+    public async Task ConnectionStringAvailableEventPublishesUpdateWithConnectionStringValue()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var resource = builder.AddResource(new TestResourceWithConnectionString("test-resource", "Server=localhost:5432;Database=testdb"));
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+        var applicationEventing = new DistributedApplicationEventing();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: applicationEventing);
+        await appOrchestrator.RunApplicationAsync();
+
+        string? connectionStringProperty = null;
+        bool? isSensitive = null;
+        var watchResourceTask = Task.Run(async () =>
+        {
+            await foreach (var item in resourceNotificationService.WatchAsync())
+            {
+                if (item.Resource == resource.Resource)
+                {
+                    var connectionStringProp = item.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.ConnectionString);
+                    if (connectionStringProp is not null)
+                    {
+                        connectionStringProperty = connectionStringProp.Value?.ToString();
+                        isSensitive = connectionStringProp.IsSensitive;
+                        return;
+                    }
+                }
+            }
+        });
+
+        // Publish the ConnectionStringAvailableEvent to trigger the update
+        await applicationEventing.PublishAsync(new ConnectionStringAvailableEvent(resource.Resource, app.Services), CancellationToken.None);
+
+        await watchResourceTask.DefaultTimeout();
+
+        Assert.Equal("Server=localhost:5432;Database=testdb", connectionStringProperty);
+        Assert.True(isSensitive);
+    }
+
     private static ApplicationOrchestrator CreateOrchestrator(
         DistributedApplicationModel distributedAppModel,
         ResourceNotificationService notificationService,
@@ -466,5 +511,16 @@ public class ApplicationOrchestratorTests
             ReferenceExpression.Create($"{parent};{SubConnectionString}");
 
         public IResource Parent { get; } = parent;
+    }
+
+    private sealed class TestResourceWithConnectionString(string name, string connectionString)
+        : Resource(name), IResourceWithConnectionString
+    {
+        public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{connectionString}");
+
+        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult<string?>(connectionString);
+        }
     }
 }


### PR DESCRIPTION
## Description

Saw a bunch of people complaining on YouTube about not being able to get the connection string of a resource. This is fixing it. If a resource implements `IResourceWithConnectionString` and publishes the `ConnectionStringAvailable` event, then it is added to the details pane as masked.

Fixes #4974

https://github.com/user-attachments/assets/55608612-52c1-47fd-b848-9cd533a84e11

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
