### PR TITLE
Don't throw in interaction service when no inputs

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
@@ -197,7 +197,7 @@ internal class InteractionService : IInteractionService
         // Run validation for inputs interaction.
         if (result.Complete && interactionState.InteractionInfo is Interaction.InputsInteractionInfo inputsInfo)
         {
-            // State could be null if the user dismissed the inputs dialog.
+            // State could be null if the user dismissed the inputs dialog. There is nothing to validate in this situation.
             if (result.State is IReadOnlyList<InteractionInput> inputs)
             {
                 var options = (InputsDialogInteractionOptions)interactionState.Options;

--- a/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
@@ -250,7 +250,7 @@ internal class InteractionService : IInteractionService
             }
         }
 
-        return false;
+        return true;
     }
 
     internal async IAsyncEnumerable<Interaction> SubscribeInteractionUpdates([EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InteractionService.cs
@@ -197,6 +197,7 @@ internal class InteractionService : IInteractionService
         // Run validation for inputs interaction.
         if (result.Complete && interactionState.InteractionInfo is Interaction.InputsInteractionInfo inputsInfo)
         {
+            // State could be null if the user dismissed the inputs dialog.
             if (result.State is IReadOnlyList<InteractionInput> inputs)
             {
                 var options = (InputsDialogInteractionOptions)interactionState.Options;
@@ -221,10 +222,6 @@ internal class InteractionService : IInteractionService
                         result = new InteractionCompletionState { Complete = false, State = inputs };
                     }
                 }
-            }
-            else
-            {
-                throw new InvalidOperationException($"Expected state of {typeof(IReadOnlyList<InteractionInput>).FullName} for completed inputs interaction.");
             }
         }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -154,7 +154,7 @@ internal sealed class DashboardServiceData : IDisposable
     {
         await _interactionService.CompleteInteractionAsync(
             request.InteractionId,
-            (interaction, serviceProvider, cancellationToken) =>
+            (interaction, serviceProvider) =>
             {
                 switch (request.KindCase)
                 {

--- a/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityProgressReporter.cs
@@ -273,7 +273,7 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
         {
             if (HasStepsInProgress())
             {
-                await _interactionService.CompleteInteractionAsync(interaction.InteractionId, (interaction, ServiceProvider, cancellationToken) =>
+                await _interactionService.CompleteInteractionAsync(interaction.InteractionId, (interaction, ServiceProvider) =>
                 {
                     // Complete the interaction with an error state
                     interaction.CompletionTcs.TrySetException(new InvalidOperationException("Cannot prompt interaction while steps are in progress."));
@@ -317,7 +317,7 @@ internal sealed class PublishingActivityProgressReporter : IPublishingActivityPr
         if (int.TryParse(promptId, CultureInfo.InvariantCulture, out var interactionId))
         {
             await _interactionService.CompleteInteractionAsync(interactionId,
-                (interaction, serviceProvider, cancellationToken) =>
+                (interaction, serviceProvider) =>
                 {
                     if (interaction.InteractionInfo is Interaction.InputsInteractionInfo inputsInfo)
                     {

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -173,7 +173,7 @@ public class InteractionServiceTests
 
     private static async Task CompleteInteractionAsync(InteractionService interactionService, int interactionId, InteractionCompletionState state)
     {
-        await interactionService.CompleteInteractionAsync(interactionId, (_, _, _) => state, CancellationToken.None);
+        await interactionService.CompleteInteractionAsync(interactionId, (_, _) => state, CancellationToken.None);
     }
 
     private static InteractionService CreateInteractionService(DistributedApplicationOptions? options = null)

--- a/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityProgressReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityProgressReporterTests.cs
@@ -6,6 +6,7 @@
 
 using Aspire.Hosting.Backchannel;
 using Aspire.Hosting.Publishing;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -474,8 +475,7 @@ public class PublishingActivityProgressReporterTests
 
         // Get the interaction ID from the activity that was emitted
         var activityReader = reporter.ActivityItemUpdated.Reader;
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var activity = await activityReader.ReadAsync(cts.Token);
+        var activity = await activityReader.ReadAsync().DefaultTimeout();
         var promptId = activity.Data.Id;
         Assert.NotNull(activity.Data.Inputs);
         var input = Assert.Single(activity.Data.Inputs);
@@ -485,10 +485,10 @@ public class PublishingActivityProgressReporterTests
         var responses = new string[] { "user-response" };
 
         // Act
-        await reporter.CompleteInteractionAsync(promptId, responses, CancellationToken.None);
+        await reporter.CompleteInteractionAsync(promptId, responses, CancellationToken.None).DefaultTimeout();
 
         // The prompt task should complete with the user's response
-        var promptResult = await promptTask;
+        var promptResult = await promptTask.DefaultTimeout();
         Assert.False(promptResult.Canceled);
         Assert.Equal("user-response", promptResult.Data?.Value);
     }


### PR DESCRIPTION
## Description

Fix issue when canceling input dialog.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
