### PR TITLE
Fix typo in `TalkingClockResource` comment

### DIFF
--- a/playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs
+++ b/playground/CustomResources/CustomResources.AppHost/TalkingClockResource.cs
@@ -85,7 +85,7 @@ public static class TalkingClockExtensions
             await notification.PublishUpdateAsync(resource.TockHand, s => s with
             {
                 StartTimeStamp = DateTime.UtcNow,
-                State = "Waiting on clock tock" // Custom state string for the tockhand.
+                State = "Waiting on clock tock" // Custom state string for the tock hand.
             });
 
             // Enter the main loop that runs as long as cancellation is not requested.


### PR DESCRIPTION
## Description

Fix a typo in `TalkingClockResource` comment.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
