### PR TITLE
Interaction service improvements

### DIFF
--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -1,0 +1,204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+internal static class InteractionCommands
+{
+    public static IResourceBuilder<T> AddInteractionCommands<T>(this IResourceBuilder<T> resource) where T : IResource
+    {
+        resource
+            .WithCommand("confirmation-interaction", "Confirmation interactions", executeCommand: async commandContext =>
+           {
+               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+               var resultTask1 = interactionService.PromptConfirmationAsync("Command confirmation", "Are you sure?", cancellationToken: commandContext.CancellationToken);
+               var resultTask2 = interactionService.PromptMessageBoxAsync("Command confirmation", "Are you really sure?", new MessageBoxInteractionOptions { Intent = MessageIntent.Warning, ShowSecondaryButton = true }, cancellationToken: commandContext.CancellationToken);
+
+               await Task.WhenAll(resultTask1, resultTask2);
+
+               if (resultTask1.Result.Data != true || resultTask2.Result.Data != true)
+               {
+                   return CommandResults.Failure("Canceled");
+               }
+
+               _ = interactionService.PromptMessageBoxAsync("Command executed", "The command successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, PrimaryButtonText = "Yeah!" });
+               return CommandResults.Success();
+           })
+           .WithCommand("messagebar-interaction", "Messagebar interactions", executeCommand: async commandContext =>
+           {
+               await Task.Yield();
+
+               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+               _ = interactionService.PromptMessageBarAsync("Success bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Success });
+               _ = interactionService.PromptMessageBarAsync("Information bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Information });
+               _ = interactionService.PromptMessageBarAsync("Warning bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Warning });
+               _ = interactionService.PromptMessageBarAsync("Error bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Error, LinkText = "Click here for more information", LinkUrl = "https://www.microsoft.com" });
+               _ = interactionService.PromptMessageBarAsync("Confirmation bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Confirmation });
+               _ = interactionService.PromptMessageBarAsync("No dismiss", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Information, ShowDismiss = false });
+
+               return CommandResults.Success();
+           })
+           .WithCommand("html-interaction", "HTML interactions", executeCommand: async commandContext =>
+           {
+               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+
+               _ = interactionService.PromptMessageBarAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Success });
+               _ = interactionService.PromptMessageBarAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Success, EscapeMessageHtml = false });
+
+               _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success });
+               _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, EscapeMessageHtml = false });
+
+               _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide <strong>your</strong> name", "<strong>Name</strong>", "Enter <strong>your</strong> name");
+               _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide <strong>your</strong> name", "<strong>Name</strong>", "Enter <strong>your</strong> name", new InputsDialogInteractionOptions { EscapeMessageHtml = false });
+
+               return CommandResults.Success();
+           })
+           .WithCommand("value-interaction", "Value interactions", executeCommand: async commandContext =>
+           {
+               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+               var result = await interactionService.PromptInputAsync(
+                   title: "Text request",
+                   message: "Provide your name",
+                   inputLabel: "Name",
+                   placeHolder: "Enter your name",
+                   options: new InputsDialogInteractionOptions
+                   {
+                       ValidationCallback = context =>
+                       {
+                           var input = context.Inputs[0];
+                           if (!string.IsNullOrEmpty(input.Value) && input.Value.Length < 3)
+                           {
+                               context.AddValidationError(input, "Name must be at least 3 characters long.");
+                           }
+                           return Task.CompletedTask;
+                       }
+                   },
+                   cancellationToken: commandContext.CancellationToken);
+
+               if (result.Canceled)
+               {
+                   return CommandResults.Failure("Canceled");
+               }
+
+               var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+               var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+
+               var input = result.Data;
+               logger.LogInformation("Input: {Label} = {Value}", input.Label, input.Value);
+
+               return CommandResults.Success();
+           })
+           .WithCommand("input-interaction", "Input interactions", executeCommand: async commandContext =>
+           {
+               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+               var dinnerInput = new InteractionInput
+               {
+                   InputType = InputType.Choice,
+                   Label = "Dinner",
+                   Placeholder = "Select dinner",
+                   Required = true,
+                   Options =
+                   [
+                       KeyValuePair.Create("pizza", "Pizza"),
+                       KeyValuePair.Create("fried-chicken", "Fried chicken"),
+                       KeyValuePair.Create("burger", "Burger"),
+                       KeyValuePair.Create("salmon", "Salmon"),
+                       KeyValuePair.Create("chicken-pie", "Chicken pie"),
+                       KeyValuePair.Create("sushi", "Sushi"),
+                       KeyValuePair.Create("tacos", "Tacos"),
+                       KeyValuePair.Create("pasta", "Pasta"),
+                       KeyValuePair.Create("salad", "Salad"),
+                       KeyValuePair.Create("steak", "Steak"),
+                       KeyValuePair.Create("vegetarian", "Vegetarian"),
+                       KeyValuePair.Create("sausage", "Sausage"),
+                       KeyValuePair.Create("lasagne", "Lasagne"),
+                       KeyValuePair.Create("fish-pie", "Fish pie"),
+                       KeyValuePair.Create("soup", "Soup"),
+                       KeyValuePair.Create("beef-stew", "Beef stew"),
+                   ]
+               };
+               var numberOfPeopleInput = new InteractionInput { InputType = InputType.Number, Label = "Number of people", Placeholder = "Enter number of people", Value = "2", Required = true };
+               var inputs = new List<InteractionInput>
+               {
+                   new InteractionInput { InputType = InputType.Text, Label = "Name", Placeholder = "Enter name", Required = true },
+                   new InteractionInput { InputType = InputType.SecretText, Label = "Password", Placeholder = "Enter password", Required = true },
+                   dinnerInput,
+                   numberOfPeopleInput,
+                   new InteractionInput { InputType = InputType.Boolean, Label = "Remember me", Placeholder = "What does this do?", Required = true },
+               };
+               var result = await interactionService.PromptInputsAsync(
+                   "Input request",
+                   "Provide your name",
+                   inputs,
+                   options: new InputsDialogInteractionOptions
+                   {
+                       ValidationCallback = context =>
+                       {
+                           if (dinnerInput.Value == "steak" && int.TryParse(numberOfPeopleInput.Value, CultureInfo.InvariantCulture, out var i) && i > 4)
+                           {
+                               context.AddValidationError(numberOfPeopleInput, "Number of people can't be greater than 4 when eating steak.");
+                           }
+                           return Task.CompletedTask;
+                       }
+                   },
+                   cancellationToken: commandContext.CancellationToken);
+
+               if (result.Canceled)
+               {
+                   return CommandResults.Failure("Canceled");
+               }
+
+               var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+               var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+
+               foreach (var updatedInput in result.Data)
+               {
+                   logger.LogInformation("Input: {Label} = {Value}", updatedInput.Label, updatedInput.Value);
+               }
+
+               return CommandResults.Success();
+           })
+           .WithCommand("many-values", "Many values", executeCommand: async commandContext =>
+           {
+               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+               var inputs = new List<InteractionInput>();
+               for (var i = 0; i < 50; i++)
+               {
+                   inputs.Add(new InteractionInput
+                   {
+                       InputType = InputType.Text,
+                       Label = $"Input {i + 1}",
+                       Placeholder = $"Enter input {i + 1}"
+                   });
+               }
+               var result = await interactionService.PromptInputsAsync(
+                   title: "Text request",
+                   message: "Provide your name",
+                   inputs: inputs,
+                   cancellationToken: commandContext.CancellationToken);
+
+               if (result.Canceled)
+               {
+                   return CommandResults.Failure("Canceled");
+               }
+
+               var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
+               var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
+
+               foreach (var input in result.Data)
+               {
+                   logger.LogInformation("Input: {Label} = {Value}", input.Label, input.Value);
+               }
+
+               return CommandResults.Success();
+           });
+
+        return resource;
+    }
+}
+
+#pragma warning restore ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -1,12 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Logging;
-
-#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 var builder = DistributedApplication.CreateBuilder(args);
 builder.Services.AddHttpClient();
@@ -92,6 +88,7 @@ builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice")
        .WithUrls(c => c.Urls.Add(new() { Url = "https://someplace.com", DisplayText = "Some place" }))
        .WithUrl("https://someotherplace.com/some-path", "Some other place")
        .WithUrl("https://extremely-long-url.com/abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz//abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz/abcdefghijklmnopqrstuvwxyz/abcdefghijklmno")
+       .AddInteractionCommands()
        .WithCommand(
            name: "long-command",
            displayName: "This is a custom command with a very long command display name",
@@ -117,157 +114,7 @@ builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice")
                await ExecuteCommandForAllResourcesAsync(c.ServiceProvider, "resource-start", c.CancellationToken);
                return CommandResults.Success();
            },
-           commandOptions: new() { IconName = "Play", IconVariant = IconVariant.Filled })
-       .WithCommand("confirmation-interaction", "Confirmation interactions", executeCommand: async commandContext =>
-       {
-           var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-           var resultTask1 = interactionService.PromptConfirmationAsync("Command confirmation", "Are you sure?", cancellationToken: commandContext.CancellationToken);
-           var resultTask2 = interactionService.PromptMessageBoxAsync("Command confirmation", "Are you really sure?", new MessageBoxInteractionOptions { Intent = MessageIntent.Warning, ShowSecondaryButton = true }, cancellationToken: commandContext.CancellationToken);
-
-           await Task.WhenAll(resultTask1, resultTask2);
-
-           if (resultTask1.Result.Data != true || resultTask2.Result.Data != true)
-           {
-               return CommandResults.Failure("Canceled");
-           }
-
-           _ = interactionService.PromptMessageBoxAsync("Command executed", "The command successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, PrimaryButtonText = "Yeah!" });
-           return CommandResults.Success();
-       })
-       .WithCommand("messagebar-interaction", "Messagebar interactions", executeCommand: async commandContext =>
-       {
-           await Task.Yield();
-
-           var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-           _ = interactionService.PromptMessageBarAsync("Success bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Success });
-           _ = interactionService.PromptMessageBarAsync("Information bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Information });
-           _ = interactionService.PromptMessageBarAsync("Warning bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Warning });
-           _ = interactionService.PromptMessageBarAsync("Error bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Error, LinkText = "Click here for more information", LinkUrl = "https://www.microsoft.com" });
-           _ = interactionService.PromptMessageBarAsync("Confirmation bar", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Confirmation });
-           _ = interactionService.PromptMessageBarAsync("No dismiss", "The command successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Information, ShowDismiss = false });
-
-           return CommandResults.Success();
-       })
-       .WithCommand("html-interaction", "HTML interactions", executeCommand: async commandContext =>
-       {
-           var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-
-           _ = interactionService.PromptMessageBarAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Success });
-           _ = interactionService.PromptMessageBarAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Success, EscapeMessageHtml = false });
-
-           _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success });
-           _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, EscapeMessageHtml = false });
-
-           _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide <strong>your</strong> name", "<strong>Name</strong>", "Enter <strong>your</strong> name");
-           _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide <strong>your</strong> name", "<strong>Name</strong>", "Enter <strong>your</strong> name", new InputsDialogInteractionOptions { EscapeMessageHtml = false });
-
-           return CommandResults.Success();
-       })
-       .WithCommand("value-interaction", "Value interactions", executeCommand: async commandContext =>
-       {
-           var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-           var result = await interactionService.PromptInputAsync(
-               title: "Text request",
-               message: "Provide your name",
-               inputLabel: "Name",
-               placeHolder: "Enter your name",
-               options: new InputsDialogInteractionOptions
-               {
-                   ValidationCallback = context =>
-                   {
-                       var input = context.Inputs[0];
-                       if (!string.IsNullOrEmpty(input.Value) && input.Value.Length < 3)
-                       {
-                           context.AddValidationError(input, "Name must be at least 3 characters long.");
-                       }
-                       return Task.CompletedTask;
-                   }
-               },
-               cancellationToken: commandContext.CancellationToken);
-
-           if (result.Canceled)
-           {
-               return CommandResults.Failure("Canceled");
-           }
-
-           var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-           var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
-
-           var input = result.Data;
-           logger.LogInformation("Input: {Label} = {Value}", input.Label, input.Value);
-
-           return CommandResults.Success();
-       })
-       .WithCommand("input-interaction", "Input interactions", executeCommand: async commandContext =>
-       {
-           var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
-           var dinnerInput = new InteractionInput
-           {
-               InputType = InputType.Choice,
-               Label = "Dinner",
-               Placeholder = "Select dinner",
-               Required = true,
-               Options =
-               [
-                   KeyValuePair.Create("pizza", "Pizza"),
-                   KeyValuePair.Create("fried-chicken", "Fried chicken"),
-                   KeyValuePair.Create("burger", "Burger"),
-                   KeyValuePair.Create("salmon", "Salmon"),
-                   KeyValuePair.Create("chicken-pie", "Chicken pie"),
-                   KeyValuePair.Create("sushi", "Sushi"),
-                   KeyValuePair.Create("tacos", "Tacos"),
-                   KeyValuePair.Create("pasta", "Pasta"),
-                   KeyValuePair.Create("salad", "Salad"),
-                   KeyValuePair.Create("steak", "Steak"),
-                   KeyValuePair.Create("vegetarian", "Vegetarian"),
-                   KeyValuePair.Create("sausage", "Sausage"),
-                   KeyValuePair.Create("lasagne", "Lasagne"),
-                   KeyValuePair.Create("fish-pie", "Fish pie"),
-                   KeyValuePair.Create("soup", "Soup"),
-                   KeyValuePair.Create("beef-stew", "Beef stew"),
-               ]
-           };
-           var numberOfPeopleInput = new InteractionInput { InputType = InputType.Number, Label = "Number of people", Placeholder = "Enter number of people", Value = "2", Required = true };
-           var inputs = new List<InteractionInput>
-           {
-               new InteractionInput { InputType = InputType.Text, Label = "Name", Placeholder = "Enter name", Required = true },
-               new InteractionInput { InputType = InputType.SecretText, Label = "Password", Placeholder = "Enter password", Required = true },
-               dinnerInput,
-               numberOfPeopleInput,
-               new InteractionInput { InputType = InputType.Boolean, Label = "Remember me", Placeholder = "What does this do?", Required = true },
-           };
-           var result = await interactionService.PromptInputsAsync(
-               "Input request",
-               "Provide your name",
-               inputs,
-               options: new InputsDialogInteractionOptions
-               {
-                   ValidationCallback = context =>
-                   {
-                       if (dinnerInput.Value == "steak" && int.TryParse(numberOfPeopleInput.Value, CultureInfo.InvariantCulture, out var i) && i > 4)
-                       {
-                           context.AddValidationError(numberOfPeopleInput, "Number of people can't be greater than 4 when eating steak.");
-                       }
-                       return Task.CompletedTask;
-                   }
-               },
-               cancellationToken: commandContext.CancellationToken);
-
-           if (result.Canceled)
-           {
-               return CommandResults.Failure("Canceled");
-           }
-
-           var resourceLoggerService = commandContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
-           var logger = resourceLoggerService.GetLogger(commandContext.ResourceName);
-
-           foreach (var updatedInput in result.Data)
-           {
-               logger.LogInformation("Input: {Label} = {Value}", updatedInput.Label, updatedInput.Value);
-           }
-
-           return CommandResults.Success();
-       });
+           commandOptions: new() { IconName = "Play", IconVariant = IconVariant.Filled });
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
@@ -312,5 +159,3 @@ static async Task ExecuteCommandForAllResourcesAsync(IServiceProvider servicePro
     }
     await Task.WhenAll(commandTasks).ConfigureAwait(false);
 }
-
-#pragma warning restore ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -201,6 +201,7 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
                     };
 
                     var dialogParameters = CreateDialogParameters(item, intent: null);
+                    dialogParameters.Id = "interactions-input-dialog";
                     dialogParameters.OnDialogResult = EventCallback.Factory.Create<DialogResult>(this, async dialogResult =>
                     {
                         // Only send notification of completion if the dialog was cancelled.

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -817,8 +817,3 @@ fluent-menu-item::part(content) {
     width: 100%;
     text-overflow: ellipsis;
 }
-
-#interactions-input-dialog .interaction-input-dialog {
-    max-height: 50vh;
-    overflow-y: auto;
-}

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -64,6 +64,8 @@ fluent-toolbar::part(end) {
     --reconnection-ui-bg: rgb(255, 255, 255);
     --error-counter-badge-foreground-color: var(--neutral-fill-rest);
     --kbd-background-color: var(--neutral-layer-4);
+    --dialog-background-color: #ffffff;
+    --dialog-border-color: #e5e5e5;
     --messagebar-success-background-color: #f1faf1;
     --messagebar-success-border-color: #9fd89f;
     --messagebar-error-background-color: #FDF3F4;
@@ -103,6 +105,8 @@ fluent-toolbar::part(end) {
     --reconnection-ui-bg: #D6D6D6;
     --error-counter-badge-foreground-color: #ffffff;
     --kbd-background-color: var(--fill-color);
+    --dialog-background-color: #272727;
+    --dialog-border-color: #3d3d3d;
     --messagebar-success-background-color: #052505;
     --messagebar-success-border-color: #107C10;
     --messagebar-error-background-color: #3F1011;
@@ -256,11 +260,16 @@ h1 {
 /* The fluent dialog's default fill color is too dark in our current dark theme.
    Setting it to the floating layer allows it to stand out more and doesn't impact light theme. */
 fluent-dialog::part(control) {
-    background: var(--neutral-layer-floating);
+    background: var(--dialog-background-color);
+    border: 1px solid var(--dialog-border-color);
+}
+
+fluent-dialog[class~="right"]::part(control) {
+    border-left-width: 1px !important;
 }
 
 fluent-dialog fluent-toolbar {
-    background-color: var(--neutral-layer-floating);
+    background-color: var(--dialog-background-color);
 }
 
 /* Changing the dialog's fill color means stealth buttons on the dialog have the wrong background,
@@ -269,7 +278,7 @@ fluent-dialog fluent-button[appearance=stealth]:not(:hover)::part(control),
 fluent-dialog fluent-button[appearance=lightweight]:not(:hover)::part(control),
 fluent-dialog fluent-anchor[appearance=stealth]:not(:hover)::part(control),
 fluent-dialog fluent-anchor[appearance=lightweight]:not(:hover)::part(control) {
-    background: var(--neutral-layer-floating);
+    background: var(--dialog-background-color);
 }
 
 /* But changing the stealth button's background in dialogs means the stealth buttons used as headers for grid cells
@@ -807,4 +816,9 @@ fluent-tooltip[anchor="dialog_close"] > div {
 fluent-menu-item::part(content) {
     width: 100%;
     text-overflow: ellipsis;
+}
+
+#interactions-input-dialog .interaction-input-dialog {
+    max-height: 50vh;
+    overflow-y: auto;
 }


### PR DESCRIPTION
## Description

- ~Max height on input dialogs. Content scrolls when exceeded~ I found a bug here: https://github.com/microsoft/fluentui-blazor/issues/3960
- Improve visibility of validation errors by making dark mode dialogs darker
- Move test interactions to their own file in stress project

Fixes https://github.com/dotnet/aspire/issues/10013

Before:

![image](https://github.com/user-attachments/assets/80cc7d8d-d28b-4be0-9b2a-8af7d02b4111)

After:

![image](https://github.com/user-attachments/assets/9e1c7576-e141-4e0b-acaa-543f8bb543ed)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
