### PR TITLE
Add `IResourceBuilder<T>` extension method for event subscriptions

### DIFF
--- a/playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs
+++ b/playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs
@@ -50,7 +50,7 @@ public static class TalkingClockExtensions
                 ]
             });
 
-        clockBuilder.OnInitializeResource(static async (@event, token) =>
+        clockBuilder.OnInitializeResource(static async (resource, @event, token) =>
         {
             // This event is published when the resource is initialized.
             // You add custom logic here to establish the lifecycle for your custom resource.
@@ -58,7 +58,6 @@ public static class TalkingClockExtensions
             var log = @event.Logger; // Get the logger for this resource instance.
             var eventing = @event.Eventing; // Get the eventing service for publishing events.
             var notification = @event.Notifications; // Get the notification service for state updates.
-            var resource = (TalkingClockResource)@event.Resource; // Get the resource instance.
             var services = @event.Services; // Get the service provider for dependency injection.
 
             // Publish an Aspire event indicating that this resource is about to start.

--- a/playground/mongo/Mongo.AppHost/Program.cs
+++ b/playground/mongo/Mongo.AppHost/Program.cs
@@ -10,13 +10,13 @@ var builder = DistributedApplication.CreateBuilder(args);
 var db = builder.AddMongoDB("mongo")
     .WithMongoExpress(c => c.WithHostPort(3022))
     .AddDatabase("db")
-    .OnResourceReady(async (@event, ct) =>{
+    .OnResourceReady(async (db, @event, ct) =>{
         // Artificial delay to demonstrate the waiting
         await Task.Delay(TimeSpan.FromSeconds(10), ct);
 
         // Seed the database with some data
         //var cs = await db.Resource.ConnectionStringExpression.GetValueAsync(ct);
-        var cs = await ((MongoDBDatabaseResource)@event.Resource).ConnectionStringExpression.GetValueAsync(ct);
+        var cs = await db.ConnectionStringExpression.GetValueAsync(ct);
         using var client = new MongoClient(cs);
 
         const string collectionName = "entries";

--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
@@ -132,10 +132,9 @@ public static class AzureAIFoundryExtensions
 
     private static IResourceBuilder<AzureAIFoundryResource> WithInitializer(this IResourceBuilder<AzureAIFoundryResource> builder)
     {
-        return builder.OnInitializeResource((@event, ct)
+        return builder.OnInitializeResource((resource, @event, ct)
             => Task.Run(async () =>
             {
-                var resource = (AzureAIFoundryResource)@event.Resource;
                 var rns = @event.Services.GetRequiredService<ResourceNotificationService>();
                 var manager = @event.Services.GetRequiredService<FoundryLocalManager>();
                 var logger = @event.Services.GetRequiredService<ResourceLoggerService>().GetLogger(resource);
@@ -185,9 +184,7 @@ public static class AzureAIFoundryExtensions
     {
         ArgumentNullException.ThrowIfNull(deployment, nameof(deployment));
 
-        var foundryResource = builder.Resource.Parent;
-
-        builder.ApplicationBuilder.Eventing.Subscribe<ResourceReadyEvent>(foundryResource, (@event, ct) =>
+        builder.OnResourceReady((foundryResource, @event, ct) =>
         {
             var rns = @event.Services.GetRequiredService<ResourceNotificationService>();
             var loggerService = @event.Services.GetRequiredService<ResourceLoggerService>();

--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
@@ -132,7 +132,7 @@ public static class AzureAIFoundryExtensions
 
     private static IResourceBuilder<AzureAIFoundryResource> WithInitializer(this IResourceBuilder<AzureAIFoundryResource> builder)
     {
-        builder.ApplicationBuilder.Eventing.Subscribe<InitializeResourceEvent>(builder.Resource, (@event, ct)
+        return builder.OnInitializeResource((@event, ct)
             => Task.Run(async () =>
             {
                 var resource = (AzureAIFoundryResource)@event.Resource;
@@ -176,8 +176,6 @@ public static class AzureAIFoundryExtensions
                 }
 
             }, ct));
-
-        return builder;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -88,17 +88,18 @@ public static class AzureCosmosExtensions
                });
 
         CosmosClient? cosmosClient = null;
-        builder.OnConnectionStringAvailable(async (cosmosDb, @event, ct) =>{
-                var connectionString = await cosmosDb.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false);
+        builder.OnConnectionStringAvailable(async (cosmosDb, @event, ct) =>
+        {
+            var connectionString = await cosmosDb.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false);
 
-                if (connectionString == null)
-                {
-                    throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{builder.Resource.Name}' resource but the connection string was null.");
-                }
+            if (connectionString == null)
+            {
+                throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{builder.Resource.Name}' resource but the connection string was null.");
+            }
 
-                cosmosClient = CreateCosmosClient(connectionString);
-            })
-            .OnResourceReady(async (cosmosDb, @event, ct) =>
+            cosmosClient = CreateCosmosClient(connectionString);
+        })
+        .OnResourceReady(async (cosmosDb, @event, ct) =>
         {
             if (cosmosClient is null)
             {

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -58,7 +58,7 @@ public static partial class SqlServerBuilderExtensions
                           context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = sqlServer.PasswordParameter;
                       })
                       .WithHealthCheck(healthCheckKey)
-                      .OnConnectionStringAvailable(async (@event, ct) =>
+                      .OnConnectionStringAvailable(async (sqlServer, @event, ct) =>
                       {
                           connectionString = await sqlServer.GetConnectionStringAsync(ct).ConfigureAwait(false);
 
@@ -67,7 +67,7 @@ public static partial class SqlServerBuilderExtensions
                               throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{sqlServer.Name}' resource but the connection string was null.");
                           }
                       })
-                      .OnResourceReady(async (@event, ct) =>
+                      .OnResourceReady(async (sqlServer, @event, ct) =>
                       {
                           if (connectionString is null)
                           {
@@ -116,7 +116,7 @@ public static partial class SqlServerBuilderExtensions
         return builder.ApplicationBuilder
             .AddResource(sqlServerDatabase)
             .WithHealthCheck(healthCheckKey)
-            .OnConnectionStringAvailable(async (@event, ct) =>
+            .OnConnectionStringAvailable(async (sqlServerDatabase, @event, ct) =>
             {
                 connectionString = await sqlServerDatabase.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false);
 

--- a/src/Aspire.Hosting/EventingExtensions.cs
+++ b/src/Aspire.Hosting/EventingExtensions.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting;
 public static class EventingExtensions
 {
     /// <summary>
-    /// Subscribes a callback to the <see cref="BeforeResourceStartedEvent"/> event within the AppHost."/>
+    /// Subscribes a callback to the <see cref="BeforeResourceStartedEvent"/> event within the AppHost.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
@@ -23,7 +23,7 @@ public static class EventingExtensions
         => builder.OnEvent(callback);
 
     /// <summary>
-    /// Subscribes a callback to the <see cref="ConnectionStringAvailableEvent"/> event within the AppHost."/>
+    /// Subscribes a callback to the <see cref="ConnectionStringAvailableEvent"/> event within the AppHost.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
@@ -34,7 +34,7 @@ public static class EventingExtensions
         => builder.OnEvent(callback);
 
     /// <summary>
-    /// Subscribes a callback to the <see cref="InitializeResourceEvent"/> event within the AppHost."/>
+    /// Subscribes a callback to the <see cref="InitializeResourceEvent"/> event within the AppHost.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
@@ -45,7 +45,7 @@ public static class EventingExtensions
         => builder.OnEvent(callback);
 
     /// <summary>
-    /// Subscribes a callback to the <see cref="ResourceEndpointsAllocatedEvent"/> event within the AppHost."/>
+    /// Subscribes a callback to the <see cref="ResourceEndpointsAllocatedEvent"/> event within the AppHost.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
@@ -56,7 +56,7 @@ public static class EventingExtensions
         => builder.OnEvent(callback);
 
     /// <summary>
-    /// Subscribes a callback to the <see cref="ResourceReadyEvent"/> event within the AppHost."/>
+    /// Subscribes a callback to the <see cref="ResourceReadyEvent"/> event within the AppHost.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>

--- a/src/Aspire.Hosting/EventingExtensions.cs
+++ b/src/Aspire.Hosting/EventingExtensions.cs
@@ -63,7 +63,7 @@ public static class EventingExtensions
     /// <param name="callback">A callback to handle the event.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<T> OnResourceReady<T>(this IResourceBuilder<T> builder, Func<ResourceReadyEvent, CancellationToken, Task> callback)
-        where T : IResourceWithWaitSupport
+        where T : IResource
         => builder.OnEvent(callback);
 
     private static IResourceBuilder<TResource> OnEvent<TResource, TEvent>(this IResourceBuilder<TResource> builder, Func<TEvent, CancellationToken, Task> callback)

--- a/src/Aspire.Hosting/EventingExtensions.cs
+++ b/src/Aspire.Hosting/EventingExtensions.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for subscribing to <see cref="IDistributedApplicationResourceEvent"/> events on resources.
+/// </summary>
+public static class EventingExtensions
+{
+    /// <summary>
+    /// Subscribes a callback to the <see cref="BeforeResourceStartedEvent"/> event within the AppHost."/>
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="callback">A callback to handle the event.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> OnBeforeResourceStarted<T>(this IResourceBuilder<T> builder, Func<BeforeResourceStartedEvent, CancellationToken, Task> callback)
+        where T : IResource
+        => builder.OnEvent(callback);
+
+    /// <summary>
+    /// Subscribes a callback to the <see cref="ConnectionStringAvailableEvent"/> event within the AppHost."/>
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="callback">A callback to handle the event.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> OnConnectionStringAvailable<T>(this IResourceBuilder<T> builder, Func<ConnectionStringAvailableEvent, CancellationToken, Task> callback)
+        where T : IResourceWithConnectionString
+        => builder.OnEvent(callback);
+
+    /// <summary>
+    /// Subscribes a callback to the <see cref="InitializeResourceEvent"/> event within the AppHost."/>
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="callback">A callback to handle the event.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> OnInitializeResource<T>(this IResourceBuilder<T> builder, Func<InitializeResourceEvent, CancellationToken, Task> callback)
+        where T : IResource
+        => builder.OnEvent(callback);
+
+    /// <summary>
+    /// Subscribes a callback to the <see cref="ResourceEndpointsAllocatedEvent"/> event within the AppHost."/>
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="callback">A callback to handle the event.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> OnResourceEndpointsAllocated<T>(this IResourceBuilder<T> builder, Func<ResourceEndpointsAllocatedEvent, CancellationToken, Task> callback)
+        where T : IResourceWithEndpoints
+        => builder.OnEvent(callback);
+
+    /// <summary>
+    /// Subscribes a callback to the <see cref="ResourceReadyEvent"/> event within the AppHost."/>
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="callback">A callback to handle the event.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> OnResourceReady<T>(this IResourceBuilder<T> builder, Func<ResourceReadyEvent, CancellationToken, Task> callback)
+        where T : IResourceWithWaitSupport
+        => builder.OnEvent(callback);
+
+    private static IResourceBuilder<TResource> OnEvent<TResource, TEvent>(this IResourceBuilder<TResource> builder, Func<TEvent, CancellationToken, Task> callback)
+        where TResource : IResource
+        where TEvent : IDistributedApplicationResourceEvent
+    {
+        builder.ApplicationBuilder.Eventing.Subscribe(builder.Resource, callback);
+        return builder;
+    }
+}

--- a/src/Aspire.Hosting/EventingExtensions.cs
+++ b/src/Aspire.Hosting/EventingExtensions.cs
@@ -18,7 +18,7 @@ public static class EventingExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="callback">A callback to handle the event.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> OnBeforeResourceStarted<T>(this IResourceBuilder<T> builder, Func<BeforeResourceStartedEvent, CancellationToken, Task> callback)
+    public static IResourceBuilder<T> OnBeforeResourceStarted<T>(this IResourceBuilder<T> builder, Func<T, BeforeResourceStartedEvent, CancellationToken, Task> callback)
         where T : IResource
         => builder.OnEvent(callback);
 
@@ -29,7 +29,7 @@ public static class EventingExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="callback">A callback to handle the event.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> OnConnectionStringAvailable<T>(this IResourceBuilder<T> builder, Func<ConnectionStringAvailableEvent, CancellationToken, Task> callback)
+    public static IResourceBuilder<T> OnConnectionStringAvailable<T>(this IResourceBuilder<T> builder, Func<T, ConnectionStringAvailableEvent, CancellationToken, Task> callback)
         where T : IResourceWithConnectionString
         => builder.OnEvent(callback);
 
@@ -40,7 +40,7 @@ public static class EventingExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="callback">A callback to handle the event.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> OnInitializeResource<T>(this IResourceBuilder<T> builder, Func<InitializeResourceEvent, CancellationToken, Task> callback)
+    public static IResourceBuilder<T> OnInitializeResource<T>(this IResourceBuilder<T> builder, Func<T, InitializeResourceEvent, CancellationToken, Task> callback)
         where T : IResource
         => builder.OnEvent(callback);
 
@@ -51,7 +51,7 @@ public static class EventingExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="callback">A callback to handle the event.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> OnResourceEndpointsAllocated<T>(this IResourceBuilder<T> builder, Func<ResourceEndpointsAllocatedEvent, CancellationToken, Task> callback)
+    public static IResourceBuilder<T> OnResourceEndpointsAllocated<T>(this IResourceBuilder<T> builder, Func<T, ResourceEndpointsAllocatedEvent, CancellationToken, Task> callback)
         where T : IResourceWithEndpoints
         => builder.OnEvent(callback);
 
@@ -62,15 +62,15 @@ public static class EventingExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="callback">A callback to handle the event.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> OnResourceReady<T>(this IResourceBuilder<T> builder, Func<ResourceReadyEvent, CancellationToken, Task> callback)
+    public static IResourceBuilder<T> OnResourceReady<T>(this IResourceBuilder<T> builder, Func<T, ResourceReadyEvent, CancellationToken, Task> callback)
         where T : IResource
         => builder.OnEvent(callback);
 
-    private static IResourceBuilder<TResource> OnEvent<TResource, TEvent>(this IResourceBuilder<TResource> builder, Func<TEvent, CancellationToken, Task> callback)
+    private static IResourceBuilder<TResource> OnEvent<TResource, TEvent>(this IResourceBuilder<TResource> builder, Func<TResource, TEvent, CancellationToken, Task> callback)
         where TResource : IResource
         where TEvent : IDistributedApplicationResourceEvent
     {
-        builder.ApplicationBuilder.Eventing.Subscribe(builder.Resource, callback);
+        builder.ApplicationBuilder.Eventing.Subscribe<TEvent>(builder.Resource, (evt, ct) => callback(builder.Resource, evt, ct));
         return builder;
     }
 }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1341,7 +1341,7 @@ public static class ResourceBuilderExtensions
 
         var endpointName = endpoint.EndpointName;
 
-        builder.OnResourceEndpointsAllocated((@event, ct) =>
+        builder.OnResourceEndpointsAllocated((_, @event, ct) =>
         {
             if (!endpoint.Exists)
             {
@@ -1352,7 +1352,7 @@ public static class ResourceBuilderExtensions
         });
 
         Uri? uri = null;
-        builder.OnBeforeResourceStarted((@event, ct) =>
+        builder.OnBeforeResourceStarted((_, @event, ct) =>
         {
             var baseUri = new Uri(endpoint.Url, UriKind.Absolute);
             uri = new Uri(baseUri, path);

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1341,7 +1341,7 @@ public static class ResourceBuilderExtensions
 
         var endpointName = endpoint.EndpointName;
 
-        builder.ApplicationBuilder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>(builder.Resource, (@event, ct) =>
+        builder.OnResourceEndpointsAllocated((@event, ct) =>
         {
             if (!endpoint.Exists)
             {
@@ -1352,7 +1352,7 @@ public static class ResourceBuilderExtensions
         });
 
         Uri? uri = null;
-        builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(builder.Resource, (@event, ct) =>
+        builder.OnBeforeResourceStarted((@event, ct) =>
         {
             var baseUri = new Uri(endpoint.Url, UriKind.Absolute);
             uri = new Uri(baseUri, path);


### PR DESCRIPTION
## Description

Add a number of extension method on `IResourceBuilder<T>` to easily subscribe to `IDistributedApplicationResourceEvent` on a resource

Refactored a few subscription calls over to use the new methods.  I can refactor more, just wanted to get a small amount (one per event) to prove the concept out.

Fixes #9168

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [x] No. Follow-up changes expected. - Follow up PR to migrate existing uses of `.Subscribe<T>` over to the new methods
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [X] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [X] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
