### PR TITLE
Fix promptText formatting in selection output

### DIFF
--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -494,7 +494,7 @@ internal abstract class PublishCommandBase : BaseCommand
             choice => choice.Value,
             cancellationToken);
 
-        AnsiConsole.MarkupLine($"{promptText)} {selectedChoice.Value.EscapeMarkup()}");
+        AnsiConsole.MarkupLine($"{promptText} {selectedChoice.Value.EscapeMarkup()}");
 
         return selectedChoice.Key;
     }

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -494,7 +494,7 @@ internal abstract class PublishCommandBase : BaseCommand
             choice => choice.Value,
             cancellationToken);
 
-        AnsiConsole.MarkupLine($"{promptText.EscapeMarkup()} {selectedChoice.Value.EscapeMarkup()}");
+        AnsiConsole.MarkupLine($"{promptText)} {selectedChoice.Value.EscapeMarkup()}");
 
         return selectedChoice.Key;
     }


### PR DESCRIPTION
`[bold][/b]` should not be escaped in this case.