### PR TITLE
Use STJ source generation in Cli backchannel

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,6 +50,8 @@
     <!-- for templates -->
     <MicrosoftAspNetCorePackageVersionForNet9>9.0.6</MicrosoftAspNetCorePackageVersionForNet9>
     <MicrosoftAspNetCorePackageVersionForNet10>10.0.0-preview.5.25277.114</MicrosoftAspNetCorePackageVersionForNet10>
+    <!-- Aspire.Cli uses a preview version of StreamJsonRpc which is needed for native AOT support. -->
+    <StreamJsonRpcPackageVersionForCli>2.23.32-alpha</StreamJsonRpcPackageVersionForCli>
   </PropertyGroup>
   <!-- .NET 9.0 Package Versions -->
   <PropertyGroup Label="Current">

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -20,7 +20,8 @@
     <RollForward>Major</RollForward>
     <PackageTags>aspire cli</PackageTags>
     <Description>Command line tool for Aspire developers.</Description>
-    <!--<PublishAot>true</PublishAot>-->
+    <!-- TODO: https://github.com/dotnet/aspire/issues/8677 - enable PublishAot when the build infrastructure supports all platforms. -->
+    <!--<PublishAot>true</PublishAot>--> 
     <!--JsonSerializerIsReflectionEnabledByDefault can be removed when PublishAot is enabled. -->
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault> 
   </PropertyGroup>
@@ -30,7 +31,7 @@
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="StreamJsonRpc" VersionOverride="2.23.32-alpha" />
+    <PackageReference Include="StreamJsonRpc" VersionOverride="$(StreamJsonRpcPackageVersionForCli)" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Semver" />

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -20,6 +20,9 @@
     <RollForward>Major</RollForward>
     <PackageTags>aspire cli</PackageTags>
     <Description>Command line tool for Aspire developers.</Description>
+    <!--<PublishAot>true</PublishAot>-->
+    <!--JsonSerializerIsReflectionEnabledByDefault can be removed when PublishAot is enabled. -->
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault> 
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,7 +30,7 @@
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="StreamJsonRpc" />
+    <PackageReference Include="StreamJsonRpc" VersionOverride="2.23.32-alpha" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Semver" />

--- a/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
+++ b/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
-    <PackageReference Include="StreamJsonRpc" />
+    <PackageReference Include="StreamJsonRpc" VersionOverride="$(StreamJsonRpcPackageVersionForCli)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

This sets us up for being AOT compatible once the build system is able to build for AOT on all platforms.

Contributes to #8677

FYI @AArnott 

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
