### PR TITLE
Fix dashboard URL display in Aspire CLI after localization changes.

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -110,7 +110,7 @@ internal class ConsoleInteractionService : IInteractionService
         if (dashboardUrls.CodespacesUrlWithLoginToken is not null)
         {
             _ansiConsole.MarkupLine(
-                $":chart_increasing:  {InteractionServiceStrings.DirectLink}: $[link={{dashboardUrls.BaseUrlWithLoginToken}}]{{dashboardUrls.BaseUrlWithLoginToken}}[/]");
+                $":chart_increasing:  {InteractionServiceStrings.DirectLink}: $[link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
             _ansiConsole.MarkupLine(
                 $":chart_increasing:  {InteractionServiceStrings.CodespacesLink}: [link={dashboardUrls.CodespacesUrlWithLoginToken}]{dashboardUrls.CodespacesUrlWithLoginToken}[/]");
         }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -110,7 +110,7 @@ internal class ConsoleInteractionService : IInteractionService
         if (dashboardUrls.CodespacesUrlWithLoginToken is not null)
         {
             _ansiConsole.MarkupLine(
-                $":chart_increasing:  {InteractionServiceStrings.DirectLink}: $[link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
+                $":chart_increasing:  {InteractionServiceStrings.DirectLink}: [link={dashboardUrls.BaseUrlWithLoginToken}]{dashboardUrls.BaseUrlWithLoginToken}[/]");
             _ansiConsole.MarkupLine(
                 $":chart_increasing:  {InteractionServiceStrings.CodespacesLink}: [link={dashboardUrls.CodespacesUrlWithLoginToken}]{dashboardUrls.CodespacesUrlWithLoginToken}[/]");
         }


### PR DESCRIPTION
Quick fix to an issue where the dashboard URL wasn't rendering correctly (string interpolation issue).