### PR TITLE
Suppress CS9881 in generated project/apphost metadata types

### DIFF
--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -46,10 +46,12 @@
 
 namespace Projects%3B
 
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters. Such names may become reserved for the language.
 [global::System.CodeDom.Compiler.GeneratedCode("Aspire.Hosting", null)]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage(Justification = "Generated code.")]
 [global::System.Diagnostics.DebuggerDisplay("Type = {GetType().Name,nq}, ProjectPath = {ProjectPath}")]
 ]]>$(AspireGeneratedClassesVisibility)<![CDATA[ class ]]>%(ClassName)<![CDATA[ : global::Aspire.Hosting.IProjectMetadata
+#pragma warning restore CS8981
 {
     public string ProjectPath => """]]>%(ProjectPath)<![CDATA["""%3B
 }]]>
@@ -86,10 +88,12 @@ namespace Projects%3B
 
 namespace Projects%3B
 
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters. Such names may become reserved for the language.
 [global::System.CodeDom.Compiler.GeneratedCode("Aspire.Hosting", null)]
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage(Justification = "Generated code.")]
 [global::System.Diagnostics.DebuggerDisplay("Type = {GetType().Name,nq}, ProjectPath = {ProjectPath}")]
 ]]>$(AspireGeneratedClassesVisibility)<![CDATA[ class ]]>%(ClassName)<![CDATA[
+#pragma warning restore CS8981
 {
     private ]]>%(ClassName)<![CDATA[() { }
     public static string ProjectPath => """]]>%(ProjectPath)<![CDATA["""%3B


### PR DESCRIPTION
## Description

These warnings show up when using a single .cs file for the AppHost in NET 10 (#9612). Suppressing as it's a generated file and feels like the right trade-off here.

Contributes to # (9612)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
