### PR TITLE
Remove HTML escaping option from interaction service

### DIFF
--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -47,13 +47,13 @@ internal static class InteractionCommands
                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
 
                _ = interactionService.PromptMessageBarAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Success });
-               _ = interactionService.PromptMessageBarAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Success, EscapeMessageHtml = false });
+               _ = interactionService.PromptMessageBarAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBarInteractionOptions { Intent = MessageIntent.Success, /*EscapeMessageHtml = false*/ });
 
                _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success });
-               _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, EscapeMessageHtml = false });
+               _ = interactionService.PromptMessageBoxAsync("Success <strong>bar</strong>", "The <strong>command</strong> successfully executed.", new MessageBoxInteractionOptions { Intent = MessageIntent.Success, /*EscapeMessageHtml = false*/ });
 
                _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide <strong>your</strong> name", "<strong>Name</strong>", "Enter <strong>your</strong> name");
-               _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide <strong>your</strong> name", "<strong>Name</strong>", "Enter <strong>your</strong> name", new InputsDialogInteractionOptions { EscapeMessageHtml = false });
+               _ = await interactionService.PromptInputAsync("Text <strong>request</strong>", "Provide <strong>your</strong> name", "<strong>Name</strong>", "Enter <strong>your</strong> name", new InputsDialogInteractionOptions {  /*EscapeMessageHtml = false*/ });
 
                return CommandResults.Success();
            })

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -24,7 +24,7 @@
 <FluentDialogBody Class="interaction-input-dialog">
     @if (!string.IsNullOrEmpty(Content.Interaction.Message))
     {
-        <p>@((MarkupString)Content.Interaction.Message)</p>
+        <p>@Content.Interaction.Message</p>
     }
 
     <EditForm EditContext="@_editContext" OnValidSubmit="@SubmitAsync">

--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -152,7 +152,7 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
                     var content = new MessageBoxContent
                     {
                         Title = item.Title,
-                        MarkupMessage = new MarkupString(item.Message),
+                        MarkupMessage = new MarkupString(WebUtility.HtmlEncode(item.Message)),
                     };
                     switch (messageBox.Intent)
                     {
@@ -313,7 +313,7 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
                             message = await MessageService.ShowMessageBarAsync(options =>
                             {
                                 options.Title = WebUtility.HtmlEncode(item.Title);
-                                options.Body = item.Message; // Message is already HTML encoded depending on options.
+                                options.Body = WebUtility.HtmlEncode(item.Message);
                                 options.Intent = MapMessageIntent(messageBar.Intent);
                                 options.Section = DashboardUIHelpers.MessageBarSection;
                                 options.AllowDismiss = item.ShowDismiss;

--- a/src/Aspire.Hosting/ApplicationModel/IInteractionService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IInteractionService.cs
@@ -321,11 +321,6 @@ public class InteractionOptions
     /// Gets or sets a value indicating whether show the dismiss button in the header.
     /// </summary>
     public bool? ShowDismiss { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to escape HTML in the message content. Defaults to <c>true</c>.
-    /// </summary>
-    public bool? EscapeMessageHtml { get; set; } = true;
 }
 
 #pragma warning restore ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
@@ -4,7 +4,6 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
@@ -331,7 +330,7 @@ internal class Interaction
     {
         InteractionId = Interlocked.Increment(ref s_nextInteractionId);
         Title = title;
-        Message = options.EscapeMessageHtml == false ? message : WebUtility.HtmlEncode(message);
+        Message = message;
         Options = options;
         InteractionInfo = interactionInfo;
         CancellationToken = cancellationToken;


### PR DESCRIPTION
## Description

HTML isn't supported by CLI. Remove for now.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
