### PR TITLE
Add support for interaction input validation to CLI

### DIFF
--- a/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
+++ b/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPUBLISHERS001
+#pragma warning disable ASPIRECOMPUTE001
+#pragma warning disable ASPIREINTERACTION001
+
+using Microsoft.Extensions.DependencyInjection;
+
+internal static class IDistributedApplicationBuilderExtensions
+{
+    public static IResourceBuilder<IComputeEnvironmentResource>? AddPublishTestResource(this IDistributedApplicationBuilder builder, string name)
+    {
+        var resource = new PublishTestResource(name);
+        return builder.AddResource(resource);
+    }
+
+    private sealed class PublishTestResource : Resource, IComputeEnvironmentResource
+    {
+        public PublishTestResource(string name) : base(name)
+        {
+            Annotations.Add(new PublishingCallbackAnnotation(PublishAsync));
+        }
+
+        private async Task PublishAsync(PublishingContext context)
+        {
+            var reporter = context.ProgressReporter;
+            var interactionService = context.Services.GetRequiredService<IInteractionService>();
+
+            // ALL PROMPTS FIRST - before any tasks are created
+
+            // Test multiple inputs with validation
+            var multiInputResult = await interactionService.PromptInputsAsync(
+                "Application Configuration",
+                "Configure additional application settings:",
+                [
+                    new InteractionInput
+                    {
+                        Label = "Application Name",
+                        InputType = InputType.Text,
+                        Required = true,
+                        Placeholder = "my-app"
+                    },
+                    new InteractionInput
+                    {
+                        Label = "Application Version",
+                        InputType = InputType.Text,
+                        Required = false,
+                        Placeholder = "1.0.0"
+                    },
+                    new InteractionInput
+                    {
+                        Label = "SSL Certificate Type",
+                        InputType = InputType.Choice,
+                        Required = true,
+                        Options =
+                        [
+                            new KeyValuePair<string, string>("self-signed", "Self-Signed Certificate"),
+                            new KeyValuePair<string, string>("lets-encrypt", "Let's Encrypt Certificate"),
+                            new KeyValuePair<string, string>("custom", "Custom Certificate")
+                        ]
+                    }
+                ],
+                new InputsDialogInteractionOptions
+                {
+                    ValidationCallback = async (validationContext) =>
+                    {
+                        var appNameInput = validationContext.Inputs.FirstOrDefault(i => i.Label == "Application Name");
+                        if (appNameInput?.Value is not null && appNameInput.Value.Length < 3)
+                        {
+                            validationContext.AddValidationError(appNameInput, "Application name must be at least 3 characters long");
+                        }
+
+                        var versionInput = validationContext.Inputs.FirstOrDefault(i => i.Label == "Application Version");
+                        if (versionInput?.Value is not null && !string.IsNullOrEmpty(versionInput.Value))
+                        {
+                            if (!System.Text.RegularExpressions.Regex.IsMatch(versionInput.Value, @"^\d+\.\d+\.\d+$"))
+                            {
+                                validationContext.AddValidationError(versionInput, "Version must be in format x.y.z (e.g., 1.0.0)");
+                            }
+                        }
+
+                        await Task.CompletedTask;
+                    }
+                },
+                cancellationToken: context.CancellationToken);
+
+            var appName = multiInputResult.Canceled ? "default-app" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "Application Name")?.Value ?? "default-app");
+            var appVersion = multiInputResult.Canceled ? "1.0.0" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "Application Version")?.Value ?? "1.0.0");
+            var sslType = multiInputResult.Canceled ? "self-signed" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "SSL Certificate Type")?.Value ?? "self-signed");
+
+            // Test Text input
+            var envResult = await interactionService.PromptInputAsync(
+                "Environment Configuration",
+                "Please enter the target environment name:",
+                new InteractionInput
+                {
+                    Label = "Environment Name",
+                    InputType = InputType.Text,
+                    Required = true,
+                    Placeholder = "dev, staging, prod"
+                },
+                new()
+                {
+                    ValidationCallback = validationContext =>
+                    {
+                        validationContext.AddValidationError(validationContext.Inputs[0], "Wrong");
+                        return Task.CompletedTask;
+                    }
+                },
+                cancellationToken: context.CancellationToken);
+            var environmentName = envResult.Canceled ? "dev" : (envResult.Data?.Value ?? "dev");
+
+            // Test Password input
+            var dbPasswordResult = await interactionService.PromptInputAsync(
+                "Database Configuration",
+                "Please enter a secure database password:",
+                new InteractionInput
+                {
+                    Label = "Database Password",
+                    InputType = InputType.SecretText,
+                    Required = true,
+                    Placeholder = "Enter a strong password"
+                },
+                cancellationToken: context.CancellationToken);
+            var dbPassword = dbPasswordResult.Canceled ? "defaultPassword" : (dbPasswordResult.Data?.Value ?? "defaultPassword");
+
+            // Test Select input
+            var regionResult = await interactionService.PromptInputAsync(
+                "Region Configuration",
+                "Select the target deployment region:",
+                new InteractionInput
+                {
+                    Label = "Region",
+                    InputType = InputType.Choice,
+                    Required = true,
+                    Options =
+                    [
+                        new KeyValuePair<string, string>("us-west-2", "US West (Oregon)"),
+                        new KeyValuePair<string, string>("us-east-1", "US East (N. Virginia)"),
+                        new KeyValuePair<string, string>("eu-central-1", "Europe (Frankfurt)"),
+                        new KeyValuePair<string, string>("ap-southeast-1", "Asia Pacific (Singapore)")
+                    ]
+                },
+                cancellationToken: context.CancellationToken);
+            var region = regionResult.Canceled ? "us-west-2" : (regionResult.Data?.Value ?? "us-west-2");
+
+            // Test Checkbox input
+            var enableLoggingResult = await interactionService.PromptInputAsync(
+                "Logging Configuration",
+                "Configure application logging settings:",
+                new InteractionInput
+                {
+                    Label = "Enable Verbose Logging",
+                    InputType = InputType.Boolean,
+                    Required = false
+                },
+                cancellationToken: context.CancellationToken);
+            var enableLogging = enableLoggingResult.Canceled ? false : bool.TryParse(enableLoggingResult.Data?.Value, out var logVal) && logVal;
+
+            // Test Number input
+            var instanceCountResult = await interactionService.PromptInputAsync(
+                "Scaling Configuration",
+                "Specify the number of application instances to deploy:",
+                new InteractionInput
+                {
+                    Label = "Instance Count",
+                    InputType = InputType.Number,
+                    Required = true,
+                    Placeholder = "1-10"
+                },
+                cancellationToken: context.CancellationToken);
+            var instanceCount = instanceCountResult.Canceled ? 2 : (int.TryParse(instanceCountResult.Data?.Value, out var count) ? Math.Max(1, Math.Min(10, count)) : 2);
+
+            // Test deployment strategy with Select input
+            var deployModeResult = await interactionService.PromptInputAsync(
+                "Deployment Strategy",
+                "Choose your deployment strategy:",
+                new InteractionInput
+                {
+                    Label = "Strategy",
+                    InputType = InputType.Choice,
+                    Required = true,
+                    Options =
+                    [
+                        new KeyValuePair<string, string>("rolling", "Rolling Deployment (Zero Downtime)"),
+                        new KeyValuePair<string, string>("blue-green", "Blue-Green Deployment (Full Replacement)"),
+                        new KeyValuePair<string, string>("canary", "Canary Deployment (Gradual Rollout)")
+                    ]
+                },
+                cancellationToken: context.CancellationToken);
+            var deployMode = deployModeResult.Canceled ? "rolling" : (deployModeResult.Data?.Value ?? "rolling");
+        }
+    }
+}

--- a/playground/publishers/Publishers.AppHost/Program.cs
+++ b/playground/publishers/Publishers.AppHost/Program.cs
@@ -17,6 +17,7 @@ IResourceBuilder<IComputeEnvironmentResource>? environment = (publisher, target)
 {
     ("default", "kube") => builder.AddKubernetesEnvironment("env"),
     ("default", "azure") => builder.AddAzureContainerAppEnvironment("env"),
+    ("default", "publish-test") => builder.AddPublishTestResource("env"),
     ("default", _) => builder.AddDockerComposeEnvironment("env"),
     _ => null
 };

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -30,5 +30,13 @@
       "environmentVariables": {
       }
     },
+    "publishers": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "publish",
+      "workingDirectory": "../../playground/publishers/Publishers.AppHost",
+      "environmentVariables": {
+        "Deployment:Target": "publish-test"
+      }
   }
 }

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -154,6 +154,11 @@ internal sealed class PublishingPromptInput
     /// Gets the default value for the input.
     /// </summary>
     public string? Value { get; init; }
+
+    /// <summary>
+    /// Gets the validation errors for the input.
+    /// </summary>
+    public IReadOnlyList<string>? ValidationErrors { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -154,7 +154,7 @@ internal sealed class DashboardServiceData : IDisposable
     {
         await _interactionService.CompleteInteractionAsync(
             request.InteractionId,
-            async (interaction, serviceProvider, cancellationToken) =>
+            (interaction, serviceProvider, cancellationToken) =>
             {
                 switch (request.KindCase)
                 {
@@ -180,24 +180,9 @@ internal sealed class DashboardServiceData : IDisposable
                             }
 
                             modelInput.SetValue(incomingValue);
-                            modelInput.ValidationErrors.Clear();
                         }
 
-                        var hasErrors = false;
-                        if (options.ValidationCallback is { } validationCallback)
-                        {
-                            var context = new InputsDialogValidationContext
-                            {
-                                CancellationToken = cancellationToken,
-                                ServiceProvider = serviceProvider,
-                                Inputs = inputsInfo.Inputs
-                            };
-                            await validationCallback(context).ConfigureAwait(false);
-
-                            hasErrors = context.HasErrors;
-                        }
-
-                        return new InteractionCompletionState { Complete = !hasErrors, State = inputsInfo.Inputs };
+                        return new InteractionCompletionState { Complete = true, State = inputsInfo.Inputs };
                     default:
                         return new InteractionCompletionState { Complete = true };
                 }

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -277,11 +277,11 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
                 {
                     // Complete the interaction with an error state
                     interaction.CompletionTcs.TrySetException(new InvalidOperationException("Cannot prompt interaction while steps are in progress."));
-                    return Task.FromResult(new InteractionCompletionState
+                    return new InteractionCompletionState
                     {
-                        Complete = false,
+                        Complete = true,
                         State = "Cannot prompt interaction while steps are in progress."
-                    });
+                    };
                 }, cancellationToken).ConfigureAwait(false);
                 return;
             }
@@ -292,7 +292,8 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
                 InputType = input.InputType.ToString(),
                 Required = input.Required,
                 Options = input.Options,
-                Value = input.Value
+                Value = input.Value,
+                ValidationErrors = input.ValidationErrors
             }).ToList();
 
             var activity = new PublishingActivity
@@ -329,18 +330,18 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
                             }
                         }
 
-                        return Task.FromResult(new InteractionCompletionState
+                        return new InteractionCompletionState
                         {
                             Complete = true,
                             State = inputsInfo.Inputs
-                        });
+                        };
                     }
 
-                    return Task.FromResult(new InteractionCompletionState
+                    return new InteractionCompletionState
                     {
                         Complete = true,
                         State = null
-                    });
+                    };
                 },
                 cancellationToken).ConfigureAwait(false);
         }

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -467,6 +467,61 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Equal("development", promptCalls[0].DefaultValue); // This verifies that our change works
     }
 
+    [Fact]
+    public async Task PublishCommand_TextInputWithValidationErrors_UsesValidationErrorsCorrectly()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var promptBackchannel = new TestPromptBackchannel();
+        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+
+        // Set up the prompt with a default value
+        promptBackchannel.AddPrompt("text-prompt-1", "Environment Name", InputTypes.Text, "Enter environment name:", isRequired: true, defaultValue: "de", validationErrors: ["Environment name must be at least 3 characters long."]);
+
+        // Set up the expected user response (they accept the default by providing the same value)
+        consoleService.SetupStringPromptResponse("development");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
+            options.DotNetCliRunnerFactory = (sp) => CreateTestRunnerWithPromptBackchannel(promptBackchannel);
+        });
+
+        services.AddSingleton<IInteractionService>(consoleService);
+
+        var serviceProvider = services.BuildServiceProvider();
+        var command = serviceProvider.GetRequiredService<RootCommand>();
+
+        // Act
+        var result = command.Parse("publish");
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+
+        // Assert
+        Assert.Equal(0, exitCode);
+
+        // Verify the prompt was handled correctly and includes the default value
+        Assert.Single(promptBackchannel.ReceivedPrompts);
+        var receivedPrompt = promptBackchannel.ReceivedPrompts[0];
+        Assert.Equal("text-prompt-1", receivedPrompt.PromptId);
+        Assert.Equal("Environment Name", receivedPrompt.Inputs[0].Label);
+        Assert.Equal(InputTypes.Text, receivedPrompt.Inputs[0].InputType);
+        Assert.Equal("de", receivedPrompt.Inputs[0].Value); // Check that the previous value is present
+        Assert.Collection(receivedPrompt.Inputs[0].ValidationErrors ?? [],
+            e => Assert.Equal("Environment name must be at least 3 characters long.", e)); // Check that validations errors are present
+
+        // Verify the correct response was sent back
+        Assert.Single(promptBackchannel.CompletedPrompts);
+        var completedPrompt = promptBackchannel.CompletedPrompts[0];
+        Assert.Equal("text-prompt-1", completedPrompt.PromptId);
+        Assert.Equal("development", completedPrompt.Answers[0]);
+
+        // Verify that the PromptForStringAsync was called with the default value
+        var promptCalls = consoleService.StringPromptCalls;
+        Assert.Single(promptCalls);
+        var displayedError = Assert.Single(consoleService.DisplayedErrors);
+        Assert.Equal("Environment name must be at least 3 characters long.", displayedError);
+    }
+
     private static TestDotNetCliRunner CreateTestRunnerWithPromptBackchannel(TestPromptBackchannel promptBackchannel)
     {
         var runner = new TestDotNetCliRunner();
@@ -502,9 +557,9 @@ internal sealed class TestPromptBackchannel : IAppHostBackchannel
     public List<PromptData> ReceivedPrompts { get; } = [];
     public List<PromptCompletion> CompletedPrompts { get; } = [];
 
-    public void AddPrompt(string promptId, string label, string inputType, string message, bool isRequired, IReadOnlyList<KeyValuePair<string, string>>? options = null, string? defaultValue = null)
+    public void AddPrompt(string promptId, string label, string inputType, string message, bool isRequired, IReadOnlyList<KeyValuePair<string, string>>? options = null, string? defaultValue = null, IReadOnlyList<string>? validationErrors = null)
     {
-        _promptsToSend.Add(new PromptData(promptId, [new PromptInputData(label, inputType, isRequired, options, defaultValue)], message));
+        _promptsToSend.Add(new PromptData(promptId, [new PromptInputData(label, inputType, isRequired, options, defaultValue, validationErrors)], message));
     }
 
     public void AddMultiInputPrompt(string promptId, string title, string message, IReadOnlyList<PromptInputData> inputs)
@@ -529,7 +584,8 @@ internal sealed class TestPromptBackchannel : IAppHostBackchannel
                 InputType = input.InputType,
                 Required = input.IsRequired,
                 Options = input.Options,
-                Value = input.Value
+                Value = input.Value,
+                ValidationErrors = input.ValidationErrors
             }).ToList();
 
             yield return new PublishingActivity
@@ -585,7 +641,7 @@ internal sealed class TestPromptBackchannel : IAppHostBackchannel
 }
 
 // Data structures for tracking prompts
-internal sealed record PromptInputData(string Label, string InputType, bool IsRequired, IReadOnlyList<KeyValuePair<string, string>>? Options = null, string? Value = null);
+internal sealed record PromptInputData(string Label, string InputType, bool IsRequired, IReadOnlyList<KeyValuePair<string, string>>? Options = null, string? Value = null, IReadOnlyList<string>? ValidationErrors = null);
 internal sealed record PromptData(string PromptId, IReadOnlyList<PromptInputData> Inputs, string Message, string? Title = null);
 internal sealed record PromptCompletion(string PromptId, string?[] Answers);
 
@@ -599,6 +655,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public List<StringPromptCall> StringPromptCalls { get; } = [];
     public List<object> SelectionPromptCalls { get; } = []; // Using object to handle generic types
     public List<BooleanPromptCall> BooleanPromptCalls { get; } = [];
+    public List<string> DisplayedErrors { get; } = [];
     
     public void SetupStringPromptResponse(string response) => _responses.Enqueue((response, ResponseType.String));
     public void SetupSelectionResponse(string response) => _responses.Enqueue((response, ResponseType.Selection));
@@ -671,7 +728,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action) => action();
     public void ShowStatus(string statusText, Action action) => action();
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
-    public void DisplayError(string errorMessage) { }
+    public void DisplayError(string errorMessage) => DisplayedErrors.Add(errorMessage);
     public void DisplayMessage(string emoji, string message) { }
     public void DisplaySuccess(string message) { }
     public void DisplaySubtleMessage(string message) { }

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -173,7 +173,7 @@ public class InteractionServiceTests
 
     private static async Task CompleteInteractionAsync(InteractionService interactionService, int interactionId, InteractionCompletionState state)
     {
-        await interactionService.CompleteInteractionAsync(interactionId, (_, _, _) => Task.FromResult(state), CancellationToken.None);
+        await interactionService.CompleteInteractionAsync(interactionId, (_, _, _) => state, CancellationToken.None);
     }
 
     private static InteractionService CreateInteractionService(DistributedApplicationOptions? options = null)


### PR DESCRIPTION
## Description

- Move validation of inputs inside `InteractionService`.
- Add `ValidationErrors` to publish activity
- Update CLI to handle displaying validation errors.
  - If there are no validation errors then no difference in behavior
  - If there are validation errors then display error and re-prompt for input
  - If the validation errors occur when displaying multiple inputs then only inputs with errors are re-prompted.

Contributes towards https://github.com/dotnet/aspire/issues/8913

![cli-interaction-validation](https://github.com/user-attachments/assets/bffa691d-8bb4-49cf-a2ea-bb8856e156a5)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
