### PR TITLE
Fix console logs clear not going back to a blank state

### DIFF
--- a/src/Shared/ConsoleLogs/LogEntries.cs
+++ b/src/Shared/ConsoleLogs/LogEntries.cs
@@ -54,6 +54,7 @@ internal sealed class LogEntries(int maximumEntryCount)
         }
 
         BaseLineNumber = null;
+        _earliestTimestampIndex = null;
     }
 
     public bool ProcessPauseFilters(LogEntry logEntry)

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
@@ -32,15 +32,18 @@ public class LogEntriesTests
         // Act
         var logParser = new LogParser(ConsoleColor.Black);
 
+        // Insert log with no timestamp.
         var logEntry1 = logParser.CreateLogEntry("Test", isErrorOutput: false);
         logEntries.InsertSorted(logEntry1);
 
+        // Insert log with timestamp that ensures collections timestamp value is not zero.
         var logEntry2 = logParser.CreateLogEntry("2024-08-19T06:12:01.000Z Test", isErrorOutput: false);
         logEntries.InsertSorted(logEntry2);
 
         logEntries.Clear(keepActivePauseEntries: true);
         logEntries.BaseLineNumber = 0;
 
+        // Insert another log entry after clearing.
         var logEntry3 = logParser.CreateLogEntry("2024-08-19T06:12:02.000Z Test", isErrorOutput: false);
         logEntries.InsertSorted(logEntry3);
 

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
@@ -48,7 +48,7 @@ public class LogEntriesTests
         logEntries.InsertSorted(logEntry3);
 
         // Assert
-        Assert.Empty(logEntries.GetEntries());
+        Assert.Single(logEntries.GetEntries());
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
@@ -24,6 +24,31 @@ public class LogEntriesTests
     }
 
     [Fact]
+    public void Clear_AfterEarliestTimestampIndex_Success()
+    {
+        // Arrange
+        var logEntries = CreateLogEntries();
+
+        // Act
+        var logParser = new LogParser(ConsoleColor.Black);
+
+        var logEntry1 = logParser.CreateLogEntry("Test", isErrorOutput: false);
+        logEntries.InsertSorted(logEntry1);
+
+        var logEntry2 = logParser.CreateLogEntry("2024-08-19T06:12:01.000Z Test", isErrorOutput: false);
+        logEntries.InsertSorted(logEntry2);
+
+        logEntries.Clear(keepActivePauseEntries: true);
+        logEntries.BaseLineNumber = 0;
+
+        var logEntry3 = logParser.CreateLogEntry("2024-08-19T06:12:02.000Z Test", isErrorOutput: false);
+        logEntries.InsertSorted(logEntry3);
+
+        // Assert
+        Assert.Empty(logEntries.GetEntries());
+    }
+
+    [Fact]
     public void Add_PauseAndThenRemove_ActivePauseKept()
     {
         // Arrange


### PR DESCRIPTION
## Description

Fix this error:

```
System.InvalidOperationException: Cannot access index 0. Buffer size is 0
at Aspire.Hosting.ConsoleLogs.LogEntries.<InsertSortedCore>g__InsertAt|15_0(Int32 index, <>c__DisplayClass15_0&) in /_/src/Shared/ConsoleLogs/LogEntries.cs:line 190
   at Aspire.Hosting.ConsoleLogs.LogEntries.InsertSortedCore(LogEntry logEntry) in /_/src/Shared/ConsoleLogs/LogEntries.cs:line 162
   at Aspire.Dashboard.Components.Pages.ConsoleLogs.<>c__DisplayClass124_0.<<LoadLogs>b__0>d.MoveNext() in /_/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs:line 536
--- End of stack trace from previous location ---
   at Aspire.Dashboard.Components.Pages.ConsoleLogs.<>c__DisplayClass124_0.<<LoadLogs>b__0>d.MoveNext() in /_/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs:line 508
--- End of stack trace from previous location ---
   at Aspire.Dashboard.Components.Pages.ConsoleLogs.<>c__DisplayClass124_0.<<LoadLogs>b__0>d.MoveNext() in /_/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs:line 552
--- End of stack trace from previous location ---
   at Aspire.Dashboard.Utils....
```

If a user have the right sequence of log values, then clears the logs, then gets a new log value, they can get this error.

Contributes to https://github.com/dotnet/aspire/issues/9537

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
