### PR TITLE
Fix race error in text visualizer

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -30,6 +30,7 @@ public partial class TextVisualizerDialog : ComponentBase, IAsyncDisposable
     private List<SelectViewModel<string>> _options = null!;
     private string? _currentValue;
     private string _formattedText = string.Empty;
+    private bool _isLoading = true;
 
     public HashSet<string?> EnabledOptions { get; } = [];
     internal bool? ShowSecretsWarning { get; private set; }
@@ -68,6 +69,10 @@ public partial class TextVisualizerDialog : ComponentBase, IAsyncDisposable
         // We do this by making them agree to a warning in the text visualizer dialog.
         var settingsResult = await LocalStorage.GetUnprotectedAsync<TextVisualizerDialogSettings>(BrowserStorageKeys.TextVisualizerDialogSettings);
         ShowSecretsWarning = settingsResult.Value is not { SecretsWarningAcknowledged: true };
+
+        // Don't display content until it is loaded.
+        // This is required because rendering uses the theme manager, and we don't want to call that code until we know it's finished initializing.
+        _isLoading = false;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -115,7 +120,18 @@ public partial class TextVisualizerDialog : ComponentBase, IAsyncDisposable
         }
     }
 
-    private bool IsTextContentDisplayed => !Content.ContainsSecret || ShowSecretsWarning is false;
+    private bool IsTextContentDisplayed
+    {
+        get
+        {
+            if (_isLoading)
+            {
+                return false;
+            }
+
+            return !Content.ContainsSecret || ShowSecretsWarning is false;
+        }
+    }
 
     private string GetLogContentClass()
     {

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -67,8 +67,11 @@ public partial class TextVisualizerDialog : ComponentBase, IAsyncDisposable
 
         // We need to make users perform an explicit action once before being able to see secret values
         // We do this by making them agree to a warning in the text visualizer dialog.
-        var settingsResult = await LocalStorage.GetUnprotectedAsync<TextVisualizerDialogSettings>(BrowserStorageKeys.TextVisualizerDialogSettings);
-        ShowSecretsWarning = settingsResult.Value is not { SecretsWarningAcknowledged: true };
+        if (Content.ContainsSecret)
+        {
+            var settingsResult = await LocalStorage.GetUnprotectedAsync<TextVisualizerDialogSettings>(BrowserStorageKeys.TextVisualizerDialogSettings);
+            ShowSecretsWarning = settingsResult.Value is not { SecretsWarningAcknowledged: true };
+        }
 
         // Don't display content until it is loaded.
         // This is required because rendering uses the theme manager, and we don't want to call that code until we know it's finished initializing.


### PR DESCRIPTION
## Description

Fixes:
```
at Aspire.Dashboard.Model.ThemeManager.AssertInitialized() in /_/src/Aspire.Dashboard/Model/ThemeManager.cs:line 95
   at Aspire.Dashboard.Model.ThemeManager.get_EffectiveTheme() in /_/src/Aspire.Dashboard/Model/ThemeManager.cs:line 84
   at Aspire.Dashboard.Components.Dialogs.TextVisualizerDialog.GetLogContentClass() in /_/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs:line 124
   at Aspire.Dashboard.Components.Dialogs.TextVisualizerDialog.<>c__DisplayClass62_1.<BuildRenderTree>b__8(RenderTreeBuilder __builder3) in /_/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor:line 43
   at Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize`1.BuildRenderTree(RenderTreeBuilder builder)
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.RenderIntoBatch(RenderBatchBuilder batchBuilder, RenderFragment renderFragment, Exception& renderFragmentException)
```

The view uses the theme manager and the theme manager must be initalized. While the control does initialize the theme manager, that doesn't delay rendering. Fix is to hide content that uses theme manager until loading is complete.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
