### PR TITLE
Add non-localhost URLs

### DIFF
--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -55,8 +55,9 @@ var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice
 
 var messaging = builder.AddRabbitMQ("messaging")
                        .WithDataVolume()
-                       .WithLifetime(ContainerLifetime.Persistent)
+                       //.WithLifetime(ContainerLifetime.Persistent)
                        .WithManagementPlugin()
+                       .WithEndpoint("management", e => e.TargetHost = "0.0.0.0", createIfNotExists: false)
                        .PublishAsContainer();
 
 var basketService = builder.AddProject("basketservice", @"..\BasketService\BasketService.csproj")

--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -55,9 +55,8 @@ var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice
 
 var messaging = builder.AddRabbitMQ("messaging")
                        .WithDataVolume()
-                       //.WithLifetime(ContainerLifetime.Persistent)
+                       .WithLifetime(ContainerLifetime.Persistent)
                        .WithManagementPlugin()
-                       .WithEndpoint("management", e => e.TargetHost = "0.0.0.0", createIfNotExists: false)
                        .PublishAsContainer();
 
 var basketService = builder.AddProject("basketservice", @"..\BasketService\BasketService.csproj")

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1581,6 +1581,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         {
             null or "" => ("localhost", EndpointBindingMode.SingleAddress), // Default is localhost
             var s when string.Equals(s, "localhost", StringComparison.OrdinalIgnoreCase) => ("localhost", EndpointBindingMode.SingleAddress), // Explicitly set to localhost
+            var s when s.Length > 10 && s.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase) => ("localhost", EndpointBindingMode.SingleAddress), // Explicitly set to localhost when using .localhost subdomain
             var s when IPAddress.TryParse(s, out var ipAddress) => ipAddress switch // The host is an IP address
             {
                 var ip when IPAddress.Any.Equals(ip) => ("localhost", EndpointBindingMode.IPv4AnyAddresses), // 0.0.0.0 (IPv4 all addresses)

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -217,13 +217,15 @@ internal sealed class ApplicationOrchestrator
                     urls.Add(url);
                     if (allocatedEndpoint.BindingMode != EndpointBindingMode.SingleAddress && (endpoint.TargetHost is not "localhost" or "127.0.0.1"))
                     {
-                        // Endpoint is listening on multiple addresses so add more URLs using
-                        var address = endpoint.TargetHost == "0.0.0.0" ? Environment.MachineName : endpoint.TargetHost;
+                        // Endpoint is listening on multiple addresses so add another URL based on the declared target hostname
+                        // For endpoints targeting all external addresses (IPv4 0.0.0.0 or IPv6 ::) use the machine name
+                        var address = endpoint.TargetHost is "0.0.0.0" or "::" ? Environment.MachineName : endpoint.TargetHost;
                         url = new ResourceUrlAnnotation { Url = $"{allocatedEndpoint.UriScheme}://{address}:{allocatedEndpoint.Port}", Endpoint = endpointReference };
                         urls.Add(url);
                     }
                     else if (endpoint.TargetHost.Length > 10 && endpoint.TargetHost.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
                     {
+                        // Add the originally declared *.localhost URL
                         url = new ResourceUrlAnnotation { Url = $"{allocatedEndpoint.UriScheme}://{endpoint.TargetHost}:{allocatedEndpoint.Port}", Endpoint = endpointReference };
                         urls.Add(url);
                     }

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -222,6 +222,11 @@ internal sealed class ApplicationOrchestrator
                         url = new ResourceUrlAnnotation { Url = $"{allocatedEndpoint.UriScheme}://{address}:{allocatedEndpoint.Port}", Endpoint = endpointReference };
                         urls.Add(url);
                     }
+                    else if (endpoint.TargetHost.Length > 10 && endpoint.TargetHost.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
+                    {
+                        url = new ResourceUrlAnnotation { Url = $"{allocatedEndpoint.UriScheme}://{endpoint.TargetHost}:{allocatedEndpoint.Port}", Endpoint = endpointReference };
+                        urls.Add(url);
+                    }
                 }
             }
 

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -212,9 +212,16 @@ internal sealed class ApplicationOrchestrator
                 Debug.Assert(endpoint.AllocatedEndpoint is not null, "Endpoint should be allocated at this point as we're calling this from ResourceEndpointsAllocatedEvent handler.");
                 if (endpoint.AllocatedEndpoint is { } allocatedEndpoint)
                 {
-                    var url = new ResourceUrlAnnotation { Url = allocatedEndpoint.UriString, Endpoint = new EndpointReference(resourceWithEndpoints, endpoint) };
+                    var endpointReference = new EndpointReference(resourceWithEndpoints, endpoint);
+                    var url = new ResourceUrlAnnotation { Url = allocatedEndpoint.UriString, Endpoint = endpointReference };
                     urls.Add(url);
-                }
+                    if (allocatedEndpoint.BindingMode != EndpointBindingMode.SingleAddress && (endpoint.TargetHost is not "localhost" or "127.0.0.1"))
+                    {
+                        // Endpoint is listening on multiple addresses so add more URLs using
+                        var address = endpoint.TargetHost == "0.0.0.0" ? Environment.MachineName : endpoint.TargetHost;
+                        url = new ResourceUrlAnnotation { Url = $"{allocatedEndpoint.UriScheme}://{address}:{allocatedEndpoint.Port}", Endpoint = endpointReference };
+                        urls.Add(url);
+                    }
             }
         }
 

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -222,55 +222,56 @@ internal sealed class ApplicationOrchestrator
                         url = new ResourceUrlAnnotation { Url = $"{allocatedEndpoint.UriScheme}://{address}:{allocatedEndpoint.Port}", Endpoint = endpointReference };
                         urls.Add(url);
                     }
-            }
-        }
-
-        if (resource.TryGetUrls(out var existingUrls))
-        {
-            // Static URLs added to the resource via WithUrl(string name, string url), i.e. not callback-based
-            urls.AddRange(existingUrls);
-        }
-
-        // Run the URL callbacks
-        if (resource.TryGetAnnotationsOfType<ResourceUrlsCallbackAnnotation>(out var callbacks))
-        {
-            var urlsCallbackContext = new ResourceUrlsCallbackContext(_executionContext, resource, urls, cancellationToken)
-            {
-                Logger = _loggerService.GetLogger(resource.Name)
-            };
-            foreach (var callback in callbacks)
-            {
-                await callback.Callback(urlsCallbackContext).ConfigureAwait(false);
-            }
-        }
-
-        // Clear existing URLs
-        if (existingUrls is not null)
-        {
-            var existing = existingUrls.ToArray();
-            for (var i = existing.Length - 1; i >= 0; i--)
-            {
-                var url = existing[i];
-                resource.Annotations.Remove(url);
-            }
-        }
-
-        // Convert relative endpoint URLs to absolute URLs
-        foreach (var url in urls)
-        {
-            if (url.Endpoint is { } endpoint)
-            {
-                if (url.Url.StartsWith('/') && endpoint.AllocatedEndpoint is { } allocatedEndpoint)
-                {
-                    url.Url = allocatedEndpoint.UriString.TrimEnd('/') + url.Url;
                 }
             }
-        }
 
-        // Add URLs
-        foreach (var url in urls)
-        {
-            resource.Annotations.Add(url);
+            if (resource.TryGetUrls(out var existingUrls))
+            {
+                // Static URLs added to the resource via WithUrl(string name, string url), i.e. not callback-based
+                urls.AddRange(existingUrls);
+            }
+
+            // Run the URL callbacks
+            if (resource.TryGetAnnotationsOfType<ResourceUrlsCallbackAnnotation>(out var callbacks))
+            {
+                var urlsCallbackContext = new ResourceUrlsCallbackContext(_executionContext, resource, urls, cancellationToken)
+                {
+                    Logger = _loggerService.GetLogger(resource.Name)
+                };
+                foreach (var callback in callbacks)
+                {
+                    await callback.Callback(urlsCallbackContext).ConfigureAwait(false);
+                }
+            }
+
+            // Clear existing URLs
+            if (existingUrls is not null)
+            {
+                var existing = existingUrls.ToArray();
+                for (var i = existing.Length - 1; i >= 0; i--)
+                {
+                    var url = existing[i];
+                    resource.Annotations.Remove(url);
+                }
+            }
+
+            // Convert relative endpoint URLs to absolute URLs
+            foreach (var url in urls)
+            {
+                if (url.Endpoint is { } endpoint)
+                {
+                    if (url.Url.StartsWith('/') && endpoint.AllocatedEndpoint is { } allocatedEndpoint)
+                    {
+                        url.Url = allocatedEndpoint.UriString.TrimEnd('/') + url.Url;
+                    }
+                }
+            }
+
+            // Add URLs
+            foreach (var url in urls)
+            {
+                resource.Annotations.Add(url);
+            }
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -617,6 +617,72 @@ public class WithEndpointTests
         Assert.Equal(System.Net.Sockets.ProtocolType.Tcp, endpoint.Protocol);
     }
 
+    [Fact]
+    public async Task LocalhostTopLevelDomainSetsAnnotationValues()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var tcs = new TaskCompletionSource();
+        var projectA = builder.AddProject<ProjectA>("projecta")
+            .WithHttpsEndpoint()
+            .WithEndpoint("https", e => e.TargetHost = "example.localhost", createIfNotExists: false)
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
+            });
+
+        var app = await builder.BuildAsync();
+        await app.StartAsync();
+        await tcs.Task;
+
+        var urls = projectA.Resource.Annotations.OfType<ResourceUrlAnnotation>();
+        Assert.Collection(urls,
+            url => Assert.StartsWith("https://localhost:", url.Url),
+            url => Assert.StartsWith("https://example.localhost:", url.Url));
+
+        EndpointAnnotation endpoint = Assert.Single(projectA.Resource.Annotations.OfType<EndpointAnnotation>());
+        Assert.NotNull(endpoint.AllocatedEndpoint);
+        Assert.Equal(EndpointBindingMode.SingleAddress, endpoint.AllocatedEndpoint.BindingMode);
+        Assert.Equal("localhost", endpoint.AllocatedEndpoint.Address);
+
+        await app.StopAsync();
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0", EndpointBindingMode.IPv4AnyAddresses)]
+    //[InlineData("::", EndpointBindingMode.IPv6AnyAddresses)] // Need to figure out a good way to check that Ipv6 binding is supported
+    public async Task TopLevelDomainSetsAnnotationValues(string host, EndpointBindingMode endpointBindingMode)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var tcs = new TaskCompletionSource();
+        var projectA = builder.AddProject<ProjectA>("projecta")
+            .WithHttpsEndpoint()
+            .WithEndpoint("https", e => e.TargetHost = host, createIfNotExists: false)
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                tcs.SetResult();
+                return Task.CompletedTask;
+            });
+
+        var app = await builder.BuildAsync();
+        await app.StartAsync();
+        await tcs.Task;
+
+        var urls = projectA.Resource.Annotations.OfType<ResourceUrlAnnotation>();
+        Assert.Collection(urls,
+            url => Assert.StartsWith("https://localhost:", url.Url),
+            url => Assert.StartsWith($"https://{Environment.MachineName}:", url.Url));
+
+        EndpointAnnotation endpoint = Assert.Single(projectA.Resource.Annotations.OfType<EndpointAnnotation>());
+        Assert.NotNull(endpoint.AllocatedEndpoint);
+        Assert.Equal(endpointBindingMode, endpoint.AllocatedEndpoint.BindingMode);
+        Assert.Equal("localhost", endpoint.AllocatedEndpoint.Address);
+
+        await app.StopAsync();
+    }
+
     private sealed class TestProject : IProjectMetadata
     {
         public string ProjectPath => "projectpath";


### PR DESCRIPTION
## Description

Adds urls for `*.localhost` and other localhost adjacent bindings.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
