### PR TITLE
Fix failing `PublishAsAzureContainerApp_ThrowsIfNoEnvironment` test

### DIFF
--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1527,7 +1527,7 @@ public class AzureContainerAppsTests
         }
 
         await RunTest(builder =>
-            builder.AddProject<Projects.ServiceA>("ServiceA")
+            builder.AddProject<Projects.ServiceA>("ServiceA", launchProfileName: null)
                 .PublishAsAzureContainerApp((_, _) => { }));
 
         await RunTest(builder =>


### PR DESCRIPTION
The project file is not available on helix, so skip the launch settings
being loaded which isn't needed for the test.

```
failed Aspire.Hosting.Azure.Tests.AzureContainerAppsTests.PublishAsAzureContainerApp_ThrowsIfNoEnvironment (9ms)
  Xunit.Runner.InProc.SystemConsole.TestingPlatform.XunitException: Aspire.Hosting.DistributedApplicationException : Project file '/mnt/vss/_work/1/s/tests/testproject/TestProject.ServiceA/TestProject.ServiceA.csproj' was not found.
    at Aspire.Hosting.LaunchProfileExtensions.GetLaunchSettings(IProjectMetadata projectMetadata, String resourceName) in /_/src/Shared/LaunchProfiles/LaunchProfileExtensions.cs:77
    at Aspire.Hosting.LaunchProfileExtensions.GetLaunchSettings(ProjectResource projectResource) in /_/src/Shared/LaunchProfiles/LaunchProfileExtensions.cs:28
    at Aspire.Hosting.LaunchProfileExtensions.TrySelectLaunchProfileByOrder(ProjectResource projectResource, String& launchProfileName) in /_/src/Shared/LaunchProfiles/LaunchProfileExtensions.cs:117
    at Aspire.Hosting.LaunchProfileExtensions.SelectLaunchProfileName(ProjectResource projectResource) in /_/src/Shared/LaunchProfiles/LaunchProfileExtensions.cs:179
    at Aspire.Hosting.LaunchProfileExtensions.GetEffectiveLaunchProfile(ProjectResource projectResource, Boolean throwIfNotFound) in /_/src/Shared/LaunchProfiles/LaunchProfileExtensions.cs:33
    at Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(IResourceBuilder`1 builder, ProjectResourceOptions options) in /_/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs:341
    at Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject[TProject](IDistributedApplicationBuilder builder, String name, Action`1 configure) in /_/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs:230
    at Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject[TProject](IDistributedApplicationBuilder builder, String name) in /_/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs:63
    at Aspire.Hosting.Azure.Tests.AzureContainerAppsTests.<>c.<PublishAsAzureContainerApp_ThrowsIfNoEnvironment>b__48_1(IDistributedApplicationBuilder builder) in /mnt/vss/_work/1/s/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs:1530
    at Aspire.Hosting.Azure.Tests.AzureContainerAppsTests.<PublishAsAzureContainerApp_ThrowsIfNoEnvironment>g__RunTest|48_0(Action`1 action) in /mnt/vss/_work/1/s/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs:1520
    at Aspire.Hosting.Azure.Tests.AzureContainerAppsTests.PublishAsAzureContainerApp_ThrowsIfNoEnvironment() in /mnt/vss/_work/1/s/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs:1529
    --- End of stack trace from previous location ---
```