### PR TITLE
Refactor settings file path handling

### DIFF
--- a/src/Aspire.Cli/Configuration/ConfigurationService.cs
+++ b/src/Aspire.Cli/Configuration/ConfigurationService.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Configuration;
 
@@ -93,7 +94,7 @@ internal sealed class ConfigurationService(DirectoryInfo currentDirectory, FileI
         // Walk up the directory tree to find existing settings file
         while (searchDirectory is not null)
         {
-            var settingsFilePath = Path.Combine(searchDirectory.FullName, ".aspire", "settings.json");
+            var settingsFilePath = ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName);
 
             if (File.Exists(settingsFilePath))
             {
@@ -104,7 +105,7 @@ internal sealed class ConfigurationService(DirectoryInfo currentDirectory, FileI
         }
 
         // If no existing settings file found, create one in current directory
-        return Path.Combine(currentDirectory.FullName, ".aspire", "settings.json");
+        return ConfigurationHelper.BuildPathToSettingsJsonFile(currentDirectory.FullName);
     }
 
     public async Task<Dictionary<string, string>> GetAllConfigurationAsync(CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -39,7 +39,7 @@ public class Program
     private static string GetGlobalSettingsPath()
     {
         var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var globalSettingsPath = Path.Combine(homeDirectory, ".aspire", "settings.json");
+        var globalSettingsPath = ConfigurationHelper.BuildPathToSettingsJsonFile(homeDirectory);
         return globalSettingsPath;
     }
 

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Projects;
@@ -79,7 +80,7 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
 
         while (true)
         {
-            var settingsFile = new FileInfo(Path.Combine(searchDirectory.FullName, ".aspire", "settings.json"));
+            var settingsFile = new FileInfo(ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName));
 
             if (settingsFile.Exists)
             {
@@ -172,7 +173,7 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
 
     private async Task CreateSettingsFileAsync(FileInfo projectFile, CancellationToken cancellationToken)
     {
-        var settingsFilePath = Path.Combine(currentDirectory.FullName, ".aspire", "settings.json");
+        var settingsFilePath = ConfigurationHelper.BuildPathToSettingsJsonFile(currentDirectory.FullName);
         var settingsFile = new FileInfo(settingsFilePath);
 
         logger.LogDebug("Creating settings file at {SettingsFilePath}", settingsFile.FullName);

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -16,7 +16,7 @@ internal static class ConfigurationHelper
 
         while (currentDirectory is not null)
         {
-            var settingsFilePath = Path.Combine(currentDirectory.FullName, ".aspire", "settings.json");
+            var settingsFilePath = BuildPathToSettingsJsonFile(currentDirectory.FullName);
 
             if (File.Exists(settingsFilePath))
             {
@@ -38,5 +38,10 @@ internal static class ConfigurationHelper
         {
             configuration.AddJsonFile(localSettingsFile.FullName, optional: true);
         }
+    }
+
+    internal static string BuildPathToSettingsJsonFile(string workingDirectory)
+    {
+        return Path.Combine(workingDirectory, ".aspire", "settings.json");
     }
 }


### PR DESCRIPTION
## Description

The added method centralizes the logic for constructing the path to the settings JSON file.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
