### PR TITLE
Enable PublishAot where available

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build with packages
         env:
           CI: false
-        run: ./build.sh -restore -build -ci -pack /bl /p:InstallBrowsersForPlaywright=false /p:SkipTestProjects=true
+        run: ./build.sh -restore -build -ci -pack -bl /p:InstallBrowsersForPlaywright=false /p:SkipTestProjects=true
 
       - name: Upload built NuGets
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           name: build_packages_logs
           path: artifacts/log
-        condition: failure()
+        if: failure()
 
   integrations_test_lin:
     uses: ./.github/workflows/run-tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,13 @@ jobs:
           name: built-nugets
           path: artifacts/packages
 
+      - name: Upload logs
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: build_packages_logs
+          path: artifacts/log
+        condition: failure()
+
   integrations_test_lin:
     uses: ./.github/workflows/run-tests.yml
     name: Integrations Linux

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,6 @@ jobs:
         with:
           name: build_packages_logs
           path: artifacts/log
-        if: failure()
 
   integrations_test_lin:
     uses: ./.github/workflows/run-tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build with packages
         env:
           CI: false
-        run: ./build.sh -restore -build -ci -pack -bl /p:InstallBrowsersForPlaywright=false /p:SkipTestProjects=true
+        run: ./build.sh -restore -build -ci -pack -bl -p:InstallBrowsersForPlaywright=false -p:SkipTestProjects=true
 
       - name: Upload built NuGets
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -3,7 +3,11 @@
     <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
-    <ProjectToBuild Include="$(RepoRoot)eng\clipack\**\*.csproj" />
+
+    <ProjectToBuild Condition="$([System.OperatingSystem]::IsWindows())" Include="$(RepoRoot)eng\clipack\Aspire.Cli.win-*" />
+    <ProjectToBuild Condition="$([System.OperatingSystem]::IsLinux())" Include="$(RepoRoot)eng\clipack\Aspire.Cli.linux-*" />
+    <ProjectToBuild Condition="$([System.OperatingSystem]::IsMacOS())" Include="$(RepoRoot)eng\clipack\Aspire.Cli.osx-*" />
+
     <ProjectToBuild Include="$(RepoRoot)playground\**\*.csproj" />
 
     <!-- `$(SkipTestProjects)` allows skipping test projects from being

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -3,11 +3,7 @@
     <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
-
-    <ProjectToBuild Condition="$([System.OperatingSystem]::IsWindows())" Include="$(RepoRoot)eng\clipack\Aspire.Cli.win-*" />
-    <ProjectToBuild Condition="$([System.OperatingSystem]::IsLinux())" Include="$(RepoRoot)eng\clipack\Aspire.Cli.linux-*" />
-    <ProjectToBuild Condition="$([System.OperatingSystem]::IsMacOS())" Include="$(RepoRoot)eng\clipack\Aspire.Cli.osx-*" />
-
+    <ProjectToBuild Include="$(RepoRoot)eng\clipack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)playground\**\*.csproj" />
 
     <!-- `$(SkipTestProjects)` allows skipping test projects from being

--- a/eng/clipack/Aspire.Cli.linux-arm64.csproj
+++ b/eng/clipack/Aspire.Cli.linux-arm64.csproj
@@ -2,15 +2,10 @@
   <PropertyGroup>
     <CliRuntime>linux-arm64</CliRuntime>
     <CliPlatformType>Unix</CliPlatformType>
+    <!-- linux builds on x64, but doesn't have arm64 native tools. So disable native AOT for now. -->
+    <PublishNativeAot>false</PublishNativeAot>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />
-
-  <ItemGroup>
-    <!-- linux builds on x64, but doesn't have arm64 native tools. So disable native AOT for now. -->
-    <AdditionalProperties Include="PublishAot=false" />
-    <AdditionalProperties Include="PublishSingleFile=true" />
-    <AdditionalProperties Include="SelfContained=true" />
-  </ItemGroup>
 
 </Project>

--- a/eng/clipack/Aspire.Cli.linux-arm64.csproj
+++ b/eng/clipack/Aspire.Cli.linux-arm64.csproj
@@ -6,4 +6,11 @@
 
   <Import Project="Common.projitems" />
 
+  <ItemGroup>
+    <!-- linux builds on x64, but doesn't have arm64 native tools. So disable native AOT for now. -->
+    <AdditionalProperties Include="PublishAot=false" />
+    <AdditionalProperties Include="PublishSingleFile=true" />
+    <AdditionalProperties Include="SelfContained=true" />
+  </ItemGroup>
+
 </Project>

--- a/eng/clipack/Aspire.Cli.linux-musl-x64.csproj
+++ b/eng/clipack/Aspire.Cli.linux-musl-x64.csproj
@@ -6,4 +6,11 @@
 
   <Import Project="Common.projitems" />
 
+  <ItemGroup>
+    <!-- need to be on a linux-musl machine to native AOT for linux-musl-->
+    <AdditionalProperties Include="PublishAot=false" />
+    <AdditionalProperties Include="PublishSingleFile=true" />
+    <AdditionalProperties Include="SelfContained=true" />
+  </ItemGroup>
+
 </Project>

--- a/eng/clipack/Aspire.Cli.linux-musl-x64.csproj
+++ b/eng/clipack/Aspire.Cli.linux-musl-x64.csproj
@@ -2,15 +2,10 @@
   <PropertyGroup>
     <CliRuntime>linux-musl-x64</CliRuntime>
     <CliPlatformType>Unix</CliPlatformType>
+    <!-- need to be on a linux-musl machine to native AOT for linux-musl-->
+    <PublishNativeAot>false</PublishNativeAot>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />
-
-  <ItemGroup>
-    <!-- need to be on a linux-musl machine to native AOT for linux-musl-->
-    <AdditionalProperties Include="PublishAot=false" />
-    <AdditionalProperties Include="PublishSingleFile=true" />
-    <AdditionalProperties Include="SelfContained=true" />
-  </ItemGroup>
 
 </Project>

--- a/eng/clipack/Aspire.Cli.win-x86.csproj
+++ b/eng/clipack/Aspire.Cli.win-x86.csproj
@@ -6,4 +6,11 @@
 
   <Import Project="Common.projitems" />
 
+  <ItemGroup>
+    <!-- native AOT doesn't support win-x86  -->
+    <AdditionalProperties Include="PublishAot=false" />
+    <AdditionalProperties Include="PublishSingleFile=true" />
+    <AdditionalProperties Include="SelfContained=true" />
+  </ItemGroup>
+
 </Project>

--- a/eng/clipack/Aspire.Cli.win-x86.csproj
+++ b/eng/clipack/Aspire.Cli.win-x86.csproj
@@ -2,15 +2,10 @@
   <PropertyGroup>
     <CliRuntime>win-x86</CliRuntime>
     <CliPlatformType>Windows</CliPlatformType>
+    <!-- native AOT doesn't support win-x86  -->
+    <PublishNativeAot>false</PublishNativeAot>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />
-
-  <ItemGroup>
-    <!-- native AOT doesn't support win-x86  -->
-    <AdditionalProperties Include="PublishAot=false" />
-    <AdditionalProperties Include="PublishSingleFile=true" />
-    <AdditionalProperties Include="SelfContained=true" />
-  </ItemGroup>
 
 </Project>

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -7,14 +7,6 @@
     <ArchiveFormat Condition="!$(CliRuntime.StartsWith('linux-'))">zip</ArchiveFormat>
   </PropertyGroup>
 
-  <!-- Enable native AOT on non-official builds to ensure the Cli is AOT compatible. -->
-  <!-- TODO: https://github.com/dotnet/aspire/issues/8677 - enable PublishAot when the official build infrastructure supports all platforms. -->
-  <PropertyGroup Condition="'$(OfficialBuildId)' == ''">
-    <PublishNativeAot Condition="$(CliRuntime.StartsWith('linux-')) AND $([System.OperatingSystem]::IsLinux())">true</PublishNativeAot>
-    <PublishNativeAot Condition="$(CliRuntime.StartsWith('osx-')) AND $([System.OperatingSystem]::IsMacOS())">true</PublishNativeAot>
-    <PublishNativeAot Condition="$(CliRuntime.StartsWith('win-')) AND '$(CliRuntime)' != 'win-x86' AND $([System.OperatingSystem]::IsWindows())">true</PublishNativeAot>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" />
   </ItemGroup>
@@ -23,26 +15,12 @@
     <ItemGroup>
       <AdditionalProperties Include="RuntimeIdentifier=$(CliRuntime)" />
       <AdditionalProperties Include="PublishDir=$(OutputPath)" />
-    </ItemGroup>
 
-    <ItemGroup Condition="'$(PublishNativeAot)' == 'true'">
       <!-- Always publish Release for native aot, since Debug hits a warning https://github.com/protocolbuffers/protobuf/issues/21824. -->
       <AdditionalProperties Include="Configuration=Release" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(PublishNativeAot)' != 'true'">
-      <AdditionalProperties Include="Configuration=$(Configuration)" />
-      <AdditionalProperties Include="PublishSingleFile=true" />
-      <AdditionalProperties Include="SelfContained=true" />
-      <AdditionalProperties Include="PublishAot=false" />
-    </ItemGroup>
-
-    <!-- Remove OutputPath, and TargetFramework so the defaults can be used -->
-    <MSBuild
-        Projects="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.csproj"
-        Targets="publish"
-        Properties="@(AdditionalProperties)"
-        RemoveProperties="OutputPath;TargetFramework" />
+    <Exec Command="dotnet publish $(RepoRoot)src/Aspire.Cli/Aspire.Cli.csproj @(AdditionalProperties -> '-p:%(Identity)', ' ')" />
 
     <!-- TODO: avoid generating the file instead of manually deleting it here -->
     <Delete Files="$(OutputPath)\aspire.xml" Condition="Exists('$(OutputPath)\aspire.xml')" />

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -42,5 +42,11 @@
 
     <!-- TODO: avoid generating the file instead of manually deleting it here -->
     <Delete Files="$(OutputPath)\aspire.xml" Condition="Exists('$(OutputPath)\aspire.xml')" />
+
+    <!-- work around https://github.com/dotnet/runtime/issues/116758 by removing the Xliff folders. -->
+    <ItemGroup>
+      <DirectoriesToRemove Include="$(XlfLanguages)" />
+    </ItemGroup>
+    <RemoveDir Directories="$(OutputPath)\%(DirectoriesToRemove.Identity)" />
   </Target>
 </Project>

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -7,17 +7,34 @@
     <ArchiveFormat Condition="!$(CliRuntime.StartsWith('linux-'))">zip</ArchiveFormat>
   </PropertyGroup>
 
+  <!-- Enable native AOT on non-official builds to ensure the Cli is AOT compatible. -->
+  <!-- TODO: https://github.com/dotnet/aspire/issues/8677 - enable PublishAot when the official build infrastructure supports all platforms. -->
+  <PropertyGroup Condition="'$(OfficialBuildId)' == ''">
+    <PublishNativeAot Condition="$(CliRuntime.StartsWith('linux-')) AND $([System.OperatingSystem]::IsLinux())">true</PublishNativeAot>
+    <PublishNativeAot Condition="$(CliRuntime.StartsWith('osx-')) AND $([System.OperatingSystem]::IsMacOS())">true</PublishNativeAot>
+    <PublishNativeAot Condition="$(CliRuntime.StartsWith('win-')) AND '$(CliRuntime)' != 'win-x86' AND $([System.OperatingSystem]::IsWindows())">true</PublishNativeAot>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" />
   </ItemGroup>
 
   <Target Name="PublishToDisk">
     <ItemGroup>
-      <AdditionalProperties Include="Configuration=$(Configuration)" />
       <AdditionalProperties Include="RuntimeIdentifier=$(CliRuntime)" />
+      <AdditionalProperties Include="PublishDir=$(OutputPath)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(PublishNativeAot)' == 'true'">
+      <!-- Always publish Release for native aot, since Debug hits a warning https://github.com/protocolbuffers/protobuf/issues/21824. -->
+      <AdditionalProperties Include="Configuration=Release" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(PublishNativeAot)' != 'true'">
+      <AdditionalProperties Include="Configuration=$(Configuration)" />
       <AdditionalProperties Include="PublishSingleFile=true" />
       <AdditionalProperties Include="SelfContained=true" />
-      <AdditionalProperties Include="PublishDir=$(OutputPath)" />
+      <AdditionalProperties Include="PublishAot=false" />
     </ItemGroup>
 
     <!-- Remove OutputPath, and TargetFramework so the defaults can be used -->

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -5,6 +5,8 @@
     <ArchiveName>aspire-cli-$(CliRuntime)</ArchiveName>
     <ArchiveFormat Condition="$(CliRuntime.StartsWith('linux-'))">tar.gz</ArchiveFormat>
     <ArchiveFormat Condition="!$(CliRuntime.StartsWith('linux-'))">zip</ArchiveFormat>
+
+    <PublishNativeAot Condition="'$(PublishNativeAot)' == ''">true</PublishNativeAot>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,9 +17,17 @@
     <ItemGroup>
       <AdditionalProperties Include="RuntimeIdentifier=$(CliRuntime)" />
       <AdditionalProperties Include="PublishDir=$(OutputPath)" />
+    </ItemGroup>
 
+    <ItemGroup Condition="'$(PublishNativeAot)' == 'true'">
       <!-- Always publish Release for native aot, since Debug hits a warning https://github.com/protocolbuffers/protobuf/issues/21824. -->
       <AdditionalProperties Include="Configuration=Release" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(PublishNativeAot)' != 'true'">
+      <AdditionalProperties Include="Configuration=$(Configuration)" />
+      <AdditionalProperties Include="PublishAot=false" />
+      <AdditionalProperties Include="PublishSingleFile=true" />
+      <AdditionalProperties Include="SelfContained=true" />
     </ItemGroup>
 
     <!-- Remove OutputPath, and TargetFramework so the defaults can be used -->

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -20,7 +20,12 @@
       <AdditionalProperties Include="Configuration=Release" />
     </ItemGroup>
 
-    <Exec Command="dotnet publish $(RepoRoot)src/Aspire.Cli/Aspire.Cli.csproj @(AdditionalProperties -> '-p:%(Identity)', ' ')" />
+    <!-- Remove OutputPath, and TargetFramework so the defaults can be used -->
+    <MSBuild
+        Projects="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.csproj"
+        Targets="Publish"
+        Properties="@(AdditionalProperties)"
+        RemoveProperties="OutputPath;TargetFramework" />
 
     <!-- TODO: avoid generating the file instead of manually deleting it here -->
     <Delete Files="$(OutputPath)\aspire.xml" Condition="Exists('$(OutputPath)\aspire.xml')" />

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -6,7 +6,10 @@
     <ArchiveFormat Condition="$(CliRuntime.StartsWith('linux-'))">tar.gz</ArchiveFormat>
     <ArchiveFormat Condition="!$(CliRuntime.StartsWith('linux-'))">zip</ArchiveFormat>
 
-    <PublishNativeAot Condition="'$(PublishNativeAot)' == ''">true</PublishNativeAot>
+    <!-- Publish native AOT if running on the target platfrom -->
+    <PublishNativeAot Condition="'$(PublishNativeAot)' == '' and $([System.OperatingSystem]::IsWindows()) and $(CliRuntime.StartsWith('win-'))">true</PublishNativeAot>
+    <PublishNativeAot Condition="'$(PublishNativeAot)' == '' and $([System.OperatingSystem]::IsLinux()) and $(CliRuntime.StartsWith('linux-'))">true</PublishNativeAot>
+    <PublishNativeAot Condition="'$(PublishNativeAot)' == '' and $([System.OperatingSystem]::IsMacOS()) and $(CliRuntime.StartsWith('osx-'))">true</PublishNativeAot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Cli/Aspire.Cli.Tool.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.Tool.csproj
@@ -13,6 +13,7 @@
     <PackageTags>aspire cli</PackageTags>
     <Description>Command line tool for Aspire developers.</Description>
     <PublishAot>false</PublishAot>
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 
 </Project>

--- a/src/Aspire.Cli/Aspire.Cli.Tool.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.Tool.csproj
@@ -1,19 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <IsCliToolProject>true</IsCliToolProject>
+  </PropertyGroup>
 
   <Import Project="Aspire.Cli.csproj" />
-
-  <PropertyGroup>
-    <!-- This package needs to remain as preview. -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <IsPackable>true</IsPackable>
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>aspire</ToolCommandName>
-    <PackageId>Aspire.Cli</PackageId>
-    <RollForward>Major</RollForward>
-    <PackageTags>aspire cli</PackageTags>
-    <Description>Command line tool for Aspire developers.</Description>
-    <PublishAot>false</PublishAot>
-    <PublishTrimmed>false</PublishTrimmed>
-  </PropertyGroup>
 
 </Project>

--- a/src/Aspire.Cli/Aspire.Cli.Tool.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.Tool.csproj
@@ -1,0 +1,18 @@
+<Project>
+
+  <Import Project="Aspire.Cli.csproj" />
+
+  <PropertyGroup>
+    <!-- This package needs to remain as preview. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>aspire</ToolCommandName>
+    <PackageId>Aspire.Cli</PackageId>
+    <RollForward>Major</RollForward>
+    <PackageTags>aspire cli</PackageTags>
+    <Description>Command line tool for Aspire developers.</Description>
+    <PublishAot>false</PublishAot>
+  </PropertyGroup>
+
+</Project>

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -12,7 +12,6 @@
     <AssemblyName>aspire</AssemblyName>
     <RootNamespace>Aspire.Cli</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <IsAotCompatible>true</IsAotCompatible>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>aspire</ToolCommandName>
@@ -20,10 +19,7 @@
     <RollForward>Major</RollForward>
     <PackageTags>aspire cli</PackageTags>
     <Description>Command line tool for Aspire developers.</Description>
-    <!-- TODO: https://github.com/dotnet/aspire/issues/8677 - enable PublishAot when the build infrastructure supports all platforms. -->
-    <!--<PublishAot>true</PublishAot>--> 
-    <!--JsonSerializerIsReflectionEnabledByDefault can be removed when PublishAot is enabled. -->
-    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <PublishAot>true</PublishAot> 
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -15,6 +15,20 @@
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 
+  <!-- Set the nuget properties when building as a global tool. -->
+  <PropertyGroup Condition="'$(IsCliToolProject)' == 'true'">
+    <!-- This package needs to remain as preview. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>aspire</ToolCommandName>
+    <PackageId>Aspire.Cli</PackageId>
+    <RollForward>Major</RollForward>
+    <PackageTags>aspire cli</PackageTags>
+    <Description>Command line tool for Aspire developers.</Description>
+    <PublishAot>false</PublishAot>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="System.CommandLine" />

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -19,7 +19,7 @@
     <RollForward>Major</RollForward>
     <PackageTags>aspire cli</PackageTags>
     <Description>Command line tool for Aspire developers.</Description>
-    <PublishAot>true</PublishAot> 
+    <PublishAot>true</PublishAot>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,8 +11,9 @@
     <RootNamespace>Aspire.Cli</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <IsAotCompatible>true</IsAotCompatible>
-    <PublishAot>true</PublishAot> 
+    <PublishAot>true</PublishAot>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
   </PropertyGroup>
 
   <!-- Set the nuget properties when building as a global tool. -->

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -20,7 +20,7 @@
     <PackageTags>aspire cli</PackageTags>
     <Description>Command line tool for Aspire developers.</Description>
     <!-- AOT not supported on our Azdo builds yet -->
-    <PublishAot Condition="'$(SYSTEM_TEAMPROJECT)' ==''">true</PublishAot>
+    <PublishAot Condition="'$(SYSTEM_TEAMPROJECT)' =='' and '$(RuntimeIdentifier)' != ''">true</PublishAot>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -19,7 +19,8 @@
     <RollForward>Major</RollForward>
     <PackageTags>aspire cli</PackageTags>
     <Description>Command line tool for Aspire developers.</Description>
-    <PublishAot>true</PublishAot>
+    <!-- AOT not supported on our Azdo builds yet -->
+    <PublishAot Condition="'$(SYSTEM_TEAMPROJECT)' ==''">true</PublishAot>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -7,20 +7,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnablePackageValidation>false</EnablePackageValidation>
-    <!-- This package needs to remain as preview. -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <AssemblyName>aspire</AssemblyName>
     <RootNamespace>Aspire.Cli</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <IsPackable>true</IsPackable>
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>aspire</ToolCommandName>
-    <PackageId>Aspire.Cli</PackageId>
-    <RollForward>Major</RollForward>
-    <PackageTags>aspire cli</PackageTags>
-    <Description>Command line tool for Aspire developers.</Description>
-    <!-- AOT not supported on our Azdo builds yet -->
-    <PublishAot Condition="'$(SYSTEM_TEAMPROJECT)' =='' and '$(RuntimeIdentifier)' != ''">true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <PublishAot>true</PublishAot> 
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -18,7 +18,7 @@
   <!-- Used by Aspire.Workload.Testing.targets -->
   <Target Name="GetPackageName" Returns="@(PackageName)">
     <ItemGroup>
-      <PackageName Include="$(MSBuildProjectName)" Condition="'$(IsPackable)' == 'true'" WithPackageVersion="$(PackageVersion)" />
+      <PackageName Include="$(PackageId)" Condition="'$(IsPackable)' == 'true'" WithPackageVersion="$(PackageVersion)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/tests/Shared/RepoTesting/Directory.Packages.Helix.props
+++ b/tests/Shared/RepoTesting/Directory.Packages.Helix.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.AppConfiguration" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="$(PackageVersion)" />

--- a/tests/helix/send-to-helix-templatestests.targets
+++ b/tests/helix/send-to-helix-templatestests.targets
@@ -42,6 +42,7 @@
       <!-- the default dotnet-tests sdk is added by inner.proj . Add the rest here -->
       <HelixCorrelationPayload Include="$(ArtifactsBinDir)dotnet-8" Destination="dotnet-8" />
       <HelixCorrelationPayload Include="$(ArtifactsBinDir)dotnet-9" Destination="dotnet-9" />
+      <HelixCorrelationPayload Include="$(ArtifactsBinDir)dotnet-10" Destination="dotnet-10" />
 
       <!-- PreCommands="" needed for batching below -->
       <_TemplateTestsClassNames TestNameSuffix="$([System.String]::Copy('%(Identity)').Replace('Aspire.Template.Tests.', ''))" PreCommands="" />


### PR DESCRIPTION
This enables native AOT publish process during the PR validation and official builds when it can (just win-x64 and win-arm64 on official builds for now). When we add more official build targets like macOS and linux, those will light up with this change.

We need to split the Aspire.Cli project into 2 separate projects because in order to publish for AOT, it is easiest to set `PublishAot=true` in the .csproj directly. Trying to pass it in during publish causes lots of problems.

Because of https://github.com/dotnet/runtime/issues/94178, this doesn't fail when there are warnings because PublishAot in net8.0 always emits warnings, which don't get turned into errors.