### PR TITLE
Add support for file types to interaction service

### DIFF
--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -129,6 +129,7 @@ internal static class InteractionCommands
                    dinnerInput,
                    numberOfPeopleInput,
                    new InteractionInput { InputType = InputType.Boolean, Label = "Remember me", Placeholder = "What does this do?", Required = true },
+                   new InteractionInput { InputType = InputType.File, Label = "Receipt", Placeholder = "Upload receipt", Required = true },
                };
                var result = await interactionService.PromptInputsAsync(
                    "Input request",
@@ -157,7 +158,12 @@ internal static class InteractionCommands
 
                foreach (var updatedInput in result.Data)
                {
-                   logger.LogInformation("Input: {Label} = {Value}", updatedInput.Label, updatedInput.Value);
+                   var value = updatedInput.Value;
+                   if (updatedInput.InputType == InputType.File && !string.IsNullOrEmpty(value))
+                   {
+                       value += $" ({updatedInput.ValueBytes!.Length} bytes)";
+                   }
+                   logger.LogInformation("Input: {Label} = {Value}", updatedInput.Label, value);
                }
 
                return CommandResults.Success();

--- a/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
+++ b/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
@@ -59,6 +59,12 @@ internal static class IDistributedApplicationBuilderExtensions
                             new KeyValuePair<string, string>("lets-encrypt", "Let's Encrypt Certificate"),
                             new KeyValuePair<string, string>("custom", "Custom Certificate")
                         ]
+                    },
+                    new InteractionInput
+                    {
+                        Label = "Certificate file",
+                        InputType = InputType.File,
+                        Required = true
                     }
                 ],
                 new InputsDialogInteractionOptions
@@ -88,6 +94,7 @@ internal static class IDistributedApplicationBuilderExtensions
             var appName = multiInputResult.Canceled ? "default-app" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "Application Name")?.Value ?? "default-app");
             var appVersion = multiInputResult.Canceled ? "1.0.0" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "Application Version")?.Value ?? "1.0.0");
             var sslType = multiInputResult.Canceled ? "self-signed" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "SSL Certificate Type")?.Value ?? "self-signed");
+            var file = multiInputResult.Canceled ? null : multiInputResult.Data?.FirstOrDefault(i => i.Label == "Certificate file")?.ValueBytes;
 
             // Test Text input
             var envResult = await interactionService.PromptInputAsync(

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -46,6 +46,7 @@
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
     <Compile Include="$(SharedDir)CircularBuffer.cs" Link="Utils\CircularBuffer.cs" />
+    <Compile Include="$(SharedDir)InteractionConfig.cs" Link="Utils\InteractionConfig.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="StringComparers.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting\Backchannel\BackchannelDataTypes.cs" Link="Backchannel\CliBackchannelDataTypes.cs" />
   </ItemGroup>

--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -21,7 +21,7 @@ internal interface IAppHostBackchannel
     Task ConnectAsync(string socketPath, CancellationToken cancellationToken);
     IAsyncEnumerable<PublishingActivity> GetPublishingActivitiesAsync(CancellationToken cancellationToken);
     Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken);
-    Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken);
+    Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
 }
 
 internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, AspireCliTelemetry telemetry) : IAppHostBackchannel
@@ -204,7 +204,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Asp
         return capabilities;
     }
 
-    public async Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken)
+    public async Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken)
     {
         using var activity = telemetry.ActivitySource.StartActivity();
 

--- a/src/Aspire.Cli/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelDataTypes.cs
@@ -43,5 +43,9 @@ internal enum InputType
     /// <summary>
     /// A numeric input.
     /// </summary>
-    Number
+    Number,
+    /// <summary>
+    /// A file input.
+    /// </summary>
+    File
 }

--- a/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
@@ -23,6 +23,7 @@ namespace Aspire.Cli.Backchannel;
 [JsonSerializable(typeof(MessageFormatterEnumerableTracker.EnumeratorResults<PublishingActivity>))]
 [JsonSerializable(typeof(RequestId))]
 [JsonSerializable(typeof(IEnumerable<DisplayLineState>))]
+[JsonSerializable(typeof(PublishingPromptInputAnswer[]))]
 [JsonSerializable(typeof(ValidationResult))]
 internal partial class BackchannelJsonSerializerContext : JsonSerializerContext
 {

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Aspire.Dashboard.Utils;
 using Aspire.Hosting;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -21,9 +22,6 @@ namespace Aspire.Cli.Commands;
 
 internal abstract class PublishCommandBase : BaseCommand
 {
-    private const int MaxFileSizeMB = 2;
-    private const int MaxFileSizeBytes = MaxFileSizeMB * 1024 * 1024;
-
     protected readonly IDotNetCliRunner _runner;
     protected readonly IInteractionService _interactionService;
     protected readonly IProjectLocator _projectLocator;
@@ -570,9 +568,9 @@ internal abstract class PublishCommandBase : BaseCommand
             }
 
             var fileInfo = new FileInfo(value);
-            if (fileInfo.Length > MaxFileSizeBytes)
+            if (fileInfo.Length > InteractionConfig.MaxFileSizeBytes)
             {
-                return ValidationResult.Error($"File size must be less than {MaxFileSizeMB} MB.");
+                return ValidationResult.Error($"File size must be less than {InteractionConfig.MaxFileSizeMegabytes} MB.");
             }
 
             return ValidationResult.Success();

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -38,5 +38,6 @@
       "environmentVariables": {
         "Deployment:Target": "publish-test"
       }
+    }
   }
 }

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -257,6 +257,7 @@
     <Compile Include="$(SharedDir)KnownFormats.cs" Link="Utils\KnownFormats.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
     <Compile Include="$(SharedDir)TaskHelpers.cs" Link="Utils\TaskHelpers.cs" />
+    <Compile Include="$(SharedDir)InteractionConfig.cs" Link="Utils\InteractionConfig.cs" />
     <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="Utils\KnownProperties.cs" />
     <Compile Include="$(SharedDir)Model\KnownResourceCommands.cs" Link="Utils\KnownResourceCommands.cs" />
     <Compile Include="$(SharedDir)Model\KnownResourceTypes.cs" Link="Utils\KnownResourceTypes.cs" />

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -97,7 +97,7 @@
                                              Mode="InputFileMode.Buffer"
                                              AnchorId="@inputId"
                                              Multiple="false"
-                                             MaximumFileSize="@(2 * 1024 * 1024)"
+                                             MaximumFileSize="@InteractionConfig.MaxFileSizeBytes"
                                              OnProgressChange="@(args => OnFileInputProgress(localItem, args))"
                                              OnCompleted="@(args => OnFileInputCompleted(localItem, args))" />
                             <FluentInputLabel ForId="@inputId" Label="@localItem.Input.Label" Required="@localItem.Input.Required" />

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -7,6 +7,7 @@
 @using Aspire.Dashboard.Extensions
 @using System.Globalization
 @using Aspire.Dashboard.Components.Controls.Grid
+@using Aspire.Dashboard.Components.Dialogs
 @using Aspire.DashboardService.Proto.V1
 @using Dialogs = Aspire.Dashboard.Resources.Dialogs
 @implements IDialogContentComponent<InteractionsInputsDialogViewModel>
@@ -82,12 +83,44 @@
                         case InputType.Number:
                             <FluentNumberField TValue="int?"
                                                @ref="@_elementRefs[localItem]"
-                                               @bind-Value="localItem.NumberValue"
+                                               @bind-Value="localItem.ValueNumber"
                                                Label="@localItem.Input.Label"
                                                Placeholder="@localItem.Input.Placeholder"
                                                Required="localItem.Input.Required"
                                                Immediate="true" />
-                            <ValidationMessage For="@(() => localItem.NumberValue)" />
+                            <ValidationMessage For="@(() => localItem.ValueNumber)" />
+                            break;
+                        case InputType.File:
+                            var inputId = $"FileUploadButton-{_inputDialogInputViewModels.IndexOf(localItem)}";
+                            <FluentInputFile @ref="@_elementRefs[localItem]"
+                                             DragDropZoneVisible="false"
+                                             Mode="InputFileMode.Buffer"
+                                             AnchorId="@inputId"
+                                             Multiple="false"
+                                             MaximumFileSize="@(2 * 1024 * 1024)"
+                                             OnProgressChange="@(args => OnFileInputProgress(localItem, args))"
+                                             OnCompleted="@(args => OnFileInputCompleted(localItem, args))" />
+                            <FluentInputLabel ForId="@inputId" Label="@localItem.Input.Label" Required="@localItem.Input.Required" />
+                            @if (!string.IsNullOrEmpty(localItem.Value))
+                            {
+                                <div class="uploaded-file-container">
+                                    <FluentIcon Icon="Icons.Filled.Size16.Document" Style="vertical-align: text-bottom;" Color="Color.Accent" />
+                                    <span>@localItem.Value</span>
+                                </div>
+                            }
+                            else if (localItem.FileProgressPercent != null)
+                            {
+                                <p>
+                                    <FluentProgress Min="0" Max="100" Value="@localItem.FileProgressPercent" />
+                                </p>
+                            }
+                            else
+                            {
+                                <FluentButton Id="@inputId" Appearance="Appearance.Accent">
+                                    @localItem.Input.Placeholder
+                                </FluentButton>
+                            }
+                            <ValidationMessage For="@(() => localItem.ValueBytes)" />
                             break;
                         default:
                             @* Ignore unexpected InputTypes *@

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
@@ -2,6 +2,8 @@
     width: 100%;
 }
 
-.interaction-input-dialog .interaction-input ::deep fluent-text-field, .interaction-input-dialog .interaction-input ::deep fluent-select {
+.interaction-input-dialog .interaction-input ::deep fluent-text-field,
+.interaction-input-dialog .interaction-input ::deep fluent-select,
+.interaction-input-dialog .interaction-input ::deep .uploaded-file-container {
     width: 75%;
 }

--- a/src/Aspire.Dashboard/Model/InputViewModel.cs
+++ b/src/Aspire.Dashboard/Model/InputViewModel.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.DashboardService.Proto.V1;
+using Google.Protobuf;
 
 namespace Aspire.Dashboard.Model;
 
@@ -46,9 +47,19 @@ public sealed class InputViewModel
     }
 
     // Used when binding to FluentNumberField.
-    public int? NumberValue
+    public int? ValueNumber
     {
         get => int.TryParse(Input.Value, CultureInfo.InvariantCulture, out var result) ? result : null;
         set => Input.Value = value?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
     }
+
+    // Used when binding to FluentInputFile data. File name is stored in Value.
+    public byte[]? ValueBytes
+    {
+        get => Input.ValueBytes?.ToByteArray();
+        set => Input.ValueBytes = value != null ? ByteString.CopyFrom(value) : ByteString.Empty;
+    }
+
+    public int? FileProgressPercent { get; set; }
+    public string? FileName { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/IInteractionService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IInteractionService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -101,6 +102,7 @@ public interface IInteractionService
 /// Represents an input for an interaction.
 /// </summary>
 [Experimental(InteractionService.DiagnosticId, UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[DebuggerDisplay("Label = {Label}, InputType = {InputType}, Required = {Required}, Value = {Value}")]
 public sealed class InteractionInput
 {
     private string? _value;
@@ -132,7 +134,7 @@ public sealed class InteractionInput
     public string? Value { get => _value; init => _value = value; }
 
     /// <summary>
-    /// Gets or sets the value of the input as a byte array. Only used by <see cref="InputType.File"/> inputs.
+    /// Gets or sets the bytes value of the input. Only used by <see cref="InputType.File"/> inputs.
     /// </summary>
     public byte[]? ValueBytes { get => _valueBytes; init => _valueBytes = value; }
 

--- a/src/Aspire.Hosting/ApplicationModel/IInteractionService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IInteractionService.cs
@@ -104,6 +104,7 @@ public interface IInteractionService
 public sealed class InteractionInput
 {
     private string? _value;
+    private byte[]? _valueBytes;
 
     /// <summary>
     /// Gets or sets the label for the input.
@@ -131,11 +132,17 @@ public sealed class InteractionInput
     public string? Value { get => _value; init => _value = value; }
 
     /// <summary>
+    /// Gets or sets the value of the input as a byte array. Only used by <see cref="InputType.File"/> inputs.
+    /// </summary>
+    public byte[]? ValueBytes { get => _valueBytes; init => _valueBytes = value; }
+
+    /// <summary>
     /// Gets or sets the placeholder text for the input.
     /// </summary>
     public string? Placeholder { get; set; }
 
     internal void SetValue(string value) => _value = value;
+    internal void SetValueBytes(byte[]? value) => _valueBytes = value;
 
     internal List<string> ValidationErrors { get; } = [];
 }
@@ -165,7 +172,11 @@ public enum InputType
     /// <summary>
     /// A numeric input.
     /// </summary>
-    Number
+    Number,
+    /// <summary>
+    /// A file input.
+    /// </summary>
+    File
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -200,7 +200,7 @@ internal class AppHostRpcTarget(
     }
 #pragma warning restore CA1822
 
-    public async Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken = default)
+    public async Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken = default)
     {
         await activityReporter.CompleteInteractionAsync(promptId, answers, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -156,6 +156,11 @@ internal sealed class PublishingPromptInput
     public string? Value { get; init; }
 
     /// <summary>
+    /// Gets or sets the bytes value of the input. Only used by file inputs.
+    /// </summary>
+    public byte[]? ValueBytes { get; init; }
+
+    /// <summary>
     /// Gets the validation errors for the input.
     /// </summary>
     public IReadOnlyList<string>? ValidationErrors { get; init; }
@@ -190,4 +195,10 @@ internal class BackchannelLogEntry
     public required string Message { get; set; }
     public required DateTimeOffset Timestamp { get; set; }
     public required string CategoryName { get; set; }
+}
+
+internal class PublishingPromptInputAnswer
+{
+    public string? Value { get; set; }
+    public byte[]? ValueBytes { get; set; }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -3,6 +3,7 @@
 
 using System.Text.RegularExpressions;
 using Aspire.DashboardService.Proto.V1;
+using Google.Protobuf;
 using Grpc.Core;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Hosting;
@@ -133,6 +134,10 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                                 {
                                     dto.Value = input.Value;
                                 }
+                                if (input.ValueBytes != null)
+                                {
+                                    dto.ValueBytes = ByteString.CopyFrom(input.ValueBytes);
+                                }
                                 if (input.Options != null)
                                 {
                                     dto.Options.Add(input.Options.ToDictionary());
@@ -200,6 +205,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
             ApplicationModel.InputType.Choice => InputType.Choice,
             ApplicationModel.InputType.Boolean => InputType.Boolean,
             ApplicationModel.InputType.Number => InputType.Number,
+            ApplicationModel.InputType.File => InputType.File,
             _ => throw new InvalidOperationException($"Unexpected input type: {inputType}"),
         };
     }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -180,6 +180,11 @@ internal sealed class DashboardServiceData : IDisposable
                             }
 
                             modelInput.SetValue(incomingValue);
+
+                            if (requestInput.InputType == Aspire.DashboardService.Proto.V1.InputType.File)
+                            {
+                                modelInput.SetValueBytes(!string.IsNullOrEmpty(incomingValue) ? requestInput.ValueBytes.ToByteArray() : null);
+                            }
                         }
 
                         return new InteractionCompletionState { Complete = true, State = inputsInfo.Inputs };

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -372,7 +372,8 @@ message InteractionInput {
     bool required = 4;
     map<string, string> options = 5;
     string value = 6;
-    repeated string validation_errors = 7;
+    bytes value_bytes = 7;
+    repeated string validation_errors = 8;
 }
 enum MessageIntent {
     MESSAGE_INTENT_NONE = 0;
@@ -389,6 +390,7 @@ enum InputType {
     INPUT_TYPE_CHOICE = 3;
     INPUT_TYPE_BOOLEAN = 4;
     INPUT_TYPE_NUMBER = 5;
+    INPUT_TYPE_FILE = 6;
 }
 
 ////////////////////////////////////////////

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -293,6 +293,7 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
                 Required = input.Required,
                 Options = input.Options,
                 Value = input.Value,
+                ValueBytes = input.ValueBytes,
                 ValidationErrors = input.ValidationErrors
             }).ToList();
 
@@ -312,7 +313,7 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
         }
     }
 
-    internal async Task CompleteInteractionAsync(string promptId, string?[]? responses, CancellationToken cancellationToken = default)
+    internal async Task CompleteInteractionAsync(string promptId, PublishingPromptInputAnswer[]? responses, CancellationToken cancellationToken = default)
     {
         if (int.TryParse(promptId, CultureInfo.InvariantCulture, out var interactionId))
         {
@@ -326,7 +327,8 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
                         {
                             for (var i = 0; i < Math.Min(inputsInfo.Inputs.Count, responses.Length); i++)
                             {
-                                inputsInfo.Inputs[i].SetValue(responses[i] ?? "");
+                                inputsInfo.Inputs[i].SetValue(responses[i].Value ?? "");
+                                inputsInfo.Inputs[i].SetValueBytes(responses[i].ValueBytes);
                             }
                         }
 

--- a/src/Shared/InteractionConfig.cs
+++ b/src/Shared/InteractionConfig.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Utils;
+
+internal static class InteractionConfig
+{
+    public const int MaxFileSizeMegabytes = 2;
+    public const int MaxFileSizeBytes = MaxFileSizeMegabytes * 1024 * 1024;
+}

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -62,7 +62,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("text-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("production", completedPrompt.Answers[0]);
+        Assert.Equal("production", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("secret-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("SecurePassword123!", completedPrompt.Answers[0]);
+        Assert.Equal("SecurePassword123!", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -161,7 +161,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("choice-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("us-east-1", completedPrompt.Answers[0]);
+        Assert.Equal("us-east-1", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -207,7 +207,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("bool-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("true", completedPrompt.Answers[0]);
+        Assert.Equal("true", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -253,7 +253,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("number-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("3", completedPrompt.Answers[0]);
+        Assert.Equal("3", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -322,13 +322,13 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Equal(3, promptBackchannel.CompletedPrompts.Count);
 
         Assert.Equal("text-prompt-1", promptBackchannel.CompletedPrompts[0].PromptId);
-        Assert.Equal("MyTestApp", promptBackchannel.CompletedPrompts[0].Answers[0]);
+        Assert.Equal("MyTestApp", promptBackchannel.CompletedPrompts[0].Answers[0].Value);
 
         Assert.Equal("choice-prompt-1", promptBackchannel.CompletedPrompts[1].PromptId);
-        Assert.Equal("prod", promptBackchannel.CompletedPrompts[1].Answers[0]);
+        Assert.Equal("prod", promptBackchannel.CompletedPrompts[1].Answers[0].Value);
 
         Assert.Equal("bool-prompt-1", promptBackchannel.CompletedPrompts[2].PromptId);
-        Assert.Equal("true", promptBackchannel.CompletedPrompts[2].Answers[0]);
+        Assert.Equal("true", promptBackchannel.CompletedPrompts[2].Answers[0].Value);
     }
 
     [Fact]
@@ -409,10 +409,10 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("multi-input-prompt-1", completedPrompt.PromptId);
         Assert.Equal(4, completedPrompt.Answers.Length);
-        Assert.Equal("Server=localhost;Database=MyApp;", completedPrompt.Answers[0]);
-        Assert.Equal("secret-api-key-12345", completedPrompt.Answers[1]);
-        Assert.Equal("staging", completedPrompt.Answers[2]);
-        Assert.Equal("true", completedPrompt.Answers[3]);
+        Assert.Equal("Server=localhost;Database=MyApp;", completedPrompt.Answers[0].Value);
+        Assert.Equal("secret-api-key-12345", completedPrompt.Answers[1].Value);
+        Assert.Equal("staging", completedPrompt.Answers[2].Value);
+        Assert.Equal("true", completedPrompt.Answers[3].Value);
     }
 
     [Fact]
@@ -459,7 +459,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("text-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("development", completedPrompt.Answers[0]);
+        Assert.Equal("development", completedPrompt.Answers[0].Value);
 
         // Verify that the PromptForStringAsync was called with the default value
         var promptCalls = consoleService.StringPromptCalls;
@@ -513,7 +513,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("text-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("development", completedPrompt.Answers[0]);
+        Assert.Equal("development", completedPrompt.Answers[0].Value);
 
         // Verify that the PromptForStringAsync was called with the default value
         var promptCalls = consoleService.StringPromptCalls;
@@ -609,7 +609,7 @@ internal sealed class TestPromptBackchannel : IAppHostBackchannel
         _completionSource.SetResult();
     }
 
-    public Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken)
+    public Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken)
     {
         CompletedPrompts.Add(new PromptCompletion(promptId, answers));
         if (_promptCompletionSources.TryGetValue(promptId, out var completionSource))
@@ -643,7 +643,7 @@ internal sealed class TestPromptBackchannel : IAppHostBackchannel
 // Data structures for tracking prompts
 internal sealed record PromptInputData(string Label, string InputType, bool IsRequired, IReadOnlyList<KeyValuePair<string, string>>? Options = null, string? Value = null, IReadOnlyList<string>? ValidationErrors = null);
 internal sealed record PromptData(string PromptId, IReadOnlyList<PromptInputData> Inputs, string Message, string? Title = null);
-internal sealed record PromptCompletion(string PromptId, string?[] Answers);
+internal sealed record PromptCompletion(string PromptId, PublishingPromptInputAnswer[] Answers);
 
 // Enhanced TestConsoleInteractionService that tracks interaction types
 [SuppressMessage("Usage", "ASPIREINTERACTION001:Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostBackchannel.cs
@@ -237,7 +237,7 @@ internal sealed class TestAppHostBackchannel : IAppHostBackchannel
         }
     }
 
-    public Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken)
+    public Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
     }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -1,14 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using System.Threading.Channels;
+using Aspire.DashboardService.Proto.V1;
 using Aspire.Hosting.ConsoleLogs;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Tests.Helpers;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Tests.Utils.Grpc;
 using Aspire.Hosting.Utils;
-using Aspire.DashboardService.Proto.V1;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -278,6 +280,69 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
             Assert.True((await resultTask.DefaultTimeout()).Canceled);
         }
+
+        await CancelTokenAndAwaitTask(cts, task).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task WatchInteractions_PromptInputAsync_CompleteOnResponse()
+    {
+        // Arrange
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddXunit(testOutputHelper);
+        });
+
+        var logger = loggerFactory.CreateLogger<DashboardServiceTests>();
+        var interactionService = new InteractionService(
+            loggerFactory.CreateLogger<InteractionService>(),
+            new DistributedApplicationOptions(),
+            new ServiceCollection().BuildServiceProvider());
+        using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
+        var dashboardService = new DashboardServiceImpl(dashboardServiceData, new TestHostEnvironment(), new TestHostApplicationLifetime(), loggerFactory.CreateLogger<DashboardServiceImpl>());
+
+        var cts = new CancellationTokenSource();
+        var context = TestServerCallContext.Create(cancellationToken: cts.Token);
+        var writer = new TestServerStreamWriter<WatchInteractionsResponseUpdate>(context);
+        var reader = new TestAsyncStreamReader<WatchInteractionsRequestUpdate>(context);
+
+        // Act
+        logger.LogInformation("Calling WatchInteractions.");
+        var task = dashboardService.WatchInteractions(
+            reader,
+            writer,
+            context);
+
+        var resultTask = interactionService.PromptInputAsync(
+            title: "Title!",
+            message: "Message!",
+            new ApplicationModel.InteractionInput { InputType = ApplicationModel.InputType.File, Label = "Input" });
+
+        // Assert
+        logger.LogInformation("Reading result from writer.");
+        var update = await writer.ReadNextAsync().DefaultTimeout();
+
+        Assert.NotEqual(0, update.InteractionId);
+        Assert.Equal(WatchInteractionsResponseUpdate.KindOneofCase.InputsDialog, update.KindCase);
+
+        Assert.False(resultTask.IsCompleted);
+
+        logger.LogInformation("Send result to reader.");
+        update.InputsDialog.InputItems[0].Value = "FileName.txt";
+        update.InputsDialog.InputItems[0].ValueBytes = ByteString.CopyFromUtf8("File content");
+        reader.AddMessage(new WatchInteractionsRequestUpdate
+        {
+            InteractionId = update.InteractionId,
+            InputsDialog = update.InputsDialog
+        });
+
+        var result = await resultTask.DefaultTimeout();
+        Assert.False(result.Canceled);
+
+        var input = result.Data;
+        Assert.Equal("FileName.txt", input.Value);
+        Assert.Equal(Encoding.UTF8.GetBytes("File content"), input.ValueBytes);
 
         await CancelTokenAndAwaitTask(cts, task).DefaultTimeout();
     }

--- a/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityProgressReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityProgressReporterTests.cs
@@ -482,7 +482,7 @@ public class PublishingActivityProgressReporterTests
         Assert.Equal("text-label", input.Label);
         Assert.Equal("Text", input.InputType);
 
-        var responses = new string[] { "user-response" };
+        var responses = new PublishingPromptInputAnswer[] { new PublishingPromptInputAnswer { Value = "user-response" } };
 
         // Act
         await reporter.CompleteInteractionAsync(promptId, responses, CancellationToken.None);


### PR DESCRIPTION
## Description

Add support for file input with InteractionService. The max file size is currently 2MB. If we want to support larger files then we'll need to increase the max allowed message size in gRPC.

Select file:
![image](https://github.com/user-attachments/assets/7fb3f919-d820-407b-a198-98e2ba92d99b)

Uploaded file:
![image](https://github.com/user-attachments/assets/e3493d43-60bc-4169-85d8-ae2f3215dc62)

~TODO: CLI needs to be updated to support new input type.~

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
