### PR TITLE
Refactor Endpoint bicep references in AI Foundry resource

### DIFF
--- a/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/foundry.module.bicep
+++ b/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/foundry.module.bicep
@@ -38,3 +38,5 @@ resource chat 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
 }
 
 output aiFoundryApiEndpoint string = foundry.properties.endpoints['AI Foundry API']
+
+output endpoint string = foundry.properties.endpoint

--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
@@ -313,12 +313,16 @@ public static class AzureAIFoundryExtensions
                     Tags = { { "aspire-resource-name", infrastructure.AspireResource.Name } }
                 });
 
-        var inferenceEndpoint = (BicepValue<string>)new IndexExpression(
-            (BicepExpression)cogServicesAccount.Properties.Endpoints!,
-            "AI Foundry API");
         infrastructure.Add(new ProvisioningOutput("aiFoundryApiEndpoint", typeof(string))
         {
-            Value = inferenceEndpoint
+            Value = (BicepValue<string>)new IndexExpression(
+                (BicepExpression)cogServicesAccount.Properties.Endpoints!,
+                "AI Foundry API")
+        });
+
+        infrastructure.Add(new ProvisioningOutput("endpoint", typeof(string))
+        {
+            Value = cogServicesAccount.Properties.Endpoint
         });
 
         var resource = (AzureAIFoundryResource)infrastructure.AspireResource;

--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryResource.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryResource.cs
@@ -21,15 +21,22 @@ public class AzureAIFoundryResource(string name, Action<AzureResourceInfrastruct
     private readonly List<AzureAIFoundryDeploymentResource> _deployments = [];
 
     /// <summary>
-    /// Gets the "connectionString" output reference from the Azure AI Foundry resource.
+    /// Gets the "aiFoundryApiEndpoint" output reference from the Azure AI Foundry resource.
     /// </summary>
     public BicepOutputReference AIFoundryApiEndpoint => new("aiFoundryApiEndpoint", this);
+
+    /// <summary>
+    /// Gets the "endpoint" output reference from the Azure AI Foundry resource.
+    /// </summary>
+    public BicepOutputReference Endpoint => new("endpoint", this);
 
     /// <summary>
     /// Gets the connection string template for the manifest for the resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"Endpoint={AIFoundryApiEndpoint};EndpointAIInference={AIFoundryApiEndpoint}models");
+        IsEmulator
+        ? ReferenceExpression.Create($"Endpoint={EmulatorServiceUri?.ToString()};Key={ApiKey}")
+        : ReferenceExpression.Create($"Endpoint={Endpoint};EndpointAIInference={AIFoundryApiEndpoint}models");
 
     /// <summary>
     /// Gets the list of deployment resources associated with the Azure AI Foundry.
@@ -68,7 +75,5 @@ public class AzureAIFoundryResource(string name, Action<AzureResourceInfrastruct
     }
 
     internal ReferenceExpression GetConnectionString(string deploymentName) =>
-        IsEmulator
-            ? ReferenceExpression.Create($"Endpoint={EmulatorServiceUri?.ToString()};Key={ApiKey};DeploymentId={deploymentName};Model={deploymentName}")
-            : ReferenceExpression.Create($"{ConnectionStringExpression};DeploymentId={deploymentName};Model={deploymentName}");
+        ReferenceExpression.Create($"{ConnectionStringExpression};DeploymentId={deploymentName};Model={deploymentName}");
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAIFoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAIFoundryExtensionsTests.cs
@@ -60,7 +60,7 @@ public class AzureAIFoundryExtensionsTests
         var resourceBuilder = builder.AddAzureAIFoundry("myAIFoundry");
         var resource = Assert.Single(builder.Resources.OfType<AzureAIFoundryResource>());
         // The connection string should reference the aiFoundryApiEndpoint output
-        var expected = $"Endpoint={resource.AIFoundryApiEndpoint.ValueExpression};EndpointAIInference={resource.AIFoundryApiEndpoint.ValueExpression}models";
+        var expected = $"Endpoint={resource.Endpoint.ValueExpression};EndpointAIInference={resource.AIFoundryApiEndpoint.ValueExpression}models";
         var connectionString = resource.ConnectionStringExpression.ValueExpression;
         Assert.Equal(expected, connectionString);
     }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAIFoundryExtensionsTests.AddAzureAIFoundry_GeneratesValidBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAIFoundryExtensionsTests.AddAzureAIFoundry_GeneratesValidBicep.verified.bicep
@@ -57,3 +57,5 @@ resource deployment2 'Microsoft.CognitiveServices/accounts/deployments@2024-10-0
 }
 
 output aiFoundryApiEndpoint string = foundry.properties.endpoints['AI Foundry API']
+
+output endpoint string = foundry.properties.endpoint


### PR DESCRIPTION
## Description

Refactor the Bicep output references to use the Cognitive Service Endpoint property instead of duplicating the AI Foundry one.
Refactor the connection string to differ if the emulator is used.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
