### PR TITLE
Yarp: defer configuration generation

### DIFF
--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
@@ -10,6 +10,10 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
 {
     private readonly IResourceBuilder<YarpResource> _parent = parent;
 
+    internal List<YarpCluster> Clusters { get; } = new();
+
+    internal List<YarpRoute> Routes { get; } = new();
+
     /// <inheritdoc/>
     public YarpRoute AddRoute(string path, YarpCluster cluster)
     {
@@ -18,7 +22,7 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
         {
             route.WithMatchPath(path);
         }
-        _parent.Resource.Routes.Add(route);
+        Routes.Add(route);
         return route;
     }
 
@@ -26,7 +30,7 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
     public YarpCluster AddCluster(EndpointReference endpoint)
     {
         var destination = new YarpCluster(endpoint);
-        _parent.Resource.Clusters.Add(destination);
+        Clusters.Add(destination);
         _parent.WithReference(endpoint);
         return destination;
     }
@@ -35,7 +39,7 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
     public YarpCluster AddCluster(IResourceBuilder<IResourceWithServiceDiscovery> resource)
     {
         var destination = new YarpCluster(resource.Resource);
-        _parent.Resource.Clusters.Add(destination);
+        Clusters.Add(destination);
         _parent.WithReference(resource);
         return destination;
     }

--- a/src/Aspire.Hosting.Yarp/IYarpJsonConfigGeneratorBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/IYarpJsonConfigGeneratorBuilder.cs
@@ -8,20 +8,20 @@ namespace Aspire.Hosting.Yarp;
 /// <summary>
 /// Interface to build a configuration file for YARP
 /// </summary>
-public interface IYarpJsonConfigurationBuilder
+public interface IYarpJsonConfigGeneratorBuilder
 {
     /// <summary>
     /// Add a RouteConfig to the YARP resource
     /// </summary>
-    public IYarpJsonConfigurationBuilder AddRoute(RouteConfig route);
+    public IYarpJsonConfigGeneratorBuilder AddRoute(RouteConfig route);
 
     /// <summary>
     /// Add a ClusterConfig to the YARP resource
     /// </summary>
-    public IYarpJsonConfigurationBuilder AddCluster(ClusterConfig cluster);
+    public IYarpJsonConfigGeneratorBuilder AddCluster(ClusterConfig cluster);
 
     /// <summary>
     /// Add a YARP config to the YARP resource
     /// </summary>
-    public IYarpJsonConfigurationBuilder WithConfigFile(string configFilePath);
+    public IYarpJsonConfigGeneratorBuilder WithConfigFile(string configFilePath);
 }

--- a/src/Aspire.Hosting.Yarp/YarpJsonConfigGeneratorBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/YarpJsonConfigGeneratorBuilder.cs
@@ -9,14 +9,14 @@ using Yarp.ReverseProxy.Configuration;
 
 namespace Aspire.Hosting.Yarp;
 
-internal sealed class YarpJsonConfigurationBuilder : IYarpJsonConfigurationBuilder
+internal sealed class YarpJsonConfigGeneratorBuilder : IYarpJsonConfigGeneratorBuilder
 {
     private string? _configFilePath;
     private readonly List<ClusterConfig> _clusterConfigs = new List<ClusterConfig>();
     private readonly List<RouteConfig> _routeConfigs = new List<RouteConfig>();
     private readonly JsonSerializerOptions _serializerOptions;
 
-    public YarpJsonConfigurationBuilder()
+    public YarpJsonConfigGeneratorBuilder()
     {
         _serializerOptions = new JsonSerializerOptions()
         {
@@ -27,7 +27,7 @@ internal sealed class YarpJsonConfigurationBuilder : IYarpJsonConfigurationBuild
         _serializerOptions.Converters.Add(new JsonStringEnumConverter(new PascalCaseJsonNamingPolicy()));
     }
 
-    public IYarpJsonConfigurationBuilder AddCluster(ClusterConfig cluster)
+    public IYarpJsonConfigGeneratorBuilder AddCluster(ClusterConfig cluster)
     {
         if (_configFilePath != null)
         {
@@ -37,7 +37,7 @@ internal sealed class YarpJsonConfigurationBuilder : IYarpJsonConfigurationBuild
         return this;
     }
 
-    public IYarpJsonConfigurationBuilder AddRoute(RouteConfig route)
+    public IYarpJsonConfigGeneratorBuilder AddRoute(RouteConfig route)
     {
         if (_configFilePath != null)
         {
@@ -47,7 +47,7 @@ internal sealed class YarpJsonConfigurationBuilder : IYarpJsonConfigurationBuild
         return this;
     }
 
-    public IYarpJsonConfigurationBuilder WithConfigFile(string configFilePath)
+    public IYarpJsonConfigGeneratorBuilder WithConfigFile(string configFilePath)
     {
         if (_clusterConfigs.Count > 0 || _routeConfigs.Count > 0)
         {

--- a/src/Aspire.Hosting.Yarp/YarpResource.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResource.cs
@@ -16,7 +16,5 @@ public class YarpResource(string name) : ContainerResource(name)
     /// </summary>
     internal YarpJsonConfigurationBuilder ConfigurationBuilder { get; } = new YarpJsonConfigurationBuilder();
 
-    internal List<YarpRoute> Routes { get; } = new();
-
-    internal List<YarpCluster> Clusters { get; } = new();
+    internal List<Action<IYarpConfigurationBuilder>> ConfigurationBuilderDelegates { get; } = new ();
 }

--- a/src/Aspire.Hosting.Yarp/YarpResource.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResource.cs
@@ -14,7 +14,7 @@ public class YarpResource(string name) : ContainerResource(name)
     /// <summary>
     /// Configuration builder used to build the config file for the YARP resource
     /// </summary>
-    internal YarpJsonConfigurationBuilder ConfigurationBuilder { get; } = new YarpJsonConfigurationBuilder();
+    internal YarpJsonConfigGeneratorBuilder JsonConfigGenerator { get; } = new YarpJsonConfigGeneratorBuilder();
 
     internal List<Action<IYarpConfigurationBuilder>> ConfigurationBuilderDelegates { get; } = new ();
 }

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -47,7 +47,7 @@ public static class YarpResourceExtensions
         // Map the configuration file
         yarpBuilder.WithContainerFiles(ConfigDirectory, async (context, ct) =>
         {
-            // Call all th config delegate
+            // Call all the config delegates
             var configBuilder = new YarpConfigurationBuilder(yarpBuilder);
             foreach (var configurator in yarpBuilder.Resource.ConfigurationBuilderDelegates)
             {

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -47,11 +47,16 @@ public static class YarpResourceExtensions
         // Map the configuration file
         yarpBuilder.WithContainerFiles(ConfigDirectory, async (context, ct) =>
         {
-            foreach (var route in yarpBuilder.Resource.Routes)
+            var configBuilder = new YarpConfigurationBuilder(yarpBuilder);
+            foreach (var configurator in yarpBuilder.Resource.ConfigurationBuilderDelegates)
+            {
+                configurator(configBuilder);
+            }
+            foreach (var route in configBuilder.Routes)
             {
                 yarpBuilder.Resource.ConfigurationBuilder.AddRoute(route.RouteConfig);
             }
-            foreach (var destination in yarpBuilder.Resource.Clusters)
+            foreach (var destination in configBuilder.Clusters)
             {
                 yarpBuilder.Resource.ConfigurationBuilder.AddCluster(destination.ClusterConfig);
             }
@@ -100,8 +105,7 @@ public static class YarpResourceExtensions
     /// <param name="configurationBuilder">The delegate to configure YARP.</param>
     public static IResourceBuilder<YarpResource> WithConfiguration(this IResourceBuilder<YarpResource> builder, Action<IYarpConfigurationBuilder> configurationBuilder)
     {
-        var configBuilder = new YarpConfigurationBuilder(builder);
-        configurationBuilder(configBuilder);
+        builder.Resource.ConfigurationBuilderDelegates.Add(configurationBuilder);
         return builder;
     }
 }

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -47,20 +47,23 @@ public static class YarpResourceExtensions
         // Map the configuration file
         yarpBuilder.WithContainerFiles(ConfigDirectory, async (context, ct) =>
         {
+            // Call all th config delegate
             var configBuilder = new YarpConfigurationBuilder(yarpBuilder);
             foreach (var configurator in yarpBuilder.Resource.ConfigurationBuilderDelegates)
             {
                 configurator(configBuilder);
             }
+            // Add all routes and cluster to the json config generator
             foreach (var route in configBuilder.Routes)
             {
-                yarpBuilder.Resource.ConfigurationBuilder.AddRoute(route.RouteConfig);
+                yarpBuilder.Resource.JsonConfigGenerator.AddRoute(route.RouteConfig);
             }
             foreach (var destination in configBuilder.Clusters)
             {
-                yarpBuilder.Resource.ConfigurationBuilder.AddCluster(destination.ClusterConfig);
+                yarpBuilder.Resource.JsonConfigGenerator.AddCluster(destination.ClusterConfig);
             }
-            var contents = await yarpBuilder.Resource.ConfigurationBuilder.Build(ct).ConfigureAwait(false);
+            // Generate the json content
+            var contents = await yarpBuilder.Resource.JsonConfigGenerator.Build(ct).ConfigureAwait(false);
 
             var configFile = new ContainerFile
             {
@@ -82,7 +85,7 @@ public static class YarpResourceExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<YarpResource> WithConfigFile(this IResourceBuilder<YarpResource> builder, string configFilePath)
     {
-        builder.Resource.ConfigurationBuilder.WithConfigFile(configFilePath);
+        builder.Resource.JsonConfigGenerator.WithConfigFile(configFilePath);
         return builder;
     }
 
@@ -92,9 +95,9 @@ public static class YarpResourceExtensions
     /// <param name="builder">The YARP resource to configure.</param>
     /// <param name="configurationBuilder">The delegate to configure YARP.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    internal static IResourceBuilder<YarpResource> WithConfiguration(this IResourceBuilder<YarpResource> builder, Action<IYarpJsonConfigurationBuilder> configurationBuilder)
+    internal static IResourceBuilder<YarpResource> WithConfiguration(this IResourceBuilder<YarpResource> builder, Action<IYarpJsonConfigGeneratorBuilder> configurationBuilder)
     {
-        configurationBuilder(builder.Resource.ConfigurationBuilder);
+        configurationBuilder(builder.Resource.JsonConfigGenerator);
         return builder;
     }
 

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpConfigGeneratorTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpConfigGeneratorTests.cs
@@ -215,7 +215,7 @@ public class YarpConfigGeneratorTests()
     [Fact]
     public async Task GenerateConfiguration()
     {
-        var config = new YarpJsonConfigurationBuilder();
+        var config = new YarpJsonConfigGeneratorBuilder();
         foreach (var cluster in _validClusters)
         {
             config.AddCluster(cluster);


### PR DESCRIPTION
## Yarp: defer configuration generation

In this PR, we defer the genration of the yarp configuration during the `WithContainerFiles` delegate call.

I also did some name refactoring so the difference between the fluent builder and the json builder is clearer.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [X] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
