### PR TITLE
update extension readme, add contributing.md

### DIFF
--- a/extension/CONTRIBUTING.MD
+++ b/extension/CONTRIBUTING.MD
@@ -1,0 +1,14 @@
+# Set up your machine to contribute
+
+## Install prereqs
+
+- Node.js (LTS version)
+- Visual Studio Code (latest)
+- .NET Aspire CLI must be installed and available in your PATH.
+
+## Run extension locally
+
+- Open the extension folder in Visual Studio Code.
+- Run `yarn install` to install dependencies and then `yarn compile` to generate loc files.
+- Press `F5` to start a new Extension Development Host instance of VS Code with the extension loaded.
+- Open the Command Palette (`Cmd+Shift+P` or `Ctrl+Shift+P`) and run the desired Aspire command.

--- a/extension/CONTRIBUTING.MD
+++ b/extension/CONTRIBUTING.MD
@@ -1,6 +1,6 @@
 # Set up your machine to contribute
 
-## Install prereqs
+## Install Prerequisites
 
 - Node.js (LTS version)
 - Visual Studio Code (latest)

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,15 +1,35 @@
-# Aspire Visual Studio Code extension
 
-This extension wraps the Aspire CLI to provide a better development experience for Aspire applications in Visual Studio Code.
+# Aspire VS Code Extension
 
-## Setup
+The Aspire VS Code extension provides a set of commands and tools to help you work with Aspire and Aspire AppHost projects directly from Visual Studio Code.
 
-1. Run `yarn install` in the extension root directory.
+## Features
 
-## Running the extension
+- **Run**: Run an Aspire app host in development mode.
+- **Add**: Add an integration to the Aspire project.
+- **New**: Create a new Aspire project.
+- **Publish**: Generates deployment artifacts for an Aspire app host project. (Preview)
+- **Config**: Manage configuration settings.
+- **Deploy**: Deploy an Aspire app host project to its supported deployment targets. (Preview)
 
-Open the `extension` directory in a new VS Code workspace, and f5 to run the extension. Note that you should have the Aspire CLI installed globally for the extension to work properly. To install the latest nightly CLI build, run `dotnet tool install --global aspire.cli --prerelease --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json`.
+## Commands
 
-## Running tests
+All commands are available from the Command Palette (`Cmd+Shift+P` or `Ctrl+Shift+P`) and are grouped under the "Aspire" category:
 
-To run the tests, you can use the `yarn test` command. This will execute the tests defined in the `src/test` directory. Make sure that you recompile the tests after making changes by running `yarn compile-tests`. If you make changes to the extension code, you can recompile the extension by running `yarn compile`.
+## Getting Started
+
+1. Install the extension from the VS Code Marketplace.
+2. Open your Aspire project folder in VS Code or use `Aspire: New Aspire project` to create a project.
+3. Use the Command Palette to access Aspire commands.
+
+## Requirements
+
+- .NET Aspire CLI installed
+
+## Feedback and Issues
+
+Please report issues or feature requests on the [GitHub repository](https://github.com/dotnet/aspire/issues).
+
+## License
+
+See [LICENSE.TXT](./LICENSE.TXT) for details.


### PR DESCRIPTION
This isn't the final form of the extension readme, but looks slightly nicer. Moves build instructions to `CONTRIBUTING.MD`