### PR TITLE
Fix glob pattern so it includes tests/Directory.Packages.props in update-dependencies workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Revert all changes except Directory.Packages.props files
         run: |
+          git add "**Directory.Packages.props"
           git add "**/Directory.Packages.props"
           rm nuget.config
           git checkout -- .

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Revert all changes except Directory.Packages.props files
         run: |
-          git add **Directory.Packages.props
+          git add "**/Directory.Packages.props"
           rm nuget.config
           git checkout -- .
 


### PR DESCRIPTION
The glob pattern in the weekly update-dependencies workflow is not currently including the updates to packages in tests/Directory.Packages.props. This small change fixes that so that those would be part of the PR as well.


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
