### PR TITLE
bump provisioning libraries to latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Azure.Provisioning" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.AppService" Version="1.1.0" />
+    <PackageVersion Include="Azure.Provisioning.AppService" Version="1.1.1" />
     <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="1.1.0" />
@@ -42,13 +42,13 @@
     <PackageVersion Include="Azure.Provisioning.EventHubs" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.KeyVault" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="1.1.0" />
+    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="1.1.1" />
     <PackageVersion Include="Azure.Provisioning.Redis" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.Search" Version="1.0.0" />
     <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.SignalR" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.Sql" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="1.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="1.1.1" />
     <PackageVersion Include="Azure.Provisioning.WebPubSub" Version="1.1.0" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.4" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Azure.Provisioning" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.AppService" Version="1.1.1" />
+    <PackageVersion Include="Azure.Provisioning.AppService" Version="1.2.0" />
     <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="1.1.0" />


### PR DESCRIPTION
## Description

Bump the following dependency versions:
- Azure.Provisioning.PostgreSql 1.1.1
- Azure.Provisioning.Storage 1.1.1
- Azure.Provisioning.AppService 1.2.0

The new version 1.2.0 for appservice fixed the following issues:
- https://github.com/Azure/azure-sdk-for-net/issues/47225
- https://github.com/Azure/azure-sdk-for-net/issues/50242

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
