### PR TITLE
Fallback to previous DNS service discovery

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,6 +77,7 @@
     <!-- external dependencies -->
     <PackageVersion Include="Confluent.Kafka" Version="2.10.1" />
     <PackageVersion Include="Dapper" Version="2.1.66" />
+    <PackageVersion Include="DnsClient" Version="1.8.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.31.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.71.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.71.0" />

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/FallbackDnsResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/FallbackDnsResolver.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using DnsClient;
+using DnsClient.Protocol;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.ServiceDiscovery.Dns.Resolver;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Dns;
+
+internal sealed class FallbackDnsResolver : IDnsResolver
+{
+    private readonly LookupClient _lookupClient;
+    private readonly IOptionsMonitor<DnsServiceEndpointProviderOptions> _options;
+    private readonly TimeProvider _timeProvider;
+
+    public FallbackDnsResolver(LookupClient lookupClient, IOptionsMonitor<DnsServiceEndpointProviderOptions> options, TimeProvider timeProvider)
+    {
+        _lookupClient = lookupClient;
+        _options = options;
+        _timeProvider = timeProvider;
+    }
+
+    private TimeSpan DefaultRefreshPeriod => _options.CurrentValue.DefaultRefreshPeriod;
+
+    public async ValueTask<AddressResult[]> ResolveIPAddressesAsync(string name, CancellationToken cancellationToken = default)
+    {
+        DateTime expiresAt = _timeProvider.GetUtcNow().DateTime.Add(DefaultRefreshPeriod);
+        var addresses = await System.Net.Dns.GetHostAddressesAsync(name, cancellationToken).ConfigureAwait(false);
+
+        var results = new AddressResult[addresses.Length];
+
+        for (int i = 0; i < addresses.Length; i++)
+        {
+            results[i] = new AddressResult
+            {
+                Address = addresses[i],
+                ExpiresAt = expiresAt
+            };
+        }
+
+        return results;
+    }
+
+    public async ValueTask<ServiceResult[]> ResolveServiceAsync(string name, CancellationToken cancellationToken = default)
+    {
+        DateTime now = _timeProvider.GetUtcNow().DateTime;
+        var queryResult = await _lookupClient.QueryAsync(name, DnsClient.QueryType.SRV, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (queryResult.HasError)
+        {
+            throw CreateException(name, queryResult.ErrorMessage);
+        }
+
+        var lookupMapping = new Dictionary<string, List<AddressResult>>();
+        foreach (var record in queryResult.Additionals.OfType<AddressRecord>())
+        {
+            if (!lookupMapping.TryGetValue(record.DomainName, out var addresses))
+            {
+                addresses = new List<AddressResult>();
+                lookupMapping[record.DomainName] = addresses;
+            }
+
+            addresses.Add(new AddressResult
+            {
+                Address = record.Address,
+                ExpiresAt = now.Add(TimeSpan.FromSeconds(record.TimeToLive))
+            });
+        }
+
+        var srvRecords = queryResult.Answers.OfType<SrvRecord>().ToList();
+
+        var results = new ServiceResult[srvRecords.Count];
+        for (int i = 0; i < srvRecords.Count; i++)
+        {
+            var record = srvRecords[i];
+
+            results[i] = new ServiceResult
+            {
+                ExpiresAt = now.Add(TimeSpan.FromSeconds(record.TimeToLive)),
+                Priority = record.Priority,
+                Weight = record.Weight,
+                Port = record.Port,
+                Target = record.Target,
+                Addresses = lookupMapping.TryGetValue(record.Target, out var addresses)
+                    ? addresses.ToArray()
+                    : Array.Empty<AddressResult>()
+            };
+        }
+
+        return results;
+    }
+
+    private static InvalidOperationException CreateException(string dnsName, string errorMessage)
+    {
+        var msg = errorMessage switch
+        {
+            { Length: > 0 } => $"No DNS SRV records were found for DNS name '{dnsName}': {errorMessage}.",
+            _ => $"No DNS SRV records were found for DNS name '{dnsName}'",
+        };
+        return new InvalidOperationException(msg);
+    }
+}

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/Microsoft.Extensions.ServiceDiscovery.Dns.csproj
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/Microsoft.Extensions.ServiceDiscovery.Dns.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DnsClient" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/Resolver/DnsResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/Resolver/DnsResolver.cs
@@ -143,7 +143,7 @@ internal sealed partial class DnsResolver : IDnsResolver, IDisposable
         return results;
     }
 
-    public ValueTask<AddressResult[]> ResolveIPAddressesAsync(string name, AddressFamily addressFamily, CancellationToken cancellationToken = default)
+    internal ValueTask<AddressResult[]> ResolveIPAddressesAsync(string name, AddressFamily addressFamily, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/Resolver/IDnsResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/Resolver/IDnsResolver.cs
@@ -1,13 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Sockets;
-
 namespace Microsoft.Extensions.ServiceDiscovery.Dns.Resolver;
 
 internal interface IDnsResolver
 {
-    ValueTask<AddressResult[]> ResolveIPAddressesAsync(string name, AddressFamily addressFamily, CancellationToken cancellationToken = default);
     ValueTask<AddressResult[]> ResolveIPAddressesAsync(string name, CancellationToken cancellationToken = default);
     ValueTask<ServiceResult[]> ResolveServiceAsync(string name, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/ServiceDiscoveryDnsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/ServiceDiscoveryDnsServiceCollectionExtensions.cs
@@ -57,7 +57,6 @@ public static class ServiceDiscoveryDnsServiceCollectionExtensions
             services.TryAddSingleton<DnsClient.LookupClient>();
         }
 
-        services.TryAddSingleton<IDnsResolver, DnsResolver>();
         services.AddSingleton<IServiceEndpointProviderFactory, DnsSrvServiceEndpointProviderFactory>();
         var options = services.AddOptions<DnsSrvServiceEndpointProviderOptions>();
         options.Configure(o => configureOptions?.Invoke(o));


### PR DESCRIPTION
## Description

Follow up work based on https://github.com/dotnet/aspire/pull/6104#issuecomment-3003845690, this allows going back to the previous DNS resolution implementations (System.Net.Dns for IP resolution, DnsClient.NET for SRV resolution)

cc @davidfowl 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
