### PR TITLE
Add linux-musl-amd64 (Alpine linux) specific build support

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,6 +17,10 @@
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
       <Sha>d3e431f5c6926c4c60175d4e8a3b891f7dd06b00</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.15.8">
+      <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
+      <Sha>d3e431f5c6926c4c60175d4e8a3b891f7dd06b00</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.15.8">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
       <Sha>d3e431f5c6926c4c60175d4e8a3b891f7dd06b00</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,6 +29,7 @@
     <MicrosoftDeveloperControlPlanedarwinarm64Version>0.15.8</MicrosoftDeveloperControlPlanedarwinarm64Version>
     <MicrosoftDeveloperControlPlanelinuxamd64Version>0.15.8</MicrosoftDeveloperControlPlanelinuxamd64Version>
     <MicrosoftDeveloperControlPlanelinuxarm64Version>0.15.8</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.15.8</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
     <MicrosoftDeveloperControlPlanewindows386Version>0.15.8</MicrosoftDeveloperControlPlanewindows386Version>
     <MicrosoftDeveloperControlPlanewindowsamd64Version>0.15.8</MicrosoftDeveloperControlPlanewindowsamd64Version>
     <MicrosoftDeveloperControlPlanewindowsarm64Version>0.15.8</MicrosoftDeveloperControlPlanewindowsarm64Version>

--- a/eng/dashboardpack/Aspire.Dashboard.Sdk.linux-musl-x64.csproj
+++ b/eng/dashboardpack/Aspire.Dashboard.Sdk.linux-musl-x64.csproj
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <DashboardRuntime>linux-x64</DashboardRuntime>
+    <DashboardPlatformType>Unix</DashboardPlatformType>
+  </PropertyGroup>
+
+  <Import Project="Common.projitems" />
+
+</Project>

--- a/eng/dashboardpack/Aspire.Dashboard.Sdk.linux-musl-x64.csproj
+++ b/eng/dashboardpack/Aspire.Dashboard.Sdk.linux-musl-x64.csproj
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <DashboardRuntime>linux-x64</DashboardRuntime>
+    <DashboardRuntime>linux-musl-x64</DashboardRuntime>
     <DashboardPlatformType>Unix</DashboardPlatformType>
   </PropertyGroup>
 

--- a/eng/dcppack/Aspire.Hosting.Orchestration.linux-musl-x64.csproj
+++ b/eng/dcppack/Aspire.Hosting.Orchestration.linux-musl-x64.csproj
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <DcpRuntime>linux-musl-x64</DcpRuntime>
+    <DcpPlatformType>Unix</DcpPlatformType>
+  </PropertyGroup>
+
+  <Import Project="Common.projitems" />
+
+</Project>

--- a/eng/dcppack/Common.projitems
+++ b/eng/dcppack/Common.projitems
@@ -40,6 +40,7 @@
     <PackageDownload Include="Microsoft.DeveloperControlPlane.darwin-arm64" Version="[$(MicrosoftDeveloperControlPlanedarwinarm64Version)]" />
     <PackageDownload Include="Microsoft.DeveloperControlPlane.linux-amd64" Version="[$(MicrosoftDeveloperControlPlanelinuxamd64Version)]" />
     <PackageDownload Include="Microsoft.DeveloperControlPlane.linux-arm64" Version="[$(MicrosoftDeveloperControlPlanelinuxarm64Version)]" />
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="[$(MicrosoftDeveloperControlPlanelinuxmuslamd64Version)]" />
     <PackageDownload Include="Microsoft.DeveloperControlPlane.windows-386" Version="[$(MicrosoftDeveloperControlPlanewindows386Version)]" />
     <PackageDownload Include="Microsoft.DeveloperControlPlane.windows-amd64" Version="[$(MicrosoftDeveloperControlPlanewindowsamd64Version)]" />
     <PackageDownload Include="Microsoft.DeveloperControlPlane.windows-arm64" Version="[$(MicrosoftDeveloperControlPlanewindowsarm64Version)]" />

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -23,7 +23,7 @@
   This defaulting needs to happen in the SDK targets so this metadata affects NuGet Restore.
   -->
   <ItemGroup Condition="'$(IsAspireHost)' == 'true'">
-    
+
     <ProjectReference Update="@(ProjectReference)">
       <IsAspireProjectResource Condition="'%(IsAspireProjectResource)' != 'false'">true</IsAspireProjectResource>
 
@@ -66,7 +66,7 @@
       <_AppHostVersion>%(_AppHostPackageReference.Version)</_AppHostVersion>
     </PropertyGroup>
 
-    <!-- If the version is still empty, then we assume the project is using Central Package Management, 
+    <!-- If the version is still empty, then we assume the project is using Central Package Management,
          and we try to extract the PackageVersion Items. -->
     <ItemGroup Condition="'$(_AppHostVersion)' == ''">
       <_AppHostPackageReference />
@@ -91,7 +91,7 @@
     </PropertyGroup>
 
     <!-- At this point, we should have the version either by CPM or PackageReference, so we fail if not. -->
-    <Error Condition="'$(_AppHostVersion)' == ''" 
+    <Error Condition="'$(_AppHostVersion)' == ''"
        Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that needs a package reference to Aspire.Hosting.AppHost version 8.2.0 or above to work correctly." />
 
     <!--The following is the list of the RIDs that we currently multitarget for DCP and Dashboard packages-->
@@ -101,6 +101,7 @@
       <_DashboardAndDCPSupportedTargetingRIDs Include="win-arm64" />
       <_DashboardAndDCPSupportedTargetingRIDs Include="linux-x64" />
       <_DashboardAndDCPSupportedTargetingRIDs Include="linux-arm64" />
+      <_DashboardAndDCPSupportedTargetingRIDs Include="linux-musl-x64" />
       <_DashboardAndDCPSupportedTargetingRIDs Include="osx-x64" />
       <_DashboardAndDCPSupportedTargetingRIDs Include="osx-arm64" />
     </ItemGroup>
@@ -136,7 +137,7 @@
       <_DashboardAndDcpRID>@(_AspireRidToolOutput)</_DashboardAndDcpRID>
     </PropertyGroup>
 
-    
+
     <!-- Now that we have the version, we add the package references -->
     <ItemGroup>
       <PackageReference Include="Aspire.Dashboard.Sdk.$(_DashboardAndDcpRID)" Version="$(_AppHostVersion)" IsImplicitlyDefined="true" />

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- This list of runtimes needs to match the set of runtimes specified in eng/workloads/workloads.csproj -->
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <!-- Enable System.GC.DynamicAdaptationMode to get a GC that dynamically adapts to the application's memory use. -->
     <GarbageCollectionAdaptationMode>1</GarbageCollectionAdaptationMode>


### PR DESCRIPTION
## Description

Update builds to support linux-musl-x64 (Alpine linux) runtime.

Fixes #9709 
