### PR TITLE
Fix ready event subscription for Foundry resource

### DIFF
--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
@@ -184,7 +184,8 @@ public static class AzureAIFoundryExtensions
     {
         ArgumentNullException.ThrowIfNull(deployment, nameof(deployment));
 
-        builder.OnResourceReady((foundryResource, @event, ct) =>
+        var foundryResource = builder.Resource.Parent;
+        builder.ApplicationBuilder.Eventing.Subscribe<ResourceReadyEvent>(foundryResource, (@event, ct) =>
         {
             var rns = @event.Services.GetRequiredService<ResourceNotificationService>();
             var loggerService = @event.Services.GetRequiredService<ResourceLoggerService>();


### PR DESCRIPTION
Fixes a regression introduced in #10097 which broke starting up Foundry resources. The issue was that we need to be subscribing to the readiness of the _parent_ resource, not the current one.