### PR TITLE
Update Event Subscriptions in tests to use new `OnXYZ` methods

### DIFF
--- a/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
+++ b/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
@@ -177,15 +177,14 @@ public class DistributedApplicationBuilderEventingTests
         var beforeResourceStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using var builder = TestDistributedApplicationBuilder.Create();
-        var redis = builder.AddRedis("redis");
-
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(redis.Resource, (e, ct) =>
-        {
-            Assert.NotNull(e.Services);
-            Assert.NotNull(e.Resource);
-            beforeResourceStartedTcs.TrySetResult();
-            return Task.CompletedTask;
-        });
+        var redis = builder.AddRedis("redis")
+            .OnBeforeResourceStarted((_, e, _) =>    
+            {
+                Assert.NotNull(e.Services);
+                Assert.NotNull(e.Resource);
+                beforeResourceStartedTcs.TrySetResult();
+                return Task.CompletedTask;
+            });
 
         using var app = builder.Build();
         await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -124,7 +124,7 @@ public class ApplicationOrchestratorTests
 
         var initResourceTcs = new TaskCompletionSource();
         InitializeResourceEvent? initEvent = null;
-        applicationEventing.Subscribe<InitializeResourceEvent>(resource.Resource, (@event, ct) =>
+        resource.OnInitializeResource((_, @event, _) =>
         {
             initEvent = @event;
             initResourceTcs.SetResult();

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -120,11 +120,18 @@ public class ApplicationOrchestratorTests
 
         var events = new DcpExecutorEvents();
         var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
-        var applicationEventing = new DistributedApplicationEventing();
+        var applicationEventing = builder.Eventing;
 
         var initResourceTcs = new TaskCompletionSource();
         InitializeResourceEvent? initEvent = null;
         resource.OnInitializeResource((_, @event, _) =>
+        {
+            initEvent = @event;
+            initResourceTcs.SetResult();
+            return Task.CompletedTask;
+        });
+
+        applicationEventing.Subscribe<InitializeResourceEvent>(resource.Resource, (@event, ct) =>
         {
             initEvent = @event;
             initResourceTcs.SetResult();
@@ -136,7 +143,7 @@ public class ApplicationOrchestratorTests
 
         await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
 
-        await initResourceTcs.Task.DefaultTimeout();
+        await initResourceTcs.Task; //.DefaultTimeout();
 
         Assert.True(initResourceTcs.Task.IsCompletedSuccessfully);
         Assert.NotNull(initEvent);
@@ -433,7 +440,7 @@ public class ApplicationOrchestratorTests
         DistributedApplicationModel distributedAppModel,
         ResourceNotificationService notificationService,
         DcpExecutorEvents? dcpEvents = null,
-        DistributedApplicationEventing? applicationEventing = null,
+        IDistributedApplicationEventing? applicationEventing = null,
         ResourceLoggerService? resourceLoggerService = null)
     {
         var serviceProvider = new ServiceCollection().BuildServiceProvider();

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -531,12 +531,12 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         });
 
         var resourceReadyTcs = new TaskCompletionSource();
-        var dependency = builder.AddResource(new CustomResource("test"));
+        var dependency = builder.AddResource(new CustomResource("test"))
+            .OnResourceReady((_, _, _) => resourceReadyTcs.Task);
+
         var nginx = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
                            .WithReference(dependency)
                            .WaitFor(dependency);
-
-        builder.Eventing.Subscribe<ResourceReadyEvent>(dependency.Resource, (e, ct) => resourceReadyTcs.Task);
 
         using var app = builder.Build();
 

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -50,23 +50,23 @@ public class WithUrlsTests
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var called = false;
-        var projectA = builder.AddProject<ProjectA>("projecta")
-            .WithUrls(c => called = true);
-
         var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<ResourceEndpointsAllocatedEvent>(projectA.Resource, (e, ct) =>
-        {
-            // Should not be called at this point
-            Assert.False(called);
-            return Task.CompletedTask;
-        });
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            // Should be called by the time resource is started
-            Assert.True(called);
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
+
+        builder.AddProject<ProjectA>("projecta")
+            .WithUrls(c => called = true)
+            .OnResourceEndpointsAllocated((_, _, _) =>
+            {
+                // Should not be called at this point
+                Assert.False(called);
+                return Task.CompletedTask;
+            })
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                // Should be called by the time resource is started
+                Assert.True(called);
+                tcs.SetResult();
+                return Task.CompletedTask;
+            });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -82,15 +82,14 @@ public class WithUrlsTests
         using var builder = TestDistributedApplicationBuilder.Create();
 
         ILogger logger = NullLogger.Instance;
-        var projectA = builder.AddProject<ProjectA>("projecta")
-            .WithUrls(c => logger = c.Logger);
-
         var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
+        var projectA = builder.AddProject<ProjectA>("projecta")
+            .WithUrls(c => logger = c.Logger)
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
+            });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -137,15 +136,14 @@ public class WithUrlsTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var projectA = builder.AddProject<ProjectA>("projecta")
-            .WithUrls(c => c.Urls.Add(new() { Url = "https://example.com", DisplayText = "Example" }));
-
         var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
+        var projectA = builder.AddProject<ProjectA>("projecta")
+            .WithUrls(c => c.Urls.Add(new() { Url = "https://example.com", DisplayText = "Example" }))
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
+            });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -162,11 +160,10 @@ public class WithUrlsTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var projectA = builder.AddProject<ProjectA>("projecta")
-            .WithUrl("https://example.com", "Example");
-
         var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
+        var projectA = builder.AddProject<ProjectA>("projecta")
+            .WithUrl("https://example.com", "Example")
+            .OnBeforeResourceStarted((_, _, _) =>
         {
             tcs.SetResult();
             return Task.CompletedTask;
@@ -189,14 +186,14 @@ public class WithUrlsTests
 
         var projectA = builder.AddProject<ProjectA>("projecta")
             .WithHttpsEndpoint();
-        projectA.WithUrl($"{projectA.Resource.GetEndpoint("https")}/test", "Example");
 
         var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
+        projectA.WithUrl($"{projectA.Resource.GetEndpoint("https")}/test", "Example")
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
+            });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -217,15 +214,14 @@ public class WithUrlsTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var projectA = builder.AddProject<ProjectA>("projecta")
-            .WithHttpEndpoint(name: "test");
-
         var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
+        var projectA = builder.AddProject<ProjectA>("projecta")
+            .WithHttpEndpoint(name: "test")
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
+            });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -242,14 +238,13 @@ public class WithUrlsTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var projectA = builder.AddProject<ProjectB>("projectb");
-
         var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
+        var projectA = builder.AddProject<ProjectB>("projectb")
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
+            });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -266,14 +261,13 @@ public class WithUrlsTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var projectA = builder.AddProject<ProjectB>("projectb", launchProfileName: "custom");
-
         var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
+        var projectA = builder.AddProject<ProjectB>("projectb", launchProfileName: "custom")
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
+            });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -290,6 +284,7 @@ public class WithUrlsTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
+        var tcs = new TaskCompletionSource();
         var projectA = builder.AddProject<ProjectA>("projecta")
             .WithHttpEndpoint(name: "test")
             .WithUrlForEndpoint("test", u =>
@@ -297,14 +292,12 @@ public class WithUrlsTests
                 u.Url = "https://example.com";
                 u.DisplayText = "Link Text";
                 u.DisplayOrder = 1000;
+            })
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
             });
-
-        var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -413,40 +406,39 @@ public class WithUrlsTests
                 CreationTimeStamp = DateTime.UtcNow,
                 State = KnownResourceStates.NotStarted,
                 Properties = []
-            });
-
-        builder.Eventing.Subscribe<InitializeResourceEvent>(custom.Resource, async (e, ct) =>
-        {
-            // Mark all the endpoints on custom resource as allocated so that the URLs are initialized
-            if (custom.Resource.TryGetEndpoints(out var endpoints))
+            })
+            .OnInitializeResource(async (custom, e, ct) =>
             {
-                var startingPort = 1234;
-                foreach (var endpoint in endpoints)
+                // Mark all the endpoints on custom resource as allocated so that the URLs are initialized
+                if (custom.TryGetEndpoints(out var endpoints))
                 {
-                    endpoint.AllocatedEndpoint = new(endpoint, endpoint.TargetHost, endpoint.Port ?? endpoint.TargetPort ?? startingPort++);
+                    var startingPort = 1234;
+                    foreach (var endpoint in endpoints)
+                    {
+                        endpoint.AllocatedEndpoint = new(endpoint, endpoint.TargetHost, endpoint.Port ?? endpoint.TargetPort ?? startingPort++);
+                    }
                 }
-            }
 
-            // Publish the ResourceEndpointsAllocatedEvent for the resource
-            await e.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(custom.Resource, e.Services), EventDispatchBehavior.BlockingConcurrent, ct);
+                // Publish the ResourceEndpointsAllocatedEvent for the resource
+                await e.Eventing.PublishAsync(new ResourceEndpointsAllocatedEvent(custom, e.Services), EventDispatchBehavior.BlockingConcurrent, ct);
 
-            // Publish the BeforeResourceStartedEvent for the resource
-            await e.Eventing.PublishAsync(new BeforeResourceStartedEvent(custom.Resource, e.Services), EventDispatchBehavior.BlockingSequential, ct);
+                // Publish the BeforeResourceStartedEvent for the resource
+                await e.Eventing.PublishAsync(new BeforeResourceStartedEvent(custom, e.Services), EventDispatchBehavior.BlockingSequential, ct);
 
-            // Mark all the endpoint URLs as active (this makes them visible in the dashboard)
-            await e.Notifications.PublishUpdateAsync(custom.Resource, s => s with
-            {
-                Urls = [.. s.Urls.Select(u => u with { IsInactive = false })]
-            });
-
-            // Move resource to the running state
-            await e.Services.GetRequiredService<ResourceNotificationService>()
-                .PublishUpdateAsync(e.Resource, s => s with
+                // Mark all the endpoint URLs as active (this makes them visible in the dashboard)
+                await e.Notifications.PublishUpdateAsync(custom, s => s with
                 {
-                    StartTimeStamp = DateTime.UtcNow,
-                    State = KnownResourceStates.Running
+                    Urls = [.. s.Urls.Select(u => u with { IsInactive = false })]
                 });
-        });
+
+                // Move resource to the running state
+                await e.Services.GetRequiredService<ResourceNotificationService>()
+                    .PublishUpdateAsync(e.Resource, s => s with
+                    {
+                        StartTimeStamp = DateTime.UtcNow,
+                        State = KnownResourceStates.Running
+                    });
+            });
 
         var app = await builder.BuildAsync();
 
@@ -616,19 +608,18 @@ public class WithUrlsTests
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var called = false;
+        var tcs = new TaskCompletionSource();
         var projectA = builder.AddProject<ProjectA>("projecta")
             .WithHttpEndpoint(name: "test")
             .WithUrlForEndpoint("non-existant", u =>
             {
                 called = true;
+            })
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
             });
-
-        var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -645,20 +636,19 @@ public class WithUrlsTests
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var called = false;
+        var tcs = new TaskCompletionSource();
         var projectA = builder.AddProject<ProjectA>("projecta")
             .WithHttpEndpoint(name: "test")
             .WithUrlForEndpoint("non-existant", ep =>
             {
                 called = true;
                 return new() { Url = "https://example.com" };
+            })
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
             });
-
-        var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -674,19 +664,18 @@ public class WithUrlsTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
+        var tcs = new TaskCompletionSource();
         var projectA = builder.AddProject<ProjectA>("projecta")
             .WithHttpEndpoint(name: "test")
             .WithUrlForEndpoint("test", url =>
             {
                 url.Url = "/sub-path";
+            })
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
             });
-
-        var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -705,19 +694,18 @@ public class WithUrlsTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
+        var tcs = new TaskCompletionSource();
         var projectA = builder.AddProject<ProjectA>("projecta")
             .WithHttpEndpoint(name: "test")
             .WithUrlForEndpoint("test", ep =>
             {
                 return new() { Url = "/sub-path" };
+            })
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
             });
-
-        var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();
@@ -736,19 +724,18 @@ public class WithUrlsTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
+        var tcs = new TaskCompletionSource();
         var projectA = builder.AddProject<ProjectA>("projecta")
             .WithHttpEndpoint(name: "test")
             .WithUrls(c =>
             {
                 c.Urls.Add(new() { Endpoint = c.GetEndpoint("test"), Url = "/sub-path" });
+            })
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
             });
-
-        var tcs = new TaskCompletionSource();
-        builder.Eventing.Subscribe<BeforeResourceStartedEvent>(projectA.Resource, (e, ct) =>
-        {
-            tcs.SetResult();
-            return Task.CompletedTask;
-        });
 
         var app = await builder.BuildAsync();
         await app.StartAsync();


### PR DESCRIPTION
## Description

Follow up to #10097 - migrating event subscriptions in tests to use the new `OnXYZ` extension methods on the ResourceBuilder

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [X] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
