### PR TITLE
Update PublishingActivityProgressReporter to support step/task views

### DIFF
--- a/src/Aspire.Cli/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelDataTypes.cs
@@ -51,9 +51,25 @@ internal sealed class DashboardUrlsState
 }
 
 /// <summary>
-/// Represents the activity and status of a publishing operation.
+/// Envelope for publishing activity items sent over the backchannel.
 /// </summary>
-internal sealed class PublishingActivityState
+internal sealed class PublishingActivity
+{
+    /// <summary>
+    /// Gets the type discriminator for the publishing activity item.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Gets the data containing all properties for the publishing activity item.
+    /// </summary>
+    public required PublishingActivityData Data { get; init; }
+}
+
+/// <summary>
+/// Common data for all publishing activity items.
+/// </summary>
+internal sealed class PublishingActivityData
 {
     /// <summary>
     /// Gets the unique identifier for the publishing activity.
@@ -74,4 +90,29 @@ internal sealed class PublishingActivityState
     /// Gets a value indicating whether the publishing activity encountered an error.
     /// </summary>
     public bool IsError { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the publishing activity completed with warnings.
+    /// </summary>
+    public bool IsWarning { get; init; }
+
+    /// <summary>
+    /// Gets the identifier of the step this task belongs to (only applicable for tasks).
+    /// </summary>
+    public string? StepId { get; init; }
+
+    /// <summary>
+    /// Gets the completion message for the publishing activity (optional).
+    /// </summary>
+    public string? CompletionMessage { get; init; }
+}
+
+/// <summary>
+/// Constants for publishing activity item types.
+/// </summary>
+internal static class PublishingActivityTypes
+{
+    public const string Step = "step";
+    public const string Task = "task";
+    public const string PublishComplete = "publish-complete";
 }

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -246,8 +246,7 @@ internal abstract class PublishCommandBase : BaseCommand
 
                 break;
             }
-
-            if (activity.Type == PublishingActivityTypes.Step)
+            else if (activity.Type == PublishingActivityTypes.Step)
             {
                 // If this is our first time encountering this step, initialize it by
                 // display the step header and configuring a new ProgressContext for the
@@ -256,7 +255,7 @@ internal abstract class PublishCommandBase : BaseCommand
                 {
                     if (currentStepProgress.Step is not null)
                     {
-                        throw new InvalidOperationException($"Step activity with ID '{activity.Data.Id}' is not complete. Expected it to be complete before processing tasks.");
+                        throw new InvalidOperationException($"Step activity with ID '{currentStepProgress.Step?.Id}' is not complete. Expected it to be complete before processing tasks.");
                     }
 
                     stepInfo = new StepInfo
@@ -389,6 +388,12 @@ internal abstract class PublishCommandBase : BaseCommand
 
     private static async Task StartProgressForStep(ProgressContextInfo progressContext, CancellationToken cancellationToken)
     {
+        if (progressContext.Context is not null)
+        {
+            // If the context is already started, we don't need to do anything.
+            return;
+        }
+
         progressContext.Context = AnsiConsole.Progress()
             .AutoClear(false)
             .HideCompleted(false)

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -29,9 +29,8 @@ internal class AppHostRpcTarget(
         {
             var publishingActivity = await activityReporter.ActivityItemUpdated.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
 
-            // Terminate the stream if the publishing activity is null or if the
-            // final PublishComplete activity is received.
-            if (publishingActivity == null || publishingActivity.Type == PublishingActivityTypes.PublishComplete)
+            // Terminate the stream if the publishing activity is null
+            if (publishingActivity == null)
             {
                 yield break;
             }

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -23,33 +23,20 @@ internal class AppHostRpcTarget(
     DistributedApplicationOptions options
     )
 {
-    public async IAsyncEnumerable<PublishingActivityState> GetPublishingActivitiesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+    public async IAsyncEnumerable<PublishingActivity> GetPublishingActivitiesAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
         while (cancellationToken.IsCancellationRequested == false)
         {
-            var publishingActivityStatus = await activityReporter.ActivityStatusUpdated.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            var publishingActivity = await activityReporter.ActivityItemUpdated.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
 
-            if (publishingActivityStatus == null)
+            // Terminate the stream if the publishing activity is null or if the
+            // final PublishComplete activity is received.
+            if (publishingActivity == null || publishingActivity.Type == PublishingActivityTypes.PublishComplete)
             {
-                // If the publishing activity is null, it means that the activity has been removed.
-                // This can happen if the activity is complete or an error occurred.
                 yield break;
             }
 
-            yield return new PublishingActivityState
-            {
-                Id = publishingActivityStatus.Activity.Id,
-                StatusText = publishingActivityStatus.StatusText,
-                IsComplete = publishingActivityStatus.IsComplete,
-                IsError = publishingActivityStatus.IsError
-            };
-
-            if (publishingActivityStatus.Activity.IsPrimary && (publishingActivityStatus.IsComplete || publishingActivityStatus.IsError))
-            {
-                // If the activity is complete or an error and it is the primary activity,
-                // we can stop listening for updates.
-                yield break;
-            }
+            yield return publishingActivity;
         }
     }
 

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -51,9 +51,25 @@ internal sealed class DashboardUrlsState
 }
 
 /// <summary>
-/// Represents the activity and status of a publishing operation.
+/// Envelope for publishing activities sent over the backchannel.
 /// </summary>
-internal sealed class PublishingActivityState
+internal sealed class PublishingActivity
+{
+    /// <summary>
+    /// Gets the type discriminator for the publishing activity.
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Gets the data containing all properties for the publishing activity.
+    /// </summary>
+    public required PublishingActivityData Data { get; init; }
+}
+
+/// <summary>
+/// Common data for all publishing activities.
+/// </summary>
+internal sealed class PublishingActivityData
 {
     /// <summary>
     /// Gets the unique identifier for the publishing activity.
@@ -74,4 +90,29 @@ internal sealed class PublishingActivityState
     /// Gets a value indicating whether the publishing activity encountered an error.
     /// </summary>
     public bool IsError { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the publishing activity completed with warnings.
+    /// </summary>
+    public bool IsWarning { get; init; }
+
+    /// <summary>
+    /// Gets the identifier of the step this task belongs to (only applicable for tasks).
+    /// </summary>
+    public string? StepId { get; init; }
+
+    /// <summary>
+    /// Gets the optional completion message for tasks (appears as dimmed child text).
+    /// </summary>
+    public string? CompletionMessage { get; init; }
+}
+
+/// <summary>
+/// Constants for publishing activity types.
+/// </summary>
+internal static class PublishingActivityTypes
+{
+    public const string Step = "step";
+    public const string Task = "task";
+    public const string PublishComplete = "publish-complete";
 }

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <!-- Shipped as experimental in 9.2 but removed because we no longer have multiple publishers -->
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Aspire.Hosting.PublisherDistributedApplicationBuilderExtensions</Target>
@@ -9,7 +8,27 @@
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
-  <!-- Shipped as experimental in 9.2 but removed because we are removing inspect mode -->
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Aspire.Hosting.Publishing.PublishingActivity</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Aspire.Hosting.Publishing.PublishingActivityStatus</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Aspire.Hosting.DistributedApplicationOperation.Inspect</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aspire.Hosting.DistributedApplicationExecutionContext.get_IsInspectMode</Target>
@@ -19,7 +38,56 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:Aspire.Hosting.DistributedApplicationOperation.Inspect</Target>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CreateActivityAsync(System.String,System.String,System.Boolean,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.UpdateActivityStatusAsync(Aspire.Hosting.Publishing.PublishingActivity,System.Func{Aspire.Hosting.Publishing.PublishingActivityStatus,Aspire.Hosting.Publishing.PublishingActivityStatus},System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CompletePublishAsync(System.Boolean,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CompleteStepAsync(Aspire.Hosting.Publishing.PublishingStep,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CompleteTaskAsync(Aspire.Hosting.Publishing.PublishingTask,Aspire.Hosting.Publishing.TaskCompletionState,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CreateStepAsync(System.String,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CreateTaskAsync(System.String,System.String,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.UpdateTaskAsync(Aspire.Hosting.Publishing.PublishingTask,System.String,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -80,7 +80,7 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CreateTaskAsync(System.String,System.String,System.String,System.Threading.CancellationToken)</Target>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CreateTaskAsync(Aspire.Hosting.Publishing.PublishingStep,System.String,System.String,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -73,14 +73,14 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CreateStepAsync(System.String,System.String,System.Threading.CancellationToken)</Target>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CreateStepAsync(System.String,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CreateTaskAsync(Aspire.Hosting.Publishing.PublishingStep,System.String,System.String,System.Threading.CancellationToken)</Target>
+    <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.CreateTaskAsync(Aspire.Hosting.Publishing.PublishingStep,System.String,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -88,6 +88,13 @@
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Aspire.Hosting.Publishing.IPublishingActivityProgressReporter.UpdateTaskAsync(Aspire.Hosting.Publishing.PublishingTask,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Publishing.IResourceContainerImageBuilder.BuildImagesAsync(System.Collections.Generic.IEnumerable{Aspire.Hosting.ApplicationModel.IResource},System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -30,12 +30,6 @@ internal sealed class DistributedApplicationRunner(ILogger<DistributedApplicatio
                 await backchannelService.BackchannelConnected.ConfigureAwait(false);
             }
 
-            var publishingActivity = await activityReporter.CreateActivityAsync(
-                "publishing-artifacts",
-                $"Publishing artifacts",
-                isPrimary: true,
-                stoppingToken).ConfigureAwait(false);
-
             try
             {
                 await eventing.PublishAsync<BeforePublishEvent>(
@@ -49,10 +43,7 @@ internal sealed class DistributedApplicationRunner(ILogger<DistributedApplicatio
                     new AfterPublishEvent(serviceProvider, model), stoppingToken
                     ).ConfigureAwait(false);
 
-                await activityReporter.UpdateActivityStatusAsync(
-                    publishingActivity,
-                    (status) => status with { IsComplete = true },
-                    stoppingToken).ConfigureAwait(false);
+                await activityReporter.CompletePublishAsync(true, stoppingToken).ConfigureAwait(false);
 
                 // If we are running in publish mode and a backchannel is being
                 // used then we don't want to stop the app host. Instead the
@@ -67,14 +58,11 @@ internal sealed class DistributedApplicationRunner(ILogger<DistributedApplicatio
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to publish the distributed application.");
-                await activityReporter.UpdateActivityStatusAsync(
-                    publishingActivity,
-                    (status) => status with { IsError = true },
-                    stoppingToken).ConfigureAwait(false);
+                await activityReporter.CompletePublishAsync(false, stoppingToken).ConfigureAwait(false);
 
                 if (!backchannelService.IsBackchannelExpected)
                 {
-                     throw new DistributedApplicationException($"Publishing failed exception message: {ex.Message}", ex);
+                    throw new DistributedApplicationException($"Publishing failed exception message: {ex.Message}", ex);
                 }
             }
         }

--- a/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
@@ -28,9 +28,9 @@ public sealed class NullPublishingActivityProgressReporter : IPublishingActivity
     }
 
     /// <inheritdoc/>
-    public Task<PublishingTask> CreateTaskAsync(string id, string stepId, string statusText, CancellationToken cancellationToken)
+    public Task<PublishingTask> CreateTaskAsync(PublishingStep step, string id, string statusText, CancellationToken cancellationToken)
     {
-        var task = new PublishingTask(id, stepId, statusText);
+        var task = new PublishingTask(id, step.Id, statusText);
         return Task.FromResult(task);
     }
 

--- a/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
@@ -21,22 +21,44 @@ public sealed class NullPublishingActivityProgressReporter : IPublishingActivity
     }
 
     /// <inheritdoc/>
-    public Task<PublishingActivity> CreateActivityAsync(string id, string initialStatusText, bool isPrimary, CancellationToken cancellationToken)
+    public Task<PublishingStep> CreateStepAsync(string id, string title, CancellationToken cancellationToken)
     {
-        var activity = new PublishingActivity(id, isPrimary);
-        activity.LastStatus = new PublishingActivityStatus
-        {
-            Activity = activity,
-            StatusText = initialStatusText,
-            IsComplete = false,
-            IsError = false
-        };
-
-        return Task.FromResult(activity);
+        var step = new PublishingStep(id, title);
+        return Task.FromResult(step);
     }
 
     /// <inheritdoc/>
-    public Task UpdateActivityStatusAsync(PublishingActivity publishingActivity, Func<PublishingActivityStatus, PublishingActivityStatus> statusUpdate, CancellationToken cancellationToken)
+    public Task<PublishingTask> CreateTaskAsync(string id, string stepId, string statusText, CancellationToken cancellationToken)
+    {
+        var task = new PublishingTask(id, stepId, statusText);
+        return Task.FromResult(task);
+    }
+
+    /// <inheritdoc/>
+    public Task CompleteStepAsync(PublishingStep step, string completionText, CancellationToken cancellationToken)
+    {
+        step.IsComplete = true;
+        step.CompletionText = completionText;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task UpdateTaskAsync(PublishingTask task, string statusText, CancellationToken cancellationToken)
+    {
+        task.StatusText = statusText;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task CompleteTaskAsync(PublishingTask task, TaskCompletionState completionState, string? completionMessage = null, CancellationToken cancellationToken = default)
+    {
+        task.CompletionState = completionState;
+        task.CompletionMessage = completionMessage ?? string.Empty;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task CompletePublishAsync(bool success, CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
     }

--- a/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/NullPublishingActivityProgressReporter.cs
@@ -21,16 +21,16 @@ public sealed class NullPublishingActivityProgressReporter : IPublishingActivity
     }
 
     /// <inheritdoc/>
-    public Task<PublishingStep> CreateStepAsync(string id, string title, CancellationToken cancellationToken)
+    public Task<PublishingStep> CreateStepAsync(string title, CancellationToken cancellationToken)
     {
-        var step = new PublishingStep(id, title);
+        var step = new PublishingStep(Guid.NewGuid().ToString(), title);
         return Task.FromResult(step);
     }
 
     /// <inheritdoc/>
-    public Task<PublishingTask> CreateTaskAsync(PublishingStep step, string id, string statusText, CancellationToken cancellationToken)
+    public Task<PublishingTask> CreateTaskAsync(PublishingStep step, string statusText, CancellationToken cancellationToken)
     {
-        var task = new PublishingTask(id, step.Id, statusText);
+        var task = new PublishingTask(Guid.NewGuid().ToString(), step.Id, statusText);
         return Task.FromResult(task);
     }
 

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -179,6 +179,7 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
     public async Task<PublishingStep> CreateStepAsync(string title, CancellationToken cancellationToken)
     {
         var step = new PublishingStep(Guid.NewGuid().ToString(), title);
+        _steps.TryAdd(step.Id, step);
 
         var state = new PublishingActivity
         {

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -3,69 +3,109 @@
 
 #pragma warning disable ASPIREPUBLISHERS001
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
+using Aspire.Hosting.Backchannel;
 
 namespace Aspire.Hosting.Publishing;
 
 /// <summary>
-/// Represents a publishing activity.
+/// Represents the completion state of a publishing task.
 /// </summary>
 [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-public sealed class PublishingActivity
+public enum TaskCompletionState
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="PublishingActivity"/> class.
+    /// The task is in progress.
     /// </summary>
-    /// <param name="id">The unique identifier for the publishing activity.</param>
-    /// <param name="isPrimary">Indicates whether this activity is the primary activity.</param>
-    public PublishingActivity(string id, bool isPrimary = false)
-    {
-        Id = id;
-        IsPrimary = isPrimary;
-    }
+    InProgress,
 
     /// <summary>
-    /// Unique Id of the publishing activity.
+    /// The task completed successfully.
     /// </summary>
-    public string Id { get; private set; }
+    Completed,
 
     /// <summary>
-    /// Indicates whether the publishing activity is the primary activity.
+    /// The task completed with warnings.
     /// </summary>
-    public bool IsPrimary { get; private set; }
+    CompletedWithWarning,
 
     /// <summary>
-    /// The status text of the publishing activity.
+    /// The task completed with an error.
     /// </summary>
-    public PublishingActivityStatus? LastStatus { get; set; }
+    CompletedWithError
 }
 
 /// <summary>
-/// Represents the status of a publishing activity.
+/// Represents a publishing step, which can contain multiple tasks.
 /// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="PublishingStep"/> class.
+/// </remarks>
+/// <param name="id">The unique identifier for the publishing step.</param>
+/// <param name="title">The title of the publishing step.</param>
 [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-public sealed record PublishingActivityStatus
+public sealed class PublishingStep(string id, string title)
+{
+
+    /// <summary>
+    /// Unique Id of the step.
+    /// </summary>
+    public string Id { get; private set; } = id;
+
+    /// <summary>
+    /// The title of the publishing step.
+    /// </summary>
+    public string Title { get; private set; } = title;
+
+    /// <summary>
+    /// Indicates whether the step is complete.
+    /// </summary>
+    public bool IsComplete { get; internal set; }
+
+    /// <summary>
+    /// The completion text for the step.
+    /// </summary>
+    public string CompletionText { get; internal set; } = string.Empty;
+}
+
+/// <summary>
+/// Represents a publishing task, which belongs to a step.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="PublishingTask"/> class.
+/// </remarks>
+/// <param name="id">The unique identifier for the publishing task.</param>
+/// <param name="stepId">The identifier of the step this task belongs to.</param>
+/// <param name="statusText">The initial status text for the task.</param>
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class PublishingTask(string id, string stepId, string statusText)
 {
     /// <summary>
-    /// The publishing activity associated with this status.
+    /// Unique Id of the task.
     /// </summary>
-    public required PublishingActivity Activity { get; init; }
+    public string Id { get; private set; } = id;
 
     /// <summary>
-    /// The status text of the publishing activity.
+    /// The identifier of the step this task belongs to.
     /// </summary>
-    public required string StatusText { get; init; }
+    public string StepId { get; private set; } = stepId;
 
     /// <summary>
-    /// Indicates whether the publishing activity is complete.
+    /// The current status text of the task.
     /// </summary>
-    public required bool IsComplete { get; init; }
+    public string StatusText { get; internal set; } = statusText;
 
     /// <summary>
-    /// Indicates whether the publishing activity encountered an error.
+    /// The completion state of the task.
     /// </summary>
-    public required bool IsError { get; init; }
+    public TaskCompletionState CompletionState { get; internal set; } = TaskCompletionState.InProgress;
+
+    /// <summary>
+    /// Optional completion message for the task.
+    /// </summary>
+    public string CompletionMessage { get; internal set; } = string.Empty;
 }
 
 /// <summary>
@@ -75,86 +115,251 @@ public sealed record PublishingActivityStatus
 public interface IPublishingActivityProgressReporter
 {
     /// <summary>
-    /// Creates a new publishing activity with the specified ID.
+    /// Creates a new publishing step with the specified ID and title.
     /// </summary>
-    /// <param name="id">Unique Id of the publishing activity.</param>
-    /// <param name="initialStatusText"></param>
-    /// <param name="isPrimary">Indicates that this activity is the primary activity.</param>
+    /// <param name="id">Unique Id of the publishing step.</param>
+    /// <param name="title">The title of the publishing step.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The publishing activity</returns>
-    /// <remarks>
-    /// When an activity is created the <paramref name="isPrimary"/> flag indicates whether this
-    /// activity is the primary activity. When the primary activity is completed any launcher
-    /// which is reading activities will stop listening for updates.
-    /// </remarks>
-    Task<PublishingActivity> CreateActivityAsync(string id, string initialStatusText, bool isPrimary, CancellationToken cancellationToken);
+    /// <returns>The publishing step</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a step with the same ID already exists.</exception>
+    Task<PublishingStep> CreateStepAsync(string id, string title, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Updates the status of an existing publishing activity.
+    /// Creates a new publishing task tied to a step.
     /// </summary>
-    /// <param name="publishingActivity">The activity with updated properties.</param>
-    /// <param name="statusUpdate"></param>
+    /// <param name="id">Unique Id of the publishing task.</param>
+    /// <param name="stepId">The ID of the step this task belongs to.</param>
+    /// <param name="statusText">The initial status text.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The publishing task</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the step does not exist or is already complete.</exception>
+    Task<PublishingTask> CreateTaskAsync(string id, string stepId, string statusText, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Completes a publishing step with the specified completion text.
+    /// </summary>
+    /// <param name="step">The step to complete.</param>
+    /// <param name="completionText">The completion text for the step.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns></returns>
-    Task UpdateActivityStatusAsync(PublishingActivity publishingActivity, Func<PublishingActivityStatus, PublishingActivityStatus> statusUpdate, CancellationToken cancellationToken);
+    Task CompleteStepAsync(PublishingStep step, string completionText, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Updates the status text of an existing publishing task.
+    /// </summary>
+    /// <param name="task">The task to update.</param>
+    /// <param name="statusText">The new status text.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">Thrown when the parent step is already complete.</exception>
+    Task UpdateTaskAsync(PublishingTask task, string statusText, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Completes a publishing task with the specified completion state and optional completion message.
+    /// </summary>
+    /// <param name="task">The task to complete.</param>
+    /// <param name="completionState">The completion state.</param>
+    /// <param name="completionMessage">Optional completion message that will appear as a dimmed child message.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">Thrown when the parent step is already complete.</exception>
+    Task CompleteTaskAsync(PublishingTask task, TaskCompletionState completionState, string? completionMessage = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Signals that the entire publishing process has completed.
+    /// </summary>
+    /// <param name="success">Whether the publishing process completed successfully.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    Task CompletePublishAsync(bool success, CancellationToken cancellationToken);
 }
 
 internal sealed class PublishingActivityProgressReporter : IPublishingActivityProgressReporter
 {
-    public async Task<PublishingActivity> CreateActivityAsync(string id, string initialStatusText, bool isPrimary, CancellationToken cancellationToken)
-    {
-        var publishingActivity = new PublishingActivity(id, isPrimary);
-        await UpdateActivityStatusAsync(
-            publishingActivity,
-            (status) => status with
-            {
-                StatusText = initialStatusText,
-                IsComplete = false,
-                IsError = false
-            },
-            cancellationToken
-            ).ConfigureAwait(false);
+    private readonly ConcurrentDictionary<string, PublishingStep> _steps = new();
 
-        return publishingActivity;
+    public async Task<PublishingStep> CreateStepAsync(string id, string title, CancellationToken cancellationToken)
+    {
+        var step = new PublishingStep(id, title);
+
+        if (!_steps.TryAdd(id, step))
+        {
+            throw new InvalidOperationException($"Step with ID '{id}' already exists.");
+        }
+
+        var state = new PublishingActivity
+        {
+            Type = PublishingActivityTypes.Step,
+            Data = new PublishingActivityData
+            {
+                Id = step.Id,
+                StatusText = title,
+                IsComplete = false,
+                IsError = false,
+                IsWarning = false,
+                StepId = null
+            }
+        };
+
+        await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
+        return step;
     }
 
-    private readonly object _updateLock = new object();
-
-    public async Task UpdateActivityStatusAsync(PublishingActivity publishingActivity, Func<PublishingActivityStatus, PublishingActivityStatus> statusUpdate, CancellationToken cancellationToken)
+    public async Task<PublishingTask> CreateTaskAsync(string id, string stepId, string statusText, CancellationToken cancellationToken)
     {
-        PublishingActivityStatus? lastStatus;
-        PublishingActivityStatus? newStatus;
-
-        lock (_updateLock)
+        if (!_steps.TryGetValue(stepId, out var parentStep))
         {
-            lastStatus = publishingActivity.LastStatus ?? new PublishingActivityStatus
+            throw new InvalidOperationException($"Step with ID '{stepId}' does not exist.");
+        }
+
+        lock (parentStep)
+        {
+            if (parentStep.IsComplete)
             {
-                Activity = publishingActivity,
-                StatusText = string.Empty,
+                throw new InvalidOperationException($"Cannot create task for step '{stepId}' because the step is already complete.");
+            }
+        }
+
+        var task = new PublishingTask(id, stepId, statusText);
+
+        var state = new PublishingActivity
+        {
+            Type = PublishingActivityTypes.Task,
+            Data = new PublishingActivityData
+            {
+                Id = task.Id,
+                StatusText = statusText,
                 IsComplete = false,
-                IsError = false
-            };
-            
-            newStatus = statusUpdate(lastStatus);
-            publishingActivity.LastStatus = newStatus;
-        }
+                IsError = false,
+                IsWarning = false,
+                StepId = stepId
+            }
+        };
 
-        if (lastStatus == newStatus)
-        {
-            throw new DistributedApplicationException(
-                $"The status of the publishing activity '{publishingActivity.Id}' was not updated. The status update function must return a new instance of the status."
-                );
-        }
-
-        await ActivityStatusUpdated.Writer.WriteAsync(newStatus, cancellationToken).ConfigureAwait(false);
-
-        if (publishingActivity.IsPrimary && (newStatus.IsComplete || newStatus.IsError))
-        {
-            // If the activity is complete or an error and it is the primary activity,
-            // we can stop listening for updates.
-            ActivityStatusUpdated.Writer.Complete();
-        }
+        await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
+        return task;
     }
 
-    internal Channel<PublishingActivityStatus> ActivityStatusUpdated { get; } = Channel.CreateUnbounded<PublishingActivityStatus>();
+    public async Task CompleteStepAsync(PublishingStep step, string completionText, CancellationToken cancellationToken)
+    {
+        lock (step)
+        {
+            step.IsComplete = true;
+            step.CompletionText = completionText;
+        }
+
+        var state = new PublishingActivity
+        {
+            Type = PublishingActivityTypes.Step,
+            Data = new PublishingActivityData
+            {
+                Id = step.Id,
+                StatusText = completionText,
+                IsComplete = true,
+                IsError = false,
+                IsWarning = false,
+                StepId = null
+            }
+        };
+
+        await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
+
+        // Remove the completed step to prevent further updates.
+        _steps.TryRemove(step.Id, out _);
+    }
+
+    public async Task UpdateTaskAsync(PublishingTask task, string statusText, CancellationToken cancellationToken)
+    {
+        if (!_steps.TryGetValue(task.StepId, out var parentStep))
+        {
+            throw new InvalidOperationException($"Parent step with ID '{task.StepId}' does not exist.");
+        }
+
+        lock (parentStep)
+        {
+            if (parentStep.IsComplete)
+            {
+                throw new InvalidOperationException($"Cannot update task '{task.Id}' because its parent step '{task.StepId}' is already complete.");
+            }
+
+            task.StatusText = statusText;
+        }
+
+        var state = new PublishingActivity
+        {
+            Type = PublishingActivityTypes.Task,
+            Data = new PublishingActivityData
+            {
+                Id = task.Id,
+                StatusText = statusText,
+                IsComplete = false,
+                IsError = false,
+                IsWarning = false,
+                StepId = task.StepId
+            }
+        };
+
+        await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task CompleteTaskAsync(PublishingTask task, TaskCompletionState completionState, string? completionMessage = null, CancellationToken cancellationToken = default)
+    {
+        if (!_steps.TryGetValue(task.StepId, out var parentStep))
+        {
+            throw new InvalidOperationException($"Parent step with ID '{task.StepId}' does not exist.");
+        }
+
+        if (task.CompletionState != TaskCompletionState.InProgress)
+        {
+            throw new InvalidOperationException($"Cannot complete task '{task.Id}' with state '{task.CompletionState}'. Only 'InProgress' tasks can be completed.");
+        }
+
+        lock (parentStep)
+        {
+            if (parentStep.IsComplete)
+            {
+                throw new InvalidOperationException($"Cannot complete task '{task.Id}' because its parent step '{task.StepId}' is already complete.");
+            }
+
+            task.CompletionState = completionState;
+            task.CompletionMessage = completionMessage ?? string.Empty;
+        }
+
+        var state = new PublishingActivity
+        {
+            Type = PublishingActivityTypes.Task,
+            Data = new PublishingActivityData
+            {
+                Id = task.Id,
+                StatusText = task.StatusText,
+                IsComplete = true,
+                IsError = completionState == TaskCompletionState.CompletedWithError,
+                IsWarning = completionState == TaskCompletionState.CompletedWithWarning,
+                StepId = task.StepId,
+                CompletionMessage = completionMessage
+            }
+        };
+
+        await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task CompletePublishAsync(bool success, CancellationToken cancellationToken)
+    {
+        var state = new PublishingActivity
+        {
+            Type = PublishingActivityTypes.PublishComplete,
+            Data = new PublishingActivityData
+            {
+                Id = PublishingActivityTypes.PublishComplete,
+                StatusText = success ? "Publishing completed successfully" : "Publishing completed with errors",
+                IsComplete = true,
+                IsError = !success,
+                IsWarning = false
+            }
+        };
+
+        await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal Channel<PublishingActivity> ActivityItemUpdated { get; } = Channel.CreateUnbounded<PublishingActivity>();
 }

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -117,23 +117,21 @@ public interface IPublishingActivityProgressReporter
     /// <summary>
     /// Creates a new publishing step with the specified ID and title.
     /// </summary>
-    /// <param name="id">Unique Id of the publishing step.</param>
     /// <param name="title">The title of the publishing step.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The publishing step</returns>
     /// <exception cref="InvalidOperationException">Thrown when a step with the same ID already exists.</exception>
-    Task<PublishingStep> CreateStepAsync(string id, string title, CancellationToken cancellationToken);
+    Task<PublishingStep> CreateStepAsync(string title, CancellationToken cancellationToken);
 
     /// <summary>
     /// Creates a new publishing task tied to a step.
     /// </summary>
     /// <param name="step">The step this task belongs to.</param>
-    /// <param name="id">Unique Id of the publishing task.</param>
     /// <param name="statusText">The initial status text.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The publishing task</returns>
     /// <exception cref="InvalidOperationException">Thrown when the step does not exist or is already complete.</exception>
-    Task<PublishingTask> CreateTaskAsync(PublishingStep step, string id, string statusText, CancellationToken cancellationToken);
+    Task<PublishingTask> CreateTaskAsync(PublishingStep step, string statusText, CancellationToken cancellationToken);
 
     /// <summary>
     /// Completes a publishing step with the specified completion text.
@@ -178,14 +176,9 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
 {
     private readonly ConcurrentDictionary<string, PublishingStep> _steps = new();
 
-    public async Task<PublishingStep> CreateStepAsync(string id, string title, CancellationToken cancellationToken)
+    public async Task<PublishingStep> CreateStepAsync(string title, CancellationToken cancellationToken)
     {
-        var step = new PublishingStep(id, title);
-
-        if (!_steps.TryAdd(id, step))
-        {
-            throw new InvalidOperationException($"Step with ID '{id}' already exists.");
-        }
+        var step = new PublishingStep(Guid.NewGuid().ToString(), title);
 
         var state = new PublishingActivity
         {
@@ -205,7 +198,7 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
         return step;
     }
 
-    public async Task<PublishingTask> CreateTaskAsync(PublishingStep step, string id, string statusText, CancellationToken cancellationToken)
+    public async Task<PublishingTask> CreateTaskAsync(PublishingStep step, string statusText, CancellationToken cancellationToken)
     {
         if (!_steps.TryGetValue(step.Id, out var parentStep))
         {
@@ -220,7 +213,7 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
             }
         }
 
-        var task = new PublishingTask(id, step.Id, statusText);
+        var task = new PublishingTask(Guid.NewGuid().ToString(), step.Id, statusText);
 
         var state = new PublishingActivity
         {

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -44,7 +44,6 @@ internal sealed class ResourceContainerImageBuilder(
     public async Task BuildImagesAsync(IEnumerable<IResource> resources, CancellationToken cancellationToken)
     {
         var step = await activityReporter.CreateStepAsync(
-            "build-container-images",
             "Building container images for resources",
             cancellationToken).ConfigureAwait(false);
 
@@ -101,7 +100,6 @@ internal sealed class ResourceContainerImageBuilder(
     {
         var publishingTask = await CreateTaskAsync(
             step,
-            $"image-build-{resource.Name}",
             $"Building image: {resource.Name}",
             cancellationToken
             ).ConfigureAwait(false);
@@ -168,7 +166,6 @@ internal sealed class ResourceContainerImageBuilder(
     {
         var publishingTask = await CreateTaskAsync(
             step,
-            $"image-build-{resourceName}",
             $"Building image: {resourceName}",
             cancellationToken
             ).ConfigureAwait(false);
@@ -210,7 +207,6 @@ internal sealed class ResourceContainerImageBuilder(
 
     private async Task<PublishingTask?> CreateTaskAsync(
         PublishingStep? step,
-        string taskId,
         string description,
         CancellationToken cancellationToken)
     {
@@ -220,7 +216,7 @@ internal sealed class ResourceContainerImageBuilder(
             return null;
         }
 
-        return await activityReporter.CreateTaskAsync(step, taskId, description, cancellationToken).ConfigureAwait(false);
+        return await activityReporter.CreateTaskAsync(step, description, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task CompleteTaskAsync(

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -33,14 +33,12 @@ internal sealed class ResourceContainerImageBuilder(
     IServiceProvider serviceProvider,
     IPublishingActivityProgressReporter activityReporter) : IResourceContainerImageBuilder
 {
-    private const string ImageBuildStepId = "image-build";
-
     public async Task BuildImageAsync(IResource resource, CancellationToken cancellationToken)
     {
         logger.LogInformation("Building container image for resource {Resource}", resource.Name);
 
         await activityReporter.CreateStepAsync(
-            ImageBuildStepId,
+            $"image-build-{resource.Name}",
             $"Building container image for resource {resource.Name}",
             cancellationToken
             ).ConfigureAwait(false);
@@ -83,7 +81,7 @@ internal sealed class ResourceContainerImageBuilder(
     {
         var publishingTask = await activityReporter.CreateTaskAsync(
             $"{resource.Name}-build-image",
-            ImageBuildStepId,
+            $"image-build-{resource.Name}",
             $"Building image: {resource.Name}",
             cancellationToken
             ).ConfigureAwait(false);
@@ -149,7 +147,7 @@ internal sealed class ResourceContainerImageBuilder(
     {
         var publishingTask = await activityReporter.CreateTaskAsync(
             $"{resourceName}-build-image",
-            ImageBuildStepId,
+            $"image-build-{resourceName}",
             $"Building image: {resourceName}",
             cancellationToken
             ).ConfigureAwait(false);

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostBackchannel.cs
@@ -24,7 +24,7 @@ internal sealed class TestAppHostBackchannel : IAppHostBackchannel
     public Func<string, CancellationToken, Task>? ConnectAsyncCallback { get; set; }
 
     public TaskCompletionSource? GetPublishingActivitiesAsyncCalled { get; set; }
-    public Func<CancellationToken, IAsyncEnumerable<(string, string, bool, bool)>>? GetPublishingActivitiesAsyncCallback { get; set; }
+    public Func<CancellationToken, IAsyncEnumerable<PublishingActivity>>? GetPublishingActivitiesAsyncCallback { get; set; }
 
     public TaskCompletionSource? GetCapabilitiesAsyncCalled { get; set; }
     public Func<CancellationToken, Task<string[]>>? GetCapabilitiesAsyncCallback { get; set; }
@@ -104,10 +104,10 @@ internal sealed class TestAppHostBackchannel : IAppHostBackchannel
         }
     }
 
-    public async IAsyncEnumerable<(string Id, string StatusText, bool IsComplete, bool IsError)> GetPublishingActivitiesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
+    public async IAsyncEnumerable<PublishingActivity> GetPublishingActivitiesAsync([EnumeratorCancellation]CancellationToken cancellationToken)
     {
         GetPublishingActivitiesAsyncCalled?.SetResult();
-        if (GetPublishingActivitiesAsyncCallback != null)
+        if (GetPublishingActivitiesAsyncCallback is not null)
         {
             var publishingActivities = GetPublishingActivitiesAsyncCallback.Invoke(cancellationToken).ConfigureAwait(false);
 
@@ -118,14 +118,110 @@ internal sealed class TestAppHostBackchannel : IAppHostBackchannel
         }
         else
         {
-            yield return ("root-activity", "Publishing artifacts", false, false);
-            yield return ("child-1", "Generating YAML goodness", false, false);
-            yield return ("child-1", "Generating YAML goodness", true, false);
-            yield return ("child-2", "Building image 1", false, false);
-            yield return ("child-2", "Building image 1", true, false);
-            yield return ("child-2", "Building image 2", false, false);
-            yield return ("child-2", "Building image 2", true, false);
-            yield return ("root-activity", "Publishing artifacts", true, false);
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Step,
+                Data = new PublishingActivityData
+                {
+                    Id = "root-step",
+                    StatusText = "Publishing artifacts",
+                    IsComplete = false,
+                    IsError = false,
+                    IsWarning = false,
+                    StepId = null
+                }
+            };
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Task,
+                Data = new PublishingActivityData
+                {
+                    Id = "child-task-1",
+                    StatusText = "Generating YAML goodness",
+                    IsComplete = false,
+                    IsError = false,
+                    IsWarning = false,
+                    StepId = "root-step"
+                }
+            };
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Task,
+                Data = new PublishingActivityData
+                {
+                    Id = "child-task-1",
+                    StatusText = "Generating YAML goodness",
+                    IsComplete = true,
+                    IsError = false,
+                    IsWarning = false,
+                    StepId = "root-step"
+                }
+            };
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Task,
+                Data = new PublishingActivityData
+                {
+                    Id = "child-task-2",
+                    StatusText = "Building image 1",
+                    IsComplete = false,
+                    IsError = false,
+                    IsWarning = false,
+                    StepId = "root-step"
+                }
+            };
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Task,
+                Data = new PublishingActivityData
+                {
+                    Id = "child-task-2",
+                    StatusText = "Building image 1",
+                    IsComplete = true,
+                    IsError = false,
+                    IsWarning = false,
+                    StepId = "root-step"
+                }
+            };
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Task,
+                Data = new PublishingActivityData
+                {
+                    Id = "child-task-2",
+                    StatusText = "Building image 2",
+                    IsComplete = false,
+                    IsError = false,
+                    IsWarning = false,
+                    StepId = "root-step"
+                }
+            };
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Task,
+                Data = new PublishingActivityData
+                {
+                    Id = "child-task-2",
+                    StatusText = "Building image 2",
+                    IsComplete = true,
+                    IsError = false,
+                    IsWarning = false,
+                    StepId = "root-step"
+                }
+            };
+            yield return new PublishingActivity
+            {
+                Type = PublishingActivityTypes.Step,
+                Data = new PublishingActivityData
+                {
+                    Id = "root-step",
+                    StatusText = "Publishing artifacts",
+                    IsComplete = true,
+                    IsError = false,
+                    IsWarning = false,
+                    StepId = null
+                }
+            };
         }
     }
 

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposePublisherTests.cs
@@ -480,6 +480,12 @@ public class DockerComposePublisherTests(ITestOutputHelper outputHelper)
             BuildImageCalled = true;
             return Task.CompletedTask;
         }
+
+        public Task BuildImagesAsync(IEnumerable<IResource> resources, CancellationToken cancellationToken)
+        {
+            BuildImageCalled = true;
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class TestProject : IProjectMetadata

--- a/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
@@ -26,7 +26,8 @@ public class NullPublishingActivityProgressReporterTests
     public async Task CanCreateTask()
     {
         var reporter = NullPublishingActivityProgressReporter.Instance;
-        var task = await reporter.CreateTaskAsync("task-1", "step-1", "task initial", default);
+        var step = new PublishingStep("step-1", "step initial");
+        var task = await reporter.CreateTaskAsync(step, "step-1", "task initial", default);
         await reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, "task completed", default);
 
         Assert.NotNull(task);

--- a/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
@@ -14,11 +14,10 @@ public class NullPublishingActivityProgressReporterTests
     public async Task CanUseNullReporter()
     {
         var reporter = NullPublishingActivityProgressReporter.Instance;
-        var step = await reporter.CreateStepAsync("1", "step initial", default);
+        var step = await reporter.CreateStepAsync("step initial", default);
         await reporter.CompleteStepAsync(step, "step completed", default);
 
         Assert.NotNull(step);
-        Assert.Equal("1", step.Id);
         Assert.True(step.IsComplete);
     }
 
@@ -27,11 +26,12 @@ public class NullPublishingActivityProgressReporterTests
     {
         var reporter = NullPublishingActivityProgressReporter.Instance;
         var step = new PublishingStep("step-1", "step initial");
-        var task = await reporter.CreateTaskAsync(step, "step-1", "task initial", default);
+        var task = await reporter.CreateTaskAsync(step, "task initial", default);
         await reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, "task completed", default);
 
         Assert.NotNull(task);
-        Assert.Equal("task-1", task.Id);
-        Assert.Equal("step-1", task.StepId);
+        Assert.NotNull(task.Id);
+        Assert.NotEmpty(task.Id);
+        Assert.Equal(step.Id, task.StepId);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/NullPublishingActivityProgressReporterTests.cs
@@ -14,9 +14,23 @@ public class NullPublishingActivityProgressReporterTests
     public async Task CanUseNullReporter()
     {
         var reporter = NullPublishingActivityProgressReporter.Instance;
-        var activity = await reporter.CreateActivityAsync("1", "initial", isPrimary: true, default);
-        await reporter.UpdateActivityStatusAsync(activity, (status) => status with { IsComplete = true }, default);
+        var step = await reporter.CreateStepAsync("1", "step initial", default);
+        await reporter.CompleteStepAsync(step, "step completed", default);
 
-        Assert.NotNull(activity);
+        Assert.NotNull(step);
+        Assert.Equal("1", step.Id);
+        Assert.True(step.IsComplete);
+    }
+
+    [Fact]
+    public async Task CanCreateTask()
+    {
+        var reporter = NullPublishingActivityProgressReporter.Instance;
+        var task = await reporter.CreateTaskAsync("task-1", "step-1", "task initial", default);
+        await reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, "task completed", default);
+
+        Assert.NotNull(task);
+        Assert.Equal("task-1", task.Id);
+        Assert.Equal("step-1", task.StepId);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityProgressReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityProgressReporterTests.cs
@@ -51,13 +51,13 @@ public class PublishingActivityProgressReporterTests
         var statusText = "Test Task";
 
         // Create parent step first
-        await reporter.CreateStepAsync(stepId, "Parent Step", CancellationToken.None);
+        var step = await reporter.CreateStepAsync(stepId, "Parent Step", CancellationToken.None);
 
         // Clear the step creation activity
         reporter.ActivityItemUpdated.Reader.TryRead(out _);
 
         // Act
-        var task = await reporter.CreateTaskAsync(taskId, stepId, statusText, CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(step, taskId, statusText, CancellationToken.None);
 
         // Assert
         Assert.NotNull(task);
@@ -84,14 +84,14 @@ public class PublishingActivityProgressReporterTests
     {
         // Arrange
         var reporter = new PublishingActivityProgressReporter();
-        var nonExistentStepId = "non-existent-step";
+        var nonExistentStep = new PublishingStep("non-existent-step", "Non-existent Step");
         var taskId = "test-task";
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => reporter.CreateTaskAsync(taskId, nonExistentStepId, "Test Task", CancellationToken.None));
+            () => reporter.CreateTaskAsync(nonExistentStep, taskId, "Test Task", CancellationToken.None));
 
-        Assert.Contains($"Step with ID '{nonExistentStepId}' does not exist.", exception.Message);
+        Assert.Contains($"Step with ID 'non-existent-step' does not exist.", exception.Message);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class PublishingActivityProgressReporterTests
 
         // Act & Assert - Step is now removed from dictionary when completed
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None));
+            () => reporter.CreateTaskAsync(step, taskId, "Test Task", CancellationToken.None));
 
         Assert.Contains($"Step with ID '{stepId}' does not exist.", exception.Message);
     }
@@ -153,8 +153,8 @@ public class PublishingActivityProgressReporterTests
         var taskId = "test-task";
         var newStatusText = "Updated status";
 
-        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
-        var task = await reporter.CreateTaskAsync(taskId, stepId, "Initial status", CancellationToken.None);
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(step, taskId, "Initial status", CancellationToken.None);
 
         // Clear previous activities
         reporter.ActivityItemUpdated.Reader.TryRead(out _);
@@ -184,8 +184,8 @@ public class PublishingActivityProgressReporterTests
         var stepId = "test-step";
         var taskId = "test-task";
 
-        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
-        var task = await reporter.CreateTaskAsync(taskId, stepId, "Initial status", CancellationToken.None);
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(step, taskId, "Initial status", CancellationToken.None);
 
         // Simulate step removal by creating a task with invalid step ID
         task = new PublishingTask(taskId, "non-existent-step", "Initial status");
@@ -206,7 +206,7 @@ public class PublishingActivityProgressReporterTests
         var taskId = "test-task";
 
         var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
-        var task = await reporter.CreateTaskAsync(taskId, stepId, "Initial status", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(step, taskId, "Initial status", CancellationToken.None);
         await reporter.CompleteStepAsync(step, "Completed", CancellationToken.None);
 
         // Act & Assert - Step is now removed from dictionary when completed
@@ -229,8 +229,8 @@ public class PublishingActivityProgressReporterTests
         var taskId = "test-task";
         var completionMessage = "Task completed";
 
-        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
-        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(step, taskId, "Test Task", CancellationToken.None);
 
         // Clear previous activities
         reporter.ActivityItemUpdated.Reader.TryRead(out _);
@@ -264,7 +264,7 @@ public class PublishingActivityProgressReporterTests
         var taskId = "test-task";
 
         var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
-        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(step, taskId, "Test Task", CancellationToken.None);
         await reporter.CompleteStepAsync(step, "Completed", CancellationToken.None);
 
         // Act & Assert - Step is now removed from dictionary when completed
@@ -316,7 +316,7 @@ public class PublishingActivityProgressReporterTests
                     .Select(async j =>
                     {
                         var taskId = $"task-{i}-{j}";
-                        var task = await reporter.CreateTaskAsync(taskId, stepId, $"Task {i}-{j}", CancellationToken.None);
+                        var task = await reporter.CreateTaskAsync(step, taskId, $"Task {i}-{j}", CancellationToken.None);
                         await reporter.UpdateTaskAsync(task, $"Updated Task {i}-{j}", CancellationToken.None);
                         await reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, null, CancellationToken.None);
                         return task;
@@ -366,8 +366,8 @@ public class PublishingActivityProgressReporterTests
         var stepId = "test-step";
         var taskId = "test-task";
 
-        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
-        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(step, taskId, "Test Task", CancellationToken.None);
 
         // Act
         await reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, null, CancellationToken.None);
@@ -401,8 +401,8 @@ public class PublishingActivityProgressReporterTests
         var stepId = "test-step";
         var taskId = "test-task";
 
-        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
-        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(step, taskId, "Test Task", CancellationToken.None);
 
         // Complete the task first time
         await reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, null, CancellationToken.None);
@@ -423,7 +423,7 @@ public class PublishingActivityProgressReporterTests
         var taskId = "test-task";
 
         var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
-        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(step, taskId, "Test Task", CancellationToken.None);
 
         // Act - Complete the step
         await reporter.CompleteStepAsync(step, "Step completed", CancellationToken.None);
@@ -440,7 +440,7 @@ public class PublishingActivityProgressReporterTests
 
         // Also verify that creating new tasks for the completed step fails
         var createException = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => reporter.CreateTaskAsync("new-task", stepId, "New Task", CancellationToken.None));
+            () => reporter.CreateTaskAsync(step, "new-task", "New Task", CancellationToken.None));
         Assert.Contains($"Step with ID '{stepId}' does not exist.", createException.Message);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityProgressReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityProgressReporterTests.cs
@@ -1,0 +1,446 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPUBLISHERS001
+
+using Aspire.Hosting.Backchannel;
+using Aspire.Hosting.Publishing;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Publishing;
+
+public class PublishingActivityProgressReporterTests
+{
+    [Fact]
+    public async Task CreateStepAsync_CreatesStepAndEmitsActivity()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var title = "Test Step";
+
+        // Act
+        var step = await reporter.CreateStepAsync(stepId, title, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(step);
+        Assert.Equal(stepId, step.Id);
+        Assert.Equal(title, step.Title);
+        Assert.False(step.IsComplete);
+        Assert.Equal(string.Empty, step.CompletionText);
+
+        // Verify activity was emitted
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.Step, activity.Type);
+        Assert.Equal(stepId, activity.Data.Id);
+        Assert.Equal(title, activity.Data.StatusText);
+        Assert.False(activity.Data.IsComplete);
+        Assert.False(activity.Data.IsError);
+        Assert.False(activity.Data.IsWarning);
+        Assert.Null(activity.Data.StepId);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_CreatesTaskAndEmitsActivity()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+        var statusText = "Test Task";
+
+        // Create parent step first
+        await reporter.CreateStepAsync(stepId, "Parent Step", CancellationToken.None);
+
+        // Clear the step creation activity
+        reporter.ActivityItemUpdated.Reader.TryRead(out _);
+
+        // Act
+        var task = await reporter.CreateTaskAsync(taskId, stepId, statusText, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(task);
+        Assert.Equal(taskId, task.Id);
+        Assert.Equal(stepId, task.StepId);
+        Assert.Equal(statusText, task.StatusText);
+        Assert.Equal(TaskCompletionState.InProgress, task.CompletionState);
+        Assert.Equal(string.Empty, task.CompletionMessage);
+
+        // Verify activity was emitted
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.Task, activity.Type);
+        Assert.Equal(taskId, activity.Data.Id);
+        Assert.Equal(statusText, activity.Data.StatusText);
+        Assert.Equal(stepId, activity.Data.StepId);
+        Assert.False(activity.Data.IsComplete);
+        Assert.False(activity.Data.IsError);
+        Assert.False(activity.Data.IsWarning);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_ThrowsWhenStepDoesNotExist()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var nonExistentStepId = "non-existent-step";
+        var taskId = "test-task";
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.CreateTaskAsync(taskId, nonExistentStepId, "Test Task", CancellationToken.None));
+
+        Assert.Contains($"Step with ID '{nonExistentStepId}' does not exist.", exception.Message);
+    }
+
+    [Fact]
+    public async Task CreateTaskAsync_ThrowsWhenStepIsComplete()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+
+        // Create and complete step
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        await reporter.CompleteStepAsync(step, "Completed", CancellationToken.None);
+
+        // Act & Assert - Step is now removed from dictionary when completed
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None));
+
+        Assert.Contains($"Step with ID '{stepId}' does not exist.", exception.Message);
+    }
+
+    [Fact]
+    public async Task CompleteStepAsync_CompletesStepAndEmitsActivity()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var completionText = "Step completed successfully";
+
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+
+        // Clear the step creation activity
+        reporter.ActivityItemUpdated.Reader.TryRead(out _);
+
+        // Act
+        await reporter.CompleteStepAsync(step, completionText, CancellationToken.None);
+
+        // Assert
+        Assert.True(step.IsComplete);
+        Assert.Equal(completionText, step.CompletionText);
+
+        // Verify activity was emitted
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.Step, activity.Type);
+        Assert.Equal(stepId, activity.Data.Id);
+        Assert.Equal(completionText, activity.Data.StatusText);
+        Assert.True(activity.Data.IsComplete);
+        Assert.False(activity.Data.IsError);
+        Assert.False(activity.Data.IsWarning);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_UpdatesTaskAndEmitsActivity()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+        var newStatusText = "Updated status";
+
+        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(taskId, stepId, "Initial status", CancellationToken.None);
+
+        // Clear previous activities
+        reporter.ActivityItemUpdated.Reader.TryRead(out _);
+        reporter.ActivityItemUpdated.Reader.TryRead(out _);
+
+        // Act
+        await reporter.UpdateTaskAsync(task, newStatusText, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(newStatusText, task.StatusText);
+
+        // Verify activity was emitted
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.Task, activity.Type);
+        Assert.Equal(taskId, activity.Data.Id);
+        Assert.Equal(newStatusText, activity.Data.StatusText);
+        Assert.Equal(stepId, activity.Data.StepId);
+        Assert.False(activity.Data.IsComplete);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_ThrowsWhenParentStepDoesNotExist()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+
+        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(taskId, stepId, "Initial status", CancellationToken.None);
+
+        // Simulate step removal by creating a task with invalid step ID
+        task = new PublishingTask(taskId, "non-existent-step", "Initial status");
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.UpdateTaskAsync(task, "New status", CancellationToken.None));
+
+        Assert.Contains("Parent step with ID 'non-existent-step' does not exist.", exception.Message);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_ThrowsWhenParentStepIsComplete()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(taskId, stepId, "Initial status", CancellationToken.None);
+        await reporter.CompleteStepAsync(step, "Completed", CancellationToken.None);
+
+        // Act & Assert - Step is now removed from dictionary when completed
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.UpdateTaskAsync(task, "New status", CancellationToken.None));
+
+        Assert.Contains($"Parent step with ID '{stepId}' does not exist.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(TaskCompletionState.Completed, false, false)]
+    [InlineData(TaskCompletionState.CompletedWithWarning, false, true)]
+    [InlineData(TaskCompletionState.CompletedWithError, true, false)]
+    public async Task CompleteTaskAsync_CompletesTaskWithCorrectStateAndEmitsActivity(
+        TaskCompletionState completionState, bool expectedIsError, bool expectedIsWarning)
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+        var completionMessage = "Task completed";
+
+        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+
+        // Clear previous activities
+        reporter.ActivityItemUpdated.Reader.TryRead(out _);
+        reporter.ActivityItemUpdated.Reader.TryRead(out _);
+
+        // Act
+        await reporter.CompleteTaskAsync(task, completionState, completionMessage, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(completionState, task.CompletionState);
+        Assert.Equal(completionMessage, task.CompletionMessage);
+
+        // Verify activity was emitted
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.Task, activity.Type);
+        Assert.Equal(taskId, activity.Data.Id);
+        Assert.Equal(stepId, activity.Data.StepId);
+        Assert.True(activity.Data.IsComplete);
+        Assert.Equal(expectedIsError, activity.Data.IsError);
+        Assert.Equal(expectedIsWarning, activity.Data.IsWarning);
+        Assert.Equal(completionMessage, activity.Data.CompletionMessage);
+    }
+
+    [Fact]
+    public async Task CompleteTaskAsync_ThrowsWhenParentStepIsComplete()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+        await reporter.CompleteStepAsync(step, "Completed", CancellationToken.None);
+
+        // Act & Assert - Step is now removed from dictionary when completed
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, null, CancellationToken.None));
+
+        Assert.Contains($"Parent step with ID '{stepId}' does not exist.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(true, "Publishing completed successfully", false)]
+    [InlineData(false, "Publishing completed with errors", true)]
+    public async Task CompletePublishAsync_EmitsCorrectActivity(bool success, string expectedStatusText, bool expectedIsError)
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+
+        // Act
+        await reporter.CompletePublishAsync(success, CancellationToken.None);
+
+        // Assert
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.PublishComplete, activity.Type);
+        Assert.Equal(PublishingActivityTypes.PublishComplete, activity.Data.Id);
+        Assert.Equal(expectedStatusText, activity.Data.StatusText);
+        Assert.True(activity.Data.IsComplete);
+        Assert.Equal(expectedIsError, activity.Data.IsError);
+        Assert.False(activity.Data.IsWarning);
+    }
+
+    [Fact]
+    public async Task ConcurrentOperations_AreThreadSafe()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        const int stepCount = 10;
+        const int tasksPerStep = 5;
+
+        // Act - Create steps and tasks concurrently
+        var stepTasks = Enumerable.Range(0, stepCount)
+            .Select(async i =>
+            {
+                var stepId = $"step-{i}";
+                var step = await reporter.CreateStepAsync(stepId, $"Step {i}", CancellationToken.None);
+
+                // Create tasks for each step concurrently
+                var taskCreationTasks = Enumerable.Range(0, tasksPerStep)
+                    .Select(async j =>
+                    {
+                        var taskId = $"task-{i}-{j}";
+                        var task = await reporter.CreateTaskAsync(taskId, stepId, $"Task {i}-{j}", CancellationToken.None);
+                        await reporter.UpdateTaskAsync(task, $"Updated Task {i}-{j}", CancellationToken.None);
+                        await reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, null, CancellationToken.None);
+                        return task;
+                    });
+
+                var completedTasks = await Task.WhenAll(taskCreationTasks);
+                await reporter.CompleteStepAsync(step, $"Step {i} completed", CancellationToken.None);
+
+                return new { Step = step, Tasks = completedTasks };
+            });
+
+        var results = await Task.WhenAll(stepTasks);
+
+        // Assert
+        Assert.Equal(stepCount, results.Length);
+
+        foreach (var result in results)
+        {
+            Assert.True(result.Step.IsComplete);
+            Assert.Equal(tasksPerStep, result.Tasks.Length);
+
+            foreach (var task in result.Tasks)
+            {
+                Assert.Equal(TaskCompletionState.Completed, task.CompletionState);
+            }
+        }
+
+        // Verify all activities were emitted
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        var activities = new List<PublishingActivity>();
+
+        while (activityReader.TryRead(out var activity))
+        {
+            activities.Add(activity);
+        }
+
+        // Expected activities: stepCount steps + (stepCount * tasksPerStep) tasks * 3 operations + stepCount step completions
+        var expectedActivityCount = stepCount + (stepCount * tasksPerStep * 3) + stepCount;
+        Assert.True(activities.Count >= expectedActivityCount);
+    }
+
+    [Fact]
+    public async Task CompleteTaskAsync_WithNullCompletionMessage_SetsEmptyString()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+
+        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+
+        // Act
+        await reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, null, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(string.Empty, task.CompletionMessage);
+    }
+
+    [Fact]
+    public async Task CreateStepAsync_WithSameId_ThrowsException()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "duplicate-step";
+
+        // Act
+        await reporter.CreateStepAsync(stepId, "First Step", CancellationToken.None);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.CreateStepAsync(stepId, "Second Step", CancellationToken.None));
+
+        Assert.Contains($"Step with ID '{stepId}' already exists.", exception.Message);
+    }
+
+    [Fact]
+    public async Task CompleteTaskAsync_ThrowsWhenTaskAlreadyCompleted()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+
+        await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+
+        // Complete the task first time
+        await reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, null, CancellationToken.None);
+
+        // Act & Assert - Try to complete the same task again
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, null, CancellationToken.None));
+
+        Assert.Contains($"Cannot complete task '{taskId}' with state 'Completed'. Only 'InProgress' tasks can be completed.", exception.Message);
+    }
+
+    [Fact]
+    public async Task CompleteStepAsync_RemovesStepFromDictionary()
+    {
+        // Arrange
+        var reporter = new PublishingActivityProgressReporter();
+        var stepId = "test-step";
+        var taskId = "test-task";
+
+        var step = await reporter.CreateStepAsync(stepId, "Test Step", CancellationToken.None);
+        var task = await reporter.CreateTaskAsync(taskId, stepId, "Test Task", CancellationToken.None);
+
+        // Act - Complete the step
+        await reporter.CompleteStepAsync(step, "Step completed", CancellationToken.None);
+
+        // Assert - Verify that operations on tasks belonging to the completed step now fail
+        // because the step has been removed from the dictionary
+        var updateException = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.UpdateTaskAsync(task, "New status", CancellationToken.None));
+        Assert.Contains($"Parent step with ID '{stepId}' does not exist.", updateException.Message);
+
+        var completeException = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.CompleteTaskAsync(task, TaskCompletionState.Completed, null, CancellationToken.None));
+        Assert.Contains($"Parent step with ID '{stepId}' does not exist.", completeException.Message);
+
+        // Also verify that creating new tasks for the completed step fails
+        var createException = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reporter.CreateTaskAsync("new-task", stepId, "New Task", CancellationToken.None));
+        Assert.Contains($"Step with ID '{stepId}' does not exist.", createException.Message);
+    }
+}


### PR DESCRIPTION
Contributes towards #9867.

This pull request introduces a hierarchical model (steps => tasks) the publishing progress UI to replace the previous flat activity structure.

https://github.com/user-attachments/assets/26cc607d-6d07-4b9f-a7f6-712fff2ea420

**Open Questions and Follow-ups**
- A failed task doesn't terminate the publish flow. Only failed steps or an entirely failed publish command do. Should failed tasks also force the completion of the publish flow?
- Should completing a step complete all in-progress tasks or should it only be possible to complete a step when all tasks attached to it have been completed? We don't currently have any safety checks here.
- Currently, the user has no way to control the top-level success/failure message. Now that we have a `PublishComplete` activity we can figure out a way for the user to control these messages.
- The modeling of steps/tasks in the ResourceContainerImageBuilder isn't the final view. We currently create a new step for each invocation of `BuildImageAsync`. We likely want to rework this so there is a single step for all calls associated with ResourceContainerImageBuilder and each image build appears as a step. Some interesting things to sort through there around sequencing for the steps/tasks depending on when ResourceContainerImageBuilder is called.


