### PR TITLE
Add k8s tooling.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,12 @@
 			]
 		},
 		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/devcontainers/features/python:1": {}
+		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "latest"
+		}
 	},
 
 	"hostRequirements": {
@@ -39,7 +44,8 @@
 				"ms-dotnettools.csdevkit",
 				"ms-azuretools.vscode-bicep",
 				"ms-azuretools.azure-dev",
-				"GitHub.copilot"
+				"GitHub.copilot",
+				"ms-kubernetes-tools.vscode-kubernetes-tools"
 			],
 			"settings": {
 				"remote.autoForwardPorts": true,


### PR DESCRIPTION
This PR adds Kubernetes tooling to our repo which will make dogfooding kubernetes scenarios in devcontainers/codespaces easier:

<img width="860" alt="image" src="https://github.com/user-attachments/assets/7862e1ad-f28b-43e8-9c0d-7e9ee8dfcd6a" />

If you want to spin up a Kubernetes cluster in your devcontainer now you can just do `minikube start`. Works in Codespaces too.