### PR TITLE
Add dashboard telemetry to interaction service

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -279,7 +279,7 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Control, nameof(ResourceDetails));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Control, TelemetryComponentIds.ResourceDetails);
 
     public void UpdateTelemetryProperties()
     {

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -6,6 +6,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -145,7 +146,7 @@ public partial class SpanDetails : IDisposable
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Control, nameof(SpanDetails));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Control, TelemetryComponentIds.SpanDetails);
 
     public void Dispose()
     {

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Telemetry;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 
@@ -149,7 +150,7 @@ public partial class StructuredLogDetails : IDisposable
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Control, nameof(StructuredLogDetails));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Control, TelemetryComponentIds.StructuredLogDetails);
 
     public void Dispose()
     {

--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -256,7 +256,6 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
                 });
 
                 Debug.Assert(currentDialogReference != null, "Dialog should have been created in UI thread.");
-
                 _interactionDialogReference = new InteractionDialogReference(item.InteractionId, currentDialogReference, CreateTelemetryContext(dialogComponentId));
             }
             finally

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -796,7 +796,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, nameof(ConsoleLogs));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.ConsoleLogs);
 
     public void UpdateTelemetryProperties()
     {

--- a/src/Aspire.Dashboard/Components/Pages/Error.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Error.razor.cs
@@ -28,7 +28,7 @@ public partial class Error : IComponentWithTelemetry, IDisposable
     public required ComponentTelemetryContextProvider TelemetryContextProvider { get; init;  }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, nameof(Error));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.Error);
 
     protected override void OnParametersSet()
     {

--- a/src/Aspire.Dashboard/Components/Pages/Login.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
@@ -117,5 +118,5 @@ public partial class Login : IAsyncDisposable, IComponentWithTelemetry
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, nameof(Login));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.Login);
 }

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -340,7 +340,7 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, nameof(Metrics));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.Metrics);
 
     public void UpdateTelemetryProperties()
     {

--- a/src/Aspire.Dashboard/Components/Pages/NotFound.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/NotFound.razor.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Telemetry;
 using Microsoft.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components.Pages;
@@ -11,7 +12,7 @@ public partial class NotFound : IComponentWithTelemetry, IDisposable
     public required ComponentTelemetryContextProvider TelemetryContextProvider { get; init; }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, nameof(NotFound));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.NotFound);
 
     protected override void OnInitialized()
     {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -888,7 +888,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, nameof(Resources));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.Resources);
 
     public void UpdateTelemetryProperties()
     {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -489,7 +489,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, nameof(StructuredLogs));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.StructuredLogs);
 
     public void UpdateTelemetryProperties()
     {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 using Microsoft.JSInterop;
+using Aspire.Dashboard.Telemetry;
 
 namespace Aspire.Dashboard.Components.Pages;
 
@@ -346,5 +347,5 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, nameof(TraceDetail));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.TraceDetail);
 }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -11,6 +11,7 @@ using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
+using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Options;
@@ -381,5 +382,5 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     }
 
     // IComponentWithTelemetry impl
-    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, nameof(Traces));
+    public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.Traces);
 }

--- a/src/Aspire.Dashboard/Telemetry/TelemetryComponentIds.cs
+++ b/src/Aspire.Dashboard/Telemetry/TelemetryComponentIds.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Telemetry;
+
+public static class TelemetryComponentIds
+{
+    // Pages
+    public const string Resources = nameof(Resources);
+    public const string Login = nameof(Login);
+    public const string Traces = nameof(Traces);
+    public const string StructuredLogs = nameof(StructuredLogs);
+    public const string NotFound = nameof(NotFound);
+    public const string Metrics = nameof(Metrics);
+    public const string Error = nameof(Error);
+    public const string ConsoleLogs = nameof(ConsoleLogs);
+
+    // Controls
+    public const string TraceDetail = nameof(TraceDetail);
+    public const string StructuredLogDetails = nameof(StructuredLogDetails);
+    public const string SpanDetails = nameof(SpanDetails);
+    public const string ResourceDetails = nameof(ResourceDetails);
+    public const string InteractionMessageBox = nameof(InteractionMessageBox);
+    public const string InteractionMessageBar = nameof(InteractionMessageBar);
+    public const string InteractionInputsDialog = nameof(InteractionInputsDialog);
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Interactions/InteractionsProviderTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Interactions/InteractionsProviderTests.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Channels;
+using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Telemetry;
+using Aspire.Dashboard.Tests;
 using Aspire.DashboardService.Proto.V1;
 using Bunit;
 using Microsoft.AspNetCore.InternalTesting;
@@ -346,5 +349,8 @@ public partial class InteractionsProviderTests : DashboardTestContext
         Services.AddSingleton<IDialogService>(dialogService ?? new TestDialogService());
         Services.AddSingleton<IMessageService, MessageService>();
         Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient());
+        Services.AddSingleton<DashboardTelemetryService>();
+        Services.AddSingleton<IDashboardTelemetrySender, TestDashboardTelemetrySender>();
+        Services.AddSingleton<ComponentTelemetryContextProvider>();
     }
 }


### PR DESCRIPTION
## Description

- Add `TelemetryComponentIds` with constants for component telemetry IDs
- Add telemetry to interaction components

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
