### PR TITLE
Use log output channel and remove abstraction

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -10,12 +10,12 @@ import { configCommand } from './commands/config';
 import { deployCommand } from './commands/deploy';
 import { publishCommand } from './commands/publish';
 import { errorMessage } from './loc/strings';
-import { vscOutputChannelWriter } from './utils/logging';
+import { extensionLogOutputChannel } from './utils/logging';
 
 export let rpcServerInfo: RpcServerInformation | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
-	vscOutputChannelWriter.appendLine("lifecycle", "Activating Aspire extension");
+	extensionLogOutputChannel.info("Activating Aspire extension");
 
 	const cliRunCommand = vscode.commands.registerCommand('aspire-vscode.run', () => tryExecuteCommand(runCommand));
 	const cliAddCommand = vscode.commands.registerCommand('aspire-vscode.add', () => tryExecuteCommand(addCommand));
@@ -27,9 +27,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(cliRunCommand, cliAddCommand, cliNewCommand, cliConfigCommand, cliDeployCommand, cliPublishCommand);
 
 	rpcServerInfo = await createRpcServer(
-		connection => new InteractionService(vscOutputChannelWriter),
-		(connection, token: string) => new RpcClient(connection, token),
-		vscOutputChannelWriter
+		connection => new InteractionService(),
+		(connection, token: string) => new RpcClient(connection, token)
 	);
 
 	// Return exported API for tests or other extensions

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -4,7 +4,9 @@ import { isFolderOpenInWorkspace } from '../utils/workspace';
 import { yesLabel, noLabel, directLink, codespacesLink, openAspireDashboard, failedToShowPromptEmpty, incompatibleAppHostError, aspireHostingSdkVersion, aspireCliVersion, requiredCapability, fieldRequired } from '../loc/strings';
 import { ICliRpcClient } from './rpcClient';
 import { formatText } from '../utils/strings';
-import { IOutputChannelWriter } from '../utils/logging';
+import { extensionLogOutputChannel } from '../utils/logging';
+
+type CSLogLevel = 'Trace' | 'Debug' | 'Info' | 'Warn' | 'Error' | 'Critical';
 
 export interface IInteractionService {
     showStatus: (statusText: string | null) => void;
@@ -21,7 +23,7 @@ export interface IInteractionService {
     displayLines: (lines: ConsoleLine[]) => void;
     displayCancellationMessage: (message: string) => void;
     openProject: (projectPath: string) => void;
-    logMessage: (logLevel: string, message: string) => void;
+    logMessage: (logLevel: CSLogLevel, message: string) => void;
 }
 
 type DashboardUrls = {
@@ -35,15 +37,10 @@ type ConsoleLine = {
 };
 
 export class InteractionService implements IInteractionService {
-    private _outputChannelWriter: IOutputChannelWriter;
     private _statusBarItem: vscode.StatusBarItem | undefined;
 
-    constructor(_outputChannelWriter: IOutputChannelWriter) {
-        this._outputChannelWriter = _outputChannelWriter;
-    }
-
     showStatus(statusText: string | null) {
-        this._outputChannelWriter.appendLine('interaction', `Setting status bar text: ${statusText ?? 'null'}`);
+        extensionLogOutputChannel.info(`Setting status bar text: ${statusText ?? 'null'}`);
 
         if (!this._statusBarItem) {
             this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
@@ -60,11 +57,11 @@ export class InteractionService implements IInteractionService {
     async promptForString(promptText: string, defaultValue: string | null, required: boolean, rpcClient: ICliRpcClient): Promise<string | null> {
         if (!promptText) {
             vscode.window.showErrorMessage(failedToShowPromptEmpty);
-            this._outputChannelWriter.appendLine('interaction', failedToShowPromptEmpty);
+            extensionLogOutputChannel.error(failedToShowPromptEmpty);
             return null;
         }
 
-        this._outputChannelWriter.appendLine('interaction', `Prompting for string: ${promptText} with default value: ${defaultValue ?? 'null'}`);
+        extensionLogOutputChannel.info(`Prompting for string: ${promptText} with default value: ${defaultValue ?? 'null'}`);
         const input = await vscode.window.showInputBox({
             prompt: formatText(promptText),
             value: formatText(defaultValue ?? ''),
@@ -88,7 +85,7 @@ export class InteractionService implements IInteractionService {
     }
 
     async confirm(promptText: string, defaultValue: boolean): Promise<boolean | null> {
-        this._outputChannelWriter.appendLine('interaction', `Confirming: ${promptText} with default value: ${defaultValue}`);
+        extensionLogOutputChannel.info(`Confirming: ${promptText} with default value: ${defaultValue}`);
         const yes = yesLabel;
         const no = noLabel;
 
@@ -111,7 +108,7 @@ export class InteractionService implements IInteractionService {
     }
 
     async promptForSelection(promptText: string, choices: string[]): Promise<string | null> {
-        this._outputChannelWriter.appendLine('interaction', `Prompting for selection: ${promptText}`);
+        extensionLogOutputChannel.info(`Prompting for selection: ${promptText}`);
 
         const selected = await vscode.window.showQuickPick(choices, {
             placeHolder: formatText(promptText),
@@ -123,7 +120,7 @@ export class InteractionService implements IInteractionService {
     }
 
     async displayIncompatibleVersionError(requiredCapabilityStr: string, appHostHostingSdkVersion: string, rpcClient: ICliRpcClient) {
-        this._outputChannelWriter.appendLine('interaction', `Displaying incompatible version error`);
+        extensionLogOutputChannel.info(`Displaying incompatible version error`);
 
         const cliInformationalVersion = await rpcClient.getCliVersion();
 
@@ -137,40 +134,40 @@ export class InteractionService implements IInteractionService {
         vscode.window.showErrorMessage(formatText(errorLines.join('. ')));
 
         errorLines.forEach(line => {
-            this._outputChannelWriter.appendLine("interaction", formatText(line));
+            extensionLogOutputChannel.error(formatText(line));
         });
     }
 
     displayError(errorMessage: string) {
-        this._outputChannelWriter.appendLine('interaction', `Displaying error: ${errorMessage}`);
+        extensionLogOutputChannel.error(`Displaying error: ${errorMessage}`);
         vscode.window.showErrorMessage(formatText(errorMessage));
         this.clearStatusBar();
     }
 
     displayMessage(emoji: string, message: string) {
-        this._outputChannelWriter.appendLine('interaction', `Displaying message: ${emoji} ${message}`);
+        extensionLogOutputChannel.info(`Displaying message: ${emoji} ${message}`);
         vscode.window.showInformationMessage(formatText(message));
     }
 
     // There is no need for a different success message handler, as a general informative message ~= success
     // in extension design philosophy.
     displaySuccess(message: string) {
-        this._outputChannelWriter.appendLine('interaction', `Displaying success message: ${message}`);
+        extensionLogOutputChannel.info(`Displaying success message: ${message}`);
         vscode.window.showInformationMessage(formatText(message));
     }
 
     displaySubtleMessage(message: string) {
-        this._outputChannelWriter.appendLine('interaction', `Displaying subtle message: ${message}`);
+        extensionLogOutputChannel.info(`Displaying subtle message: ${message}`);
         vscode.window.setStatusBarMessage(formatText(message), 5000);
     }
 
     // No direct equivalent in VS Code, so don't display anything visually, just log to output channel.
     displayEmptyLine() {
-        this._outputChannelWriter.append('\n');
+        extensionLogOutputChannel.append('\n');
     }
 
     async displayDashboardUrls(dashboardUrls: DashboardUrls) {
-        this._outputChannelWriter.appendLine('interaction', `Displaying dashboard URLs: ${JSON.stringify(dashboardUrls)}`);
+        extensionLogOutputChannel.info(`Displaying dashboard URLs: ${JSON.stringify(dashboardUrls)}`);
 
         const actions: vscode.MessageItem[] = [
             { title: directLink }
@@ -189,7 +186,7 @@ export class InteractionService implements IInteractionService {
             return;
         }
 
-        this._outputChannelWriter.appendLine('interaction', `Selected action: ${selected.title}`);
+        extensionLogOutputChannel.info(`Selected action: ${selected.title}`);
 
         if (selected.title === directLink) {
             vscode.env.openExternal(vscode.Uri.parse(dashboardUrls.baseUrlWithLoginToken));
@@ -202,16 +199,16 @@ export class InteractionService implements IInteractionService {
     displayLines(lines: ConsoleLine[]) {
         const displayText = lines.map(line => line.line).join('\n');
         vscode.window.showInformationMessage(formatText(displayText));
-        lines.forEach(line => this._outputChannelWriter.appendLine('interaction', formatText(line.line)));
+        lines.forEach(line => extensionLogOutputChannel.info(formatText(line.line)));
     }
 
     displayCancellationMessage(message: string) {
-        this._outputChannelWriter.appendLine('interaction', `Displaying cancellation message: ${message}`);
+        extensionLogOutputChannel.info(`Displaying cancellation message: ${message}`);
         vscode.window.showWarningMessage(formatText(message));
     }
 
     openProject(projectPath: string) {
-        this._outputChannelWriter.appendLine('interaction', `Opening project at path: ${projectPath}`);
+        extensionLogOutputChannel.info(`Opening project at path: ${projectPath}`);
 
         if (isFolderOpenInWorkspace(projectPath)) {
             return;
@@ -221,9 +218,22 @@ export class InteractionService implements IInteractionService {
         vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: false });
     }
 
-    logMessage(logLevel: string, message: string) {
-        // logLevel currently unused, but can be extended in the future
-        this._outputChannelWriter.appendLine('cli', `[${logLevel}] ${formatText(message)}`);
+    logMessage(logLevel: CSLogLevel, message: string) {
+        if (logLevel === 'Trace') {
+            extensionLogOutputChannel.trace(formatText(message));
+        }
+        else if (logLevel === 'Debug') {
+            extensionLogOutputChannel.debug(formatText(message));
+        }
+        else if (logLevel === 'Info') {
+            extensionLogOutputChannel.info(formatText(message));
+        }
+        else if (logLevel === 'Warn') {
+            extensionLogOutputChannel.warn(formatText(message));
+        }
+        else if (logLevel === 'Error' || logLevel === 'Critical') {
+            extensionLogOutputChannel.error(formatText(message));
+        }
     }
 
     clearStatusBar() {

--- a/extension/src/server/rpcClient.ts
+++ b/extension/src/server/rpcClient.ts
@@ -22,7 +22,6 @@ export class RpcClient implements ICliRpcClient {
 
     getCliVersion(): Promise<string> {
         return logAsyncOperation(
-            "interaction",
             `Requesting CLI version from CLI`,
             (version: string) => `Received CLI version: ${version}`,
             async () => {
@@ -33,7 +32,6 @@ export class RpcClient implements ICliRpcClient {
 
     validatePromptInputString(input: string): Promise<ValidationResult | null> {
         return logAsyncOperation(
-            "interaction",
             `Validating prompt input string`,
             (result: ValidationResult | null) => `Received validation result: ${JSON.stringify(result)}`,
             async () => {

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -6,7 +6,7 @@ import { codespacesLink, directLink } from '../../loc/strings';
 import { createRpcServer, RpcServerInformation } from '../../server/rpcServer';
 import { IInteractionService, InteractionService } from '../../server/interactionService';
 import { ICliRpcClient, ValidationResult } from '../../server/rpcClient';
-import { IOutputChannelWriter } from '../../utils/logging';
+import { extensionLogOutputChannel } from '../../utils/logging';
 
 suite('InteractionService endpoints', () => {
 	let statusBarItem: vscode.StatusBarItem;
@@ -124,10 +124,11 @@ suite('InteractionService endpoints', () => {
 	});
 
 	test("displayEmptyLine endpoint", async () => {
+		const stub = sinon.stub(extensionLogOutputChannel, 'append');
 		const testInfo = await createTestRpcServer();
 		testInfo.interactionService.displayEmptyLine();
-		const appendSpy = testInfo.outputChannelWriter.append as sinon.SinonStub;
-		assert.ok(appendSpy.calledWith('\n'));
+		assert.ok(stub.calledWith('\n'));
+		stub.restore();
 	});
 
 	test("displayDashboardUrls shows correct actions and URLs", async () => {
@@ -159,8 +160,9 @@ suite('InteractionService endpoints', () => {
 	});
 
 	test("displayDashboardUrls writes URLs to output channel", async () => {
+		const stub = sinon.stub(extensionLogOutputChannel, 'info');
+		const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
 		const testInfo = await createTestRpcServer();
-		const showInfoMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves(undefined);
 
 		const baseUrl = 'http://localhost';
 		const codespacesUrl = 'http://codespaces';
@@ -168,14 +170,16 @@ suite('InteractionService endpoints', () => {
 			baseUrlWithLoginToken: baseUrl,
 			codespacesUrlWithLoginToken: codespacesUrl
 		});
-		const appendLineStub = testInfo.outputChannelWriter.appendLine as sinon.SinonStub;
-		const outputLines = appendLineStub.getCalls().map(call => call.args[1]);
+		const outputLines = stub.getCalls().map(call => call.args[0]);
 		assert.ok(outputLines.some(line => line.includes(baseUrl)), 'Output should contain base URL');
 		assert.ok(outputLines.some(line => line.includes(codespacesUrl)), 'Output should contain codespaces URL');
-		showInfoMessageStub.restore();
+		assert.equal(showInformationMessageStub.callCount, 1);
+		stub.restore();
+		showInformationMessageStub.restore();
 	});
 
 	test("displayLines endpoint", async () => {
+		const stub = sinon.stub(extensionLogOutputChannel, 'info');
 		const testInfo = await createTestRpcServer();
 		const showInformationMessageSpy = sinon.spy(vscode.window, 'showInformationMessage');
 		testInfo.interactionService.displayLines([
@@ -183,9 +187,8 @@ suite('InteractionService endpoints', () => {
 			{ stream: 'stderr', line: 'line2' }
 		]);
 		assert.ok(showInformationMessageSpy.called);
-		const appendLineStub = testInfo.outputChannelWriter.appendLine as sinon.SinonStub;
-		assert.ok(appendLineStub.calledWith('interaction', 'line1'));
-		assert.ok(appendLineStub.calledWith('interaction', 'line2'));
+		assert.ok(stub.calledWith('line1'));
+		assert.ok(stub.calledWith('line2'));
 		showInformationMessageSpy.restore();
 	});
 
@@ -200,16 +203,9 @@ suite('InteractionService endpoints', () => {
 
 type RpcServerTestInfo = {
 	rpcServerInfo: RpcServerInformation;
-	outputChannelWriter: IOutputChannelWriter;
 	rpcClient: ICliRpcClient;
 	interactionService: IInteractionService;
 };
-
-class TestOutputChannelWriter implements IOutputChannelWriter {
-	append = sinon.stub();
-	appendLine = sinon.stub();
-	show = sinon.stub();
-}
 
 class TestCliRpcClient implements ICliRpcClient {
 	getCliVersion(): Promise<string> {
@@ -230,14 +226,12 @@ class TestCliRpcClient implements ICliRpcClient {
 }
 
 async function createTestRpcServer(): Promise<RpcServerTestInfo> {
-	const outputChannel = new TestOutputChannelWriter();
 	const rpcClient = new TestCliRpcClient();
-	const interactionService = new InteractionService(outputChannel);
+	const interactionService = new InteractionService();
 
 	const rpcServerInfo = await createRpcServer(
 		() => interactionService,
-		() => rpcClient,
-		outputChannel
+		() => rpcClient
 	);
 
 	if (!rpcServerInfo) {
@@ -246,7 +240,6 @@ async function createTestRpcServer(): Promise<RpcServerTestInfo> {
 
 	return {
 		rpcServerInfo,
-		outputChannelWriter: outputChannel,
 		rpcClient: rpcClient,
 		interactionService: interactionService
 	};

--- a/extension/src/utils/logging.ts
+++ b/extension/src/utils/logging.ts
@@ -1,42 +1,17 @@
 import * as vscode from 'vscode';
 import { aspireOutputChannelName } from '../loc/strings';
 
-export type OutputLogCategory = "lifecycle" | "command" | "interaction" | "rpc-server" | "cli";
+export const extensionLogOutputChannel: vscode.LogOutputChannel = vscode.window.createOutputChannel(aspireOutputChannelName, { log: true });
 
-export interface IOutputChannelWriter {
-    appendLine(category: OutputLogCategory, message: string): void;
-    append(message: string): void;
-}
-
-const outputChannel = vscode.window.createOutputChannel(aspireOutputChannelName);
-
-class VSCOutputChannelWriter implements IOutputChannelWriter {
-    private _channel: vscode.OutputChannel;
-
-    constructor() {
-        this._channel = outputChannel;
-    }
-
-    appendLine(category: OutputLogCategory, message: string): void {
-        this._channel.appendLine(`[${category}] ${message}`);
-    }
-
-    append(message: string): void {
-        this._channel.append(message);
-    }
-}
-
-export const vscOutputChannelWriter: IOutputChannelWriter = new VSCOutputChannelWriter();
-
-export async function logAsyncOperation<T>(category: OutputLogCategory, beforeMessage: string, afterMessage: (result: T) => string, operation: () => Promise<T>): Promise<T> {
-    vscOutputChannelWriter.appendLine(category, beforeMessage);
+export async function logAsyncOperation<T>(beforeMessage: string, afterMessage: (result: T) => string, operation: () => Promise<T>): Promise<T> {
+    extensionLogOutputChannel.info( beforeMessage);
     try {
         const result = await operation();
-        vscOutputChannelWriter.appendLine(category, afterMessage(result));
+        extensionLogOutputChannel.info(afterMessage(result));
         return result;
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-        vscOutputChannelWriter.appendLine(category, `Error during operation: ${errorMessage}`);
+        extensionLogOutputChannel.error(`Error during operation: ${errorMessage}`);
         throw error;
     }
 }

--- a/extension/src/utils/terminal.ts
+++ b/extension/src/utils/terminal.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { rpcServerInfo } from '../extension';
 import { aspireTerminalName } from '../loc/strings';
-import { vscOutputChannelWriter } from './logging';
+import { extensionLogOutputChannel } from './logging';
 
 let hasRunGetAspireTerminal = false;
 export function getAspireTerminal(): vscode.Terminal {
@@ -15,7 +15,7 @@ export function getAspireTerminal(): vscode.Terminal {
     if (existingTerminal) {
         if (!hasRunGetAspireTerminal) {
             existingTerminal.dispose();
-            vscOutputChannelWriter.appendLine("lifecycle", `Recreating existing Aspire terminal`);
+            extensionLogOutputChannel.info(`Recreating existing Aspire terminal`);
             hasRunGetAspireTerminal = true;
         }
         else {
@@ -23,7 +23,7 @@ export function getAspireTerminal(): vscode.Terminal {
         }
     }
 
-    vscOutputChannelWriter.appendLine("lifecycle", `Creating new Aspire terminal`);
+    extensionLogOutputChannel.info(`Creating new Aspire terminal`);
 
     const env = {
         ...process.env,
@@ -42,7 +42,7 @@ export function getAspireTerminal(): vscode.Terminal {
 
 export function sendToAspireTerminal(command: string) {
     const terminal = getAspireTerminal();
-    vscOutputChannelWriter.appendLine("command", `Sending command to Aspire terminal: ${command}`);
+    extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${command}`);
     terminal.sendText(command);
     terminal.show();
 }

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -481,6 +481,11 @@ internal sealed class ExtensionBackchannel(ILogger<ExtensionBackchannel> logger,
 
     public async Task LogMessageAsync(LogLevel logLevel, string message, CancellationToken cancellationToken)
     {
+        if (logLevel == LogLevel.None)
+        {
+            return;
+        }
+
         await ConnectAsync(cancellationToken);
 
         using var activity = _activitySource.StartActivity();


### PR DESCRIPTION
…s none

## Description

At the advice of @timheuer, moving logging to a `LogOutputChannel` so that it comes with timestamps and better log level display. Removing the `IOutputChannelWriter` abstraction because I've subsequently found that it's easier just to stub the output channel export in tests.

Also, avoids logging if log level from the cli is none 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
