### PR TITLE
Add new YARP fluent configuration

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -282,6 +282,11 @@
     <Project Path="playground/webpubsub/WebPubSub.AppHost/WebPubSub.AppHost.csproj" />
     <Project Path="playground/webpubsub/WebPubSubWeb/WebPubSubWeb.csproj" />
   </Folder>
+  <Folder Name="/playground/yarp/">
+    <Project Path="playground/yarp/Yarp.AppHost/Yarp.AppHost.csproj" Id="8dcffdd3-e0d3-44cc-8fb7-6d7a3db2e1d5" />
+    <Project Path="playground/yarp/Yarp.Backend/Yarp.Backend.csproj" Id="1a96af46-9332-4e00-9202-fb00bd7d37b3" />
+    <Project Path="playground/yarp/Yarp.Frontend/Yarp.Frontend.csproj" Id="a5c7276a-9ac5-4b89-9c1a-34efd457c7a4" />
+  </Folder>
   <Folder Name="/ServiceDiscovery/">
     <Project Path="src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Microsoft.Extensions.ServiceDiscovery.Abstractions.csproj" />
     <Project Path="src/Microsoft.Extensions.ServiceDiscovery.Dns/Microsoft.Extensions.ServiceDiscovery.Dns.csproj" />
@@ -403,8 +408,8 @@
   </Folder>
   <Folder Name="/Tools/">
     <Project Path="src/Tools/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj" />
-    <Project Path="tools/GenerateTestSummary/GenerateTestSummary.csproj" />
     <Project Path="tools/AspireMcpTools/AspireMcpTools.csproj" />
+    <Project Path="tools/GenerateTestSummary/GenerateTestSummary.csproj" />
   </Folder>
   <Folder Name="/Workload/">
     <Project Path="src/Aspire.AppHost.Sdk/Aspire.AppHost.Sdk.csproj" />

--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -1,3 +1,4 @@
+using Aspire.Hosting.Yarp.Transforms;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -77,10 +78,23 @@ var frontend = builder.AddProject<Projects.MyFrontend>("frontend")
 builder.AddProject<Projects.OrderProcessor>("orderprocessor", launchProfileName: "OrderProcessor")
         .WithReference(messaging).WaitFor(messaging);
 
+#if YARP_USE_CONFIG_FILE
 builder.AddYarp("apigateway")
        .WithConfigFile("yarp.json")
        .WithReference(basketService)
        .WithReference(catalogService);
+#else
+var yarp = builder.AddYarp("apigateway");
+yarp.WithConfiguration(builder =>
+{
+    // catalog 
+    builder.AddRoute("/catalog/{**catch-all}", catalogService.GetEndpoint("http"))
+           .WithTransformPathRemovePrefix("/catalog");
+    // basket
+    builder.AddRoute("/basket/{**catch-all}", basketService.GetEndpoint("http"))
+           .WithTransformPathRemovePrefix("/basket");
+});
+#endif
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/yarp/Yarp.AppHost/Program.cs
+++ b/playground/yarp/Yarp.AppHost/Program.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Yarp.Transforms;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var backendService = builder.AddProject<Projects.Yarp_Backend>("backend");
+
+var frontendService = builder.AddProject<Projects.Yarp_Frontend>("frontend");
+
+var gateway = builder.AddYarp("gateway")
+                     .WithConfiguration(yarp =>
+                     {
+                         yarp.AddRoute(frontendService.GetEndpoint("http"));
+                         yarp.AddRoute("/api/{**catch-all}", backendService.GetEndpoint("http"))
+                             .WithTransformPathRemovePrefix("/api");
+                     });
+
+#if !SKIP_DASHBOARD_REFERENCE
+// This project is only added in playground projects to support development/debugging
+// of the dashboard. It is not required in end developer code. Comment out this code
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
+builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
+
+var app = builder.Build();
+
+await app.RunAsync();

--- a/playground/yarp/Yarp.AppHost/Properties/launchSettings.json
+++ b/playground/yarp/Yarp.AppHost/Properties/launchSettings.json
@@ -1,0 +1,43 @@
+{
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16037",
+        //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:16038",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
+        //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16032",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17031",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    },
+    "generate-manifest": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  },
+  "$schema": "https://json.schemastore.org/launchsettings.json"
+}

--- a/playground/yarp/Yarp.AppHost/Yarp.AppHost.csproj
+++ b/playground/yarp/Yarp.AppHost/Yarp.AppHost.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Yarp" />
+    <ProjectReference Include="..\Yarp.Backend\Yarp.Backend.csproj" />
+    <ProjectReference Include="..\Yarp.Frontend\Yarp.Frontend.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/playground/yarp/Yarp.Backend/Program.cs
+++ b/playground/yarp/Yarp.Backend/Program.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+}
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+})
+.WithName("GetWeatherForecast");
+
+app.Run();
+
+internal sealed record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/playground/yarp/Yarp.Backend/Properties/launchSettings.json
+++ b/playground/yarp/Yarp.Backend/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5180",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/playground/yarp/Yarp.Backend/Yarp.Backend.csproj
+++ b/playground/yarp/Yarp.Backend/Yarp.Backend.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/playground/yarp/Yarp.Backend/Yarp.Backend.http
+++ b/playground/yarp/Yarp.Backend/Yarp.Backend.http
@@ -1,0 +1,6 @@
+@Yarp.Backend_HostAddress = http://localhost:5180
+
+GET {{Yarp.Backend_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/playground/yarp/Yarp.Backend/appsettings.Development.json
+++ b/playground/yarp/Yarp.Backend/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/playground/yarp/Yarp.Backend/appsettings.json
+++ b/playground/yarp/Yarp.Backend/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/playground/yarp/Yarp.Frontend/Program.cs
+++ b/playground/yarp/Yarp.Frontend/Program.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+var app = builder.Build();
+
+app.UseFileServer();
+
+app.Run();

--- a/playground/yarp/Yarp.Frontend/Properties/launchSettings.json
+++ b/playground/yarp/Yarp.Frontend/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5097",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/playground/yarp/Yarp.Frontend/Yarp.Frontend.csproj
+++ b/playground/yarp/Yarp.Frontend/Yarp.Frontend.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/playground/yarp/Yarp.Frontend/Yarp.Frontend.http
+++ b/playground/yarp/Yarp.Frontend/Yarp.Frontend.http
@@ -1,0 +1,6 @@
+@Yarp.Frontend_HostAddress = http://localhost:5097
+
+GET {{Yarp.Frontend_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/playground/yarp/Yarp.Frontend/appsettings.Development.json
+++ b/playground/yarp/Yarp.Frontend/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/playground/yarp/Yarp.Frontend/appsettings.json
+++ b/playground/yarp/Yarp.Frontend/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/playground/yarp/Yarp.Frontend/wwwroot/index.html
+++ b/playground/yarp/Yarp.Frontend/wwwroot/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Weather Forecast</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2rem;
+        }
+
+        #data-container {
+            margin-top: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>Weather Forecast</h1>
+    <button onclick="fetchData()">Load forecast</button>
+    <div id="data-container"></div>
+
+    <script>
+        async function fetchData() {
+            const container = document.getElementById('data-container');
+            container.innerHTML = 'Loading...';
+
+            try {
+                const response = await fetch('/api/weatherforecast');
+                if (!response.ok) throw new Error('Network response was not ok');
+                const data = await response.json();
+
+                container.innerHTML = '<pre>' + JSON.stringify(data, null, 2) + '</pre>';
+            } catch (error) {
+                container.innerHTML = 'Error fetching data: ' + error.message;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
@@ -59,7 +59,7 @@ public static class YarpConfigurationBuilderExtensions
     }
 
     /// <summary>
-    /// Add a new new catch all route to YARP that will target the cluster in parameter.
+    /// Add a new catch all route to YARP that will target the cluster in parameter.
     /// </summary>
     /// <param name="builder">The builder instance.</param>
     /// <param name="endpoint">The target endpoint for this route.</param>

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
@@ -24,7 +24,7 @@ public interface IYarpConfigurationBuilder
     /// </summary>
     /// <param name="endpoint">The endpoint used by this cluster.</param>
     /// <returns></returns>
-    public YarpCluster AddDestination(EndpointReference endpoint);
+    public YarpCluster AddCluster(EndpointReference endpoint);
 }
 
 /// <summary>
@@ -54,7 +54,7 @@ public static class YarpConfigurationBuilderExtensions
     /// <returns></returns>
     public static YarpRoute AddRoute(this IYarpConfigurationBuilder builder, string path, EndpointReference endpoint)
     {
-        var cluster = builder.AddDestination(endpoint);
+        var cluster = builder.AddCluster(endpoint);
         return builder.AddRoute(path, cluster);
     }
 

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Yarp;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Interface to build a configuration file for YARP
+/// </summary>
+public interface IYarpConfigurationBuilder
+{
+    /// <summary>
+    /// Add a new route to YARP that will target the cluster in parameter.
+    /// </summary>
+    /// <param name="path">The path to match for this route.</param>
+    /// <param name="cluster">The target cluster for this route.</param>
+    /// <returns></returns>
+    public YarpRoute AddRoute(string path, YarpCluster cluster);
+
+    /// <summary>
+    /// Add a new cluster to YARP.
+    /// </summary>
+    /// <param name="endpoint">The endpoint used by this cluster.</param>
+    /// <returns></returns>
+    public YarpCluster AddDestination(EndpointReference endpoint);
+}
+
+/// <summary>
+/// Collection of extensions methods for <see cref="IYarpConfigurationBuilder"/>
+/// </summary>
+public static class YarpConfigurationBuilderExtensions
+{
+    private const string CatchAllPath = "/{**catchall}";
+
+    /// <summary>
+    /// Add a new catch all route to YARP that will target the cluster in parameter.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="cluster">The target cluster for this route.</param>
+    /// <returns></returns>
+    public static YarpRoute AddRoute(this IYarpConfigurationBuilder builder, YarpCluster cluster)
+    {
+        return builder.AddRoute(CatchAllPath, cluster);
+    }
+
+    /// <summary>
+    /// Add a new route to YARP that will target the cluster in parameter.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="path">The path to match for this route.</param>
+    /// <param name="endpoint">The target endpoint for this route.</param>
+    /// <returns></returns>
+    public static YarpRoute AddRoute(this IYarpConfigurationBuilder builder, string path, EndpointReference endpoint)
+    {
+        var cluster = builder.AddDestination(endpoint);
+        return builder.AddRoute(path, cluster);
+    }
+
+    /// <summary>
+    /// Add a new new catch all route to YARP that will target the cluster in parameter.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="endpoint">The target endpoint for this route.</param>
+    /// <returns></returns>
+    public static YarpRoute AddRoute(this IYarpConfigurationBuilder builder, EndpointReference endpoint)
+    {
+        return builder.AddRoute(CatchAllPath, endpoint);
+    }
+}

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/ForwardedTransformExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/ForwardedTransformExtensions.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Yarp.Transforms;
+using Yarp.ReverseProxy.Transforms;
+
+namespace Aspire.Hosting.Yarp.Transforms;
+
+/// <summary>
+/// Extensions for adding forwarded header transforms.
+/// </summary>
+public static class ForwardedTransformExtensions
+{
+    /// <summary>
+    /// Adds the transform which will add X-Forwarded-* headers.
+    /// </summary>
+    public static YarpRoute WithTransformXForwarded(
+        this YarpRoute route,
+        string headerPrefix = "X-Forwarded-",
+        ForwardedTransformActions xDefault = ForwardedTransformActions.Set,
+        ForwardedTransformActions? xFor = null,
+        ForwardedTransformActions? xHost = null,
+        ForwardedTransformActions? xProto = null,
+        ForwardedTransformActions? xPrefix = null)
+    {
+        route.Configure(r => r.WithTransformXForwarded(headerPrefix, xDefault, xFor, xHost, xProto, xPrefix));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will add the Forwarded header as defined by [RFC 7239](https://tools.ietf.org/html/rfc7239).
+    /// </summary>
+    public static YarpRoute WithTransformForwarded(this YarpRoute route, bool useHost = true, bool useProto = true,
+        NodeFormat forFormat = NodeFormat.Random, NodeFormat byFormat = NodeFormat.Random, ForwardedTransformActions action = ForwardedTransformActions.Set)
+    {
+        route.Configure(r => r.WithTransformForwarded(useHost, useProto, forFormat, byFormat, action));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will set the given header with the Base64 encoded client certificate.
+    /// </summary>
+    public static YarpRoute WithTransformClientCertHeader(this YarpRoute route, string headerName)
+    {
+        route.Configure(r => r.WithTransformClientCertHeader(headerName));
+        return route;
+    }
+}

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/HttpMethodTransformExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/HttpMethodTransformExtensions.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Yarp.Transforms;
+using Yarp.ReverseProxy.Transforms;
+
+namespace Aspire.Hosting.Yarp.Transforms;
+
+/// <summary>
+/// Extensions for modifying the request method.
+/// </summary>
+public static class HttpMethodTransformExtensions
+{
+    /// <summary>
+    /// Adds the transform that will replace the HTTP method if it matches.
+    /// </summary>
+    public static YarpRoute WithTransformHttpMethodChange(this YarpRoute route, string fromHttpMethod, string toHttpMethod)
+    {
+        route.Configure(r => r.WithTransformHttpMethodChange(fromHttpMethod, toHttpMethod));
+        return route;
+    }
+}

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/PathTransformExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/PathTransformExtensions.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.Yarp.Transforms;
+using Microsoft.AspNetCore.Http;
+using Yarp.ReverseProxy.Transforms;
+
+namespace Aspire.Hosting.Yarp.Transforms;
+
+/// <summary>
+/// Extensions for adding path transforms.
+/// </summary>
+public static class PathTransformExtensions
+{
+    /// <summary>
+    /// Adds the transform which sets the request path with the given value.
+    /// </summary>
+    public static YarpRoute WithTransformPathSet(this YarpRoute route, PathString path)
+    {
+        if (path.Value is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        route.Configure(r => r.WithTransformPathSet(path));
+
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will prefix the request path with the given value.
+    /// </summary>
+    public static YarpRoute WithTransformPathPrefix(this YarpRoute route, PathString prefix)
+    {
+        if (prefix.Value is null)
+        {
+            throw new ArgumentNullException(nameof(prefix));
+        }
+
+        route.Configure(r => r.WithTransformPathPrefix(prefix));
+
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will remove the matching prefix from the request path.
+    /// </summary>
+    public static YarpRoute WithTransformPathRemovePrefix(this YarpRoute route, PathString prefix)
+    {
+        if (prefix.Value is null)
+        {
+            throw new ArgumentNullException(nameof(prefix));
+        }
+
+        route.Configure(r => r.WithTransformPathRemovePrefix(prefix));
+
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will set the request path with the given value.
+    /// </summary>
+    public static YarpRoute WithTransformPathRouteValues(this YarpRoute route, [StringSyntax("Route")] PathString pattern)
+    {
+        if (pattern.Value is null)
+        {
+            throw new ArgumentNullException(nameof(pattern));
+        }
+
+        route.Configure(r => r.WithTransformPathRouteValues(pattern));
+        
+        return route;
+    }
+}

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/QueryTransformExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/QueryTransformExtensions.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Yarp.Transforms;
+using Yarp.ReverseProxy.Transforms;
+
+namespace Aspire.Hosting.Yarp.Transforms;
+
+/// <summary>
+/// Extensions for adding query transforms.
+/// </summary>
+public static class QueryTransformExtensions
+{
+    /// <summary>
+    /// Adds the transform that will append or set the query parameter from the given value.
+    /// </summary>
+    public static YarpRoute WithTransformQueryValue(this YarpRoute route, string queryKey, string value, bool append = true)
+    {
+        route.Configure(r => r.WithTransformQueryValue(queryKey, value, append));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform that will append or set the query parameter from a route value.
+    /// </summary>
+    public static YarpRoute WithTransformQueryRouteValue(this YarpRoute route, string queryKey, string routeValueKey, bool append = true)
+    {
+        route.Configure(r => r.WithTransformQueryRouteValue(queryKey, routeValueKey, append));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform that will remove the given query key.
+    /// </summary>
+    public static YarpRoute WithTransformQueryRemoveKey(this YarpRoute route, string queryKey)
+    {
+        route.Configure(r => r.WithTransformQueryRemoveKey(queryKey));
+        return route;
+    }
+}

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/RequestHeadersTransformExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/RequestHeadersTransformExtensions.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Yarp.Transforms;
+using Yarp.ReverseProxy.Transforms;
+
+namespace Aspire.Hosting.Yarp.Transforms;
+
+/// <summary>
+/// Extensions for adding request header transforms.
+/// </summary>
+public static class RequestHeadersTransformExtensions
+{
+    /// <summary>
+    /// Adds the transform which will enable or suppress copying request headers to the proxy request.
+    /// </summary>
+    public static YarpRoute WithTransformCopyRequestHeaders(this YarpRoute route, bool copy = true)
+    {
+        route.Configure(r => r.WithTransformCopyRequestHeaders(copy));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will copy the incoming request Host header to the proxy request.
+    /// </summary>
+    public static YarpRoute WithTransformUseOriginalHostHeader(this YarpRoute route, bool useOriginal = true)
+    {
+        route.Configure(r => r.WithTransformUseOriginalHostHeader(useOriginal));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will append or set the request header.
+    /// </summary>
+    public static YarpRoute WithTransformRequestHeader(this YarpRoute route, string headerName, string value, bool append = true)
+    {
+        route.Configure(r => r.WithTransformRequestHeader(headerName, value, append));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will append or set the request header from a route value.
+    /// </summary>
+    public static YarpRoute WithTransformRequestHeaderRouteValue(this YarpRoute route, string headerName, string routeValueKey, bool append = true)
+    {
+        route.Configure(r => r.WithTransformRequestHeaderRouteValue(headerName, routeValueKey, append));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will remove the request header.
+    /// </summary>
+    public static YarpRoute WithTransformRequestHeaderRemove(this YarpRoute route, string headerName)
+    {
+        route.Configure(r => r.WithTransformRequestHeaderRemove(headerName));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will only copy the allowed request headers. Other transforms
+    /// that modify or append to existing headers may be affected if not included in the allow list.
+    /// </summary>
+    public static YarpRoute WithTransformRequestHeadersAllowed(this YarpRoute route, params string[] allowedHeaders)
+    {
+        route.Configure(r => r.WithTransformRequestHeadersAllowed(allowedHeaders));
+        return route;
+    }
+}

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/RequestHeadersTransformExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/RequestHeadersTransformExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Yarp.Transforms;
 using Yarp.ReverseProxy.Transforms;
 
 namespace Aspire.Hosting.Yarp.Transforms;

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/ResponseTransformExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/ResponseTransformExtensions.cs
@@ -15,7 +15,7 @@ public static class ResponseTransformExtensions
     /// </summary>
     public static YarpRoute WithTransformCopyResponseHeaders(this YarpRoute route, bool copy = true)
     {
-        route.Configure(r => r.WithTransformCopyResponseHeaders(true));
+        route.Configure(r => r.WithTransformCopyResponseHeaders(copy));
         return route;
     }
 
@@ -24,7 +24,7 @@ public static class ResponseTransformExtensions
     /// </summary>
     public static YarpRoute WithTransformCopyResponseTrailers(this YarpRoute route, bool copy = true)
     {
-        route.Configure(r => r.WithTransformCopyResponseTrailers(true));
+        route.Configure(r => r.WithTransformCopyResponseTrailers(copy));
         return route;
     }
 

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/ResponseTransformExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/Transforms/ResponseTransformExtensions.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Yarp.ReverseProxy.Transforms;
+
+namespace Aspire.Hosting.Yarp.Transforms;
+
+/// <summary>
+/// Extensions for adding response header and trailer transforms.
+/// </summary>
+public static class ResponseTransformExtensions
+{
+    /// <summary>
+    /// Adds the transform which will enable or suppress copying response headers to the client response.
+    /// </summary>
+    public static YarpRoute WithTransformCopyResponseHeaders(this YarpRoute route, bool copy = true)
+    {
+        route.Configure(r => r.WithTransformCopyResponseHeaders(true));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will enable or suppress copying response trailers to the client response.
+    /// </summary>
+    public static YarpRoute WithTransformCopyResponseTrailers(this YarpRoute route, bool copy = true)
+    {
+        route.Configure(r => r.WithTransformCopyResponseTrailers(true));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will append or set the response header.
+    /// </summary>
+    public static YarpRoute WithTransformResponseHeader(this YarpRoute route, string headerName, string value, bool append = true, ResponseCondition condition = ResponseCondition.Success)
+    {
+        route.Configure(r => r.WithTransformResponseHeader(headerName, value, append, condition));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will remove the response header.
+    /// </summary>
+    public static YarpRoute WithTransformResponseHeaderRemove(this YarpRoute route, string headerName, ResponseCondition condition = ResponseCondition.Success)
+    {
+        route.Configure(r => r.WithTransformResponseHeaderRemove(headerName, condition));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will only copy the allowed response headers. Other transforms
+    /// that modify or append to existing headers may be affected if not included in the allow list.
+    /// </summary>
+    public static YarpRoute WithTransformResponseHeadersAllowed(this YarpRoute route, params string[] allowedHeaders)
+    {
+        route.Configure(r => r.WithTransformResponseHeadersAllowed(allowedHeaders));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will append or set the response trailer.
+    /// </summary>
+    public static YarpRoute WithTransformResponseTrailer(this YarpRoute route, string headerName, string value, bool append = true, ResponseCondition condition = ResponseCondition.Success)
+    {
+        route.Configure(r => r.WithTransformResponseTrailer(headerName, value, append, condition));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will remove the response trailer.
+    /// </summary>
+    public static YarpRoute WithTransformResponseTrailerRemove(this YarpRoute route, string headerName, ResponseCondition condition = ResponseCondition.Success)
+    {
+        route.Configure(r => r.WithTransformResponseTrailerRemove(headerName, condition));
+        return route;
+    }
+
+    /// <summary>
+    /// Adds the transform which will only copy the allowed response trailers. Other transforms
+    /// that modify or append to existing trailers may be affected if not included in the allow list.
+    /// </summary>
+    public static YarpRoute WithTransformResponseTrailersAllowed(this YarpRoute route, params string[] allowedHeaders)
+    {
+        route.Configure(r => r.WithTransformResponseTrailersAllowed(allowedHeaders));
+        return route;
+    }
+}

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Yarp.ReverseProxy.Configuration;
+using Yarp.ReverseProxy.Forwarder;
+
+namespace Aspire.Hosting.Yarp;
+
+/// <summary>
+/// Represents a cluster for YARP routes
+/// </summary>
+public class YarpCluster(EndpointReference endpoint)
+{
+    internal ClusterConfig ClusterConfig { get; private set; } = new()
+    {
+        ClusterId = $"cluster_{Guid.NewGuid().ToString("N")}",
+        Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "destination1", new DestinationConfig { Address = $"{endpoint.Scheme}://{endpoint.Resource.Name}" } },
+        }
+    };
+
+    internal void Configure(Func<ClusterConfig, ClusterConfig> configure)
+    {
+        ClusterConfig = configure(ClusterConfig);
+    }
+}
+
+/// <summary>
+/// Provides extension methods for configuring a YARP cluster.
+/// </summary>
+public static class YarpClusterExtensions
+{
+    /// <summary>
+    /// Set the ForwarderRequestConfig for the cluster.
+    /// </summary>
+    public static YarpCluster WithForwarderRequestConfig(this YarpCluster cluster, ForwarderRequestConfig config)
+    {
+        cluster.Configure(c => c with { HttpRequest = config });
+        return cluster;
+    }
+
+    /// <summary>
+    /// Set the ForwarderRequestConfig for the cluster.
+    /// </summary>
+    public static YarpCluster WithHttpClientConfig(this YarpCluster cluster, HttpClientConfig config)
+    {
+        cluster.Configure(c => c with { HttpClient = config });
+        return cluster;
+    }
+
+    /// <summary>
+    /// Set the SessionAffinityConfig for the cluster.
+    /// </summary>
+    public static YarpCluster WithSessionAffinityConfig(this YarpCluster cluster, SessionAffinityConfig config)
+    {
+        cluster.Configure(c => c with { SessionAffinity = config });
+        return cluster;
+    }
+
+    /// <summary>
+    /// Set the HealthCheckConfig for the cluster.
+    /// </summary>
+    public static YarpCluster WithHealthCheckConfig(this YarpCluster cluster, HealthCheckConfig config)
+    {
+        cluster.Configure(c => c with { HealthCheck = config });
+        return cluster;
+    }
+
+    /// <summary>
+    /// Set the LoadBalancingPolicy for the cluster.
+    /// </summary>
+    public static YarpCluster WithLoadBalancingPolicy(this YarpCluster cluster, string policy)
+    {
+        cluster.Configure(c => c with { LoadBalancingPolicy = policy });
+        return cluster;
+    }
+
+    /// <summary>
+    /// Set the Metadata for the cluster.
+    /// </summary>
+    public static YarpCluster WithMetadata(this YarpCluster cluster, IReadOnlyDictionary<string, string> metadata)
+    {
+        cluster.Configure(c => c with { Metadata = metadata });
+        return cluster;
+    }
+}

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -14,7 +14,7 @@ public class YarpCluster(EndpointReference endpoint)
 {
     internal ClusterConfig ClusterConfig { get; private set; } = new()
     {
-        ClusterId = $"cluster_{Guid.NewGuid().ToString("N")}",
+        ClusterId = $"cluster_{endpoint.Resource.Name}_{Guid.NewGuid().ToString("N")}",
         Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
         {
             { "destination1", new DestinationConfig { Address = $"{endpoint.Scheme}://{endpoint.Resource.Name}" } },

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Yarp;
+
+namespace Aspire.Hosting;
+
+internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) : IYarpConfigurationBuilder
+{
+    private readonly IResourceBuilder<YarpResource> _parent = parent;
+
+    /// <inheritdoc/>
+    public YarpRoute AddRoute(string path, YarpCluster cluster)
+    {
+        var route = new YarpRoute(cluster);
+        if (path != null)
+        {
+            route.WithMatchPath(path);
+        }
+        _parent.Resource.Routes.Add(route);
+        return route;
+    }
+
+    /// <inheritdoc/>
+    public YarpCluster AddDestination(EndpointReference endpoint)
+    {
+        var destination = new YarpCluster(endpoint);
+        _parent.Resource.Destinations.Add(destination);
+        _parent.WithReference(endpoint);
+        return destination;
+    }
+}

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
@@ -23,7 +23,7 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
     }
 
     /// <inheritdoc/>
-    public YarpCluster AddDestination(EndpointReference endpoint)
+    public YarpCluster AddCluster(EndpointReference endpoint)
     {
         var destination = new YarpCluster(endpoint);
         _parent.Resource.Destinations.Add(destination);

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpRoute.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpRoute.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Yarp.ReverseProxy.Configuration;
+
+namespace Aspire.Hosting.Yarp;
+
+/// <summary>
+/// Represents a route for YARP
+/// </summary>
+public class YarpRoute(YarpCluster cluster)
+{
+    internal RouteConfig RouteConfig { get; private set; } = new RouteConfig
+    {
+        RouteId = $"route_{Guid.NewGuid().ToString("N")}",
+        ClusterId = cluster.ClusterConfig.ClusterId,
+        Match = new RouteMatch(),
+    };
+
+    internal void Configure(Func<RouteConfig, RouteConfig> configure)
+    {
+        RouteConfig = configure(RouteConfig);
+    }
+}
+
+/// <summary>
+/// Provides extension methods for configuring a YARP destination
+/// </summary>
+public static class YarpRouteExtensions
+{
+    /// <summary>
+    /// Set the parameters used to match requests.
+    /// </summary>
+    public static YarpRoute WithMatch(this YarpRoute route, RouteMatch match)
+    {
+        route.Configure(r => r with { Match = match });
+        return route;
+    }
+
+    #region RouteMatch helpers
+
+    private static YarpRoute ConfigureMatch(this YarpRoute route, Func<RouteMatch, RouteMatch> match)
+    {
+        route.Configure(r => r with { Match = match(r.Match) });
+        return route;
+    }
+
+    /// <summary>
+    /// Only match requests with the given Path pattern.
+    /// </summary>
+    public static YarpRoute WithMatchPath(this YarpRoute route, string path)
+    {
+        route.ConfigureMatch(match => match with { Path = path });
+        return route;
+    }
+
+    /// <summary>
+    /// Only match requests that use these optional HTTP methods. E.g. GET, POST.
+    /// </summary>
+    public static YarpRoute WithMatchMethods(this YarpRoute route, params string[] methods)
+    {
+        route.ConfigureMatch(match => match with { Methods = methods });
+        return route;
+    }
+
+    /// <summary>
+    /// Only match requests that contain all of these headers.
+    /// </summary>
+    public static YarpRoute WithMatchHeaders(this YarpRoute route, params RouteHeader[] headers)
+    {
+        route.ConfigureMatch(match => match with { Headers = headers.ToList() });
+        return route;
+    }
+
+    /// <summary>
+    ///  Only match requests with the given Host header. Supports wildcards and ports.
+    ///  For unicode host names, do not use punycode.
+    /// </summary>
+    public static YarpRoute WithMatchHosts(this YarpRoute route, params string[] hosts)
+    {
+        route.ConfigureMatch(match => match with { Hosts = hosts.ToList() });
+        return route;
+    }
+
+    /// <summary>
+    ///  Only match requests that contain all of these query parameters.
+    /// </summary>
+    public static YarpRoute WithMatchRouteQueryParameter(this YarpRoute route, params RouteQueryParameter[] queryParameters)
+    {
+        route.ConfigureMatch(match => match with { QueryParameters = queryParameters.ToList() });
+        return route;
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Set the order for the destination
+    /// </summary>
+    public static YarpRoute WithOrder(this YarpRoute route, int? order)
+    {
+        route.Configure(r => r with { Order = order });
+        return route;
+    }
+
+    /// <summary>
+    /// Set the MaxRequestBodySize for the destination
+    /// </summary>
+    public static YarpRoute WithMaxRequestBodySize(this YarpRoute route, long maxRequestBodySize)
+    {
+        route.Configure(r => r with { MaxRequestBodySize = maxRequestBodySize });
+        return route;
+    }
+
+    /// <summary>
+    /// Set the Metadata of the destination
+    /// </summary>
+    public static YarpRoute WithMetadata(this YarpRoute route, IReadOnlyDictionary<string, string>? metadata)
+    {
+        route.Configure(r => r with { Metadata = metadata });
+        return route;
+    }
+
+    /// <summary>
+    /// Set the Transforms of the destination
+    /// </summary>
+    public static YarpRoute WithTransforms(this YarpRoute route, IReadOnlyList<IReadOnlyDictionary<string, string>>? transforms)
+    {
+        route.Configure(r => r with { Transforms = transforms });
+        return route;
+    }
+
+    /// <summary>
+    /// Add a new transform to the destination
+    /// </summary>
+    public static YarpRoute WithTransform(this YarpRoute route, Action<IDictionary<string, string>> createTransform)
+    {
+        ArgumentNullException.ThrowIfNull(createTransform);
+
+        route.Configure(r =>
+        {
+            List<IReadOnlyDictionary<string, string>> transforms;
+            if (r.Transforms is null)
+            {
+                transforms = new List<IReadOnlyDictionary<string, string>>();
+            }
+            else
+            {
+                transforms = new List<IReadOnlyDictionary<string, string>>(r.Transforms.Count + 1);
+                transforms.AddRange(r.Transforms);
+            }
+
+            var transform = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            createTransform(transform);
+            transforms.Add(transform);
+
+            return r with { Transforms = transforms };
+        });
+
+        return route;
+    }
+}

--- a/src/Aspire.Hosting.Yarp/IYarpJsonConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/IYarpJsonConfigurationBuilder.cs
@@ -8,20 +8,20 @@ namespace Aspire.Hosting.Yarp;
 /// <summary>
 /// Interface to build a configuration file for YARP
 /// </summary>
-public interface IYarpConfigurationBuilder
+public interface IYarpJsonConfigurationBuilder
 {
     /// <summary>
     /// Add a RouteConfig to the YARP resource
     /// </summary>
-    public IYarpConfigurationBuilder AddRoute(RouteConfig route);
+    public IYarpJsonConfigurationBuilder AddRoute(RouteConfig route);
 
     /// <summary>
     /// Add a ClusterConfig to the YARP resource
     /// </summary>
-    public IYarpConfigurationBuilder AddCluster(ClusterConfig cluster);
+    public IYarpJsonConfigurationBuilder AddCluster(ClusterConfig cluster);
 
     /// <summary>
     /// Add a YARP config to the YARP resource
     /// </summary>
-    public IYarpConfigurationBuilder WithConfigFile(string configFilePath);
+    public IYarpJsonConfigurationBuilder WithConfigFile(string configFilePath);
 }

--- a/src/Aspire.Hosting.Yarp/YarpJsonConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/YarpJsonConfigurationBuilder.cs
@@ -9,14 +9,14 @@ using Yarp.ReverseProxy.Configuration;
 
 namespace Aspire.Hosting.Yarp;
 
-internal sealed class YarpConfigurationBuilder : IYarpConfigurationBuilder
+internal sealed class YarpJsonConfigurationBuilder : IYarpJsonConfigurationBuilder
 {
     private string? _configFilePath;
     private readonly List<ClusterConfig> _clusterConfigs = new List<ClusterConfig>();
     private readonly List<RouteConfig> _routeConfigs = new List<RouteConfig>();
     private readonly JsonSerializerOptions _serializerOptions;
 
-    public YarpConfigurationBuilder()
+    public YarpJsonConfigurationBuilder()
     {
         _serializerOptions = new JsonSerializerOptions()
         {
@@ -27,7 +27,7 @@ internal sealed class YarpConfigurationBuilder : IYarpConfigurationBuilder
         _serializerOptions.Converters.Add(new JsonStringEnumConverter(new PascalCaseJsonNamingPolicy()));
     }
 
-    public IYarpConfigurationBuilder AddCluster(ClusterConfig cluster)
+    public IYarpJsonConfigurationBuilder AddCluster(ClusterConfig cluster)
     {
         if (_configFilePath != null)
         {
@@ -37,7 +37,7 @@ internal sealed class YarpConfigurationBuilder : IYarpConfigurationBuilder
         return this;
     }
 
-    public IYarpConfigurationBuilder AddRoute(RouteConfig route)
+    public IYarpJsonConfigurationBuilder AddRoute(RouteConfig route)
     {
         if (_configFilePath != null)
         {
@@ -47,7 +47,7 @@ internal sealed class YarpConfigurationBuilder : IYarpConfigurationBuilder
         return this;
     }
 
-    public IYarpConfigurationBuilder WithConfigFile(string configFilePath)
+    public IYarpJsonConfigurationBuilder WithConfigFile(string configFilePath)
     {
         if (_clusterConfigs.Count > 0 || _routeConfigs.Count > 0)
         {

--- a/src/Aspire.Hosting.Yarp/YarpResource.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResource.cs
@@ -15,4 +15,8 @@ public class YarpResource(string name) : ContainerResource(name)
     /// Configuration builder used to build the config file for the YARP resource
     /// </summary>
     internal YarpJsonConfigurationBuilder ConfigurationBuilder { get; } = new YarpJsonConfigurationBuilder();
+
+    internal List<YarpRoute> Routes { get; } = new();
+
+    internal List<YarpCluster> Destinations { get; } = new();
 }

--- a/src/Aspire.Hosting.Yarp/YarpResource.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResource.cs
@@ -14,5 +14,5 @@ public class YarpResource(string name) : ContainerResource(name)
     /// <summary>
     /// Configuration builder used to build the config file for the YARP resource
     /// </summary>
-    internal YarpConfigurationBuilder ConfigurationBuilder { get; } = new YarpConfigurationBuilder();
+    internal YarpJsonConfigurationBuilder ConfigurationBuilder { get; } = new YarpJsonConfigurationBuilder();
 }

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting;
 /// <summary>
 /// Provides extension methods for adding YARP resources to the application model.
 /// </summary>
-public static class YarpServiceExtensions
+public static class YarpResourceExtensions
 {
     private const int Port = 5000;
 

--- a/src/Aspire.Hosting.Yarp/YarpServiceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpServiceExtensions.cs
@@ -79,7 +79,7 @@ public static class YarpServiceExtensions
     /// <param name="builder">The YARP resource to configure.</param>
     /// <param name="configurationBuilder">The delegate to configure YARP.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<YarpResource> WithConfiguration(this IResourceBuilder<YarpResource> builder, Action<IYarpConfigurationBuilder> configurationBuilder)
+    internal static IResourceBuilder<YarpResource> WithConfiguration(this IResourceBuilder<YarpResource> builder, Action<IYarpJsonConfigurationBuilder> configurationBuilder)
     {
         configurationBuilder(builder.Resource.ConfigurationBuilder);
         return builder;

--- a/src/Aspire.Hosting.Yarp/YarpServiceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpServiceExtensions.cs
@@ -47,6 +47,14 @@ public static class YarpServiceExtensions
         // Map the configuration file
         yarpBuilder.WithContainerFiles(ConfigDirectory, async (context, ct) =>
         {
+            foreach (var route in yarpBuilder.Resource.Routes)
+            {
+                yarpBuilder.Resource.ConfigurationBuilder.AddRoute(route.RouteConfig);
+            }
+            foreach (var destination in yarpBuilder.Resource.Destinations)
+            {
+                yarpBuilder.Resource.ConfigurationBuilder.AddCluster(destination.ClusterConfig);
+            }
             var contents = await yarpBuilder.Resource.ConfigurationBuilder.Build(ct).ConfigureAwait(false);
 
             var configFile = new ContainerFile
@@ -82,6 +90,18 @@ public static class YarpServiceExtensions
     internal static IResourceBuilder<YarpResource> WithConfiguration(this IResourceBuilder<YarpResource> builder, Action<IYarpJsonConfigurationBuilder> configurationBuilder)
     {
         configurationBuilder(builder.Resource.ConfigurationBuilder);
+        return builder;
+    }
+
+    /// <summary>
+    /// Configure the YARP resource.
+    /// </summary>
+    /// <param name="builder">The YARP resource to configure.</param>
+    /// <param name="configurationBuilder">The delegate to configure YARP.</param>
+    public static IResourceBuilder<YarpResource> WithConfiguration(this IResourceBuilder<YarpResource> builder, Action<IYarpConfigurationBuilder> configurationBuilder)
+    {
+        var configBuilder = new YarpConfigurationBuilder(builder);
+        configurationBuilder(configBuilder);
         return builder;
     }
 }

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpConfigGeneratorTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpConfigGeneratorTests.cs
@@ -215,7 +215,7 @@ public class YarpConfigGeneratorTests()
     [Fact]
     public async Task GenerateConfiguration()
     {
-        var config = new YarpConfigurationBuilder();
+        var config = new YarpJsonConfigurationBuilder();
         foreach (var cluster in _validClusters)
         {
             config.AddCluster(cluster);

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
+using Aspire.Hosting.Yarp.Transforms;
 using Aspire.TestUtilities;
 using Yarp.ReverseProxy.Configuration;
 
@@ -14,7 +15,7 @@ public class YarpFunctionalTests(ITestOutputHelper testOutputHelper)
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/9344")]
     public async Task VerifyYarpResourceConfigFile()
     {
-        await VerifyYarpResource(false);
+        await VerifyYarpResource((yarp, endpoint) => yarp.WithReference(endpoint).WithConfigFile("yarp.json"));
     }
 
     [Fact]
@@ -22,10 +23,56 @@ public class YarpFunctionalTests(ITestOutputHelper testOutputHelper)
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/9344")]
     public async Task VerifyYarpResourceProgrammaticConfig()
     {
-        await VerifyYarpResource(true);
+        await VerifyYarpResource((yarp, endpoint) =>
+        {
+            yarp.WithReference(endpoint)
+                .WithConfiguration(configuration =>
+                {
+                    configuration
+                        .AddRoute(new RouteConfig()
+                        {
+                            RouteId = "route1",
+                            ClusterId = "cluster1",
+                            Match = new RouteMatch()
+                            {
+                                Path = "/aspnetapp/{**catch-all}"
+                            },
+                            Transforms = new[]
+                            {
+                                new Dictionary<string, string>
+                                {
+                                    { "PathRemovePrefix", "/aspnetapp" },
+                                }
+                            }
+                        })
+                        .AddCluster(new ClusterConfig()
+                        {
+                            ClusterId = "cluster1",
+                            Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
+                            {
+                                { "destination1", new DestinationConfig { Address = $"{endpoint.Scheme}://{endpoint.Resource.Name}" } },
+                            }
+                        });
+                });
+        });
     }
 
-    private async Task VerifyYarpResource(bool useProgrammaticConfig)
+    [Fact]
+    [RequiresDocker]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9344")]
+    public async Task VerifyYarpResourceExtensionsConfig()
+    {
+        await VerifyYarpResource((yarp, endpoint) =>
+        {
+            yarp.WithConfiguration(builder =>
+            {
+                builder.AddRoute("/aspnetapp/{**catch-all}", endpoint)
+                       .WithTransformPathRemovePrefix("/aspnetapp");
+            });
+        });
+    }
+
+    private async Task VerifyYarpResource(Action<IResourceBuilder<YarpResource>, EndpointReference> configurator)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 
@@ -37,44 +84,10 @@ public class YarpFunctionalTests(ITestOutputHelper testOutputHelper)
             .WithExternalHttpEndpoints();
 
         var yarp = builder.AddYarp("yarp");
-        if (useProgrammaticConfig)
-        {
-            yarp.WithConfiguration(configuration =>
-            {
-                configuration
-                    .AddRoute(new RouteConfig()
-                    {
-                        RouteId = "route1",
-                        ClusterId = "cluster1",
-                        Match = new RouteMatch()
-                        {
-                            Path = "/aspnetapp/{**catch-all}"
-                        },
-                        Transforms = new[]
-                        {
-                            new Dictionary<string, string>
-                            {
-                                { "PathRemovePrefix", "/aspnetapp" },
-                            }
-                        }
-                    })
-                    .AddCluster(new ClusterConfig()
-                    {
-                        ClusterId = "cluster1",
-                        Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
-                        {
-                            { "destination1", new DestinationConfig { Address = "http://backend" } },
-                        }
-                    });
-            });
-        }
-        else
-        {
-            yarp.WithConfigFile("yarp.json");
-        }
 
-        yarp.WithReference(backend.GetEndpoint("http"))
-            .WithHttpHealthCheck("/heath", 404); // TODO we don't have real health check path yet
+        configurator(yarp, backend.GetEndpoint("http"));
+
+        yarp.WithHttpHealthCheck("/heath", 404); // TODO we don't have real health check path yet
 
         var app = builder.Build();
 


### PR DESCRIPTION
## Description

This PR is split in 3 main commits:
- first one is just a  renaming and accessibility change of the raw programmatic way to configure YARP. We can decide to make it public later
- second one is the meat of this PR:
    - introducing a new `IYarpConfigurationBuilder` (along with its internal implementation) to fluently build the YARP config, using Aspire types (`EndpointReference`)
        - `YarpCluster` is a mutable type to customize the `ClusterConfig` object.
        - `YarpRoute` is a mutable type to customize the `RouteConfig` object. It takes a `YarpCluster` in the constructor to configure automatically the `RouteConfig.ClusterId` part.
        - A set of extensions methods to make `YarpCluster` and `YarpRoute` easier to configure.
    - a set of extensions to make some usecase simpler (catch all path, implicit creation of `YarpCluster` from an `EndpointReference`, ect.)
    - everything inside the `Transforms` subfolder is a 1:1 translation of helper methods on `RouteConfig` transformers available in  YARP 
- last one is a simple playground project just for the YARP integration

Fixes #9878

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [X] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [X] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
