### PR TITLE
Clear status after error

### DIFF
--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -22,7 +22,6 @@ export interface IInteractionService {
     displayCancellationMessage: (message: string) => void;
     openProject: (projectPath: string) => void;
     logMessage: (logLevel: string, message: string) => void;
-    clearStatusBar: () => void;
 }
 
 type DashboardUrls = {

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -22,6 +22,7 @@ export interface IInteractionService {
     displayCancellationMessage: (message: string) => void;
     openProject: (projectPath: string) => void;
     logMessage: (logLevel: string, message: string) => void;
+    clearStatusBar: () => void;
 }
 
 type DashboardUrls = {
@@ -144,6 +145,7 @@ export class InteractionService implements IInteractionService {
     displayError(errorMessage: string) {
         this._outputChannelWriter.appendLine('interaction', `Displaying error: ${errorMessage}`);
         vscode.window.showErrorMessage(formatText(errorMessage));
+        this.clearStatusBar();
     }
 
     displayMessage(emoji: string, message: string) {
@@ -223,6 +225,14 @@ export class InteractionService implements IInteractionService {
     logMessage(logLevel: string, message: string) {
         // logLevel currently unused, but can be extended in the future
         this._outputChannelWriter.appendLine('cli', `[${logLevel}] ${formatText(message)}`);
+    }
+
+    clearStatusBar() {
+        if (this._statusBarItem) {
+            this._statusBarItem.hide();
+            this._statusBarItem.dispose();
+            this._statusBarItem = undefined;
+        }
     }
 }
 


### PR DESCRIPTION
This needs to be done, as if the cli action is not completed, showStatus(null) will not be called. It could also be done cli-side but this is simpler as the call would have to be made in each catch block for every command.

fixes #10184 