### PR TITLE
Fix space between header and content in trace detail

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -47,6 +47,7 @@
 ::deep .trace-view-grid .column-header {
     padding: 0 !important;
     min-height: 32px !important;
+    height: 32px !important;
     border-bottom: 0;
 }
 


### PR DESCRIPTION
## Description

Fix the small space between the tick line in the header and the tick line in the body.

Before:

![image](https://github.com/user-attachments/assets/c2080d17-772e-47fe-a83c-9dbb6c31fae6)

After:

![image](https://github.com/user-attachments/assets/5f0b98d5-ce63-4192-8ca9-ac60c46221bc)