### PR TITLE
Fix `YarpCluster` construction and add constructor that takes `IResourceWithServiceDiscovery`

### DIFF
--- a/playground/yarp/Yarp.AppHost/Program.cs
+++ b/playground/yarp/Yarp.AppHost/Program.cs
@@ -12,8 +12,8 @@ var frontendService = builder.AddProject<Projects.Yarp_Frontend>("frontend");
 var gateway = builder.AddYarp("gateway")
                      .WithConfiguration(yarp =>
                      {
-                         yarp.AddRoute(frontendService.GetEndpoint("http"));
-                         yarp.AddRoute("/api/{**catch-all}", backendService.GetEndpoint("http"))
+                         yarp.AddRoute(frontendService);
+                         yarp.AddRoute("/api/{**catch-all}", backendService)
                              .WithTransformPathRemovePrefix("/api");
                      });
 

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
@@ -22,9 +22,16 @@ public interface IYarpConfigurationBuilder
     /// <summary>
     /// Add a new cluster to YARP.
     /// </summary>
-    /// <param name="endpoint">The endpoint used by this cluster.</param>
+    /// <param name="endpoint">The endpoint target for this cluster.</param>
     /// <returns></returns>
     public YarpCluster AddCluster(EndpointReference endpoint);
+
+    /// <summary>
+    /// Add a new cluster to YARP.
+    /// </summary>
+    /// <param name="resource">The resource target for this cluster.</param>
+    /// <returns></returns>
+    public YarpCluster AddCluster(IResourceBuilder<IResourceWithServiceDiscovery> resource);
 }
 
 /// <summary>
@@ -46,6 +53,28 @@ public static class YarpConfigurationBuilderExtensions
     }
 
     /// <summary>
+    /// Add a new catch all route to YARP that will target the cluster in parameter.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="endpoint">The target endpoint for this route.</param>
+    /// <returns></returns>
+    public static YarpRoute AddRoute(this IYarpConfigurationBuilder builder, EndpointReference endpoint)
+    {
+        return builder.AddRoute(CatchAllPath, endpoint);
+    }
+
+    /// <summary>
+    /// Add a new catch all route to YARP that will target the cluster in parameter.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="resource">The target resource for this route.</param>
+    /// <returns></returns>
+    public static YarpRoute AddRoute(this IYarpConfigurationBuilder builder, IResourceBuilder<IResourceWithServiceDiscovery> resource)
+    {
+        return builder.AddRoute(CatchAllPath, resource);
+    }
+
+    /// <summary>
     /// Add a new route to YARP that will target the cluster in parameter.
     /// </summary>
     /// <param name="builder">The builder instance.</param>
@@ -59,13 +88,15 @@ public static class YarpConfigurationBuilderExtensions
     }
 
     /// <summary>
-    /// Add a new catch all route to YARP that will target the cluster in parameter.
+    /// Add a new route to YARP that will target the cluster in parameter.
     /// </summary>
     /// <param name="builder">The builder instance.</param>
-    /// <param name="endpoint">The target endpoint for this route.</param>
+    /// <param name="path">The path to match for this route.</param>
+    /// <param name="resource">The target endpoint for this route.</param>
     /// <returns></returns>
-    public static YarpRoute AddRoute(this IYarpConfigurationBuilder builder, EndpointReference endpoint)
+    public static YarpRoute AddRoute(this IYarpConfigurationBuilder builder, string path, IResourceBuilder<IResourceWithServiceDiscovery> resource)
     {
-        return builder.AddRoute(CatchAllPath, endpoint);
+        var cluster = builder.AddCluster(resource);
+        return builder.AddRoute(path, cluster);
     }
 }

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -17,7 +17,7 @@ public class YarpCluster(EndpointReference endpoint)
         ClusterId = $"cluster_{endpoint.Resource.Name}_{Guid.NewGuid().ToString("N")}",
         Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
         {
-            { "destination1", new DestinationConfig { Address = $"{endpoint.Scheme}://{endpoint.Resource.Name}" } },
+            { "destination1", new DestinationConfig { Address = $"{endpoint.Scheme}://_{endpoint.EndpointName}.{endpoint.Resource.Name}" } },
         }
     };
 

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -25,8 +25,8 @@ public class YarpCluster
     /// Construct a new YarpCluster targeting the resource in parameter.
     /// </summary>
     /// <param name="resource">The resource to target.</param>
-    public YarpCluster(IResourceBuilder<IResourceWithServiceDiscovery> resource)
-        : this(resource.Resource.Name, BuildEndpointUri(resource.Resource))
+    public YarpCluster(IResourceWithServiceDiscovery resource)
+        : this(resource.Name, BuildEndpointUri(resource))
     {
     }
 

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
@@ -26,7 +26,7 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
     public YarpCluster AddCluster(EndpointReference endpoint)
     {
         var destination = new YarpCluster(endpoint);
-        _parent.Resource.Destinations.Add(destination);
+        _parent.Resource.Clusters.Add(destination);
         _parent.WithReference(endpoint);
         return destination;
     }

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
@@ -30,4 +30,13 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
         _parent.WithReference(endpoint);
         return destination;
     }
+
+    /// <inheritdoc/>
+    public YarpCluster AddCluster(IResourceBuilder<IResourceWithServiceDiscovery> resource)
+    {
+        var destination = new YarpCluster(resource);
+        _parent.Resource.Clusters.Add(destination);
+        _parent.WithReference(resource);
+        return destination;
+    }
 }

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
@@ -34,7 +34,7 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
     /// <inheritdoc/>
     public YarpCluster AddCluster(IResourceBuilder<IResourceWithServiceDiscovery> resource)
     {
-        var destination = new YarpCluster(resource);
+        var destination = new YarpCluster(resource.Resource);
         _parent.Resource.Clusters.Add(destination);
         _parent.WithReference(resource);
         return destination;

--- a/src/Aspire.Hosting.Yarp/YarpResource.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResource.cs
@@ -18,5 +18,5 @@ public class YarpResource(string name) : ContainerResource(name)
 
     internal List<YarpRoute> Routes { get; } = new();
 
-    internal List<YarpCluster> Destinations { get; } = new();
+    internal List<YarpCluster> Clusters { get; } = new();
 }

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -51,7 +51,7 @@ public static class YarpResourceExtensions
             {
                 yarpBuilder.Resource.ConfigurationBuilder.AddRoute(route.RouteConfig);
             }
-            foreach (var destination in yarpBuilder.Resource.Destinations)
+            foreach (var destination in yarpBuilder.Resource.Clusters)
             {
                 yarpBuilder.Resource.ConfigurationBuilder.AddCluster(destination.ClusterConfig);
             }

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpClusterTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpClusterTests.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Yarp.Tests;
+
+public class YarpClusterTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void Create_YarpCluster_From_Endpoints_With_Names()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var resource = builder.AddResource(new TestResource("ServiceA"))
+                              .WithHttpEndpoint(name: "testendpoint")
+                              .WithHttpsEndpoint(name: "anotherendpoint");
+
+        var httpEndpoint = resource.GetEndpoint("testendpoint");
+        var httpsEndpoint = resource.GetEndpoint("anotherendpoint");
+
+        var httpCluster = new YarpCluster(httpEndpoint);
+        var httpDestination = httpCluster.ClusterConfig.Destinations!.FirstOrDefault();
+        Assert.Equal($"http://_testendpoint.ServiceA", httpDestination.Value.Address);
+
+        var httpsCluster = new YarpCluster(httpsEndpoint);
+        var httpsDestination = httpsCluster.ClusterConfig.Destinations!.FirstOrDefault();
+        Assert.Equal($"https://_anotherendpoint.ServiceA", httpsDestination.Value.Address);
+    }
+
+    [Fact]
+    public void Create_YarpCluster_From_Endpoints_Without_Names()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var resource = builder.AddResource(new TestResource("ServiceC"))
+                              .WithHttpEndpoint()
+                              .WithHttpsEndpoint();
+
+        var httpEndpoint = resource.GetEndpoint("http");
+        var httpsEndpoint = resource.GetEndpoint("https");
+
+        var httpCluster = new YarpCluster(httpEndpoint);
+        var httpDestination = httpCluster.ClusterConfig.Destinations!.FirstOrDefault();
+        Assert.Equal($"http://_http.ServiceC", httpDestination.Value.Address);
+
+        var httpsCluster = new YarpCluster(httpsEndpoint);
+        var httpsDestination = httpsCluster.ClusterConfig.Destinations!.FirstOrDefault();
+        Assert.Equal($"https://_https.ServiceC", httpsDestination.Value.Address);
+    }
+
+    [Fact]
+    public void Create_YarpCluster_From_Resource_With_One_Endpoint()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var httpService = builder.AddResource(new TestResource("ServiceC"))
+                                 .WithHttpEndpoint()
+                                 .WithHttpEndpoint(name: "grpc");
+
+        var httpCluster = new YarpCluster(httpService);
+        var httpDestination = httpCluster.ClusterConfig.Destinations!.FirstOrDefault();
+        Assert.Equal($"http://ServiceC", httpDestination.Value.Address);
+
+        var httpsService = builder.AddResource(new TestResource("ServiceD"))
+                                  .WithHttpsEndpoint()
+                                  .WithHttpsEndpoint(name: "grpc");
+
+        var httpsCluster = new YarpCluster(httpsService);
+        var httpsDestination = httpsCluster.ClusterConfig.Destinations!.FirstOrDefault();
+        Assert.Equal($"https://ServiceD", httpsDestination.Value.Address);
+    }
+
+    [Fact]
+    public void Create_YarpCluster_From_Resource_With_Both_Endpoints()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        var serviceA = builder.AddResource(new TestResource("ServiceA"))
+                              .WithHttpEndpoint()
+                              .WithHttpsEndpoint();
+
+        var clusterA = new YarpCluster(serviceA);
+        var httpDestination = clusterA.ClusterConfig.Destinations!.FirstOrDefault();
+        Assert.Equal($"https+http://ServiceA", httpDestination.Value.Address);
+    }
+
+    private sealed class TestResource(string name) : IResourceWithServiceDiscovery
+    {
+        public string Name => name;
+
+        public ResourceAnnotationCollection Annotations { get; } = new ResourceAnnotationCollection();
+    }
+}

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpClusterTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpClusterTests.cs
@@ -57,7 +57,7 @@ public class YarpClusterTests(ITestOutputHelper testOutputHelper)
                                  .WithHttpEndpoint()
                                  .WithHttpEndpoint(name: "grpc");
 
-        var httpCluster = new YarpCluster(httpService);
+        var httpCluster = new YarpCluster(httpService.Resource);
         var httpDestination = httpCluster.ClusterConfig.Destinations!.FirstOrDefault();
         Assert.Equal($"http://ServiceC", httpDestination.Value.Address);
 
@@ -65,7 +65,7 @@ public class YarpClusterTests(ITestOutputHelper testOutputHelper)
                                   .WithHttpsEndpoint()
                                   .WithHttpsEndpoint(name: "grpc");
 
-        var httpsCluster = new YarpCluster(httpsService);
+        var httpsCluster = new YarpCluster(httpsService.Resource);
         var httpsDestination = httpsCluster.ClusterConfig.Destinations!.FirstOrDefault();
         Assert.Equal($"https://ServiceD", httpsDestination.Value.Address);
     }
@@ -78,7 +78,7 @@ public class YarpClusterTests(ITestOutputHelper testOutputHelper)
                               .WithHttpEndpoint()
                               .WithHttpsEndpoint();
 
-        var clusterA = new YarpCluster(serviceA);
+        var clusterA = new YarpCluster(serviceA.Resource);
         var httpDestination = clusterA.ClusterConfig.Destinations!.FirstOrDefault();
         Assert.Equal($"https+http://ServiceA", httpDestination.Value.Address);
     }


### PR DESCRIPTION
## Fix `YarpCluster` construction and add constructor that takes `IResourceWithServiceDiscovery`

- The conversion from an `EndpointReference` to a usable YARP url in the config was a bit broken if there was multiple endpoints with the same scheme
- Added methods to construct routes and cluster with a `IResourceWithServiceDiscovery`. It is now possible to have:
```csharp
var backend = builder.AddProject<Projects.Backend>("backend");
var yarp = builder.AddYarp("gateway").WithConfiguration(config => 
{
    // no need to bind a specific endpoint
    config.AddRoute("/api/{**catch-all}", backend);
};
  ```

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [X] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [X] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
