### PR TITLE
Add ability to override DCP path for test runs

### DIFF
--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -63,6 +63,12 @@ public static class TestDistributedApplicationBuilder
             builder.WithTestAndResourceLogging(testOutputHelper);
         }
 
+        var dcpPathOverride = Environment.GetEnvironmentVariable("TEST_DCP_PATH");
+        if (!string.IsNullOrEmpty(dcpPathOverride))
+        {
+            builder.Configuration["DcpPublisher:CliPath"] = dcpPathOverride;
+        }
+
         builder.WithTempAspireStore();
 
         return builder;

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -51,6 +51,11 @@ public class TestProgram : IDisposable
             EnableResourceLogging = true
         });
 
+        var dcpPathOverride = Environment.GetEnvironmentVariable("TEST_DCP_PATH");
+        if (!string.IsNullOrEmpty(dcpPathOverride))
+        {
+            builder.Configuration["DcpPublisher:CliPath"] = dcpPathOverride;
+        }
         builder.Configuration["DcpPublisher:ResourceNameSuffix"] = $"{Random.Shared.Next():x}";
         builder.Configuration["DcpPublisher:RandomizePorts"] = randomizePorts.ToString(CultureInfo.InvariantCulture);
         builder.Configuration["DcpPublisher:WaitForResourceCleanup"] = "true";


### PR DESCRIPTION
## Description

Adds the ability to override the path to DCP for some test runs via `TEST_DCP_PATH` environment variable. The main goal is to make it easier to run Aspire tests against development builds of DCP.