### PR TITLE
Bump System.CommandLine.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -126,7 +126,7 @@
     <PackageVersion Include="Microsoft.Signed.Wix" Version="$(MicrosoftSignedWixVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Installers" Version="8.0.0-beta.23564.4" />
     <PackageVersion Include="Microsoft.DotNet.GenAPI.Task" Version="9.0.103-servicing.25065.25" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25256.109" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
     <!-- playground apps dependencies -->
     <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.1.2" />
     <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.1.2" />


### PR DESCRIPTION
Bumping `System.CommandLine` to the latest preview bits (now on NuGet.org).