### PR TITLE
Added support for prompting for parameter values in run mode

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/MissingParameterValueException.cs
+++ b/src/Aspire.Hosting/ApplicationModel/MissingParameterValueException.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// The exception that is thrown when a parameter resource cannot be initialized because its value is missing or cannot be resolved.
+/// </summary>
+/// <remarks>
+/// This exception is typically thrown when:
+/// <list type="bullet">
+/// <item><description>A parameter value is not provided in configuration and has no default value</description></item>
+/// <item><description>A parameter's value callback throws an exception during execution</description></item>
+/// <item><description>A parameter's value cannot be retrieved from the configured source (e.g., user secrets, environment variables)</description></item>
+/// </list>
+/// </remarks>
+public class MissingParameterValueException : DistributedApplicationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingParameterValueException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public MissingParameterValueException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingParameterValueException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+    public MissingParameterValueException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -350,6 +350,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
             // Orchestrator
             _innerBuilder.Services.AddSingleton<ApplicationOrchestrator>();
+            _innerBuilder.Services.AddSingleton<ParameterProcessor>();
             _innerBuilder.Services.AddHostedService<OrchestratorHostService>();
 
             // DCP stuff

--- a/src/Aspire.Hosting/MissingParameterValueException.cs
+++ b/src/Aspire.Hosting/MissingParameterValueException.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Hosting.ApplicationModel;
+namespace Aspire.Hosting;
 
 /// <summary>
 /// The exception that is thrown when a parameter resource cannot be initialized because its value is missing or cannot be resolved.

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -114,10 +114,17 @@ internal sealed class ParameterProcessor(
         }
     }
 
-    public async Task HandleUnresolvedParametersAsync()
+    // Internal for testing purposes.
+    private async Task HandleUnresolvedParametersAsync()
+    {
+        await HandleUnresolvedParametersAsync(_unresolvedParameters).ConfigureAwait(false);
+    }
+
+    // Internal for testing purposes - allows passing specific parameters to test.
+    internal async Task HandleUnresolvedParametersAsync(IList<ParameterResource> unresolvedParameters)
     {
         // This method will continue in a loop until all unresolved parameters are resolved.
-        while (_unresolvedParameters.Count > 0)
+        while (unresolvedParameters.Count > 0)
         {
             // First we show a notification that there are unresolved parameters.
             var result = await interactionService.PromptMessageBarAsync(
@@ -135,7 +142,7 @@ internal sealed class ParameterProcessor(
                 // Now we build up a new form base on the unresolved parameters.
                 var inputs = new List<InteractionInput>();
 
-                foreach (var parameter in _unresolvedParameters)
+                foreach (var parameter in unresolvedParameters)
                 {
                     // Create an input for each unresolved parameter.
                     inputs.Add(new InteractionInput
@@ -161,9 +168,9 @@ internal sealed class ParameterProcessor(
                 if (!valuesPrompt.Canceled)
                 {
                     // Iterate through the unresolved parameters and set their values based on user input.
-                    for (var i = _unresolvedParameters.Count - 1; i >= 0; i--)
+                    for (var i = unresolvedParameters.Count - 1; i >= 0; i--)
                     {
-                        var parameter = _unresolvedParameters[i];
+                        var parameter = unresolvedParameters[i];
                         var inputValue = valuesPrompt.Data[i].Value;
 
                         if (inputValue is null)
@@ -186,7 +193,7 @@ internal sealed class ParameterProcessor(
                         .ConfigureAwait(false);
 
                         // Remove the parameter from unresolved parameters list.
-                        _unresolvedParameters.RemoveAt(i);
+                        unresolvedParameters.RemoveAt(i);
                     }
                 }
             }

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -148,7 +148,6 @@ internal sealed class ParameterProcessor(
                         InputType = parameter.Secret ? InputType.SecretText : InputType.Text,
                         Label = parameter.Name,
                         Placeholder = "Enter value for " + parameter.Name,
-                        Required = true,
                     });
                 }
 
@@ -158,7 +157,7 @@ internal sealed class ParameterProcessor(
                     inputs,
                     new InputsDialogInteractionOptions
                     {
-                        PrimaryButtonText = "Submit",
+                        PrimaryButtonText = "Save",
                         ShowDismiss = true
                     })
                     .ConfigureAwait(false);
@@ -171,7 +170,7 @@ internal sealed class ParameterProcessor(
                         var parameter = unresolvedParameters[i];
                         var inputValue = valuesPrompt.Data[i].Value;
 
-                        if (inputValue is null)
+                        if (string.IsNullOrEmpty(inputValue))
                         {
                             // If the input value is null, we skip this parameter.
                             continue;

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -1,0 +1,195 @@
+#pragma warning disable ASPIREINTERACTION001
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Orchestrator;
+
+/// <summary>
+/// Handles processing of parameter resources during application orchestration.
+/// </summary>
+internal sealed class ParameterProcessor(
+    ResourceNotificationService notificationService,
+    ResourceLoggerService loggerService,
+    IInteractionService interactionService,
+    ILogger<ParameterProcessor> logger)
+{
+    private readonly ResourceNotificationService _notificationService = notificationService;
+    private readonly ResourceLoggerService _loggerService = loggerService;
+    private readonly List<ParameterResource> _unresolvedParameters = [];
+
+    public async Task InitializeParametersAsync(IEnumerable<ParameterResource> parameterResources)
+    {
+        // Initialize all parameter resources by setting their WaitForValueTcs.
+        // This allows them to be processed asynchronously later.
+        foreach (var parameterResource in parameterResources)
+        {
+            parameterResource.WaitForValueTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            await ProcessParameterAsync(parameterResource).ConfigureAwait(false);
+        }
+
+        // If interaction service is available, we can handle unresolved parameters.
+        // This will allow the user to provide values for parameters that could not be initialized.
+        if (interactionService.IsAvailable)
+        {
+            // All parameters have been processed, we can now handle unresolved parameters if any.
+            if (_unresolvedParameters.Count > 0)
+            {
+                // Start the loop that will allow the user to specify values for unresolved parameters.
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await HandleUnresolvedParametersAsync().ConfigureAwait(false);
+
+                        logger.LogDebug("All unresolved parameters have been handled successfully.");
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Failed to handle unresolved parameters");
+                    }
+                });
+            }
+        }
+    }
+
+    private async Task ProcessParameterAsync(ParameterResource parameterResource)
+    {
+        try
+        {
+            var value = parameterResource.Value ?? "";
+
+            await _notificationService.PublishUpdateAsync(parameterResource, s =>
+            {
+                return s with
+                {
+                    Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, value, parameterResource.Secret),
+                    State = new(KnownResourceStates.Active, KnownResourceStateStyles.Success)
+                };
+            })
+            .ConfigureAwait(false);
+
+            parameterResource.WaitForValueTcs?.SetResult(value);
+        }
+        catch (Exception ex)
+        {
+            // Missing parameter values throw a MissingParameterValueException.
+            if (interactionService.IsAvailable && ex is MissingParameterValueException)
+            {
+                // If interaction service is available, we can prompt the user to provide a value.
+                // Add the parameter to unresolved parameters list.
+                _unresolvedParameters.Add(parameterResource);
+
+                _loggerService.GetLogger(parameterResource)
+                    .LogWarning(ex, "Parameter resource {ResourceName} could not be initialized. Waiting for user input.", parameterResource.Name);
+            }
+            else
+            {
+                // If interaction service is not available, we log the error and set the state to error.
+                parameterResource.WaitForValueTcs?.SetException(ex);
+
+                _loggerService.GetLogger(parameterResource)
+                    .LogError(ex, "Failed to initialize parameter resource {ResourceName}", parameterResource.Name);
+            }
+
+            var stateText = ex is MissingParameterValueException ?
+                "Value missing" :
+                "Error initializing parameter";
+
+            await _notificationService.PublishUpdateAsync(parameterResource, s =>
+            {
+                return s with
+                {
+                    State = new(stateText, KnownResourceStateStyles.Error),
+                    Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, ex.Message),
+                    IsHidden = false
+                };
+            })
+            .ConfigureAwait(false);
+        }
+    }
+
+    public async Task HandleUnresolvedParametersAsync()
+    {
+        // This method will continue in a loop until all unresolved parameters are resolved.
+        while (_unresolvedParameters.Count > 0)
+        {
+            // First we show a notification that there are unresolved parameters.
+            var result = await interactionService.PromptMessageBarAsync(
+                 "Unresolved Parameters",
+                 "There are unresolved parameters that need to be set. Please provide values for them.",
+                 new MessageBarInteractionOptions
+                 {
+                     Intent = MessageIntent.Warning,
+                     PrimaryButtonText = "Enter Values"
+                 })
+                 .ConfigureAwait(false);
+
+            if (result.Data)
+            {
+                // Now we build up a new form base on the unresolved parameters.
+                var inputs = new Dictionary<ParameterResource, InteractionInput>();
+
+                foreach (var parameter in _unresolvedParameters)
+                {
+                    // Create an input for each unresolved parameter.
+                    inputs.Add(parameter, new InteractionInput
+                    {
+                        InputType = parameter.Secret ? InputType.SecretText : InputType.Text,
+                        Label = parameter.Name,
+                        Placeholder = "Enter value for " + parameter.Name,
+                        Required = true,
+                    });
+                }
+
+                var valuesPrompt = await interactionService.PromptInputsAsync(
+                    "Set Unresolved Parameters",
+                    "Please provide values for the unresolved parameters.",
+                    [.. inputs.Values],
+                    new InputsDialogInteractionOptions
+                    {
+                        PrimaryButtonText = "Submit",
+                        ShowDismiss = true
+                    })
+                    .ConfigureAwait(false);
+
+                if (!valuesPrompt.Canceled)
+                {
+                    // Iterate through the unresolved parameters and set their values based on user input.
+                    for (var i = _unresolvedParameters.Count - 1; i >= 0; i--)
+                    {
+                        var parameter = _unresolvedParameters[i];
+                        var inputValue = valuesPrompt.Data[i].Value;
+
+                        if (inputValue is null)
+                        {
+                            // If the input value is null, we skip this parameter.
+                            continue;
+                        }
+
+                        parameter.WaitForValueTcs?.TrySetResult(inputValue);
+
+                        // Update the parameter resource state to active with the provided value.
+                        await _notificationService.PublishUpdateAsync(parameter, s =>
+                        {
+                            return s with
+                            {
+                                Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, inputValue, parameter.Secret),
+                                State = new(KnownResourceStates.Active, KnownResourceStateStyles.Success)
+                            };
+                        })
+                        .ConfigureAwait(false);
+
+                        // Remove the parameter from unresolved parameters list.
+                        _unresolvedParameters.RemoveAt(i);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -133,12 +133,12 @@ internal sealed class ParameterProcessor(
             if (result.Data)
             {
                 // Now we build up a new form base on the unresolved parameters.
-                var inputs = new Dictionary<ParameterResource, InteractionInput>();
+                var inputs = new List<InteractionInput>();
 
                 foreach (var parameter in _unresolvedParameters)
                 {
                     // Create an input for each unresolved parameter.
-                    inputs.Add(parameter, new InteractionInput
+                    inputs.Add(new InteractionInput
                     {
                         InputType = parameter.Secret ? InputType.SecretText : InputType.Text,
                         Label = parameter.Name,
@@ -150,7 +150,7 @@ internal sealed class ParameterProcessor(
                 var valuesPrompt = await interactionService.PromptInputsAsync(
                     "Set Unresolved Parameters",
                     "Please provide values for the unresolved parameters.",
-                    [.. inputs.Values],
+                    [.. inputs],
                     new InputsDialogInteractionOptions
                     {
                         PrimaryButtonText = "Submit",

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -153,7 +153,7 @@ public static class ParameterResourceBuilderExtensions
         configurationKey ??= $"Parameters:{name}";
         return configuration[configurationKey]
             ?? parameterDefault?.GetDefaultValue()
-            ?? throw new DistributedApplicationException($"Parameter resource could not be used because configuration key '{configurationKey}' is missing and the Parameter has no default value.");
+            ?? throw new MissingParameterValueException($"Parameter resource could not be used because configuration key '{configurationKey}' is missing and the Parameter has no default value.");
     }
 
     internal static IResourceBuilder<T> AddParameter<T>(this IDistributedApplicationBuilder builder, T resource)
@@ -191,7 +191,7 @@ public static class ParameterResourceBuilderExtensions
                 new ConnectionStringParameterResource(
                     name,
                     _ => builder.Configuration.GetConnectionString(name) ??
-                        throw new DistributedApplicationException($"Connection string parameter resource could not be used because connection string '{name}' is missing."),
+                        throw new MissingParameterValueException($"Connection string parameter resource could not be used because connection string '{name}' is missing."),
                     environmentVariableName)
                 );
     }

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Aspire.Hosting.Tests.Orchestrator;
@@ -444,6 +445,7 @@ public class ApplicationOrchestratorTests
         ResourceLoggerService? resourceLoggerService = null)
     {
         var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        resourceLoggerService ??= new ResourceLoggerService();
 
         return new ApplicationOrchestrator(
             distributedAppModel,
@@ -451,12 +453,25 @@ public class ApplicationOrchestratorTests
             dcpEvents ?? new DcpExecutorEvents(),
             [],
             notificationService,
-            resourceLoggerService ?? new ResourceLoggerService(),
+            resourceLoggerService,
             applicationEventing ?? new DistributedApplicationEventing(),
             serviceProvider,
             new DistributedApplicationExecutionContext(
-                new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = serviceProvider })
+                new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = serviceProvider }),
+            new ParameterProcessor(
+                notificationService,
+                resourceLoggerService,
+                CreateInteractionService(),
+                NullLogger<ParameterProcessor>.Instance)
             );
+    }
+
+    private static InteractionService CreateInteractionService(DistributedApplicationOptions? options = null)
+    {
+        return new InteractionService(
+            NullLogger<InteractionService>.Instance,
+            options ?? new DistributedApplicationOptions(),
+            new ServiceCollection().BuildServiceProvider());
     }
 
     private sealed class CustomResource(string name) : Resource(name);

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -204,16 +204,19 @@ public class ParameterProcessorTests
             {
                 Assert.Equal("param1", input.Label);
                 Assert.Equal(InputType.Text, input.InputType);
+                Assert.False(input.Required);
             },
             input =>
             {
                 Assert.Equal("param2", input.Label);
                 Assert.Equal(InputType.Text, input.InputType);
+                Assert.False(input.Required);
             },
             input =>
             {
                 Assert.Equal("secretParam", input.Label);
                 Assert.Equal(InputType.SecretText, input.InputType);
+                Assert.False(input.Required);
             });
 
         inputsInteraction.Inputs[0].SetValue("value1");

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -188,7 +188,7 @@ public class ParameterProcessorTests
 
         // Assert - Wait for the first interaction (message bar)
         var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        Assert.Equal("Unresolved Parameters", messageBarInteraction.Title);
+        Assert.Equal("Unresolved parameters", messageBarInteraction.Title);
         Assert.Equal("There are unresolved parameters that need to be set. Please provide values for them.", messageBarInteraction.Message);
 
         // Complete the message bar interaction to proceed to inputs dialog
@@ -196,7 +196,7 @@ public class ParameterProcessorTests
 
         // Wait for the inputs interaction
         var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        Assert.Equal("Set Unresolved Parameters", inputsInteraction.Title);
+        Assert.Equal("Set unresolved parameters", inputsInteraction.Title);
         Assert.Equal("Please provide values for the unresolved parameters.", inputsInteraction.Message);
 
         Assert.Collection(inputsInteraction.Inputs,
@@ -264,14 +264,14 @@ public class ParameterProcessorTests
 
         // Wait for the message bar interaction
         var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        Assert.Equal("Unresolved Parameters", messageBarInteraction.Title);
+        Assert.Equal("Unresolved parameters", messageBarInteraction.Title);
 
         // Complete the message bar interaction with false (user chose not to enter values)
         messageBarInteraction.CompletionTcs.SetResult(new InteractionResult<bool>(false, false)); // Data = false (user dismissed/cancelled)
 
         // Assert that the message bar will show up again if there are still unresolved parameters
         var nextMessageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        Assert.Equal("Unresolved Parameters", nextMessageBarInteraction.Title);
+        Assert.Equal("Unresolved parameters", nextMessageBarInteraction.Title);
 
         // Assert - Parameter should remain unresolved since user cancelled
         Assert.NotNull(parameterWithMissingValue.WaitForValueTcs);

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -161,7 +161,7 @@ public class ParameterProcessorTests
     }
 
     [Fact]
-    public async Task HandleUnresolvedParametersAsync_WithMultipleUnresolvedParameters_CreatesInteractions()
+    public void HandleUnresolvedParametersAsync_WithMultipleUnresolvedParameters_CreatesInteractions()
     {
         // Arrange
         var interactionService = CreateInteractionService();
@@ -170,8 +170,16 @@ public class ParameterProcessorTests
         var param2 = CreateParameterWithMissingValue("param2");
         var secretParam = CreateParameterWithMissingValue("secretParam");
 
+        ParameterResource[] parameters = [param1, param2, secretParam];
+
+        foreach (var param in parameters)
+        {
+            // Initialize the parameters' WaitForValueTcs
+            param.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
         // Act - Initialize parameters to add them to unresolved list
-        await parameterProcessor.HandleUnresolvedParametersAsync([param1, param2, secretParam]);
+        var task = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
 
         // Assert - All parameters should be unresolved and interaction should be created
         Assert.NotNull(param1.WaitForValueTcs);

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Orchestrator;
+using Aspire.Hosting.Tests.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+namespace Aspire.Hosting.Tests.Orchestrator;
+
+public class ParameterProcessorTests
+{
+    [Fact]
+    public async Task InitializeParametersAsync_WithValidParameters_SetsActiveState()
+    {
+        // Arrange
+        var parameterProcessor = CreateParameterProcessor();
+        var parameters = new[]
+        {
+            CreateParameterResource("param1", "value1"),
+            CreateParameterResource("param2", "value2")
+        };
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync(parameters);
+
+        // Assert
+        foreach (var param in parameters)
+        {
+            Assert.NotNull(param.WaitForValueTcs);
+            Assert.True(param.WaitForValueTcs.Task.IsCompletedSuccessfully);
+            Assert.Equal(param.Value, await param.WaitForValueTcs.Task);
+        }
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithSecretParameter_MarksAsSecret()
+    {
+        // Arrange
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var parameterProcessor = CreateParameterProcessor(notificationService: notificationService);
+        var secretParam = CreateParameterResource("secret", "secretValue", secret: true);
+
+        var updates = new List<(IResource Resource, CustomResourceSnapshot Snapshot)>();
+        var watchTask = Task.Run(async () =>
+        {
+            await foreach (var resourceEvent in notificationService.WatchAsync().ConfigureAwait(false))
+            {
+                updates.Add((resourceEvent.Resource, resourceEvent.Snapshot));
+                break; // Only collect the first update
+            }
+        });
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync([secretParam]);
+
+        // Wait for the notification
+        await watchTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert
+        Assert.Single(updates);
+        var (resource, snapshot) = updates[0];
+        Assert.Equal(secretParam, resource);
+        Assert.Equal(KnownResourceStates.Active, snapshot.State?.Text);
+        Assert.Equal(KnownResourceStateStyles.Success, snapshot.State?.Style);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithMissingParameterValue_AddsToUnresolvedWhenInteractionAvailable()
+    {
+        // Arrange
+        var interactionService = CreateInteractionService();
+        var parameterProcessor = CreateParameterProcessor(interactionService: interactionService);
+        var parameterWithMissingValue = CreateParameterWithMissingValue("missingParam");
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]);
+
+        // Assert
+        Assert.NotNull(parameterWithMissingValue.WaitForValueTcs);
+        Assert.False(parameterWithMissingValue.WaitForValueTcs.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithMissingParameterValue_SetsExceptionWhenInteractionNotAvailable()
+    {
+        // Arrange
+        var interactionService = CreateInteractionService(disableDashboard: true);
+        var parameterProcessor = CreateParameterProcessor(interactionService: interactionService);
+        var parameterWithMissingValue = CreateParameterWithMissingValue("missingParam");
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]);
+
+        // Assert
+        Assert.NotNull(parameterWithMissingValue.WaitForValueTcs);
+        Assert.True(parameterWithMissingValue.WaitForValueTcs.Task.IsCompleted);
+        Assert.True(parameterWithMissingValue.WaitForValueTcs.Task.IsFaulted);
+        Assert.IsType<MissingParameterValueException>(parameterWithMissingValue.WaitForValueTcs.Task.Exception?.InnerException);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithNonMissingParameterException_SetsException()
+    {
+        // Arrange
+        var parameterProcessor = CreateParameterProcessor();
+        var parameterWithError = CreateParameterWithGenericError("errorParam");
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync([parameterWithError]);
+
+        // Assert
+        Assert.NotNull(parameterWithError.WaitForValueTcs);
+        Assert.True(parameterWithError.WaitForValueTcs.Task.IsCompleted);
+        Assert.True(parameterWithError.WaitForValueTcs.Task.IsFaulted);
+        Assert.IsType<InvalidOperationException>(parameterWithError.WaitForValueTcs.Task.Exception?.InnerException);
+    }
+
+    [Fact]
+    public async Task HandleUnresolvedParametersAsync_WithInteractionService_DoesNotThrow()
+    {
+        // Arrange
+        var interactionService = CreateInteractionService();
+        var parameterProcessor = CreateParameterProcessor(interactionService: interactionService);
+        var parameterWithMissingValue = CreateParameterWithMissingValue("missingParam");
+
+        // Act - Initialize parameters first to add to unresolved list
+        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]);
+
+        // Allow background task to start
+        await Task.Delay(50);
+
+        // Assert - The background task should have started without throwing
+        Assert.NotNull(parameterWithMissingValue.WaitForValueTcs);
+        // The parameter should remain unresolved since we don't complete the interaction
+        Assert.False(parameterWithMissingValue.WaitForValueTcs.Task.IsCompleted);
+        
+        // Verify there's an active interaction for the parameter
+        var interactions = interactionService.GetCurrentInteractions();
+        Assert.NotEmpty(interactions);
+    }
+
+    [Fact]
+    public async Task HandleUnresolvedParametersAsync_CallDirectly_DoesNotThrow()
+    {
+        // Arrange
+        var interactionService = CreateInteractionService();
+        var parameterProcessor = CreateParameterProcessor(interactionService: interactionService);
+
+        // Act & Assert - Should not throw even when called directly with no unresolved parameters
+        await parameterProcessor.HandleUnresolvedParametersAsync();
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithEmptyParameterList_CompletesSuccessfully()
+    {
+        // Arrange
+        var parameterProcessor = CreateParameterProcessor();
+
+        // Act & Assert - Should not throw
+        await parameterProcessor.InitializeParametersAsync(Array.Empty<ParameterResource>());
+    }
+
+    private static ParameterProcessor CreateParameterProcessor(
+        ResourceNotificationService? notificationService = null,
+        ResourceLoggerService? loggerService = null,
+        IInteractionService? interactionService = null,
+        ILogger<ParameterProcessor>? logger = null,
+        bool disableDashboard = true)
+    {
+        return new ParameterProcessor(
+            notificationService ?? ResourceNotificationServiceTestHelpers.Create(),
+            loggerService ?? new ResourceLoggerService(),
+            interactionService ?? CreateInteractionService(disableDashboard),
+            logger ?? new NullLogger<ParameterProcessor>()
+        );
+    }
+
+    private static InteractionService CreateInteractionService(bool disableDashboard = false)
+    {
+        return new InteractionService(
+            new NullLogger<InteractionService>(),
+            new DistributedApplicationOptions { DisableDashboard = disableDashboard },
+            new ServiceCollection().BuildServiceProvider());
+    }
+
+    private static ParameterResource CreateParameterResource(string name, string value, bool secret = false)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { [$"Parameters:{name}"] = value })
+            .Build();
+
+        return new ParameterResource(name, _ => configuration[$"Parameters:{name}"] ?? throw new MissingParameterValueException($"Parameter '{name}' is missing"), secret);
+    }
+
+    private static ParameterResource CreateParameterWithMissingValue(string name)
+    {
+        return new ParameterResource(name, _ => throw new MissingParameterValueException($"Parameter '{name}' is missing"), secret: false);
+    }
+
+    private static ParameterResource CreateParameterWithGenericError(string name)
+    {
+        return new ParameterResource(name, _ => throw new InvalidOperationException($"Generic error for parameter '{name}'"), secret: false);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -161,7 +161,7 @@ public class WithEnvironmentTests
         var projectA = builder.AddProject<ProjectA>("projectA")
             .WithEnvironment("MY_PARAMETER", parameter);
 
-        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () => await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
+        var exception = await Assert.ThrowsAsync<MissingParameterValueException>(async () => await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             projectA.Resource,
             DistributedApplicationOperation.Run,
             TestServiceProvider.Instance

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -191,7 +191,7 @@ public class WithReferenceTests
                               .WithReference(missingResource);
 
         // Call environment variable callbacks.
-        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
+        var exception = await Assert.ThrowsAsync<MissingParameterValueException>(async () =>
         {
             var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
         }).DefaultTimeout();


### PR DESCRIPTION
## Description

- Handle prompting for parameters once they have all been processed. This also handles re-prompting until they have all been processed.
- Introduced MissingParameterValueException to detect when parameters are have a missing value.
- Moved all parameter processing logic into ParameterProcessor


https://github.com/user-attachments/assets/4ee83c3a-6b2e-4177-8b46-002ccc9e80c8


**Missing features**
- Optional persistence of parameters to user secrets
- Changing the state of dependent waiting resources to "waiting on parameter" or something like that.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
