### PR TITLE
Fix Kubernetes publisher Kubernetes and Helm resource names

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/Extensions/HelmExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/Extensions/HelmExtensions.cs
@@ -16,38 +16,55 @@ internal static class HelmExtensions
     public const string ConfigKey = "config";
     public const string TemplateFileSeparator = "---";
 
-    public static string ToManifestFriendlyResourceName(this string name)
-        => name.Replace("-", "_");
+    /// <summary>
+    /// Converts the specified resource name into a Helm configuration section name.
+    /// </summary>
+    /// <remarks>
+    /// The section names in Helm values files can not contain hyphens ('-').
+    /// <see href="link">https://helm.sh/docs/chart_best_practices/values/</see>
+    /// </remarks>
+    public static string ToHelmValuesSectionName(this string resourceName)
+        => $"{resourceName.Replace("-", "_")}";
 
     public static string ToHelmParameterExpression(this string parameterName, string resourceName)
-        => $"{{{{ {ValuesSegment}.{ParametersKey}.{resourceName}.{parameterName} }}}}";
+        => $"{{{{ {ValuesSegment}.{ParametersKey}.{resourceName.ToHelmValuesSectionName()}.{parameterName} }}}}";
 
     public static string ToHelmSecretExpression(this string parameterName, string resourceName)
-        => $"{{{{ {ValuesSegment}.{SecretsKey}.{resourceName}.{parameterName} }}}}";
+        => $"{{{{ {ValuesSegment}.{SecretsKey}.{resourceName.ToHelmValuesSectionName()}.{parameterName} }}}}";
 
     public static string ToHelmConfigExpression(this string parameterName, string resourceName)
-        => $"{{{{ {ValuesSegment}.{ConfigKey}.{resourceName}.{parameterName} }}}}";
+        => $"{{{{ {ValuesSegment}.{ConfigKey}.{resourceName.ToHelmValuesSectionName()}.{parameterName} }}}}";
+
+    /// <summary>
+    /// Converts the specified resource name into a Kubernetes resource name.
+    /// </summary>
+    /// <remarks>
+    /// Kubernetes resource object names can only contain lowercase alphanumeric characters, '-', and '.'.
+    /// <see href="link">https://kubernetes.io/docs/concepts/overview/working-with-objects/names/</see>
+    /// </remarks>
+    public static string ToKubernetesResourceName(this string resourceName)
+        => $"{resourceName.ToLowerInvariant()}";
 
     public static string ToConfigMapName(this string resourceName)
-        => $"{resourceName}-{ConfigKey}";
+        => $"{resourceName.ToKubernetesResourceName()}-{ConfigKey}";
 
     public static string ToSecretName(this string resourceName)
-        => $"{resourceName}-{SecretsKey}";
+        => $"{resourceName.ToKubernetesResourceName()}-{SecretsKey}";
 
     public static string ToDeploymentName(this string resourceName)
-        => $"{resourceName}-{DeploymentKey}";
+        => $"{resourceName.ToKubernetesResourceName()}-{DeploymentKey}";
 
     public static string ToStatefulSetName(this string resourceName)
-        => $"{resourceName}-{StatefulSetKey}";
+        => $"{resourceName.ToKubernetesResourceName()}-{StatefulSetKey}";
 
     public static string ToServiceName(this string resourceName)
-        => $"{resourceName}-{ServiceKey}";
+        => $"{resourceName.ToKubernetesResourceName()}-{ServiceKey}";
 
     public static string ToPvcName(this string resourceName, string volumeName)
-        => $"{resourceName}-{volumeName}-{PvcKey}";
+        => $"{resourceName.ToKubernetesResourceName()}-{volumeName}-{PvcKey}";
 
     public static string ToPvName(this string resourceName, string volumeName)
-        => $"{resourceName}-{volumeName}-{PvKey}";
+        => $"{resourceName.ToKubernetesResourceName()}-{volumeName}-{PvKey}";
 
     public static bool ContainsHelmExpression(this string value)
         => value.Contains($"{{{{ {ValuesSegment}.", StringComparison.Ordinal);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPublishingContext.cs
@@ -119,7 +119,7 @@ internal sealed class KubernetesPublishingContext(
 
         if (paramValues.Count > 0)
         {
-            helmSection[resource.Name] = paramValues;
+            helmSection[resource.Name.ToHelmValuesSectionName()] = paramValues;
         }
     }
 
@@ -148,7 +148,7 @@ internal sealed class KubernetesPublishingContext(
         }
 
         var resourceName = templatedItem.Metadata.Name;
-        if (resourceName.StartsWith($"{baseName}-"))
+        if (resourceName.StartsWith($"{baseName.ToLowerInvariant()}-"))
         {
             resourceName = resourceName.Substring(baseName.Length + 1); // +1 for the hyphen
         }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -131,7 +131,7 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
             }
         }
 
-        var imageEnvName = $"{resourceInstance.Name.ToManifestFriendlyResourceName()}_image";
+        var imageEnvName = $"{resourceInstance.Name.ToHelmValuesSectionName()}_image";
         var value = $"{resourceInstance.Name}:latest";
         var expression = imageEnvName.ToHelmParameterExpression(resource.Name);
 
@@ -175,7 +175,7 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
     {
         const string defaultPort = "8080";
 
-        var paramName = $"port_{endpoint.Name}".ToManifestFriendlyResourceName();
+        var paramName = $"port_{endpoint.Name}".ToHelmValuesSectionName();
 
         var helmExpression = paramName.ToHelmParameterExpression(resource.Name);
         Parameters[paramName] = new(helmExpression, defaultPort);
@@ -254,7 +254,7 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
 
             foreach (var environmentVariable in context.EnvironmentVariables)
             {
-                var key = environmentVariable.Key.ToManifestFriendlyResourceName();
+                var key = environmentVariable.Key.ToHelmValuesSectionName();
                 var value = await this.ProcessValueAsync(environmentContext, executionContext, environmentVariable.Value).ConfigureAwait(false);
 
                 switch (value)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesServiceResourceExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesServiceResourceExtensions.cs
@@ -116,7 +116,7 @@ internal static class KubernetesServiceResourceExtensions
 
     private static HelmExpressionWithValue AllocateParameter(ParameterResource parameter, IResource resource)
     {
-        var formattedName = parameter.Name.ToManifestFriendlyResourceName();
+        var formattedName = parameter.Name.ToHelmValuesSectionName();
 
         var expression = parameter.Secret ?
             formattedName.ToHelmSecretExpression(resource.Name) :
@@ -131,7 +131,7 @@ internal static class KubernetesServiceResourceExtensions
         var formattedName = parameter.ValueExpression.Replace("{", "")
             .Replace("}", "")
             .Replace(".", "_")
-            .ToManifestFriendlyResourceName();
+            .ToHelmValuesSectionName();
 
         var helmExpression = parameter.ValueExpression.ContainsHelmSecretExpression() ?
             formattedName.ToHelmSecretExpression(resource.Name) :

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#00.verified.yaml
@@ -1,0 +1,11 @@
+apiVersion: "v2"
+name: "aspire"
+version: "0.1.0"
+kubeVersion: ">= 1.18.0-0"
+description: "Aspire Helm Chart"
+type: "application"
+keywords:
+  - "aspire"
+  - "kubernetes"
+appVersion: "0.1.0"
+deprecated: false

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#01.verified.yaml
@@ -1,0 +1,11 @@
+parameters:
+  SpeciaL_ApP:
+    SpeciaL_ApP_image: "SpeciaL-ApP:latest"
+secrets:
+  SpeciaL_ApP:
+    param3: ""
+config:
+  SpeciaL_ApP:
+    OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "true"
+    OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
+    OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "in_memory"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#02.verified.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "special-app-deployment"
+spec:
+  template:
+    metadata:
+      labels:
+        app: "aspire"
+        component: "SpeciaL-ApP"
+    spec:
+      containers:
+        - image: "{{ .Values.parameters.SpeciaL_ApP.SpeciaL_ApP_image }}"
+          name: "SpeciaL-ApP"
+          envFrom:
+            - configMapRef:
+                name: "special-app-config"
+            - secretRef:
+                name: "special-app-secrets"
+          imagePullPolicy: "IfNotPresent"
+  selector:
+    matchLabels:
+      app: "aspire"
+      component: "SpeciaL-ApP"
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: "RollingUpdate"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#03.verified.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "special-app-config"
+  labels:
+    app: "aspire"
+    component: "SpeciaL-ApP"
+data:
+  OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "{{ .Values.config.SpeciaL_ApP.OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES }}"
+  OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "{{ .Values.config.SpeciaL_ApP.OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES }}"
+  OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "{{ .Values.config.SpeciaL_ApP.OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY }}"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#04.verified.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: "v1"
+kind: "Secret"
+metadata:
+  name: "special-app-secrets"
+  labels:
+    app: "aspire"
+    component: "SpeciaL-ApP"
+stringData:
+  param3: "{{ .Values.secrets.SpeciaL_ApP.param3 }}"
+type: "Opaque"


### PR DESCRIPTION
## Description

This pull request ensures the Aspire resource name is appropriately formatted to generate valid Kubernetes object and Helm values section names.

Fixes #9897
Also partially fixes #9382

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
