### PR TITLE
Subscribe to this specific resource, not all.

### DIFF
--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -45,7 +45,7 @@ public static class YarpResourceExtensions
             // perspective, the url will be something like https://docker.host.internal, so it will NOT be valid.
             yarpBuilder.WithEnvironment("YARP_UNSAFE_OLTP_CERT_ACCEPT_ANY_SERVER_CERTIFICATE", "true");
 
-            yarpBuilder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>((ctx, ct) =>
+            yarpBuilder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(resource, (ctx, ct) =>
             {
                 configBuilder.BuildAndPopulateEnvironment();
                 return Task.CompletedTask;


### PR DESCRIPTION
Fix a regression where yarp failing to resolve an env would break the dashboard.