### PR TITLE
Increase BrowserTokenAuthenticationTests timeouts

### DIFF
--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -30,7 +30,6 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9345")]
     public async Task BrowserToken_LoginPage_Success_RedirectToResources()
     {
         // Arrange
@@ -57,7 +56,6 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9697")]
     public async Task BrowserToken_LoginPage_Failure_DisplayFailureMessage()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -37,22 +37,22 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
         await RunTestAsync(async page =>
         {
             // Act
-            var response = await page.GotoAsync("/").DefaultTimeout();
+            var response = await page.GotoAsync("/").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
             var uri = new Uri(response!.Url);
 
             Assert.Equal("/login?returnUrl=%2F", uri.PathAndQuery);
 
             var tokenTextBox = page.GetByRole(AriaRole.Textbox);
-            await tokenTextBox.FillAsync("VALID_TOKEN").DefaultTimeout();
+            await tokenTextBox.FillAsync("VALID_TOKEN").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
             var submitButton = page.GetByRole(AriaRole.Button);
-            await submitButton.ClickAsync().DefaultTimeout();
+            await submitButton.ClickAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
             // Assert
             await Assertions
                 .Expect(page.GetByText(MockDashboardClient.TestResource1.DisplayName))
                 .ToBeVisibleAsync()
-                .DefaultTimeout();
+                .DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         });
     }
 
@@ -64,24 +64,22 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
         await RunTestAsync(async page =>
         {
             // Act
-            var response = await page.GotoAsync("/").DefaultTimeout();
+            var response = await page.GotoAsync("/").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
             var uri = new Uri(response!.Url);
 
             Assert.Equal("/login?returnUrl=%2F", uri.PathAndQuery);
 
             var tokenTextBox = page.GetByRole(AriaRole.Textbox);
-            await tokenTextBox.FillAsync("INVALID_TOKEN").DefaultTimeout();
+            await tokenTextBox.FillAsync("INVALID_TOKEN").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
             var submitButton = page.GetByRole(AriaRole.Button);
-            await submitButton.ClickAsync().DefaultTimeout();
+            await submitButton.ClickAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
             // Assert
-            const int pageVisibleTimeout = 10000;
-
             await Assertions
                 .Expect(page.GetByText(Login.InvalidTokenErrorMessage))
                 .ToBeVisibleAsync()
-                .DefaultTimeout(pageVisibleTimeout);
+                .DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         });
     }
 
@@ -92,13 +90,13 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
         await RunTestAsync(async page =>
         {
             // Act
-            await page.GotoAsync("/login?t=VALID_TOKEN").DefaultTimeout();
+            await page.GotoAsync("/login?t=VALID_TOKEN").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
             // Assert
             await Assertions
                 .Expect(page.GetByText(MockDashboardClient.TestResource1.DisplayName))
                 .ToBeVisibleAsync()
-                .DefaultTimeout();
+                .DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
         });
     }
 
@@ -109,10 +107,10 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
         await RunTestAsync(async page =>
         {
             // Act
-            await page.GotoAsync("/login?t=INVALID_TOKEN").DefaultTimeout();
+            await page.GotoAsync("/login?t=INVALID_TOKEN").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
             var submitButton = page.GetByRole(AriaRole.Button);
-            var name = await submitButton.GetAttributeAsync("name").DefaultTimeout();
+            var name = await submitButton.GetAttributeAsync("name").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
 
             // Assert
             Assert.Equal("submit-token", name);


### PR DESCRIPTION
## Description

Similarly to the 'fixes' to previous playwright tests, I think we just need to increase the timeout for these tests. Increased in all tests in the class for consistency. 

relevant: #9345 and #9697

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
