### PR TITLE
Fix logic for filtering packages coming back from GetPackagesAsync.

### DIFF
--- a/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
@@ -27,7 +27,9 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, IDotN
 
         var packages = await memoryCache.GetOrCreateAsync(key, async (entry) =>
         {
-            return await GetPackagesAsync(workingDirectory, "Aspire.ProjectTemplates", prerelease, source, cancellationToken);
+            var packages = await GetPackagesAsync(workingDirectory, "Aspire.ProjectTemplates", prerelease, source, cancellationToken);
+            return packages.Where(p => p.Id.Equals("Aspire.ProjectTemplates", StringComparison.OrdinalIgnoreCase));
+
         }) ?? throw new NuGetPackageCacheException(ErrorStrings.FailedToRetrieveCachedTemplatePackages);
 
         return packages;
@@ -46,7 +48,8 @@ internal sealed class NuGetPackageCache(ILogger<NuGetPackageCache> logger, IDotN
         {
             // Set cache expiration to 1 hour for CLI updates
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
-            return await GetPackagesAsync(workingDirectory, "Aspire.Cli", prerelease, source, cancellationToken);
+            var packages = await GetPackagesAsync(workingDirectory, "Aspire.Cli", prerelease, source, cancellationToken);
+            return packages.Where(p => p.Id.Equals("Aspire.Cli", StringComparison.OrdinalIgnoreCase));
         }) ?? [];
 
         return packages;

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.NuGet;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Cli.Tests.NuGet;
+
+public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task NonAspireCliPackagesWillNotBeConsidered()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, configure =>
+        {
+            configure.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (_, _, _, _, _, _, _, _) =>
+                {
+                    // Simulate a search that returns packages that do not match Aspire.Cli
+                    return (0, [
+                        new NuGetPackage { Id = "CommunityToolkit.Aspire.Hosting.Foo", Version = "9.4.0-xyz", Source = "nuget.org" },
+                        new NuGetPackage { Id = "Aspire.Cli", Version = "9.4.0-preview", Source = "nuget.org" }
+                    ]);
+                };
+
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        var nuGetPackageCache = provider.GetRequiredService<INuGetPackageCache>();
+        var packages = await nuGetPackageCache.GetCliPackagesAsync(workspace.WorkspaceRoot, prerelease: true, source: null, CancellationToken.None).WaitAsync(CliTestConstants.DefaultTimeout);
+
+        Assert.Collection(
+            packages,
+            package => Assert.Equal("Aspire.Cli", package.Id)
+        );
+    }
+}


### PR DESCRIPTION
Was dogfooding tonight and noticed that the update logic was picking up an incorrect version. Its a side effect of the way our package search works by running a query on Nuget which is fuzzy and then filtering out packages which don't match our strict criteria.

This is a quick fix that applies a non-fuzzy filter for the specific CLI and templates package searches. It didn't impact ProjectTemplates due to sorting, but it impacted Aspire.Cli.

Didn't show up in our repo because we didn't pull in the CommunityToolkit packages in dotnet/aspire.