### PR TITLE
Add vscode setting to load local ./.dotnet sdks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "dotnet.previewSolution-freeWorkspaceMode": true,
     "dotnet.testWindow.useTestingPlatformProtocol": true,
     "dotnet.defaultSolution": "./Aspire.slnx",
-    "dotnet.preview.enableSupportForSlnx": true
+    "dotnet.preview.enableSupportForSlnx": true,
+    "omnisharp.sdkPath": "./.dotnet/"
 }


### PR DESCRIPTION
With this DevKit will pick up the correct sdks installed with ./build.cmd

Tried starting a playground app and finding/debugging tests, it works fine.

