### PR TITLE
Handle interaction service unimplemented and tests

### DIFF
--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Using Include="Aspire.Dashboard.Components.Resize" />
     <Using Include="Aspire.Dashboard.Model.BrowserStorage" />
+    <Using Include="Aspire.Dashboard.ServiceClient" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/Components/Controls/ApplicationName.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ApplicationName.razor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 

--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -19,18 +19,21 @@ namespace Aspire.Dashboard.Components.Interactions;
 
 public class InteractionsProvider : ComponentBase, IAsyncDisposable
 {
-    private record InteractionMessageBarReference(int InteractionId, Message Message);
-    private record InteractionDialogReference(int InteractionId, IDialogReference Dialog);
+    internal record InteractionMessageBarReference(int InteractionId, Message Message);
+    internal record InteractionDialogReference(int InteractionId, IDialogReference Dialog);
 
     private readonly CancellationTokenSource _cts = new();
     private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
     private readonly KeyedInteractionCollection _pendingInteractions = new();
     private readonly KeyedMessageCollection _openMessageBars = new();
 
-    private Task? _interactionsDisplayTask;
+    private Task? _dialogDisplayTask;
     private Task? _watchInteractionsTask;
     private TaskCompletionSource _interactionAvailableTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private InteractionDialogReference? _interactionDialogReference;
+
+    // Internal for testing.
+    internal bool? _enabled;
+    internal InteractionDialogReference? _interactionDialogReference;
 
     [Inject]
     public required IDashboardClient DashboardClient { get; init; }
@@ -52,345 +55,385 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
         // Exit quickly if the dashboard client is not enabled. For example, the dashboard is running in the standalone container.
         if (!DashboardClient.IsEnabled)
         {
+            Logger.LogDebug("InteractionProvider is disabled because the DashboardClient is not enabled.");
+            _enabled = false;
             return;
         }
-
-        _interactionsDisplayTask = Task.Run(async () =>
+        else
         {
-            var waitForInteractionAvailableTask = Task.CompletedTask;
+            _enabled = true;
+        }
 
-            while (!_cts.IsCancellationRequested)
+        _dialogDisplayTask = Task.Run(async () =>
+        {
+            try
             {
-                // If there are no pending interactions then wait on this task to get notified when one is added.
-                await waitForInteractionAvailableTask.WaitAsync(_cts.Token).ConfigureAwait(false);
-
-                IDialogReference? currentDialogReference = null;
-
-                await _semaphore.WaitAsync(_cts.Token).ConfigureAwait(false);
-                try
-                {
-                    if (_pendingInteractions.Count == 0)
-                    {
-                        // Task is set when a new interaction is added.
-                        // Continue here will exit the async lock and wait for the task to complete.
-                        waitForInteractionAvailableTask = _interactionAvailableTcs.Task;
-                        continue;
-                    }
-
-                    waitForInteractionAvailableTask = Task.CompletedTask;
-                    var item = ((IList<WatchInteractionsResponseUpdate>)_pendingInteractions)[0];
-                    _pendingInteractions.RemoveAt(0);
-
-                    Func<IDialogService, Task<IDialogReference>> openDialog;
-
-                    if (item.MessageBox is { } messageBox)
-                    {
-                        var dialogParameters = CreateDialogParameters(item, messageBox.Intent);
-                        dialogParameters.OnDialogResult = EventCallback.Factory.Create<DialogResult>(this, async dialogResult =>
-                        {
-                            var request = new WatchInteractionsRequestUpdate
-                            {
-                                InteractionId = item.InteractionId
-                            };
-
-                            if (dialogResult.Cancelled)
-                            {
-                                // There will be data in the dialog result on cancel if the secondary button is clicked.
-                                if (dialogResult.Data != null)
-                                {
-                                    messageBox.Result = false;
-                                    request.MessageBox = messageBox;
-                                }
-                                else
-                                {
-                                    request.Complete = new InteractionComplete();
-                                }
-                            }
-                            else
-                            {
-                                messageBox.Result = true;
-                                request.MessageBox = messageBox;
-                            }
-
-                            await DashboardClient.SendInteractionRequestAsync(request, _cts.Token).ConfigureAwait(false);
-                        });
-
-                        var content = new MessageBoxContent
-                        {
-                            Title = item.Title,
-                            MarkupMessage = new MarkupString(item.Message),
-                        };
-                        switch (messageBox.Intent)
-                        {
-                            case MessageIntentDto.None:
-                                content.Icon = null;
-                                break;
-                            case MessageIntentDto.Success:
-                                content.IconColor = Color.Success;
-                                content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.CheckmarkCircle();
-                                break;
-                            case MessageIntentDto.Warning:
-                                content.IconColor = Color.Warning;
-                                content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.Warning();
-                                break;
-                            case MessageIntentDto.Error:
-                                content.IconColor = Color.Error;
-                                content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.DismissCircle();
-                                break;
-                            case MessageIntentDto.Information:
-                                content.IconColor = Color.Info;
-                                content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.Info();
-                                break;
-                            case MessageIntentDto.Confirmation:
-                                content.IconColor = Color.Success;
-                                content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.QuestionCircle();
-                                break;
-                        }
-
-                        openDialog = dialogService => ShowMessageBoxAsync(dialogService, content, dialogParameters);
-                    }
-                    else if (item.InputsDialog is { } inputs)
-                    {
-                        var vm = new InteractionsInputsDialogViewModel
-                        {
-                            Interaction = item,
-                            OnSubmitCallback = async savedInteraction =>
-                            {
-                                var request = new WatchInteractionsRequestUpdate
-                                {
-                                    InteractionId = item.InteractionId,
-                                    InputsDialog = savedInteraction.InputsDialog
-                                };
-
-                                await DashboardClient.SendInteractionRequestAsync(request, _cts.Token).ConfigureAwait(false);
-                            }
-                        };
-
-                        var dialogParameters = CreateDialogParameters(item, intent: null);
-                        dialogParameters.OnDialogResult = EventCallback.Factory.Create<DialogResult>(this, async dialogResult =>
-                        {
-                            // Only send notification of completion if the dialog was cancelled.
-                            // A non-cancelled dialog result means the user submitted the form and we already sent the request.
-                            if (dialogResult.Cancelled)
-                            {
-                                var request = new WatchInteractionsRequestUpdate
-                                {
-                                    InteractionId = item.InteractionId,
-                                    Complete = new InteractionComplete()
-                                };
-
-                                await DashboardClient.SendInteractionRequestAsync(request, _cts.Token).ConfigureAwait(false);
-                            }
-                        });
-
-                        openDialog = dialogService => dialogService.ShowDialogAsync<InteractionsInputDialog>(vm, dialogParameters);
-                    }
-                    else
-                    {
-                        Logger.LogWarning("Unexpected interaction kind: {Kind}", item.KindCase);
-                        continue;
-                    }
-
-                    await InvokeAsync(async () =>
-                    {
-                        currentDialogReference = await openDialog(DialogService);
-                    });
-
-                    Debug.Assert(currentDialogReference != null, "Dialog should have been created in UI thread.");
-                    _interactionDialogReference = new InteractionDialogReference(item.InteractionId, currentDialogReference);
-                }
-                finally
-                {
-                    _semaphore.Release();
-                }
-
-                try
-                {
-                    if (currentDialogReference != null)
-                    {
-                        await currentDialogReference.Result.WaitAsync(_cts.Token);
-                    }
-                }
-                catch
-                {
-                    // Ignore any exceptions that occur while waiting for the dialog to close.
-                }
+                await InteractionsDisplayAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!_cts.IsCancellationRequested)
+            {
+                Logger.LogError(ex, "Unexpected error while displaying interaction dialogs.");
             }
         });
 
         _watchInteractionsTask = Task.Run(async () =>
         {
-            var interactions = DashboardClient.SubscribeInteractionsAsync(_cts.Token);
-            await foreach (var item in interactions)
+            try
             {
-                await _semaphore.WaitAsync(_cts.Token).ConfigureAwait(false);
-                try
+                await WatchInteractionsAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!_cts.IsCancellationRequested)
+            {
+                Logger.LogError(ex, "Unexpected error while watching interactions.");
+            }
+        });
+    }
+
+    private async Task InteractionsDisplayAsync()
+    {
+        var waitForInteractionAvailableTask = Task.CompletedTask;
+
+        while (!_cts.IsCancellationRequested)
+        {
+            // If there are no pending interactions then wait on this task to get notified when one is added.
+            await waitForInteractionAvailableTask.WaitAsync(_cts.Token).ConfigureAwait(false);
+
+            IDialogReference? currentDialogReference = null;
+
+            await _semaphore.WaitAsync(_cts.Token).ConfigureAwait(false);
+            try
+            {
+                if (_pendingInteractions.Count == 0)
                 {
-                    switch (item.KindCase)
+                    // Task is set when a new interaction is added.
+                    // Continue here will exit the async lock and wait for the task to complete.
+                    waitForInteractionAvailableTask = _interactionAvailableTcs.Task;
+                    continue;
+                }
+
+                waitForInteractionAvailableTask = Task.CompletedTask;
+                var item = ((IList<WatchInteractionsResponseUpdate>)_pendingInteractions)[0];
+                _pendingInteractions.RemoveAt(0);
+
+                Func<IDialogService, Task<IDialogReference>> openDialog;
+
+                if (item.MessageBox is { } messageBox)
+                {
+                    var dialogParameters = CreateDialogParameters(item, messageBox.Intent);
+                    dialogParameters.OnDialogResult = EventCallback.Factory.Create<DialogResult>(this, async dialogResult =>
                     {
-                        case WatchInteractionsResponseUpdate.KindOneofCase.MessageBox:
-                        case WatchInteractionsResponseUpdate.KindOneofCase.InputsDialog:
-                            if (_interactionDialogReference != null &&
-                                _interactionDialogReference.InteractionId == item.InteractionId)
+                        var request = new WatchInteractionsRequestUpdate
+                        {
+                            InteractionId = item.InteractionId
+                        };
+
+                        if (dialogResult.Cancelled)
+                        {
+                            // There will be data in the dialog result on cancel if the secondary button is clicked.
+                            if (dialogResult.Data != null)
                             {
-                                // If the dialog is already open for this interaction, update it with the new data.
-                                var c = (InteractionsInputsDialogViewModel)_interactionDialogReference.Dialog.Instance.Content;
-                                await c.UpdateInteractionAsync(item);
+                                messageBox.Result = false;
+                                request.MessageBox = messageBox;
                             }
                             else
                             {
-                                // New or updated interaction.
-                                if (_pendingInteractions.Contains(item.InteractionId))
-                                {
-                                    // Update existing interaction at the same place in collection.
-                                    var existingItem = _pendingInteractions[item.InteractionId];
-                                    var index = _pendingInteractions.IndexOf(existingItem);
-                                    _pendingInteractions.RemoveAt(index);
-                                    _pendingInteractions.Insert(index, item); // Reinsert at the same index to maintain order.
-                                }
-                                else
-                                {
-                                    _pendingInteractions.Add(item);
-                                }
-
-                                NotifyInteractionAvailable();
+                                request.Complete = new InteractionComplete();
                             }
+                        }
+                        else
+                        {
+                            messageBox.Result = true;
+                            request.MessageBox = messageBox;
+                        }
+
+                        await DashboardClient.SendInteractionRequestAsync(request, _cts.Token).ConfigureAwait(false);
+                    });
+
+                    var content = new MessageBoxContent
+                    {
+                        Title = item.Title,
+                        MarkupMessage = new MarkupString(item.Message),
+                    };
+                    switch (messageBox.Intent)
+                    {
+                        case MessageIntentDto.None:
+                            content.Icon = null;
                             break;
-                        case WatchInteractionsResponseUpdate.KindOneofCase.MessageBar:
-                            var messageBar = item.MessageBar;
-
-                            Message? message = null;
-                            await InvokeAsync(async () =>
-                            {
-                                message = await MessageService.ShowMessageBarAsync(options =>
-                                {
-                                    options.Title = WebUtility.HtmlEncode(item.Title);
-                                    options.Body = item.Message; // Message is already HTML encoded depending on options.
-                                    options.Intent = MapMessageIntent(messageBar.Intent);
-                                    options.Section = DashboardUIHelpers.MessageBarSection;
-                                    options.AllowDismiss = item.ShowDismiss;
-                                    if (!string.IsNullOrEmpty(messageBar.LinkText))
-                                    {
-                                        options.Link = new()
-                                        {
-                                            Text = messageBar.LinkText,
-                                            Href = messageBar.LinkUrl
-                                        };
-                                    }
-
-                                    var primaryButtonText = item.PrimaryButtonText;
-                                    var secondaryButtonText = item.ShowSecondaryButton ? item.SecondaryButtonText : null;
-                                    if (messageBar.Intent == MessageIntentDto.Confirmation)
-                                    {
-                                        primaryButtonText = ResolvedPrimaryButtonText(item, messageBar.Intent);
-                                        secondaryButtonText = ResolvedSecondaryButtonText(item);
-                                    }
-
-                                    bool? result = null;
-
-                                    if (!string.IsNullOrEmpty(primaryButtonText))
-                                    {
-                                        options.PrimaryAction = new ActionButton<Message>
-                                        {
-                                            Text = primaryButtonText,
-                                            OnClick = m =>
-                                            {
-                                                result = true;
-                                                m.Close();
-                                                return Task.CompletedTask;
-                                            }
-                                        };
-                                    }
-                                    if (item.ShowSecondaryButton && !string.IsNullOrEmpty(secondaryButtonText))
-                                    {
-                                        options.SecondaryAction = new ActionButton<Message>
-                                        {
-                                            Text = secondaryButtonText,
-                                            OnClick = m =>
-                                            {
-                                                result = false;
-                                                m.Close();
-                                                return Task.CompletedTask;
-                                            }
-                                        };
-                                    }
-
-                                    options.OnClose = async m =>
-                                    {
-                                        // Only send complete notification if in the open message bars list.
-                                        if (_openMessageBars.TryGetValue(item.InteractionId, out var openMessageBar))
-                                        {
-                                            var request = new WatchInteractionsRequestUpdate
-                                            {
-                                                InteractionId = item.InteractionId
-                                            };
-
-                                            if (result == null)
-                                            {
-                                                request.Complete = new InteractionComplete();
-                                            }
-                                            else
-                                            {
-                                                messageBar.Result = result.Value;
-                                                request.MessageBar = messageBar;
-                                            }
-
-                                            _openMessageBars.Remove(item.InteractionId);
-
-                                            await DashboardClient.SendInteractionRequestAsync(request, _cts.Token).ConfigureAwait(false);
-                                        }
-                                    };
-                                });
-                            });
-
-                            Debug.Assert(message != null, "Message should have been created in UI thread.");
-                            _openMessageBars.Add(new InteractionMessageBarReference(item.InteractionId, message));
+                        case MessageIntentDto.Success:
+                            content.IconColor = Color.Success;
+                            content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.CheckmarkCircle();
                             break;
-                        case WatchInteractionsResponseUpdate.KindOneofCase.Complete:
-                            // Complete interaction.
-                            _pendingInteractions.Remove(item.InteractionId);
-
-                            // Close the interaction's dialog if it is open.
-                            if (_interactionDialogReference?.InteractionId == item.InteractionId)
-                            {
-                                try
-                                {
-                                    await InvokeAsync(async () =>
-                                    {
-                                        await _interactionDialogReference.Dialog.CloseAsync();
-                                    });
-                                }
-                                catch (Exception ex)
-                                {
-                                    Logger.LogDebug(ex, "Unexpected error when closing interaction {InteractionId} dialog reference.", item.InteractionId);
-                                }
-                                finally
-                                {
-                                    _interactionDialogReference = null;
-                                }
-                            }
-
-                            if (_openMessageBars.TryGetValue(item.InteractionId, out var openMessageBar))
-                            {
-                                // The presence of the item in the collection is used to decide whether to report completion to the server.
-                                // This item is already completed (we're reacting to a completion notification) so remove before close.
-                                _openMessageBars.Remove(item.InteractionId);
-
-                                // InvokeAsync not necessary here. It's called internally.
-                                openMessageBar.Message.Close();
-                            }
+                        case MessageIntentDto.Warning:
+                            content.IconColor = Color.Warning;
+                            content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.Warning();
                             break;
-                        default:
-                            Logger.LogWarning("Unexpected interaction kind: {Kind}", item.KindCase);
+                        case MessageIntentDto.Error:
+                            content.IconColor = Color.Error;
+                            content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.DismissCircle();
+                            break;
+                        case MessageIntentDto.Information:
+                            content.IconColor = Color.Info;
+                            content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.Info();
+                            break;
+                        case MessageIntentDto.Confirmation:
+                            content.IconColor = Color.Success;
+                            content.Icon = new Microsoft.FluentUI.AspNetCore.Components.Icons.Filled.Size24.QuestionCircle();
                             break;
                     }
+
+                    openDialog = dialogService => ShowMessageBoxAsync(dialogService, content, dialogParameters);
                 }
-                finally
+                else if (item.InputsDialog is { } inputs)
                 {
-                    _semaphore.Release();
+                    var vm = new InteractionsInputsDialogViewModel
+                    {
+                        Interaction = item,
+                        OnSubmitCallback = async savedInteraction =>
+                        {
+                            var request = new WatchInteractionsRequestUpdate
+                            {
+                                InteractionId = savedInteraction.InteractionId,
+                                InputsDialog = savedInteraction.InputsDialog
+                            };
+
+                            await DashboardClient.SendInteractionRequestAsync(request, _cts.Token).ConfigureAwait(false);
+                        }
+                    };
+
+                    var dialogParameters = CreateDialogParameters(item, intent: null);
+                    dialogParameters.OnDialogResult = EventCallback.Factory.Create<DialogResult>(this, async dialogResult =>
+                    {
+                        // Only send notification of completion if the dialog was cancelled.
+                        // A non-cancelled dialog result means the user submitted the form and we already sent the request.
+                        if (dialogResult.Cancelled)
+                        {
+                            var request = new WatchInteractionsRequestUpdate
+                            {
+                                InteractionId = item.InteractionId,
+                                Complete = new InteractionComplete()
+                            };
+
+                            await DashboardClient.SendInteractionRequestAsync(request, _cts.Token).ConfigureAwait(false);
+                        }
+                    });
+
+                    openDialog = dialogService => dialogService.ShowDialogAsync<InteractionsInputDialog>(vm, dialogParameters);
+                }
+                else
+                {
+                    Logger.LogWarning("Unexpected interaction kind: {Kind}", item.KindCase);
+                    continue;
+                }
+
+                await InvokeAsync(async () =>
+                {
+                    currentDialogReference = await openDialog(DialogService);
+                });
+
+                Debug.Assert(currentDialogReference != null, "Dialog should have been created in UI thread.");
+                _interactionDialogReference = new InteractionDialogReference(item.InteractionId, currentDialogReference);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+
+            try
+            {
+                if (currentDialogReference != null)
+                {
+                    await currentDialogReference.Result.WaitAsync(_cts.Token);
+
+                    await _semaphore.WaitAsync(_cts.Token).ConfigureAwait(false);
+                    try
+                    {
+                        if (_interactionDialogReference?.Dialog == currentDialogReference)
+                        {
+                            _interactionDialogReference = null;
+                        }
+                    }
+                    finally
+                    {
+                        _semaphore.Release();
+                    }
                 }
             }
-        });
+            catch
+            {
+                // Ignore any exceptions that occur while waiting for the dialog to close.
+            }
+        }
+    }
+
+    private async Task WatchInteractionsAsync()
+    {
+        var interactions = DashboardClient.SubscribeInteractionsAsync(_cts.Token);
+        await foreach (var item in interactions)
+        {
+            await _semaphore.WaitAsync(_cts.Token).ConfigureAwait(false);
+            try
+            {
+                switch (item.KindCase)
+                {
+                    case WatchInteractionsResponseUpdate.KindOneofCase.MessageBox:
+                    case WatchInteractionsResponseUpdate.KindOneofCase.InputsDialog:
+                        if (_interactionDialogReference != null &&
+                            _interactionDialogReference.InteractionId == item.InteractionId)
+                        {
+                            // If the dialog is already open for this interaction, update it with the new data.
+                            var c = (InteractionsInputsDialogViewModel)_interactionDialogReference.Dialog.Instance.Content;
+                            await c.UpdateInteractionAsync(item);
+                        }
+                        else
+                        {
+                            // New or updated interaction.
+                            if (_pendingInteractions.Contains(item.InteractionId))
+                            {
+                                // Update existing interaction at the same place in collection.
+                                var existingItem = _pendingInteractions[item.InteractionId];
+                                var index = _pendingInteractions.IndexOf(existingItem);
+                                _pendingInteractions.RemoveAt(index);
+                                _pendingInteractions.Insert(index, item); // Reinsert at the same index to maintain order.
+                            }
+                            else
+                            {
+                                _pendingInteractions.Add(item);
+                            }
+
+                            NotifyInteractionAvailable();
+                        }
+                        break;
+                    case WatchInteractionsResponseUpdate.KindOneofCase.MessageBar:
+                        var messageBar = item.MessageBar;
+
+                        Message? message = null;
+                        await InvokeAsync(async () =>
+                        {
+                            message = await MessageService.ShowMessageBarAsync(options =>
+                            {
+                                options.Title = WebUtility.HtmlEncode(item.Title);
+                                options.Body = item.Message; // Message is already HTML encoded depending on options.
+                                options.Intent = MapMessageIntent(messageBar.Intent);
+                                options.Section = DashboardUIHelpers.MessageBarSection;
+                                options.AllowDismiss = item.ShowDismiss;
+                                if (!string.IsNullOrEmpty(messageBar.LinkText))
+                                {
+                                    options.Link = new()
+                                    {
+                                        Text = messageBar.LinkText,
+                                        Href = messageBar.LinkUrl
+                                    };
+                                }
+
+                                var primaryButtonText = item.PrimaryButtonText;
+                                var secondaryButtonText = item.ShowSecondaryButton ? item.SecondaryButtonText : null;
+                                if (messageBar.Intent == MessageIntentDto.Confirmation)
+                                {
+                                    primaryButtonText = ResolvedPrimaryButtonText(item, messageBar.Intent);
+                                    secondaryButtonText = ResolvedSecondaryButtonText(item);
+                                }
+
+                                bool? result = null;
+
+                                if (!string.IsNullOrEmpty(primaryButtonText))
+                                {
+                                    options.PrimaryAction = new ActionButton<Message>
+                                    {
+                                        Text = primaryButtonText,
+                                        OnClick = m =>
+                                        {
+                                            result = true;
+                                            m.Close();
+                                            return Task.CompletedTask;
+                                        }
+                                    };
+                                }
+                                if (item.ShowSecondaryButton && !string.IsNullOrEmpty(secondaryButtonText))
+                                {
+                                    options.SecondaryAction = new ActionButton<Message>
+                                    {
+                                        Text = secondaryButtonText,
+                                        OnClick = m =>
+                                        {
+                                            result = false;
+                                            m.Close();
+                                            return Task.CompletedTask;
+                                        }
+                                    };
+                                }
+
+                                options.OnClose = async m =>
+                                {
+                                    // Only send complete notification if in the open message bars list.
+                                    if (_openMessageBars.TryGetValue(item.InteractionId, out var openMessageBar))
+                                    {
+                                        var request = new WatchInteractionsRequestUpdate
+                                        {
+                                            InteractionId = item.InteractionId
+                                        };
+
+                                        if (result == null)
+                                        {
+                                            request.Complete = new InteractionComplete();
+                                        }
+                                        else
+                                        {
+                                            messageBar.Result = result.Value;
+                                            request.MessageBar = messageBar;
+                                        }
+
+                                        _openMessageBars.Remove(item.InteractionId);
+
+                                        await DashboardClient.SendInteractionRequestAsync(request, _cts.Token).ConfigureAwait(false);
+                                    }
+                                };
+                            });
+                        });
+
+                        Debug.Assert(message != null, "Message should have been created in UI thread.");
+                        _openMessageBars.Add(new InteractionMessageBarReference(item.InteractionId, message));
+                        break;
+                    case WatchInteractionsResponseUpdate.KindOneofCase.Complete:
+                        // Complete interaction.
+                        _pendingInteractions.Remove(item.InteractionId);
+
+                        // Close the interaction's dialog if it is open.
+                        if (_interactionDialogReference?.InteractionId == item.InteractionId)
+                        {
+                            try
+                            {
+                                await InvokeAsync(_interactionDialogReference.Dialog.CloseAsync);
+                            }
+                            catch (Exception ex)
+                            {
+                                Logger.LogDebug(ex, "Unexpected error when closing interaction {InteractionId} dialog reference.", item.InteractionId);
+                            }
+                            finally
+                            {
+                                _interactionDialogReference = null;
+                            }
+                        }
+
+                        if (_openMessageBars.TryGetValue(item.InteractionId, out var openMessageBar))
+                        {
+                            // The presence of the item in the collection is used to decide whether to report completion to the server.
+                            // This item is already completed (we're reacting to a completion notification) so remove before close.
+                            _openMessageBars.Remove(item.InteractionId);
+
+                            // InvokeAsync not necessary here. It's called internally.
+                            openMessageBar.Message.Close();
+                        }
+                        break;
+                    default:
+                        Logger.LogWarning("Unexpected interaction kind: {Kind}", item.KindCase);
+                        break;
+                }
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
     }
 
     private static MessageIntentUI MapMessageIntent(MessageIntentDto intent)
@@ -478,7 +521,7 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
     {
         _cts.Cancel();
 
-        await TaskHelpers.WaitIgnoreCancelAsync(_interactionsDisplayTask);
+        await TaskHelpers.WaitIgnoreCancelAsync(_dialogDisplayTask);
         await TaskHelpers.WaitIgnoreCancelAsync(_watchInteractionsTask);
     }
 

--- a/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor
@@ -1,5 +1,4 @@
-﻿@using Aspire.Dashboard.Model
-@using Aspire.Dashboard.Resources
+﻿@using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils
 @inject IStringLocalizer<Layout> Loc
 @inject IDashboardClient DashboardClient

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -199,7 +199,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         {
             Title = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogTitle)],
             DismissTitle = DialogsLoc[nameof(Resources.Dialogs.DialogCloseButtonText)],
-            PrimaryAction =  Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)].Value,
+            PrimaryAction = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)].Value,
             SecondaryAction = null,
             TrapFocus = true,
             Modal = true,

--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor.cs
@@ -3,12 +3,11 @@
 
 using System.Text.RegularExpressions;
 using Aspire.Dashboard.Components.CustomIcons;
-using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
-using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 using Microsoft.JSInterop;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Layout;
 

--- a/src/Aspire.Dashboard/Components/_Imports.razor
+++ b/src/Aspire.Dashboard/Components/_Imports.razor
@@ -17,6 +17,8 @@
 @using Aspire.Dashboard.Components
 @using Aspire.Dashboard.Components.Controls
 @using Aspire.Dashboard.Components.Layout
+@using Aspire.Dashboard.Model
+@using Aspire.Dashboard.ServiceClient
 @using Microsoft.Extensions.Localization
 
 @* Require authorization for all pages of the web app *@

--- a/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
@@ -2,9 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using Aspire.Dashboard.Model;
 using Aspire.DashboardService.Proto.V1;
 
-namespace Aspire.Dashboard.Model;
+namespace Aspire.Dashboard.ServiceClient;
 
 /// <summary>
 /// Provides data about active resources to external components, such as the dashboard.

--- a/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
@@ -315,7 +315,7 @@ internal sealed class InteractionCompletionState
 [DebuggerDisplay("InteractionId = {InteractionId}, State = {State}, Title = {Title}")]
 internal class Interaction
 {
-    private static int s_nextInteractionId = 1;
+    private static int s_nextInteractionId;
 
     public int InteractionId { get; }
     public InteractionState State { get; set; }

--- a/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
+++ b/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
@@ -20,10 +20,11 @@
     <Compile Include="$(TestsSharedDir)Telemetry\*.cs" LinkBase="shared/Telemetry" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
     <Compile Include="$(TestsSharedDir)DashboardModel\*.cs" LinkBase="shared/DashboardModel" />
+    <Compile Include="..\Aspire.Dashboard.Tests\Model\MockKnownPropertyLookup.cs" Link="Shared\MockKnownPropertyLookup.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Aspire.Dashboard.Tests\Model\MockKnownPropertyLookup.cs" Link="Shared\MockKnownPropertyLookup.cs" />
+    <Using Include="Aspire.Dashboard.ServiceClient" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Dashboard.Components.Tests/Interactions/InteractionsProviderTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Interactions/InteractionsProviderTests.cs
@@ -1,0 +1,292 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Model;
+using Aspire.DashboardService.Proto.V1;
+using Bunit;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Interactions;
+
+[UseCulture("en-US")]
+public partial class InteractionsProviderTests : DashboardTestContext
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public InteractionsProviderTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async Task Initialize_DashboardClientNotEnabled_ProviderDisabledAsync()
+    {
+        // Arrange
+        var dashboardClient = new TestDashboardClient(isEnabled: false);
+
+        SetupInteractionProviderServices(dashboardClient);
+
+        // Act
+        var cut = RenderComponent<Components.Interactions.InteractionsProvider>();
+
+        var instance = cut.Instance;
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.False(instance._enabled);
+        });
+
+        await instance.DisposeAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task Initialize_DashboardClientEnabled_ProviderEnabledAsync()
+    {
+        // Arrange
+        var interactionsChannel = Channel.CreateUnbounded<WatchInteractionsResponseUpdate>();
+
+        var dashboardClient = new TestDashboardClient(isEnabled: true, interactionChannelProvider: () => interactionsChannel);
+
+        SetupInteractionProviderServices(dashboardClient);
+
+        // Act
+        var cut = RenderComponent<Components.Interactions.InteractionsProvider>();
+
+        var instance = cut.Instance;
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(instance._enabled);
+        });
+
+        await instance.DisposeAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task ReceiveData_MessageBoxOpen_OpenDialog()
+    {
+        // Arrange
+        var interactionsChannel = Channel.CreateUnbounded<WatchInteractionsResponseUpdate>();
+
+        var dialogReference = new DialogReference("abc", null!);
+        var dashboardClient = new TestDashboardClient(isEnabled: true, interactionChannelProvider: () => interactionsChannel);
+        var dialogService = new TestDialogService(onShowDialog: (data, parameters) => Task.FromResult<IDialogReference>(dialogReference));
+
+        SetupInteractionProviderServices(dashboardClient: dashboardClient, dialogService: dialogService);
+
+        // Act 1
+        var cut = RenderComponent<Components.Interactions.InteractionsProvider>();
+
+        var instance = cut.Instance;
+
+        await interactionsChannel.Writer.WriteAsync(new WatchInteractionsResponseUpdate
+        {
+            InteractionId = 1,
+            MessageBox = new InteractionMessageBox()
+        });
+
+        // Assert 1
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() =>
+        {
+            var reference = instance._interactionDialogReference;
+            if (reference == null)
+            {
+                return false;
+            }
+
+            return dialogReference == reference.Dialog && reference.InteractionId == 1;
+        }, "Wait for dialog reference created.");
+
+        // Act 2
+        dialogReference.Dismiss(DialogResult.Ok(true));
+
+        // Assert 2
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() => instance._interactionDialogReference == null, "Wait for dialog reference dismissed.");
+
+        await instance.DisposeAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task ReceiveData_MessageBoxOpenAndCompletion_OpenAndCloseDialog()
+    {
+        // Arrange
+        var interactionsChannel = Channel.CreateUnbounded<WatchInteractionsResponseUpdate>();
+
+        var dialogReference = new DialogReference("abc", null!);
+        var dashboardClient = new TestDashboardClient(isEnabled: true, interactionChannelProvider: () => interactionsChannel);
+        var dialogService = new TestDialogService(onShowDialog: (data, parameters) => Task.FromResult<IDialogReference>(dialogReference));
+
+        SetupInteractionProviderServices(dashboardClient: dashboardClient, dialogService: dialogService);
+
+        // Act 1
+        var cut = RenderComponent<Components.Interactions.InteractionsProvider>();
+
+        var instance = cut.Instance;
+
+        await interactionsChannel.Writer.WriteAsync(new WatchInteractionsResponseUpdate
+        {
+            InteractionId = 1,
+            MessageBox = new InteractionMessageBox()
+        });
+
+        // Assert 1
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() =>
+        {
+            var reference = instance._interactionDialogReference;
+            if (reference == null)
+            {
+                return false;
+            }
+
+            return dialogReference == reference.Dialog && reference.InteractionId == 1;
+        }, "Wait for dialog reference created.");
+
+        // Act 2
+        await interactionsChannel.Writer.WriteAsync(new WatchInteractionsResponseUpdate
+        {
+            InteractionId = 1,
+            Complete = new InteractionComplete()
+        });
+
+        // Assert 2
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() => instance._interactionDialogReference == null, "Wait for dialog reference dismissed.");
+
+        await instance.DisposeAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task ReceiveData_InputDialogOpenAndCancel_OpenDialogAndSendCompletion()
+    {
+        // Arrange
+        var interactionsChannel = Channel.CreateUnbounded<WatchInteractionsResponseUpdate>();
+        var sendInteractionUpdatesChannel = Channel.CreateUnbounded<WatchInteractionsRequestUpdate>();
+
+        DialogParameters? dialogParameters = null;
+        var dialogReference = new DialogReference("abc", null!);
+        var dashboardClient = new TestDashboardClient(isEnabled: true,
+            interactionChannelProvider: () => interactionsChannel,
+            sendInteractionUpdateChannel: sendInteractionUpdatesChannel);
+        var dialogService = new TestDialogService(onShowDialog: (data, parameters) =>
+        {
+            dialogParameters = parameters;
+            return Task.FromResult<IDialogReference>(dialogReference);
+        });
+
+        SetupInteractionProviderServices(dashboardClient: dashboardClient, dialogService: dialogService);
+
+        // Act 1
+        var cut = RenderComponent<Components.Interactions.InteractionsProvider>();
+
+        var instance = cut.Instance;
+
+        await interactionsChannel.Writer.WriteAsync(new WatchInteractionsResponseUpdate
+        {
+            InteractionId = 1,
+            InputsDialog = new InteractionInputsDialog()
+        });
+
+        // Assert 1
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() =>
+        {
+            var reference = instance._interactionDialogReference;
+            if (reference == null)
+            {
+                return false;
+            }
+
+            return dialogReference == reference.Dialog && reference.InteractionId == 1;
+        }, "Wait for dialog reference created.");
+
+        // Act 2
+        Assert.NotNull(dialogParameters);
+
+        await cut.InvokeAsync(() => dialogParameters.OnDialogResult.InvokeAsync(DialogResult.Cancel())).DefaultTimeout();
+
+        var update = await sendInteractionUpdatesChannel.Reader.ReadAsync();
+
+        Assert.Equal(1, update.InteractionId);
+        Assert.Equal(WatchInteractionsRequestUpdate.KindOneofCase.Complete, update.KindCase);
+
+        await instance.DisposeAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task ReceiveData_InputDialogOpenAndSubmit_OpenDialogAndSendCompletion()
+    {
+        // Arrange
+        var interactionsChannel = Channel.CreateUnbounded<WatchInteractionsResponseUpdate>();
+        var sendInteractionUpdatesChannel = Channel.CreateUnbounded<WatchInteractionsRequestUpdate>();
+
+        InteractionsInputsDialogViewModel? vm = null;
+        DialogParameters? dialogParameters = null;
+        var dialogReference = new DialogReference("abc", null!);
+        var dashboardClient = new TestDashboardClient(isEnabled: true,
+            interactionChannelProvider: () => interactionsChannel,
+            sendInteractionUpdateChannel: sendInteractionUpdatesChannel);
+        var dialogService = new TestDialogService(onShowDialog: (data, parameters) =>
+        {
+            vm = (InteractionsInputsDialogViewModel)data;
+            dialogParameters = parameters;
+            return Task.FromResult<IDialogReference>(dialogReference);
+        });
+
+        SetupInteractionProviderServices(dashboardClient: dashboardClient, dialogService: dialogService);
+
+        // Act 1
+        var cut = RenderComponent<Components.Interactions.InteractionsProvider>();
+
+        var instance = cut.Instance;
+
+        var response = new WatchInteractionsResponseUpdate
+        {
+            InteractionId = 1,
+            InputsDialog = new InteractionInputsDialog()
+        };
+        await interactionsChannel.Writer.WriteAsync(response);
+
+        // Assert 1
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() =>
+        {
+            var reference = instance._interactionDialogReference;
+            if (reference == null)
+            {
+                return false;
+            }
+
+            return dialogReference == reference.Dialog && reference.InteractionId == 1;
+        }, "Wait for dialog reference created.");
+
+        // Act 2
+        Assert.NotNull(dialogParameters);
+        Assert.NotNull(vm);
+
+        await vm.OnSubmitCallback(response).DefaultTimeout();
+
+        var update = await sendInteractionUpdatesChannel.Reader.ReadAsync();
+
+        Assert.Equal(1, update.InteractionId);
+        Assert.Equal(WatchInteractionsRequestUpdate.KindOneofCase.InputsDialog, update.KindCase);
+
+        await instance.DisposeAsync().DefaultTimeout();
+    }
+
+    private void SetupInteractionProviderServices(TestDashboardClient? dashboardClient = null, TestDialogService? dialogService = null)
+    {
+        var loggerFactory = IntegrationTestHelpers.CreateLoggerFactory(_testOutputHelper);
+
+        Services.AddLocalization();
+        Services.AddSingleton<ILoggerFactory>(loggerFactory);
+
+        Services.AddSingleton<IDialogService>(dialogService ?? new TestDialogService());
+        Services.AddSingleton<IMessageService, MessageService>();
+        Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient());
+    }
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/LoginTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/LoginTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Tests.Shared;
-using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Tests;
 using Bunit;

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashboardClient.cs
@@ -13,7 +13,9 @@ public class TestDashboardClient : IDashboardClient
 {
     private readonly Func<string, Channel<IReadOnlyList<ResourceLogLine>>>? _consoleLogsChannelProvider;
     private readonly Func<Channel<IReadOnlyList<ResourceViewModelChange>>>? _resourceChannelProvider;
+    private readonly Func<Channel<WatchInteractionsResponseUpdate>>? _interactionChannelProvider;
     private readonly Channel<ResourceCommandResponseViewModel>? _resourceCommandsChannel;
+    private readonly Channel<WatchInteractionsRequestUpdate>? _sendInteractionUpdateChannel;
     private readonly IList<ResourceViewModel>? _initialResources;
 
     public bool IsEnabled { get; }
@@ -24,13 +26,17 @@ public class TestDashboardClient : IDashboardClient
         bool? isEnabled = false,
         Func<string, Channel<IReadOnlyList<ResourceLogLine>>>? consoleLogsChannelProvider = null,
         Func<Channel<IReadOnlyList<ResourceViewModelChange>>>? resourceChannelProvider = null,
+        Func<Channel<WatchInteractionsResponseUpdate>>? interactionChannelProvider = null,
         Channel<ResourceCommandResponseViewModel>? resourceCommandsChannel = null,
+        Channel<WatchInteractionsRequestUpdate>? sendInteractionUpdateChannel = null,
         IList<ResourceViewModel>? initialResources = null)
     {
         IsEnabled = isEnabled ?? false;
         _consoleLogsChannelProvider = consoleLogsChannelProvider;
         _resourceChannelProvider = resourceChannelProvider;
+        _interactionChannelProvider = interactionChannelProvider;
         _resourceCommandsChannel = resourceCommandsChannel;
+        _sendInteractionUpdateChannel = sendInteractionUpdateChannel;
         _initialResources = initialResources;
     }
 
@@ -91,11 +97,31 @@ public class TestDashboardClient : IDashboardClient
 
     public IAsyncEnumerable<WatchInteractionsResponseUpdate> SubscribeInteractionsAsync(CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        if (_interactionChannelProvider == null)
+        {
+            throw new InvalidOperationException("No channel provider set.");
+        }
+
+        var channel = _interactionChannelProvider();
+
+        return BuildSubscription(channel, cancellationToken);
+
+        async static IAsyncEnumerable<WatchInteractionsResponseUpdate> BuildSubscription(Channel<WatchInteractionsResponseUpdate> channel, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken))
+            {
+                yield return item;
+            }
+        }
     }
 
-    public Task SendInteractionRequestAsync(WatchInteractionsRequestUpdate request, CancellationToken cancellationToken)
+    public async Task SendInteractionRequestAsync(WatchInteractionsRequestUpdate request, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        if (_sendInteractionUpdateChannel == null)
+        {
+            throw new InvalidOperationException("No resource command channel set.");
+        }
+
+        await _sendInteractionUpdateChannel.Writer.WriteAsync(request, cancellationToken);
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestDialogService.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestDialogService.cs
@@ -1,0 +1,238 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Tests.Shared;
+
+public class TestDialogService : IDialogService
+{
+    private readonly Func<object, DialogParameters, Task<IDialogReference>>? _onShowDialog;
+
+    public TestDialogService(Func<object, DialogParameters, Task<IDialogReference>>? onShowDialog = null)
+    {
+        _onShowDialog = onShowDialog;
+    }
+
+#pragma warning disable CS0067
+    public event Action<IDialogReference, Type?, DialogParameters, object>? OnShow;
+    public event Func<IDialogReference, Type?, DialogParameters, object, Task<IDialogReference>>? OnShowAsync;
+    public event Action<string, DialogParameters>? OnUpdate;
+    public event Func<string, DialogParameters, Task<IDialogReference?>>? OnUpdateAsync;
+    public event Action<IDialogReference, DialogResult>? OnDialogCloseRequested;
+#pragma warning restore CS0067
+
+    public Task CloseAsync(DialogReference dialog)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task CloseAsync(DialogReference dialog, DialogResult result)
+    {
+        throw new NotImplementedException();
+    }
+
+    public EventCallback<DialogResult> CreateDialogCallback(object receiver, Func<DialogResult, Task> callback)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowConfirmation(object receiver, Func<DialogResult, Task> callback, string message, string primaryText = "Yes", string secondaryText = "No", string? title = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowConfirmationAsync(object receiver, Func<DialogResult, Task> callback, string message, string primaryText = "Yes", string secondaryText = "No", string? title = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowConfirmationAsync(string message, string primaryText = "Yes", string secondaryText = "No", string? title = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowDialog<TDialog, TData>(DialogParameters<TData> parameters)
+        where TDialog : IDialogContentComponent<TData>
+        where TData : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowDialog<TData>(Type dialogComponent, TData data, DialogParameters parameters) where TData : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowDialogAsync<TData>(Type dialogComponent, TData data, DialogParameters parameters) where TData : class
+    {
+        return _onShowDialog?.Invoke(data, parameters) ?? throw new InvalidOperationException("No dialog callback specified.");
+    }
+
+    public Task<IDialogReference> ShowDialogAsync<TDialog>(object data, DialogParameters parameters) where TDialog : IDialogContentComponent
+    {
+        return _onShowDialog?.Invoke(data, parameters) ?? throw new InvalidOperationException("No dialog callback specified.");
+    }
+
+    public Task<IDialogReference> ShowDialogAsync<TDialog>(DialogParameters parameters) where TDialog : IDialogContentComponent
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowDialogAsync(RenderFragment renderFragment, DialogParameters dialogParameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowDialogAsync<TDialog, TData>(DialogParameters<TData> parameters)
+        where TDialog : IDialogContentComponent<TData>
+        where TData : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowError(string message, string? title = null, string? primaryText = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowErrorAsync(string message, string? title = null, string? primaryText = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowInfo(string message, string? title = null, string? primaryText = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowInfoAsync(string message, string? title = null, string? primaryText = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowMessageBox(DialogParameters<MessageBoxContent> parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowMessageBoxAsync(DialogParameters<MessageBoxContent> parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowPanel<TDialog, TData>(DialogParameters<TData> parameters)
+        where TDialog : IDialogContentComponent<TData>
+        where TData : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowPanel<TData>(Type dialogComponent, DialogParameters<TData> parameters) where TData : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowPanelAsync<TData>(Type dialogComponent, TData data, DialogParameters parameters) where TData : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowPanelAsync<TDialog>(object data, DialogParameters parameters) where TDialog : IDialogContentComponent
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowPanelAsync<TDialog>(DialogParameters parameters) where TDialog : IDialogContentComponent
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowPanelAsync<TDialog, TData>(DialogParameters<TData> parameters)
+        where TDialog : IDialogContentComponent<TData>
+        where TData : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowPanelAsync<TData>(Type dialogComponent, DialogParameters<TData> parameters) where TData : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowSplashScreen(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowSplashScreen<T>(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters) where T : IDialogContentComponent<SplashScreenContent>
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowSplashScreen(Type component, object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowSplashScreenAsync(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowSplashScreenAsync(DialogParameters<SplashScreenContent> parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowSplashScreenAsync<T>(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters) where T : IDialogContentComponent<SplashScreenContent>
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowSplashScreenAsync<T>(DialogParameters<SplashScreenContent> parameters) where T : IDialogContentComponent<SplashScreenContent>
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowSplashScreenAsync(Type component, object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowSplashScreenAsync(Type component, DialogParameters<SplashScreenContent> parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowSuccess(string message, string? title = null, string? primaryText = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowSuccessAsync(string message, string? title = null, string? primaryText = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ShowWarning(string message, string? title = null, string? primaryText = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference> ShowWarningAsync(string message, string? title = null, string? primaryText = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void UpdateDialog<TData>(string id, DialogParameters<TData> parameters) where TData : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IDialogReference?> UpdateDialogAsync<TData>(string id, DialogParameters<TData> parameters) where TData : class
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -38,5 +38,9 @@
     <Content Include="..\..\src\Aspire.Dashboard\wwwroot\**\*.*" LinkBase="wwwroot" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="Aspire.Dashboard.ServiceClient" />
+  </ItemGroup>
+
   <Import Project="..\Shared\Playwright\Playwright.targets" />
 </Project>

--- a/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
@@ -4,7 +4,6 @@
 using System.Net;
 using System.Threading.Channels;
 using Aspire.Dashboard.Configuration;
-using Aspire.Dashboard.Model;
 using Aspire.DashboardService.Proto.V1;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using Aspire.Dashboard.Configuration;
-using Aspire.Dashboard.Model;
 using Aspire.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
 using Microsoft.AspNetCore.InternalTesting;
+using Grpc.Core;
 
 namespace Aspire.Dashboard.Tests.Model;
 
@@ -152,7 +153,6 @@ public sealed class DashboardClientTests
     public async Task SubscribeInteractions_OnCancel_ChannelRemoved()
     {
         await using var instance = CreateResourceServiceClient();
-        instance.SetInitialDataReceived();
 
         IDashboardClient client = instance;
 
@@ -182,7 +182,6 @@ public sealed class DashboardClientTests
     public async Task SubscribeInteractions_OnDispose_ChannelRemoved()
     {
         await using var instance = CreateResourceServiceClient();
-        instance.SetInitialDataReceived();
 
         IDashboardClient client = instance;
 
@@ -220,7 +219,6 @@ public sealed class DashboardClientTests
     public async Task SubscribeInteractions_IncreasesSubscriberCount()
     {
         await using var instance = CreateResourceServiceClient();
-        instance.SetInitialDataReceived();
 
         IDashboardClient client = instance;
 
@@ -233,6 +231,79 @@ public sealed class DashboardClientTests
         await instance.DisposeAsync().DefaultTimeout();
 
         Assert.Equal(0, instance.OutgoingInteractionSubscriberCount);
+    }
+
+    [Fact]
+    public async Task WhenConnected_InteractionMethodUnimplemented_InteractionWatchCompleted()
+    {
+        await using var instance = CreateResourceServiceClient();
+        instance.SetDashboardServiceClient(new MockDashboardServiceClient());
+
+        await instance.WhenConnected.DefaultTimeout();
+
+        await instance.InteractionWatchCompleteTask.DefaultTimeout();
+    }
+
+    private sealed class MockDashboardServiceClient : Aspire.DashboardService.Proto.V1.DashboardService.DashboardServiceClient
+    {
+        public override AsyncDuplexStreamingCall<WatchInteractionsRequestUpdate, WatchInteractionsResponseUpdate> WatchInteractions(CallOptions options)
+        {
+            return new AsyncDuplexStreamingCall<WatchInteractionsRequestUpdate, WatchInteractionsResponseUpdate>(
+                new ClientStreamWriter<WatchInteractionsRequestUpdate>(),
+                new AsyncStreamReader<WatchInteractionsResponseUpdate>(),
+                Task.FromResult(new Metadata()),
+                () => new Status(StatusCode.Unimplemented, "Unimplemented!"),
+                () => new Metadata(),
+                () => { });
+        }
+
+        public override AsyncUnaryCall<ApplicationInformationResponse> GetApplicationInformationAsync(ApplicationInformationRequest request, CallOptions options)
+        {
+            return new AsyncUnaryCall<ApplicationInformationResponse>(
+                Task.FromResult(new ApplicationInformationResponse
+                {
+                    ApplicationName = "TestApplication"
+                }),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { });
+        }
+
+        public override AsyncServerStreamingCall<WatchResourcesUpdate> WatchResources(WatchResourcesRequest request, CallOptions options)
+        {
+            return new AsyncServerStreamingCall<WatchResourcesUpdate>(
+                new AsyncStreamReader<WatchResourcesUpdate>(),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { });
+        }
+    }
+
+    private sealed class AsyncStreamReader<T> : IAsyncStreamReader<T>
+    {
+        public T Current { get; } = default!;
+
+        public Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    private sealed class ClientStreamWriter<T> : IClientStreamWriter<T>
+    {
+        public WriteOptions? WriteOptions { get; set; }
+
+        public Task CompleteAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteAsync(T message)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     private DashboardClient CreateResourceServiceClient()

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -2,16 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Configuration;
-using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
-using Google.Protobuf.WellKnownTypes;
 using Aspire.DashboardService.Proto.V1;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
-using Microsoft.AspNetCore.InternalTesting;
-using Grpc.Core;
 
 namespace Aspire.Dashboard.Tests.Model;
 

--- a/tests/Aspire.Hosting.Tests/Utils/Grpc/TestAsyncStreamReader.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/Grpc/TestAsyncStreamReader.cs
@@ -27,9 +27,9 @@ public class TestAsyncStreamReader<T> : IAsyncStreamReader<T> where T : class
         }
     }
 
-    public void Complete()
+    public void Complete(Exception? ex = null)
     {
-        _channel.Writer.Complete();
+        _channel.Writer.Complete(ex);
     }
 
     public async Task<bool> MoveNext(CancellationToken cancellationToken)

--- a/tests/Aspire.Hosting.Tests/Utils/Grpc/TestServerStreamWriter.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/Grpc/TestServerStreamWriter.cs
@@ -20,9 +20,9 @@ public class TestServerStreamWriter<T> : IServerStreamWriter<T> where T : class
         _serverCallContext = serverCallContext;
     }
 
-    public void Complete()
+    public void Complete(Exception? ex = null)
     {
-        _channel.Writer.Complete();
+        _channel.Writer.Complete(ex);
     }
 
     public IAsyncEnumerable<T> ReadAllAsync()


### PR DESCRIPTION
## Description

It's possible an app host doesn't implement the interaction service. We don't want the client to go into an infinite retry loop.

This change detects an unimplemented response from the server and stops the background task in the client watching for interactions.

Also, lots of tests.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
