### PR TITLE
Reorder & don't remember Aspire version in IDE's

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/ide.host.json
@@ -10,21 +10,15 @@
     },
     {
       "id": "AspireVersion",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     },
     {
       "id": "AspireVersionNet9",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     },
     {
       "id": "AspireVersionNet10",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     }
   ],
   "unsupportedHosts": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
@@ -64,14 +64,14 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -84,14 +84,13 @@
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },{
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -104,14 +103,14 @@
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -124,14 +123,14 @@
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
@@ -5,10 +5,7 @@
   "disableHttpsSymbol": "NoHttps",
   "symbolInfo": [
     {
-      "id": "AspireVersion",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "id": "AspireVersion"
     }
   ],
   "unsupportedHosts": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
@@ -5,7 +5,8 @@
   "disableHttpsSymbol": "NoHttps",
   "symbolInfo": [
     {
-      "id": "AspireVersion"
+      "id": "AspireVersion",
+      "isVisible": true
     }
   ],
   "unsupportedHosts": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -92,14 +92,14 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/ide.host.json
@@ -9,21 +9,15 @@
     },
     {
       "id": "AspireVersion",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     },
     {
       "id": "AspireVersionNet9",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     },
     {
       "id": "AspireVersionNet10",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     }
   ],
   "unsupportedHosts": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -67,14 +67,14 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -87,14 +87,14 @@
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -107,14 +107,14 @@
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -127,14 +127,14 @@
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/ide.host.json
@@ -9,21 +9,15 @@
     },
     {
       "id": "AspireVersion",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     },
     {
       "id": "AspireVersionNet9",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     },
     {
       "id": "AspireVersionNet10",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     }
   ],
   "unsupportedHosts": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -67,14 +67,14 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -87,14 +87,14 @@
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -107,14 +107,14 @@
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -127,14 +127,14 @@
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/ide.host.json
@@ -8,13 +8,16 @@
       "isVisible": false
     },
     {
-      "id": "AspireVersion"
+      "id": "AspireVersion",
+      "isVisible": true
     },
     {
-      "id": "AspireVersionNet9"
+      "id": "AspireVersionNet9",
+      "isVisible": true
     },
     {
-      "id": "AspireVersionNet10"
+      "id": "AspireVersionNet10",
+      "isVisible": true
     }
   ],
   "unsupportedHosts": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/ide.host.json
@@ -8,22 +8,13 @@
       "isVisible": false
     },
     {
-      "id": "AspireVersion",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "id": "AspireVersion"
     },
     {
-      "id": "AspireVersionNet9",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "id": "AspireVersionNet9"
     },
     {
-      "id": "AspireVersionNet10",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "id": "AspireVersionNet10"
     }
   ],
   "unsupportedHosts": [

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
@@ -65,14 +65,14 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -85,14 +85,14 @@
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -105,14 +105,14 @@
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -125,14 +125,14 @@
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/ide.host.json
@@ -16,21 +16,15 @@
     },
     {
       "id": "AspireVersion",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     },
     {
       "id": "AspireVersionNet9",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     },
     {
       "id": "AspireVersionNet10",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "isVisible": true
     },
     {
       "id": "XUnitVersion",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -108,14 +108,14 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -128,14 +128,14 @@
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -148,14 +148,14 @@
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -168,14 +168,14 @@
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/ide.host.json
@@ -8,13 +8,16 @@
       "isVisible": false
     },
     {
-      "id": "AspireVersion"
+      "id": "AspireVersion",
+      "isVisible": true
     },
     {
-      "id": "AspireVersionNet9"
+      "id": "AspireVersionNet9",
+      "isVisible": true
     },
     {
-      "id": "AspireVersionNet10"
+      "id": "AspireVersionNet10",
+      "isVisible": true
     },
     {
       "id": "XUnitVersion",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/ide.host.json
@@ -8,22 +8,13 @@
       "isVisible": false
     },
     {
-      "id": "AspireVersion",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "id": "AspireVersion"
     },
     {
-      "id": "AspireVersionNet9",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "id": "AspireVersionNet9"
     },
     {
-      "id": "AspireVersionNet10",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
+      "id": "AspireVersionNet10"
     },
     {
       "id": "XUnitVersion",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -67,14 +67,14 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -87,14 +87,14 @@
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -107,14 +107,14 @@
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
@@ -127,14 +127,14 @@
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
-          "choice": "9.3",
-          "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
-        },
-        {
           "choice": "9.4",
           "displayName": "9.4",
           "description": "Chooses .NET Aspire 9.4"
+        },
+        {
+          "choice": "9.3",
+          "displayName": "9.3",
+          "description": "Chooses .NET Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"


### PR DESCRIPTION
## Description

Reorders the options for Aspire version in the templates so the latest version is the first option.
Disables stickiness for the Aspire version option so that latest version is always the default selected.

Fixes #9521

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
