### PR TITLE
Fix Foundry Local setup link

### DIFF
--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
@@ -152,7 +152,7 @@ public static class AzureAIFoundryExtensions
                 }
                 catch (Exception e)
                 {
-                    logger.LogInformation("Foundry Local could not be started. Ensure it's installed correctly: https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started. Error: {Error}", e.Message);
+                    logger.LogInformation("Foundry Local could not be started. Ensure it's installed correctly: https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started (Error: {Error}).", e.Message);
                 }
 
                 if (manager.IsServiceRunning)


### PR DESCRIPTION
Minor fix; clicking on this link from the console logs currently takes you to a 404 page because of the trailing period.
