### PR TITLE
Increase name column width on the trace detail page

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -69,7 +69,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         TelemetryContextProvider.Initialize(TelemetryContext);
 
         _gridColumns = [
-            new GridColumn(Name: NameColumn, DesktopWidth: "4fr", MobileWidth: "4fr"),
+            new GridColumn(Name: NameColumn, DesktopWidth: "6fr", MobileWidth: "6fr"),
             new GridColumn(Name: TicksColumn, DesktopWidth: "12fr", MobileWidth: "12fr"),
             new GridColumn(Name: ActionsColumn, DesktopWidth: "100px", MobileWidth: null)
         ];


### PR DESCRIPTION
Increase width of the name column on the trace detail page. Go from 25% to 33%.

After:

![image](https://github.com/user-attachments/assets/32c0ceb2-aa42-4b85-9b94-e42e0e044123)
