### PR TITLE
Update launchSettings.json to support manifest generation

### DIFF
--- a/playground/publishers/Publishers.AppHost/Properties/launchSettings.json
+++ b/playground/publishers/Publishers.AppHost/Properties/launchSettings.json
@@ -28,7 +28,7 @@
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
-    "publish-manifest": {
+    "generate-manifest": {
       "commandName": "Project",
       "launchBrowser": true,
       "dotnetRunMessages": true,


### PR DESCRIPTION
This launchSettings.json file has a wrong verb and the `refreshManifests.ps1` script complains about it missing
