### PR TITLE
Fix thread safety issue in Razor view

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SelectResourceOptions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SelectResourceOptions.razor
@@ -14,10 +14,10 @@
                     ShowIndeterminate="false"
                     ThreeStateOrderUncheckToIntermediate="true"
                     @bind-CheckState:get="@GetCheckState(Values)"
-                    @bind-CheckState:set="@OnAllValuesCheckedChangedInternalAsync"
-    />
+                    @bind-CheckState:set="@OnAllValuesCheckedChangedInternalAsync" />
 
-    @foreach (var (key, isChecked) in Values.OrderBy(pair => pair.Key.ToString(), StringComparer.OrdinalIgnoreCase))
+    @* OrderBy doesn't use thread safe APIs on ConcurrentDictionary. Call ToArray first. *@
+    @foreach (var (key, isChecked) in Values.ToArray().OrderBy(pair => pair.Key.ToString(), StringComparer.OrdinalIgnoreCase))
     {
         var label = string.IsNullOrEmpty(key.ToString()) ? Loc[nameof(Resources.ResourceFilterOptionEmpty)] : key.ToString();
 
@@ -26,17 +26,3 @@
                         @bind-Value:set="@(c => OnValueVisibilityChangedInternalAsync(key, c))" />
     }
 </FluentStack>
-
-@code {
-    [Parameter, EditorRequired]
-    public required ConcurrentDictionary<TValue, bool> Values { get; set; }
-
-    [Parameter, EditorRequired]
-    public required Func<Task> OnAllValuesCheckedChangedAsync { get; set; }
-
-    [Parameter, EditorRequired]
-    public required Func<TValue, bool, Task> OnValueVisibilityChangedAsync { get; set; }
-
-    [Parameter]
-    public string? Id { get; set; }
-}

--- a/src/Aspire.Dashboard/Components/Controls/SelectResourceOptions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SelectResourceOptions.razor.cs
@@ -1,12 +1,25 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components;
 
 public partial class SelectResourceOptions<TValue>
 {
+    [Parameter, EditorRequired]
+    public required ConcurrentDictionary<TValue, bool> Values { get; set; }
+
+    [Parameter, EditorRequired]
+    public required Func<Task> OnAllValuesCheckedChangedAsync { get; set; }
+
+    [Parameter, EditorRequired]
+    public required Func<TValue, bool, Task> OnValueVisibilityChangedAsync { get; set; }
+
+    [Parameter]
+    public string? Id { get; set; }
+
     private async Task OnAllValuesCheckedChangedInternalAsync(bool? newAreAllVisible)
     {
         SetCheckState(newAreAllVisible, Values);


### PR DESCRIPTION
Fix test error. Looks like a thread safety issue.

https://stackoverflow.com/questions/47630824/is-c-sharp-linq-orderby-threadsafe-when-used-with-concurrentdictionarytkey-tva

```
  failed Aspire.Dashboard.Components.Tests.Pages.ResourcesTests.ResourcesShouldRemainUnchangedWhenFilterDoesNotMatchUpdatedResource (30ms)
    Xunit.Runner.InProc.SystemConsole.TestingPlatform.XunitException: System.ArgumentException : The index is equal to or greater than the length of the array, or the number of elements in the dictionary is greater than the available space from index to the end of the destination array.
      at System.Collections.Concurrent.ConcurrentDictionary`2.System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(KeyValuePair`2[] array, Int32 index)
      at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source, Int32& length)
      at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
      at System.Linq.OrderedEnumerable`1.GetEnumerator()+MoveNext()
      at Aspire.Dashboard.Components.SelectResourceOptions`1.<BuildRenderTree>b__4_0(RenderTreeBuilder __builder2) in /_/src/Aspire.Dashboard/Components/Controls/SelectResourceOptions.razor:20
      at Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddContent(Int32 sequence, RenderFragment fragment)
      at Microsoft.FluentUI.AspNetCore.Components.FluentStack.BuildRenderTree(RenderTreeBuilder __builder)
      at Microsoft.AspNetCore.Components.Rendering.ComponentState.RenderIntoBatch(RenderBatchBuilder batchBuilder, RenderFragment renderFragment, Exception& renderFragmentException)
      --- End of stack trace from previous location ---
      at Bunit.RenderedFragmentWaitForHelperExtensions.WaitForState(IRenderedFragmentBase renderedFragment, Func`1 statePredicate, Nullable`1 timeout) in /_/src/bunit.core/Extensions/WaitForHelpers/RenderedFragmentWaitForHelperExtensions.cs:32
      at Aspire.Dashboard.Components.Tests.Pages.ResourcesTests.ResourcesShouldRemainUnchangedWhenFilterDoesNotMatchUpdatedResource() in /_/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs:347
      at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
      at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```