### PR TITLE
Option to persist parameters to secrets

### DIFF
--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -6,6 +6,7 @@
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.SecretManager.Tools.Internal;
 
 namespace Aspire.Hosting.Orchestrator;
 
@@ -16,7 +17,8 @@ internal sealed class ParameterProcessor(
     ResourceNotificationService notificationService,
     ResourceLoggerService loggerService,
     IInteractionService interactionService,
-    ILogger<ParameterProcessor> logger)
+    ILogger<ParameterProcessor> logger,
+    DistributedApplicationOptions options)
 {
     private readonly List<ParameterResource> _unresolvedParameters = [];
 
@@ -138,23 +140,30 @@ internal sealed class ParameterProcessor(
             if (result.Data)
             {
                 // Now we build up a new form base on the unresolved parameters.
-                var inputs = new List<InteractionInput>();
+                var resourceInputs = new List<(ParameterResource ParameterResource, InteractionInput Input)>();
 
                 foreach (var parameter in unresolvedParameters)
                 {
                     // Create an input for each unresolved parameter.
-                    inputs.Add(new InteractionInput
+                    var input = new InteractionInput
                     {
                         InputType = parameter.Secret ? InputType.SecretText : InputType.Text,
                         Label = parameter.Name,
                         Placeholder = "Enter value for " + parameter.Name,
-                    });
+                    };
+                    resourceInputs.Add((parameter, input));
                 }
+
+                var saveParameters = new InteractionInput
+                {
+                    InputType = InputType.Boolean,
+                    Label = "Save to secrets"
+                };
 
                 var valuesPrompt = await interactionService.PromptInputsAsync(
                     "Set unresolved parameters",
                     "Please provide values for the unresolved parameters.",
-                    inputs,
+                    [.. resourceInputs.Select(i => i.Input), saveParameters],
                     new InputsDialogInteractionOptions
                     {
                         PrimaryButtonText = "Save",
@@ -165,10 +174,10 @@ internal sealed class ParameterProcessor(
                 if (!valuesPrompt.Canceled)
                 {
                     // Iterate through the unresolved parameters and set their values based on user input.
-                    for (var i = unresolvedParameters.Count - 1; i >= 0; i--)
+                    for (var i = resourceInputs.Count - 1; i >= 0; i--)
                     {
-                        var parameter = unresolvedParameters[i];
-                        var inputValue = valuesPrompt.Data[i].Value;
+                        var (parameter, input) = (resourceInputs[i].ParameterResource, resourceInputs[i].Input);
+                        var inputValue = input.Value;
 
                         if (string.IsNullOrEmpty(inputValue))
                         {
@@ -188,6 +197,12 @@ internal sealed class ParameterProcessor(
                             };
                         })
                         .ConfigureAwait(false);
+
+                        // Persist the parameter value to user secrets if requested.
+                        if (bool.TryParse(saveParameters.Value, out var saveToSecrets) && saveToSecrets)
+                        {
+                            SecretsStore.TrySetUserSecret(options.Assembly, parameter.ConfigurationKey, inputValue);
+                        }
 
                         // Remove the parameter from unresolved parameters list.
                         unresolvedParameters.RemoveAt(i);

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -149,7 +149,7 @@ internal sealed class ParameterProcessor(
                     {
                         InputType = parameter.Secret ? InputType.SecretText : InputType.Text,
                         Label = parameter.Name,
-                        Placeholder = "Enter value for " + parameter.Name,
+                        Placeholder = $"Enter value for {parameter.Name}",
                     };
                     resourceInputs.Add((parameter, input));
                 }

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -162,9 +162,7 @@ internal sealed class ParameterProcessor(
 
                 var valuesPrompt = await interactionService.PromptInputsAsync(
                     "Set unresolved parameters",
-                    """
-                    Please provide values for the unresolved parameters. Parameters can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
-                    """,
+                    "Please provide values for the unresolved parameters. Parameters can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.",
                     [.. resourceInputs.Select(i => i.Input), saveParameters],
                     new InputsDialogInteractionOptions
                     {

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -157,17 +157,20 @@ internal sealed class ParameterProcessor(
                 var saveParameters = new InteractionInput
                 {
                     InputType = InputType.Boolean,
-                    Label = "Save to secrets"
+                    Label = "Save to user secrets"
                 };
 
                 var valuesPrompt = await interactionService.PromptInputsAsync(
                     "Set unresolved parameters",
-                    "Please provide values for the unresolved parameters.",
+                    """
+                    Please provide values for the unresolved parameters. Parameters can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+                    """,
                     [.. resourceInputs.Select(i => i.Input), saveParameters],
                     new InputsDialogInteractionOptions
                     {
                         PrimaryButtonText = "Save",
-                        ShowDismiss = true
+                        ShowDismiss = true,
+                        EnableMessageMarkdown = true,
                     })
                     .ConfigureAwait(false);
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -462,7 +462,8 @@ public class ApplicationOrchestratorTests
                 notificationService,
                 resourceLoggerService,
                 CreateInteractionService(),
-                NullLogger<ParameterProcessor>.Instance)
+                NullLogger<ParameterProcessor>.Instance,
+                new DistributedApplicationOptions())
             );
     }
 

--- a/tests/Aspire.Hosting.Tests/TestInteractionService.cs
+++ b/tests/Aspire.Hosting.Tests/TestInteractionService.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+namespace Aspire.Hosting.Tests;
+
+internal sealed record InteractionData(string Title, string? Message, IReadOnlyList<InteractionInput> Inputs, InteractionOptions? Options, TaskCompletionSource<object> CompletionTcs);
+
+internal sealed class TestInteractionService : IInteractionService
+{
+    public Channel<InteractionData> Interactions { get; } = Channel.CreateUnbounded<InteractionData>();
+
+    public bool IsAvailable { get; set; } = true;
+
+    public Task<InteractionResult<bool>> PromptConfirmationAsync(string title, string message, MessageBoxInteractionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<InteractionResult<InteractionInput>> PromptInputAsync(string title, string? message, string inputLabel, string placeHolder, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<InteractionResult<InteractionInput>> PromptInputAsync(string title, string? message, InteractionInput input, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<InteractionResult<IReadOnlyList<InteractionInput>>> PromptInputsAsync(string title, string? message, IReadOnlyList<InteractionInput> inputs, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var data = new InteractionData(title, message, inputs, options, new TaskCompletionSource<object>());
+        Interactions.Writer.TryWrite(data);
+        return (InteractionResult<IReadOnlyList<InteractionInput>>)await data.CompletionTcs.Task;
+    }
+
+    public async Task<InteractionResult<bool>> PromptMessageBarAsync(string title, string message, MessageBarInteractionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var data = new InteractionData(title, message, [], options, new TaskCompletionSource<object>());
+        Interactions.Writer.TryWrite(data);
+        return (InteractionResult<bool>)await data.CompletionTcs.Task;
+    }
+
+    public Task<InteractionResult<bool>> PromptMessageBoxAsync(string title, string message, MessageBoxInteractionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+#pragma warning restore ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.Threading.Channels;
 using Aspire.Hosting.VersionChecking;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
@@ -230,47 +229,6 @@ public class VersionCheckServiceTests
         {
             FetchCalled = true;
             return _versionTask;
-        }
-    }
-
-    private sealed record InteractionData(string Title, string? Message, InteractionOptions? Options, TaskCompletionSource<object> CompletionTcs);
-
-    private sealed class TestInteractionService : IInteractionService
-    {
-        public Channel<InteractionData> Interactions { get; } = Channel.CreateUnbounded<InteractionData>();
-
-        public bool IsAvailable { get; set; } = true;
-
-        public Task<InteractionResult<bool>> PromptConfirmationAsync(string title, string message, MessageBoxInteractionOptions? options = null, CancellationToken cancellationToken = default)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<InteractionResult<InteractionInput>> PromptInputAsync(string title, string? message, string inputLabel, string placeHolder, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<InteractionResult<InteractionInput>> PromptInputAsync(string title, string? message, InteractionInput input, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<InteractionResult<IReadOnlyList<InteractionInput>>> PromptInputsAsync(string title, string? message, IReadOnlyList<InteractionInput> inputs, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
-        {
-            throw new NotImplementedException();
-        }
-
-        public async Task<InteractionResult<bool>> PromptMessageBarAsync(string title, string message, MessageBarInteractionOptions? options = null, CancellationToken cancellationToken = default)
-        {
-            var data = new InteractionData(title, message, options, new TaskCompletionSource<object>());
-            Interactions.Writer.TryWrite(data);
-            return (InteractionResult<bool>)await data.CompletionTcs.Task;
-        }
-
-        public Task<InteractionResult<bool>> PromptMessageBoxAsync(string title, string message, MessageBoxInteractionOptions? options = null, CancellationToken cancellationToken = default)
-        {
-            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

![image](https://github.com/user-attachments/assets/c2518d10-0847-483b-a53b-e68b28a16c15)

Fixes https://github.com/dotnet/aspire/issues/10247

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
