### PR TITLE
Quick fix to codespaces dashboard link.

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -157,12 +157,12 @@ internal sealed class RunCommand : BaseCommand
             grid.AddColumn();
 
             grid.AddRow(new Markup("[bold green]Dashboard[/]:"), new Markup($"[link]{dashboardUrls.BaseUrlWithLoginToken}[/]"));
-            grid.AddRow(new Markup("[bold green]Logs[/]:"), new Text(logFile.FullName));
-
             if (dashboardUrls.CodespacesUrlWithLoginToken is { } codespacesUrlWithLoginToken)
             {
                 grid.AddRow(new Text(string.Empty), new Markup($"[link]{codespacesUrlWithLoginToken}[/]"));
             }
+            grid.AddRow(new Markup("[bold green]Logs[/]:"), new Text(logFile.FullName));
+
 
             _ansiConsole.Write(grid);
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -163,7 +163,6 @@ internal sealed class RunCommand : BaseCommand
             }
             grid.AddRow(new Markup("[bold green]Logs[/]:"), new Text(logFile.FullName));
 
-
             _ansiConsole.Write(grid);
 
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code


### PR DESCRIPTION
Quick fix to the output ordering of the dashboard links in `aspire run`. When running in codespaces/devcontainer we need the second link.