### PR TITLE
Mitchdenny/run-apphost-logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ playground/**/publish/
 
 # Verify
 *.received.*
+**/.aspire/settings.json

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -387,10 +387,7 @@ internal sealed class RunCommand : BaseCommand
                 // resource state streaming fails - but there are some cases
                 // where we want to just silently exit (such as the case of
                 // cancellation).
-                dashboardState.Updates.Writer.TryWrite((state, cancellationToken) =>
-                {
-                    throw ex;
-                });
+                dashboardState.Updates.Writer.Complete(ex);
             }
         }, cancellationToken);
     }

--- a/src/Aspire.Cli/Rendering/Dashboard/AppHostLogRenderable.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/AppHostLogRenderable.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Aspire.Cli.Rendering.Dashboard;
+
+internal sealed class AppHostLogRenderable(DashboardState state) : JustInTimeRenderable
+{
+    protected override IRenderable Build()
+    {
+        _ = state;
+        var table = new Table().NoBorder();
+        table.AddColumn("Stream");
+        table.AddColumn("Message");
+
+        foreach (var logEntry in state.AppHostLogs)
+        {
+            var stream = logEntry.Stream switch
+            {
+                "stdout" => new Markup("[white]stdout[/]"),
+                "stderr" => new Markup("[bold red]stderr[/]"),
+                _ => throw new InvalidOperationException($"Unknown stream type: {logEntry.Stream}")
+            };
+
+            table.AddRow(stream, new Text(logEntry.Message));
+        }
+        
+        return table;
+    }
+}

--- a/src/Aspire.Cli/Rendering/Dashboard/DashboardLinksRenderable.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/DashboardLinksRenderable.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Resources;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Aspire.Cli.Rendering.Dashboard;
+
+internal sealed class DashboardLinksRenderable(DashboardState state) : JustInTimeRenderable
+{
+    protected override IRenderable Build()
+    {
+        _ = state;
+        var rows = new List<IRenderable>();
+        rows.Add(new Markup($" [green bold]{InteractionServiceStrings.Dashboard}[/]:"));
+
+        rows.Add(state.DirectDashboardUrl switch
+        {
+            { } directUrl => new Markup($" :chart_increasing:  {InteractionServiceStrings.DirectLink}: [link={directUrl}]{directUrl}[/]"),
+            null => new Markup($" :chart_increasing:  {InteractionServiceStrings.DirectLink}: (pending)")
+        });
+
+        if (state.CodespacesDashboardUrl is { } codespacesUrl)
+        {
+            rows.Add(new Markup($" :chart_increasing:  {InteractionServiceStrings.CodespacesLink}: [link={codespacesUrl}]{codespacesUrl}[/]"));
+        }
+
+        return new Rows(rows.ToArray());
+    }
+}

--- a/src/Aspire.Cli/Rendering/Dashboard/DashboardRenderable.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/DashboardRenderable.cs
@@ -16,7 +16,17 @@ internal sealed class DashboardRenderable(DashboardState state) : JustInTimeRend
 
     protected override IRenderable Build()
     {
-        return BuildResourcesTable();
+        if (!state.ShowAppHostLogs)
+        {
+            return BuildResourcesTable();
+        }
+        else
+        {
+            var lines = state.Collector.GetLines();
+            var outputText = string.Join(Environment.NewLine, lines);
+            return new Text(outputText);
+        }
+
     }
 
     private IRenderable BuildResourcesTable()

--- a/src/Aspire.Cli/Rendering/Dashboard/DashboardRenderable.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/DashboardRenderable.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Resources;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Aspire.Cli.Rendering.Dashboard;
+
+internal sealed class DashboardRenderable(DashboardState state) : JustInTimeRenderable
+{
+    protected override bool HasDirtyChildren()
+    {
+        return true;
+    }
+
+    protected override IRenderable Build()
+    {
+        return BuildResourcesTable();
+    }
+
+    private IRenderable BuildResourcesTable()
+    {
+        var table = new Table().Border(TableBorder.Rounded);
+
+        // Add columns
+        table.AddColumn(RunCommandStrings.Resource);
+        table.AddColumn(RunCommandStrings.Type);
+        table.AddColumn(RunCommandStrings.State);
+        table.AddColumn(RunCommandStrings.Health);
+        table.AddColumn(RunCommandStrings.Endpoints);
+
+        foreach (var resourceStates in state.ResourceStates)
+        {
+            var nameRenderable = new Text(resourceStates.Key, new Style().Foreground(Color.White));
+
+            var typeRenderable = new Text(resourceStates.Value.Type, new Style().Foreground(Color.White));
+
+            var stateRenderable = resourceStates.Value.State switch
+            {
+                "Running" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Green)),
+                "Starting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.LightGreen)),
+                "FailedToStart" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Red)),
+                "Waiting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.White)),
+                "Unhealthy" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Yellow)),
+                "Exited" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
+                "Finished" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
+                "NotStarted" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
+                _ => new Text(resourceStates.Value.State ?? "Unknown", new Style().Foreground(Color.Grey))
+            };
+
+            var healthRenderable = resourceStates.Value.Health switch
+            {
+                "Healthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Green)),
+                "Degraded" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Yellow)),
+                "Unhealthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Red)),
+                null => new Text(TemplatingStrings.Unknown, new Style().Foreground(Color.Grey)),
+                _ => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Grey))
+            };
+
+            IRenderable endpointsRenderable = new Text(TemplatingStrings.None);
+            if (resourceStates.Value.Endpoints?.Length > 0)
+            {
+                endpointsRenderable = new Rows(
+                    resourceStates.Value.Endpoints.Select(e => new Text(e, new Style().Link(e)))
+                );
+            }
+
+            table.AddRow(nameRenderable, typeRenderable, stateRenderable, healthRenderable, endpointsRenderable);
+        }
+
+        return table;
+    }
+}

--- a/src/Aspire.Cli/Rendering/Dashboard/DashboardRenderable.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/DashboardRenderable.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Resources;
+using Spectre.Console;
 using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Rendering.Dashboard;
@@ -16,7 +18,14 @@ internal sealed class DashboardRenderable(DashboardState state) : JustInTimeRend
     {
         if (!state.ShowAppHostLogs)
         {
-            return new ResourceTableRenderable(state);
+            var rows = new Rows(
+                new DashboardLinksRenderable(state),
+                new ResourceTableRenderable(state),
+                new Markup(RunCommandStrings.PressCtrlCToStopAppHost),
+                new Markup(RunCommandStrings.PressVToViewLogs)
+            );
+
+            return rows;
         }
         else
         {

--- a/src/Aspire.Cli/Rendering/Dashboard/DashboardRenderable.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/DashboardRenderable.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Cli.Resources;
-using Spectre.Console;
 using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Rendering.Dashboard;
@@ -18,67 +16,11 @@ internal sealed class DashboardRenderable(DashboardState state) : JustInTimeRend
     {
         if (!state.ShowAppHostLogs)
         {
-            return BuildResourcesTable();
+            return new ResourceTableRenderable(state);
         }
         else
         {
-            var lines = state.Collector.GetLines();
-            var outputText = string.Join(Environment.NewLine, lines);
-            return new Text(outputText);
+            return new AppHostLogRenderable(state);
         }
-
-    }
-
-    private IRenderable BuildResourcesTable()
-    {
-        var table = new Table().Border(TableBorder.Rounded);
-
-        // Add columns
-        table.AddColumn(RunCommandStrings.Resource);
-        table.AddColumn(RunCommandStrings.Type);
-        table.AddColumn(RunCommandStrings.State);
-        table.AddColumn(RunCommandStrings.Health);
-        table.AddColumn(RunCommandStrings.Endpoints);
-
-        foreach (var resourceStates in state.ResourceStates)
-        {
-            var nameRenderable = new Text(resourceStates.Key, new Style().Foreground(Color.White));
-
-            var typeRenderable = new Text(resourceStates.Value.Type, new Style().Foreground(Color.White));
-
-            var stateRenderable = resourceStates.Value.State switch
-            {
-                "Running" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Green)),
-                "Starting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.LightGreen)),
-                "FailedToStart" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Red)),
-                "Waiting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.White)),
-                "Unhealthy" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Yellow)),
-                "Exited" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
-                "Finished" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
-                "NotStarted" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
-                _ => new Text(resourceStates.Value.State ?? "Unknown", new Style().Foreground(Color.Grey))
-            };
-
-            var healthRenderable = resourceStates.Value.Health switch
-            {
-                "Healthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Green)),
-                "Degraded" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Yellow)),
-                "Unhealthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Red)),
-                null => new Text(TemplatingStrings.Unknown, new Style().Foreground(Color.Grey)),
-                _ => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Grey))
-            };
-
-            IRenderable endpointsRenderable = new Text(TemplatingStrings.None);
-            if (resourceStates.Value.Endpoints?.Length > 0)
-            {
-                endpointsRenderable = new Rows(
-                    resourceStates.Value.Endpoints.Select(e => new Text(e, new Style().Link(e)))
-                );
-            }
-
-            table.AddRow(nameRenderable, typeRenderable, stateRenderable, healthRenderable, endpointsRenderable);
-        }
-
-        return table;
     }
 }

--- a/src/Aspire.Cli/Rendering/Dashboard/DashboardState.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/DashboardState.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Aspire.Cli.Backchannel;
+
+namespace Aspire.Cli.Rendering.Dashboard;
+
+internal sealed class DashboardState
+{
+    public string? DirectDashboardUrl { get; set; }
+    public string? CodespacesDashboardUrl { get; set; }
+    public Dictionary<string, RpcResourceState> ResourceStates { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public Channel<Func<DashboardState, CancellationToken, Task>> Updates { get; } = Channel.CreateUnbounded<Func<DashboardState, CancellationToken, Task>>();
+}

--- a/src/Aspire.Cli/Rendering/Dashboard/DashboardState.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/DashboardState.cs
@@ -3,11 +3,14 @@
 
 using System.Threading.Channels;
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Rendering.Dashboard;
 
-internal sealed class DashboardState
+internal sealed class DashboardState(OutputCollector collector)
 {
+    public OutputCollector Collector { get; } = collector;
+    public bool ShowAppHostLogs { get; set; }
     public string? DirectDashboardUrl { get; set; }
     public string? CodespacesDashboardUrl { get; set; }
     public Dictionary<string, RpcResourceState> ResourceStates { get; } = new(StringComparer.OrdinalIgnoreCase);

--- a/src/Aspire.Cli/Rendering/Dashboard/DashboardState.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/DashboardState.cs
@@ -3,17 +3,28 @@
 
 using System.Threading.Channels;
 using Aspire.Cli.Backchannel;
-using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Rendering.Dashboard;
 
-internal sealed class DashboardState(OutputCollector collector)
+internal sealed class DashboardState()
 {
-    public OutputCollector Collector { get; } = collector;
     public bool ShowAppHostLogs { get; set; }
     public string? DirectDashboardUrl { get; set; }
     public string? CodespacesDashboardUrl { get; set; }
     public Dictionary<string, RpcResourceState> ResourceStates { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public string? LastMessage { get; set; }
 
     public Channel<Func<DashboardState, CancellationToken, Task>> Updates { get; } = Channel.CreateUnbounded<Func<DashboardState, CancellationToken, Task>>();
+
+    public List<(string Stream, string Message)> AppHostLogs { get; } = new();
+
+    public void AppendOutput(string output)
+    {
+        AppHostLogs.Add(("stdout", output));
+    }
+
+    public void AppendError(string error)
+    {
+        AppHostLogs.Add(("stdout", error));
+    }
 }

--- a/src/Aspire.Cli/Rendering/Dashboard/DashboardState.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/DashboardState.cs
@@ -9,6 +9,7 @@ namespace Aspire.Cli.Rendering.Dashboard;
 internal sealed class DashboardState()
 {
     public bool ShowAppHostLogs { get; set; }
+    public bool AppHostLogsHaveErrors { get; set; }
     public string? DirectDashboardUrl { get; set; }
     public string? CodespacesDashboardUrl { get; set; }
     public Dictionary<string, RpcResourceState> ResourceStates { get; } = new(StringComparer.OrdinalIgnoreCase);
@@ -25,6 +26,7 @@ internal sealed class DashboardState()
 
     public void AppendError(string error)
     {
+        AppHostLogsHaveErrors = true;
         AppHostLogs.Add(("stdout", error));
     }
 }

--- a/src/Aspire.Cli/Rendering/Dashboard/ResourceTableRenderable.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/ResourceTableRenderable.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Resources;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Aspire.Cli.Rendering.Dashboard;
+
+internal sealed class ResourceTableRenderable(DashboardState state) : JustInTimeRenderable
+{
+    protected override IRenderable Build()
+    {
+        var table = new Table().Border(TableBorder.Rounded);
+
+        // Add columns
+        table.AddColumn(RunCommandStrings.Resource);
+        table.AddColumn(RunCommandStrings.Type);
+        table.AddColumn(RunCommandStrings.State);
+        table.AddColumn(RunCommandStrings.Health);
+        table.AddColumn(RunCommandStrings.Endpoints);
+
+        foreach (var resourceStates in state.ResourceStates)
+        {
+            var nameRenderable = new Text(resourceStates.Key, new Style().Foreground(Color.White));
+
+            var typeRenderable = new Text(resourceStates.Value.Type, new Style().Foreground(Color.White));
+
+            var stateRenderable = resourceStates.Value.State switch
+            {
+                "Running" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Green)),
+                "Starting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.LightGreen)),
+                "FailedToStart" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Red)),
+                "Waiting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.White)),
+                "Unhealthy" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Yellow)),
+                "Exited" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
+                "Finished" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
+                "NotStarted" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
+                _ => new Text(resourceStates.Value.State ?? "Unknown", new Style().Foreground(Color.Grey))
+            };
+
+            var healthRenderable = resourceStates.Value.Health switch
+            {
+                "Healthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Green)),
+                "Degraded" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Yellow)),
+                "Unhealthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Red)),
+                null => new Text(TemplatingStrings.Unknown, new Style().Foreground(Color.Grey)),
+                _ => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Grey))
+            };
+
+            IRenderable endpointsRenderable = new Text(TemplatingStrings.None);
+            if (resourceStates.Value.Endpoints?.Length > 0)
+            {
+                endpointsRenderable = new Rows(
+                    resourceStates.Value.Endpoints.Select(e => new Text(e, new Style().Link(e)))
+                );
+            }
+
+            table.AddRow(nameRenderable, typeRenderable, stateRenderable, healthRenderable, endpointsRenderable);
+        }
+
+        table.Expand();
+
+        return table;
+    }
+}

--- a/src/Aspire.Cli/Rendering/Dashboard/ResourceTableRenderable.cs
+++ b/src/Aspire.Cli/Rendering/Dashboard/ResourceTableRenderable.cs
@@ -20,44 +20,54 @@ internal sealed class ResourceTableRenderable(DashboardState state) : JustInTime
         table.AddColumn(RunCommandStrings.Health);
         table.AddColumn(RunCommandStrings.Endpoints);
 
-        foreach (var resourceStates in state.ResourceStates)
+        if (state.ResourceStates.Count == 0)
         {
-            var nameRenderable = new Text(resourceStates.Key, new Style().Foreground(Color.White));
-
-            var typeRenderable = new Text(resourceStates.Value.Type, new Style().Foreground(Color.White));
-
-            var stateRenderable = resourceStates.Value.State switch
-            {
-                "Running" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Green)),
-                "Starting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.LightGreen)),
-                "FailedToStart" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Red)),
-                "Waiting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.White)),
-                "Unhealthy" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Yellow)),
-                "Exited" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
-                "Finished" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
-                "NotStarted" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
-                _ => new Text(resourceStates.Value.State ?? "Unknown", new Style().Foreground(Color.Grey))
-            };
-
-            var healthRenderable = resourceStates.Value.Health switch
-            {
-                "Healthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Green)),
-                "Degraded" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Yellow)),
-                "Unhealthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Red)),
-                null => new Text(TemplatingStrings.Unknown, new Style().Foreground(Color.Grey)),
-                _ => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Grey))
-            };
-
-            IRenderable endpointsRenderable = new Text(TemplatingStrings.None);
-            if (resourceStates.Value.Endpoints?.Length > 0)
-            {
-                endpointsRenderable = new Rows(
-                    resourceStates.Value.Endpoints.Select(e => new Text(e, new Style().Link(e)))
-                );
-            }
-
-            table.AddRow(nameRenderable, typeRenderable, stateRenderable, healthRenderable, endpointsRenderable);
+                var placeholders = new Markup[table.Columns.Count];
+                for (int i = 0; i < table.Columns.Count; i++)
+                {
+                    placeholders[i] = new Markup("--");
+                }
+                table.Rows.Add(placeholders);
         }
+
+        foreach (var resourceStates in state.ResourceStates)
+            {
+                var nameRenderable = new Text(resourceStates.Key, new Style().Foreground(Color.White));
+
+                var typeRenderable = new Text(resourceStates.Value.Type, new Style().Foreground(Color.White));
+
+                var stateRenderable = resourceStates.Value.State switch
+                {
+                    "Running" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Green)),
+                    "Starting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.LightGreen)),
+                    "FailedToStart" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Red)),
+                    "Waiting" => new Text(resourceStates.Value.State, new Style().Foreground(Color.White)),
+                    "Unhealthy" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Yellow)),
+                    "Exited" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
+                    "Finished" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
+                    "NotStarted" => new Text(resourceStates.Value.State, new Style().Foreground(Color.Grey)),
+                    _ => new Text(resourceStates.Value.State ?? "Unknown", new Style().Foreground(Color.Grey))
+                };
+
+                var healthRenderable = resourceStates.Value.Health switch
+                {
+                    "Healthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Green)),
+                    "Degraded" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Yellow)),
+                    "Unhealthy" => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Red)),
+                    null => new Text(TemplatingStrings.Unknown, new Style().Foreground(Color.Grey)),
+                    _ => new Text(resourceStates.Value.Health, new Style().Foreground(Color.Grey))
+                };
+
+                IRenderable endpointsRenderable = new Text(TemplatingStrings.None);
+                if (resourceStates.Value.Endpoints?.Length > 0)
+                {
+                    endpointsRenderable = new Rows(
+                        resourceStates.Value.Endpoints.Select(e => new Text(e, new Style().Link(e)))
+                    );
+                }
+
+                table.AddRow(nameRenderable, typeRenderable, stateRenderable, healthRenderable, endpointsRenderable);
+            }
 
         table.Expand();
 

--- a/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
@@ -117,6 +117,12 @@ namespace Aspire.Cli.Resources {
             }
         }
         
+        public static string PressVToViewLogs {
+            get {
+                return ResourceManager.GetString("PressVToViewLogs", resourceCulture);
+            }
+        }
+        
         public static string ProjectCouldNotBeRun {
             get {
                 return ResourceManager.GetString("ProjectCouldNotBeRun", resourceCulture);

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -148,7 +148,7 @@
     <comment>[bold] should not be localized</comment>
   </data>
   <data name="PressVToViewLogs" xml:space="preserve">
-    <value>Press [bold]V[/] to to view app host logs.</value>
+    <value>Press [bold]V[/] to view app host logs.</value>
     <comment>[bold] should not be localized</comment>
   </data>
   <data name="ProjectCouldNotBeRun" xml:space="preserve">

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -137,13 +137,18 @@
     <comment>The state of the resource, eg Running</comment>
   </data>
   <data name="Health" xml:space="preserve">
-    <value>The health of the resource, eg Healthy</value>
+    <value>Health</value>
+    <comment>The health of the resource, eg Healthy</comment>
   </data>
   <data name="Endpoints" xml:space="preserve">
     <value>Endpoints</value>
   </data>
   <data name="PressCtrlCToStopAppHost" xml:space="preserve">
     <value>Press [bold]Ctrl+C[/] to stop the app host and exit.</value>
+    <comment>[bold] should not be localized</comment>
+  </data>
+  <data name="PressVToViewLogs" xml:space="preserve">
+    <value>Press [bold]V[/] to to view app host logs.</value>
     <comment>[bold] should not be localized</comment>
   </data>
   <data name="ProjectCouldNotBeRun" xml:space="preserve">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -13,9 +13,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Health">
-        <source>The health of the resource, eg Healthy</source>
-        <target state="new">The health of the resource, eg Healthy</target>
-        <note />
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note>The health of the resource, eg Healthy</note>
       </trans-unit>
       <trans-unit id="IsCompatibleAppHostIsNull">
         <source>IsCompatibleAppHost is null</source>
@@ -25,6 +25,11 @@
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]Ctrl+C[/] to stop the app host and exit.</source>
         <target state="new">Press [bold]Ctrl+C[/] to stop the app host and exit.</target>
+        <note>[bold] should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PressVToViewLogs">
+        <source>Press [bold]V[/] to to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -28,8 +28,8 @@
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="PressVToViewLogs">
-        <source>Press [bold]V[/] to to view app host logs.</source>
-        <target state="new">Press [bold]V[/] to to view app host logs.</target>
+        <source>Press [bold]V[/] to view app host logs.</source>
+        <target state="new">Press [bold]V[/] to view app host logs.</target>
         <note>[bold] should not be localized</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">


### PR DESCRIPTION
Fixes: #9622

This change changes the way that we render the terminal dashboard for `aspire run`. Here is a summary of the changes:

1. Introduced a custom set of "renderables" which represent the dashboard.
2. Used this custom renderable in the `_ansiConsole.Live(...)` call and changed the callback code for `Live(...)` to effectively be a render loop.
3. State used to control what is rendered is in a `DashboardState` type which is passed to a set of background threads that do things like process keyboard input, stream resource states, and get dashboard URLs.
4. Now that we are in control of the rendering and we have a keyboard input process we react to the user pressing the V key they see the latest apphost logs.

This isn't a replacement for `aspire run --debug` but its something that you can use to get a quick glance at apphost logs. This is also not a fully blown TUI since that is a lot larger effort (based on some spiking that I did):


https://github.com/user-attachments/assets/1803414e-0f78-481c-81b2-43b215cdb8f0

