### PR TITLE
Emit Int32OrStringV1 as int from Kubernetes publisher.

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/Yaml/IntOrStringConverter.cs
+++ b/src/Aspire.Hosting.Kubernetes/Yaml/IntOrStringConverter.cs
@@ -60,8 +60,14 @@ public class IntOrStringYamlConverter : IYamlTypeConverter
             throw new InvalidOperationException($"Expected {nameof(Int32OrStringV1)} but got {value?.GetType()}");
         }
 
-        var val = obj.Value ?? string.Empty;
-
-        serializer(val);
+        if (obj.Number != null)
+        {
+            serializer(obj.Number);
+        }
+        else
+        {
+            var val = obj.Value ?? string.Empty;
+            serializer(val);
+        }
     }
 }

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#02.verified.yaml
@@ -23,7 +23,7 @@ spec:
           ports:
             - name: "http"
               protocol: "TCP"
-              containerPort: "8080"
+              containerPort: 8080
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#03.verified.yaml
@@ -11,5 +11,5 @@ spec:
   ports:
     - name: "http"
       protocol: "TCP"
-      port: "8080"
-      targetPort: "8080"
+      port: 8080
+      targetPort: 8080

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#04.verified.yaml
@@ -24,7 +24,7 @@ spec:
           ports:
             - name: "http"
               protocol: "TCP"
-              containerPort: "8080"
+              containerPort: 8080
           volumeMounts:
             - name: "logs"
               mountPath: "/logs"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#05.verified.yaml
@@ -11,5 +11,5 @@ spec:
   ports:
     - name: "http"
       protocol: "TCP"
-      port: "8080"
-      targetPort: "8080"
+      port: 8080
+      targetPort: 8080


### PR DESCRIPTION
## Description

The Int32OrStringV1 type is used in the ServicePortV1:port and :TargetPort as well as ContainerPortV1:ContainerPort and :HostPort. Each of these needs to be serialized as int, so that helm is able to parse the values. If these values are quoted, helm will generate the following error message, also mentioned in issue #9382. 

"json: cannot unmarshal string into Go struct field ServicePort.spec.ports.port of type int32"

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#containerport-v1-core
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#serviceport-v1-core

## Discussion

This pull request fixes all cases where the port numbers are non-variables. However, when using WithHttpEndpoint() on a project resource, Aspire will generate a variable like "{{ .Values.parameters.myapp.port_http }}", which will be serialized as quoted string. Helm will not accept this. The variable should be serialized unquoted instead, but I have not found an elegant way of doing this.

Changing the IntOrStringConvert:WriteYaml() to use the emitter instead of the serializer works great, but unfortunately the ForceQuotedStringsEventEmitter will lose its position and start doublequoting scalar keys instead of the scalar values. The issue is described here.

https://github.com/aaubry/YamlDotNet/issues/473

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
