### PR TITLE
Aspire cli: Add AOT builds for Linux, and macOS

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,7 +35,7 @@ Make sure you [build the repo](#build-the-repo) from command line at least once.
 
 The default build includes native builds for `Aspire.Cli` which produces Native AOT binaries for some platforms. These projects are in `eng/clipack/Aspire.Cli.*`.
 
-By default it builds the cli native project for the current Runtime Identifier. A specific RID can be specified too by setting `$(TargetRid)`.
+By default it builds the cli native project for the current Runtime Identifier. A specific RIDs can be specified too by setting `$(TargetRids)` to a colon separated list like `$(TargetRids) = osx-x64:osx-arm64`.
 
 Native build can be disabled with `$(BuildNative) = false`. And to only the native bits use `$(BuildNativeOnly) = true`.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,9 +35,9 @@ Make sure you [build the repo](#build-the-repo) from command line at least once.
 
 The default build includes native builds for `Aspire.Cli` which produces Native AOT binaries for some platforms. These projects are in `eng/clipack/Aspire.Cli.*`.
 
-By default it builds the cli native project for the current Runtime Identifier. A specific RIDs can be specified too by setting `$(TargetRids)` to a colon separated list like `$(TargetRids) = osx-x64:osx-arm64`.
+By default it builds the cli native project for the current Runtime Identifier. A specific RIDs can be specified too by setting `$(TargetRids)` to a colon separated list like `/p:TargetRids=osx-x64:osx-arm64`.
 
-Native build can be disabled with `$(BuildNative) = false`. And to only the native bits use `$(BuildNativeOnly) = true`.
+Native build can be disabled with `/p:BuildNative=false`. And to only the native bits use `/p:BuildNativeOnly=true`.
 
 ## View Dashboard
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,7 +37,7 @@ The default build includes native builds for `Aspire.Cli` which produces Native 
 
 By default it builds the cli native project for the current Runtime Identifier. A specific RIDs can be specified too by setting `$(TargetRids)` to a colon separated list like `/p:TargetRids=osx-x64:osx-arm64`.
 
-Native build can be disabled with `/p:BuildNative=false`. And to only the native bits use `/p:BuildNativeOnly=true`.
+Native build can be disabled with `/p:SkipNativeBuild=true`. And to only the native bits use `/p:SkipManagedBuild=true`.
 
 ## View Dashboard
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,6 +31,14 @@ Or, if you are using Visual Studio:
 
 Make sure you [build the repo](#build-the-repo) from command line at least once. Then use `./start-code.sh` (macOS and Linux) or `.\start-code.cmd` to start VS Code.
 
+## Native build
+
+The default build includes native builds for `Aspire.Cli` which produces Native AOT binaries for some platforms. These projects are in `eng/clipack/Aspire.Cli.*`.
+
+By default it builds the cli native project for the current Runtime Identifier. A specific RID can be specified too by setting `$(TargetRid)`.
+
+Native build can be disabled with `$(BuildNative) = false`. And to only the native bits use `$(BuildNativeOnly) = true`.
+
 ## View Dashboard
 
 When you start the sample app in Visual Studio, it will automatically open your browser to show the dashboard.

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,11 +1,14 @@
-<Project>
+<Project TreatAsLocalProperty="TargetRids">
   <PropertyGroup>
     <_AspireOnlyBuild Condition="'$(DotNetBuildFromSource)' != 'true' and '$(DotNetBuild)' != 'true'">true</_AspireOnlyBuild>
 
     <BuildNative>true</BuildNative>
 
     <BuildRid>$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</BuildRid>
-    <TargetRid Condition="'$(TargetRid)' == ''">$(BuildRid)</TargetRid>
+
+    <!-- this property is meant only for CI use. Use a colon separate list of RIDs here, like osx-x64:osx-arm64 .
+         It is helpful to allow building the non-aot cli builds on a single CI job -->
+    <TargetRids Condition="'$(TargetRids)' == ''">$(BuildRid)</TargetRids>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(_AspireOnlyBuild)' == 'true' and '$(BuildNativeOnly)' != 'true'">
@@ -13,7 +16,8 @@
     <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
 
-    <ProjectToBuild Condition="'$(BuildNative)' == 'true'" Include="$(RepoRoot)eng\clipack\Aspire.Cli.$(TargetRid).csproj" />
+    <_TargetRidItem Include="$(TargetRids.Split(':'))" />
+    <ProjectToBuild Condition="'$(BuildNative)' == 'true'" Include="@(_TargetRidItem -> '$(RepoRoot)eng\clipack\Aspire.Cli.%(Identity).csproj')" />
 
     <ProjectToBuild Include="$(RepoRoot)playground\**\*.csproj" />
 
@@ -27,7 +31,8 @@
   <ItemGroup Condition="'$(_AspireOnlyBuild)' == 'true' and '$(BuildNativeOnly)' == 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.csproj" />
 
-    <ProjectToBuild Include="$(RepoRoot)eng\clipack\Aspire.Cli.$(TargetRid).csproj" />
+    <_TargetRidItem Include="$(TargetRids.Split(':'))" />
+    <ProjectToBuild Include="@(_TargetRidItem -> '$(RepoRoot)eng\clipack\Aspire.Cli.%(Identity).csproj')" />
   </ItemGroup>
 
   <!-- When building from source, we want to use the live repo contents as opposed to cloning the repo. -->

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -27,8 +27,11 @@
          instead of a ProjectReference -->
     <ProjectToBuild Condition="'$(SkipManagedBuild)' == 'true'" Include="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.csproj" />
 
+    <!-- Skip any unknown target rids.
+         TODO: Map unknown rids to the available native projects -->
     <_TargetRidItem Include="$(TargetRids.Split(':'))" />
-    <ProjectToBuild Include="@(_TargetRidItem -> '$(RepoRoot)eng\clipack\Aspire.Cli.%(Identity).csproj')" />
+    <_NativeProjectToBuild Include="@(_TargetRidItem -> '$(RepoRoot)eng\clipack\Aspire.Cli.%(Identity).csproj')" />
+    <ProjectToBuild Include="@(_NativeProjectToBuild->Exists())" />
   </ItemGroup>
 
   <!-- When building from source, we want to use the live repo contents as opposed to cloning the repo. -->

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -5,8 +5,6 @@
     <!-- Use a colon separate list of RIDs here, like osx-x64:osx-arm64 .
          It is helpful to allow building the non-aot cli builds on a single CI job -->
     <TargetRids Condition="'$(TargetRids)' == ''">$(BuildRid)</TargetRids>
-    <SkipManagedBuild Condition="'$(SkipManagedBuild)' == ''">false</SkipManagedBuild>
-    <SkipNativeBuild Condition="'$(SkipNativeBuild)' == ''">false</SkipNativeBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SkipManagedBuild)' != 'true'">

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,23 +1,18 @@
 <Project TreatAsLocalProperty="TargetRids">
   <PropertyGroup>
-    <_AspireOnlyBuild Condition="'$(DotNetBuildFromSource)' != 'true' and '$(DotNetBuild)' != 'true'">true</_AspireOnlyBuild>
-
-    <BuildNative>true</BuildNative>
-
     <BuildRid>$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</BuildRid>
 
     <!-- Use a colon separate list of RIDs here, like osx-x64:osx-arm64 .
          It is helpful to allow building the non-aot cli builds on a single CI job -->
     <TargetRids Condition="'$(TargetRids)' == ''">$(BuildRid)</TargetRids>
+    <SkipManagedBuild Condition="'$(SkipManagedBuild)' == ''">false</SkipManagedBuild>
+    <SkipNativeBuild Condition="'$(SkipNativeBuild)' == ''">false</SkipNativeBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(_AspireOnlyBuild)' == 'true' and '$(BuildNativeOnly)' != 'true'">
+  <ItemGroup Condition="'$(SkipManagedBuild)' != 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
-
-    <_TargetRidItem Include="$(TargetRids.Split(':'))" />
-    <ProjectToBuild Condition="'$(BuildNative)' == 'true'" Include="@(_TargetRidItem -> '$(RepoRoot)eng\clipack\Aspire.Cli.%(Identity).csproj')" />
 
     <ProjectToBuild Include="$(RepoRoot)playground\**\*.csproj" />
 
@@ -28,8 +23,11 @@
   </ItemGroup>
 
   <!-- Native build only -->
-  <ItemGroup Condition="'$(_AspireOnlyBuild)' == 'true' and '$(BuildNativeOnly)' == 'true'">
-    <ProjectToBuild Include="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.csproj" />
+  <ItemGroup Condition="'$(SkipNativeBuild)' != 'true'">
+    <!-- Add Aspire.Cli project here for native-only builds so it gets picked
+         up Restore, because Aspire.Cli.$(RID).csproj uses MSBuild task to build
+         instead of a ProjectReference -->
+    <ProjectToBuild Condition="'$(SkipManagedBuild)' == 'true'" Include="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.csproj" />
 
     <_TargetRidItem Include="$(TargetRids.Split(':'))" />
     <ProjectToBuild Include="@(_TargetRidItem -> '$(RepoRoot)eng\clipack\Aspire.Cli.%(Identity).csproj')" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -6,7 +6,7 @@
 
     <BuildRid>$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</BuildRid>
 
-    <!-- this property is meant only for CI use. Use a colon separate list of RIDs here, like osx-x64:osx-arm64 .
+    <!-- Use a colon separate list of RIDs here, like osx-x64:osx-arm64 .
          It is helpful to allow building the non-aot cli builds on a single CI job -->
     <TargetRids Condition="'$(TargetRids)' == ''">$(BuildRid)</TargetRids>
   </PropertyGroup>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,15 +1,33 @@
 <Project>
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true' and '$(DotNetBuild)' != 'true'">
+  <PropertyGroup>
+    <_AspireOnlyBuild Condition="'$(DotNetBuildFromSource)' != 'true' and '$(DotNetBuild)' != 'true'">true</_AspireOnlyBuild>
+
+    <BuildNative>true</BuildNative>
+
+    <BuildRid>$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</BuildRid>
+    <TargetRid Condition="'$(TargetRid)' == ''">$(BuildRid)</TargetRid>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_AspireOnlyBuild)' == 'true' and '$(BuildNativeOnly)' != 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
-    <ProjectToBuild Include="$(RepoRoot)eng\clipack\**\*.csproj" />
+
+    <ProjectToBuild Condition="'$(BuildNative)' == 'true'" Include="$(RepoRoot)eng\clipack\Aspire.Cli.$(TargetRid).csproj" />
+
     <ProjectToBuild Include="$(RepoRoot)playground\**\*.csproj" />
 
     <!-- `$(SkipTestProjects)` allows skipping test projects from being
           included in the build at all. This is useful for cases like when we are
           just building the packages, and don't need to build the test projects. -->
     <ProjectToBuild Include="$(RepoRoot)tests\**\*.csproj" Condition="'$(SkipTestProjects)' != 'true'" />
+  </ItemGroup>
+
+  <!-- Native build only -->
+  <ItemGroup Condition="'$(_AspireOnlyBuild)' == 'true' and '$(BuildNativeOnly)' == 'true'">
+    <ProjectToBuild Include="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.csproj" />
+
+    <ProjectToBuild Include="$(RepoRoot)eng\clipack\Aspire.Cli.$(TargetRid).csproj" />
   </ItemGroup>
 
   <!-- When building from source, we want to use the live repo contents as opposed to cloning the repo. -->

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -23,7 +23,6 @@
     <_InstallersToPublish Include="$(ArtifactsDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' == 'true'" />
     <_InstallerManifestFilesToPublish Include="$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\**\*.zip" />
     <_DashboardFilesToPublish Include="$(DashboardPublishedArtifactsOutputDir)\**\*.zip" />
-    <_CliFilesToPublish Include="$(ArtifactsShippingPackagesDir)\aspire-cli-*" />
   </ItemGroup>
 
   <Target Name="_PublishBlobItems">
@@ -38,6 +37,27 @@
       Properties="SuppressFinalPackageVersion=true">
       <Output TaskParameter="TargetOutputs" PropertyName="_PackageVersion" />
     </MSBuild>
+
+    <ItemGroup>
+      <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.zip" />
+      <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.tar.gz" />
+
+      <_CliPackProjects Include="$(RepoRoot)eng\clipack\Aspire.Cli.*.csproj" />
+      <_ExpectedRuntimeIdentifiers Include="@(_CliPackProjects->'%(Filename)'->Replace('Aspire.Cli.', ''))" />
+    </ItemGroup>
+
+    <CheckExpectedAspireCliArchives ArchiveFiles="@(_ArchiveFiles)" ExpectedRuntimeIdentifiers="@(_ExpectedRuntimeIdentifiers)" />
+
+    <!-- Generate checksums for aspire-cli packages -->
+    <ItemGroup>
+      <_CliFileToPublish Include="@(_ArchiveFiles)" />
+      <GenerateChecksumItems Include="@(_CliFileToPublish)" DestinationPath="%(FullPath).sha512" />
+    </ItemGroup>
+
+    <GenerateChecksums Items="@(GenerateChecksumItems)" />
+    <ItemGroup>
+      <_CliFileToPublish Include="@(GenerateChecksumItems->'%(DestinationPath)')" />
+    </ItemGroup>
 
     <ItemGroup>
       <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)">
@@ -55,11 +75,85 @@
         <PublishFlatContainer>true</PublishFlatContainer>
         <RelativeBlobPath>$(_UploadPathRoot)/$(_PackageVersion)/%(Filename)%(Extension)</RelativeBlobPath>
       </ItemsToPushToBlobFeed>
-      <ItemsToPushToBlobFeed Include="@(_CliFilesToPublish)">
+      <ItemsToPushToBlobFeed Include="@(_CliFileToPublish)">
         <IsShipping>false</IsShipping>
         <PublishFlatContainer>true</PublishFlatContainer>
         <RelativeBlobPath>$(_UploadPathRoot)/$(_PackageVersion)/%(Filename)%(Extension)</RelativeBlobPath>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
   </Target>
+
+  <UsingTask TaskName="CheckExpectedAspireCliArchives" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <ArchiveFiles ParameterType="System.String[]" Required="true" />
+      <ExpectedRuntimeIdentifiers ParameterType="System.String[]" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Linq" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+
+        if (ArchiveFiles.Length == 0)
+        {
+          Log.LogError($"Missing {nameof(ArchiveFiles)} argument.");
+          return false;
+        }
+
+        if (ExpectedRuntimeIdentifiers.Length == 0)
+        {
+          Log.LogError($"Missing {nameof(ExpectedRuntimeIdentifiers)} argument.");
+          return false;
+        }
+
+        var archiveFileNames = ArchiveFiles.Select(filepath => Path.GetFileName(filepath)).ToArray();
+
+        var missingRids = new List<string>();
+        var matchedFiles = new HashSet<string>();
+
+        foreach (var rid in ExpectedRuntimeIdentifiers)
+        {
+            // filenames are like aspire-cli-linux-musl-x64-9.4.0-dev.tar.gz
+            var pattern = $"aspire-cli-{rid}-";
+            var matchingArchives = archiveFileNames
+                .Where(filename => filename.StartsWith(pattern, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            if (matchingArchives.Length == 0)
+            {
+                missingRids.Add(rid);
+                Log.LogMessage(MessageImportance.Low, $"Missing CLI files for runtime identifier: {rid}");
+            }
+            else
+            {
+                foreach (var archive in matchingArchives)
+                {
+                    matchedFiles.Add(archive);
+                }
+                Log.LogMessage(MessageImportance.Low, $"Found CLI files for {rid}: {string.Join(", ", matchingArchives)}");
+            }
+        }
+
+        // Find unexpected files - CLI archives that don't match any expected runtime identifier
+        var unexpectedFiles = archiveFileNames
+            .Where(filename => !matchedFiles.Contains(filename))
+            .ToArray();
+
+        // Emit errors and warnings
+        if (unexpectedFiles.Length > 0)
+        {
+            Log.LogWarning($"Found unexpected CLI files: {string.Join(", ", unexpectedFiles)}");
+        }
+
+        if (missingRids.Count > 0)
+        {
+          Log.LogError($"Missing CLI archive(s) for runtime identifier(s): {string.Join(", ", missingRids)}. Found {string.Join(", ", matchedFiles)} .");
+        }
+
+        Success = !Log.HasLoggedErrors;
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -26,6 +26,25 @@
   </ItemGroup>
 
   <Target Name="_PublishBlobItems">
+    <!-- Validate list of aspire-cli packages on disk vs expected ones.
+         And do this first to fail early -->
+    <ItemGroup>
+      <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.zip" />
+      <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.tar.gz" />
+
+      <_CliPackProjects Include="$(RepoRoot)eng\clipack\Aspire.Cli.*.csproj" />
+      <_ExpectedRids Include="@(_CliPackProjects->'%(Filename)'->Replace('Aspire.Cli.', ''))" />
+
+      <!-- Extract the rid from filenames like aspire-cli-linux-x64-9.0-dev.tar.gz and aspire-cli-linux-arm64-9.4.0-preview.1.25358.11.zip -->
+      <_FoundRidInCliArchiveFile Include="$([System.Text.RegularExpressions.Regex]::Match(%(_ArchiveFiles.FileName), 'aspire-cli-(.*)-\d+.*').Groups[1].Value)" />
+
+      <_MissingRids Include="@(_ExpectedRids)" Exclude="@(_FoundRidInCliArchiveFile)" />
+      <_UnexpectedRids Include="@(_FoundRidInCliArchiveFile)" Exclude="@(_ExpectedRids)" />
+    </ItemGroup>
+
+    <Warning Condition="@(_UnexpectedRids->Count()) > 0" Text="Found unexpected CLI archives for @(_UnexpectedRids, ',') . These are all the cli archives found - @(_ArchiveFiles, ', ')" />
+    <Error Condition="@(_MissingRids->Count()) > 0" Text="Missing CLI archive(s) for runtime identifiers: @(_MissingRids, ', '). These are all the cli archives found - @(_ArchiveFiles, ', ')" />
+
     <!--
       For blob items for the Dashboard, we want to make sure that the version we get back is not stable, even when the repo is producing stable versions.
       This is because we want to be able to re-spin the build if necessary without hitting issues of blob items clashing with each other. For this reason,
@@ -37,16 +56,6 @@
       Properties="SuppressFinalPackageVersion=true">
       <Output TaskParameter="TargetOutputs" PropertyName="_PackageVersion" />
     </MSBuild>
-
-    <ItemGroup>
-      <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.zip" />
-      <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.tar.gz" />
-
-      <_CliPackProjects Include="$(RepoRoot)eng\clipack\Aspire.Cli.*.csproj" />
-      <_ExpectedRuntimeIdentifiers Include="@(_CliPackProjects->'%(Filename)'->Replace('Aspire.Cli.', ''))" />
-    </ItemGroup>
-
-    <CheckExpectedAspireCliArchives ArchiveFiles="@(_ArchiveFiles)" ExpectedRuntimeIdentifiers="@(_ExpectedRuntimeIdentifiers)" />
 
     <!-- Generate checksums for aspire-cli packages -->
     <ItemGroup>
@@ -82,78 +91,4 @@
       </ItemsToPushToBlobFeed>
     </ItemGroup>
   </Target>
-
-  <UsingTask TaskName="CheckExpectedAspireCliArchives" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <ArchiveFiles ParameterType="System.String[]" Required="true" />
-      <ExpectedRuntimeIdentifiers ParameterType="System.String[]" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Linq" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-
-        if (ArchiveFiles.Length == 0)
-        {
-          Log.LogError($"Missing {nameof(ArchiveFiles)} argument.");
-          return false;
-        }
-
-        if (ExpectedRuntimeIdentifiers.Length == 0)
-        {
-          Log.LogError($"Missing {nameof(ExpectedRuntimeIdentifiers)} argument.");
-          return false;
-        }
-
-        var archiveFileNames = ArchiveFiles.Select(filepath => Path.GetFileName(filepath)).ToArray();
-
-        var missingRids = new List<string>();
-        var matchedFiles = new HashSet<string>();
-
-        foreach (var rid in ExpectedRuntimeIdentifiers)
-        {
-            // filenames are like aspire-cli-linux-musl-x64-9.4.0-dev.tar.gz
-            var pattern = $"aspire-cli-{rid}-";
-            var matchingArchives = archiveFileNames
-                .Where(filename => filename.StartsWith(pattern, StringComparison.OrdinalIgnoreCase))
-                .ToArray();
-
-            if (matchingArchives.Length == 0)
-            {
-                missingRids.Add(rid);
-                Log.LogMessage(MessageImportance.Low, $"Missing CLI files for runtime identifier: {rid}");
-            }
-            else
-            {
-                foreach (var archive in matchingArchives)
-                {
-                    matchedFiles.Add(archive);
-                }
-                Log.LogMessage(MessageImportance.Low, $"Found CLI files for {rid}: {string.Join(", ", matchingArchives)}");
-            }
-        }
-
-        // Find unexpected files - CLI archives that don't match any expected runtime identifier
-        var unexpectedFiles = archiveFileNames
-            .Where(filename => !matchedFiles.Contains(filename))
-            .ToArray();
-
-        // Emit errors and warnings
-        if (unexpectedFiles.Length > 0)
-        {
-            Log.LogWarning($"Found unexpected CLI files: {string.Join(", ", unexpectedFiles)}");
-        }
-
-        if (missingRids.Count > 0)
-        {
-          Log.LogError($"Missing CLI archive(s) for runtime identifier(s): {string.Join(", ", missingRids)}. Found {string.Join(", ", matchedFiles)} .");
-        }
-
-        Success = !Log.HasLoggedErrors;
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -34,6 +34,10 @@
     <FileSignInfo Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.Extensions.Hosting.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Semver.dll" CertificateName="3PartySHA2" />
+
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="aspire.exe" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsLinux())" Include="aspire" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsMacOS())" Include="aspire" CertificateName="MacDeveloperHardenWithNotarization" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -45,6 +49,8 @@
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSignPostBuild Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' == 'true'" />
     <ItemsToSign Include="$(VisualStudioSetupInsertionPath)\**\*.zip" Condition="'$(PostBuildSign)' != 'true'" />
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\aspire-cli-*.zip" />
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**\aspire-cli-*.tar.gz" />
     <ItemsToSignPostBuild Include="$(VisualStudioSetupInsertionPath)\**\*.zip" Condition="'$(PostBuildSign)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -50,14 +50,8 @@
         RemoveProperties="OutputPath;TargetFramework" />
 
     <PropertyGroup>
-      <_ShouldCodeSignOnMacOS Condition="$([System.OperatingSystem]::IsMacOS()) and '$(Sign)' == 'true' and '$(DotNetSignType)' == 'real' and '$(PublishNativeAot)' == 'true'" />
       <_OutputBinaryPath>$(OutputPath)/aspire</_OutputBinaryPath>
     </PropertyGroup>
-
-    <!-- Codesign on macos -->
-    <Message Text="Codesigning $(_OutputBinaryPath) .." Importance="High" Condition="'$(_ShouldCodeSignOnMacOS)' == 'true'" />
-    <!-- '-o runtime' is to enable hardened runtime -->
-    <Exec Command="codesign -s - -o runtime -f $(_OutputBinaryPath)" Condition="'$(_ShouldCodeSignOnMacOS)' == 'true'" />
 
     <!-- TODO: avoid generating the file instead of manually deleting it here -->
     <Delete Files="$(_OutputBinaryPath).xml" Condition="Exists('$(_OutputBinaryPath).xml')" />

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -54,7 +54,7 @@
     </PropertyGroup>
 
     <!-- TODO: avoid generating the file instead of manually deleting it here -->
-    <Delete Files="$(_OutputBinaryPath).xml" Condition="Exists('$(_OutputBinaryPath).xml')" />
+    <Delete Files="$(OutputPath)\aspire.xml" Condition="Exists('$(OutputPath)\aspire.xml')" />
 
     <!-- work around https://github.com/dotnet/runtime/issues/116758 by removing the Xliff folders. -->
     <ItemGroup>

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -3,10 +3,11 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
 
     <ArchiveName>aspire-cli-$(CliRuntime)</ArchiveName>
-    <ArchiveFormat Condition="$(CliRuntime.StartsWith('linux-'))">tar.gz</ArchiveFormat>
-    <ArchiveFormat Condition="!$(CliRuntime.StartsWith('linux-'))">zip</ArchiveFormat>
+    <ArchiveFormat Condition="'$(ArchiveFormat)' == '' and $(CliRuntime.StartsWith('win-'))">zip</ArchiveFormat>
+    <ArchiveFormat Condition="'$(ArchiveFormat)' == ''">tar.gz</ArchiveFormat>
 
-    <!-- Publish native AOT if running on the target platfrom -->
+    <!-- PublishNativeAot is explicitly set to false in the projects for cases where we don't want to AOT at all.
+         For the rest, publish native AOT if running on the target platfrom -->
     <PublishNativeAot Condition="'$(PublishNativeAot)' == '' and $([System.OperatingSystem]::IsWindows()) and $(CliRuntime.StartsWith('win-'))">true</PublishNativeAot>
     <PublishNativeAot Condition="'$(PublishNativeAot)' == '' and $([System.OperatingSystem]::IsLinux()) and $(CliRuntime.StartsWith('linux-'))">true</PublishNativeAot>
     <PublishNativeAot Condition="'$(PublishNativeAot)' == '' and $([System.OperatingSystem]::IsMacOS()) and $(CliRuntime.StartsWith('osx-'))">true</PublishNativeAot>
@@ -48,8 +49,18 @@
         Properties="@(AdditionalProperties)"
         RemoveProperties="OutputPath;TargetFramework" />
 
+    <PropertyGroup>
+      <_ShouldCodeSignOnMacOS Condition="$([System.OperatingSystem]::IsMacOS()) and '$(Sign)' == 'true' and '$(DotNetSignType)' == 'real' and '$(PublishNativeAot)' == 'true'" />
+      <_OutputBinaryPath>$(OutputPath)/aspire</_OutputBinaryPath>
+    </PropertyGroup>
+
+    <!-- Codesign on macos -->
+    <Message Text="Codesigning $(_OutputBinaryPath) .." Importance="High" Condition="'$(_ShouldCodeSignOnMacOS)' == 'true'" />
+    <!-- '-o runtime' is to enable hardened runtime -->
+    <Exec Command="codesign -s - -o runtime -f $(_OutputBinaryPath)" Condition="'$(_ShouldCodeSignOnMacOS)' == 'true'" />
+
     <!-- TODO: avoid generating the file instead of manually deleting it here -->
-    <Delete Files="$(OutputPath)\aspire.xml" Condition="Exists('$(OutputPath)\aspire.xml')" />
+    <Delete Files="$(_OutputBinaryPath).xml" Condition="Exists('$(_OutputBinaryPath).xml')" />
 
     <!-- work around https://github.com/dotnet/runtime/issues/116758 by removing the Xliff folders. -->
     <ItemGroup>

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -112,11 +112,45 @@ extends:
 
     stages:
 
+    - stage: build_sign_native
+      displayName: Build+Sign native packages
+
+      jobs:
+      - template: /eng/pipelines/templates/build_sign_native.yml@self
+        parameters:
+          agentOs: macos
+          targetRidsForSameOS:
+            - osx-arm64
+            - osx-x64
+          codeSign: true
+          teamName: $(_TeamName)
+          extraBuildArgs: >-
+            /p:Configuration=$(_BuildConfig)
+            $(_SignArgs)
+            $(_OfficialBuildIdArgs)
+
+      - template: /eng/pipelines/templates/build_sign_native.yml@self
+        parameters:
+          agentOs: linux
+          targetRidsForSameOS:
+            - linux-x64
+            - linux-arm64
+            - linux-musl-x64
+          # no need to sign ELF binaries on linux
+          codeSign: false
+          teamName: $(_TeamName)
+          extraBuildArgs: >-
+            /p:Configuration=$(_BuildConfig)
+            $(_SignArgs)
+            $(_OfficialBuildIdArgs)
+
     # ----------------------------------------------------------------
     # This stage performs build, test, packaging
     # ----------------------------------------------------------------
     - stage: build
       displayName: Build
+      dependsOn:
+      - build_sign_native
       jobs:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
@@ -160,6 +194,21 @@ extends:
                 clean: true
 
             steps:
+              - task: DownloadPipelineArtifact@2
+                displayName: 🟣Download All Native Archives
+                inputs:
+                  itemPattern: |
+                    **/aspire-cli-*.zip
+                    **/aspire-cli-*.tar.gz
+                  targetPath: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+
+              - task: PowerShell@2
+                displayName: 🟣List artifacts packages contents
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\packages" -File -Recurse | Select-Object -ExpandProperty FullName
+
               - template: /eng/pipelines/templates/BuildAndTest.yml
                 parameters:
                   dotnetScript: $(Build.SourcesDirectory)/dotnet.cmd
@@ -169,40 +218,6 @@ extends:
                   repoLogPath: $(Build.Arcade.LogsPath)
                   repoTestResultsPath: $(Build.Arcade.TestResultsPath)
                   isWindows: true
-
-          - ${{ if eq(variables._RunAsPublic, True) }}:
-            - job: Linux
-              ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
-                # If the build is getting signed, then the timeout should be increased.
-                timeoutInMinutes: 120
-              ${{ else }}:
-                # timeout accounts for wait times for helix agents up to 30mins
-                timeoutInMinutes: 90
-
-              pool:
-                name: NetCore1ESPool-Internal
-                image: 1es-mariner-2
-                os: linux
-
-              variables:
-                - name: _buildScript
-                  value: $(Build.SourcesDirectory)/build.sh --ci
-
-              preSteps:
-                - checkout: self
-                  fetchDepth: 1
-                  clean: true
-
-              steps:
-                - template: /eng/pipelines/templates/BuildAndTest.yml
-                  parameters:
-                    dotnetScript: $(Build.SourcesDirectory)/dotnet.sh
-                    buildScript: $(_buildScript)
-                    buildConfig: $(_BuildConfig)
-                    repoArtifactsPath: $(Build.Arcade.ArtifactsPath)
-                    repoLogPath: $(Build.Arcade.LogsPath)
-                    repoTestResultsPath: $(Build.Arcade.TestResultsPath)
-                    isWindows: false
 
       - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
         - template: /eng/common/templates-official/job/onelocbuild.yml@self

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -134,8 +134,6 @@ extends:
           agentOs: linux
           targetRidsForSameOS:
             - linux-x64
-            - linux-arm64
-            - linux-musl-x64
           # no need to sign ELF binaries on linux
           codeSign: false
           teamName: $(_TeamName)
@@ -207,7 +205,7 @@ extends:
                 inputs:
                   targetType: 'inline'
                   script: |
-                    Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\packages" -File -Recurse | Select-Object -ExpandProperty FullName
+                    Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\packages" -File -Recurse | Select-Object FullName, @{Name="Size(MB)";Expression={[math]::Round($_.Length/1MB,2)}} | Format-Table -AutoSize
 
               - template: /eng/pipelines/templates/BuildAndTest.yml
                 parameters:
@@ -218,6 +216,14 @@ extends:
                   repoLogPath: $(Build.Arcade.LogsPath)
                   repoTestResultsPath: $(Build.Arcade.TestResultsPath)
                   isWindows: true
+                  targetRids:
+                    # aot
+                    - win-x64
+                    - win-arm64
+                    # non-aot - single file builds
+                    - win-x86
+                    - linux-arm64
+                    - linux-musl-x64
 
       - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
         - template: /eng/common/templates-official/job/onelocbuild.yml@self

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -18,6 +18,7 @@ parameters:
     type: string
   - name: targetRids
     type: object
+    default: ''
   - name: runHelixTests
     type: boolean
     default: false

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -39,13 +39,13 @@ steps:
               $(_OfficialBuildIdArgs)
               $(_InternalBuildArgs)
               /p:SkipTestProjects=true
-      displayName: Build
+      displayName: 🟣Build
 
     - script: ${{ parameters.dotnetScript }}
               build
               tests/workloads.proj
               /p:SkipPackageCheckForTemplatesTesting=true
-      displayName: Prepare sdks for templates testing
+      displayName: 🟣Prepare sdks for templates testing
 
     - script: ${{ parameters.buildScript }}
               -build
@@ -63,7 +63,7 @@ steps:
         DEV_TEMP: $(Build.SourcesDirectory)\..
         DOTNET_ROOT: $(Build.SourcesDirectory)\.dotnet
         TEST_LOG_PATH: $(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\Aspire.Templates.Tests
-      displayName: Run Template tests
+      displayName: 🟣Run Template tests
 
   # Public pipeline - helix tests
   - ${{ if eq(parameters.runAsPublic, 'true') }}:

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -16,6 +16,8 @@ parameters:
     type: string
   - name: dotnetScript
     type: string
+  - name: targetRids
+    type: object
   - name: runHelixTests
     type: boolean
     default: false
@@ -38,6 +40,7 @@ steps:
               /bl:${{ parameters.repoLogPath }}/build.binlog
               $(_OfficialBuildIdArgs)
               $(_InternalBuildArgs)
+              /p:TargetRids=${{ join(':', parameters.targetRids) }}
               /p:SkipTestProjects=true
       displayName: 🟣Build
 

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -57,7 +57,7 @@ jobs:
           # Installing Microbuild plugin fails due to https://github.com/dotnet/arcade/issues/15946#issuecomment-3045780552
           # because of the preview sdk. To fix that `restore` from `global.json` so the above step
           # does not have to install anything.
-          - script: $(Build.SourcesDirectory)/$(scriptName) -restore
+          - script: $(Build.SourcesDirectory)/$(scriptName) -restore /p:Configuration=$(_BuildConfig)
             displayName: 🟣Restore
 
         steps:
@@ -66,7 +66,7 @@ jobs:
               --ci
               --build
               --restore
-              /p:BuildNativeOnly=true
+              /p:SkipManagedBuild=true
               /p:TargetRids=${{ targetRid }}
               $(_buildArgs)
               ${{ parameters.extraBuildArgs }}

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -67,7 +67,7 @@ jobs:
               --build
               --restore
               /p:BuildNativeOnly=true
-              /p:TargetRid=${{ targetRid }}
+              /p:TargetRids=${{ targetRid }}
               $(_buildArgs)
               ${{ parameters.extraBuildArgs }}
               /bl:$(Build.Arcade.LogsPath)Build.binlog

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -54,7 +54,7 @@ jobs:
             fetchDepth: 1
             clean: true
 
-          # Installing Microbuild plugin fails due to https://github.com/dotnet/arcade/issues/15946
+          # Installing Microbuild plugin fails due to https://github.com/dotnet/arcade/issues/15946#issuecomment-3045780552
           # because of the preview sdk. To fix that `restore` from `global.json` so the above step
           # does not have to install anything.
           - script: $(Build.SourcesDirectory)/$(scriptName) -restore

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -1,0 +1,81 @@
+parameters:
+  # values: windows/mac/linux
+  agentOs: 'windows'
+  targetRidsForSameOS:
+    - win_x64
+  extraBuildArgs: ''
+  codeSign: false
+  teamName: ''
+
+jobs:
+
+- ${{ each targetRid in parameters.targetRidsForSameOS }}:
+  - template: /eng/common/templates-official/jobs/jobs.yml@self
+    parameters:
+      enableMicrobuild: ${{ eq(parameters.codeSign, true) }}
+      enableMicrobuildForMacAndLinux: ${{ and(eq(parameters.codeSign, true), ne(parameters.agentOs, 'windows')) }}
+      enableTelemetry: true
+      # Publish build logs
+      enablePublishBuildArtifacts: true
+
+      jobs:
+      - job: BuildNative_${{ replace(targetRid, '-', '_') }}
+        displayName: ${{ replace(targetRid, '-', '_') }}
+        timeoutInMinutes: 40
+
+        variables:
+        - TeamName: ${{ parameters.teamName }}
+        - ${{ if eq(parameters.codeSign, true) }}:
+          - _buildArgs: '--sign'
+        - ${{ else }}:
+          - _buildArgs: ''
+
+        - ${{ if eq(parameters.agentOs, 'windows') }}:
+          - scriptName: build.cmd
+        - ${{ else }}:
+          - scriptName: build.sh
+
+        pool:
+          ${{ if eq(parameters.agentOs, 'windows') }}:
+            name: NetCore1ESPool-Internal
+            image: windows.vs2022preview.amd64
+            os: windows
+          ${{ if eq(parameters.agentOs, 'linux') }}:
+            name: NetCore1ESPool-Internal
+            image: 1es-mariner-2
+            os: linux
+          ${{ if eq(parameters.agentOs, 'macos') }}:
+            name: Azure Pipelines
+            vmImage: macOS-latest-internal
+            os: macOS
+
+        preSteps:
+          - checkout: self
+            fetchDepth: 1
+            clean: true
+
+          # Installing Microbuild plugin fails due to https://github.com/dotnet/arcade/issues/15946
+          # because of the preview sdk. To fix that `restore` from `global.json` so the above step
+          # does not have to install anything.
+          - script: $(Build.SourcesDirectory)/$(scriptName) -restore
+            displayName: 🟣Restore
+
+        steps:
+          - script: >-
+              $(Build.SourcesDirectory)/$(scriptName)
+              --ci
+              --build
+              --restore
+              /p:BuildNativeOnly=true
+              /p:TargetRid=${{ targetRid }}
+              $(_buildArgs)
+              ${{ parameters.extraBuildArgs }}
+              /bl:$(Build.Arcade.LogsPath)Build.binlog
+            displayName: 🟣Build native packages
+
+          - task: 1ES.PublishBuildArtifacts@1
+            displayName: 🟣Publish Artifacts
+            condition: always()
+            inputs:
+              PathtoPublish: '$(Build.Arcade.ArtifactsPath)packages/'
+              ArtifactName: native_archives_${{ replace(targetRid, '-', '_') }}

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -2,7 +2,7 @@ parameters:
   # values: windows/mac/linux
   agentOs: 'windows'
   targetRidsForSameOS:
-    - win_x64
+    - linux-x64
   extraBuildArgs: ''
   codeSign: false
   teamName: ''


### PR DESCRIPTION
Add AOT builds for Linux, and macOS

## What?

This PR adds AOT builds for Linux, and macOS on the internal builds. On macOS the binaries are appropriately signed, and notarized making them usable after downloading.

## How?

This is done by having separate OS-specific jobs just to build the AOTed aspire cli. And these upload the archives for use by a "joining" Windows job which builds windows binaries, and publishes all the archives. Checksum (`sha512`) files are also generated for the archives which can be used to verify the archive when downloading.

This is the current supported matrix:

| Runtime Identifier | AOTed |
|-------------------|-------------|
| `win-x64` | ✅ |
| `win-arm64` | ✅ |
| `win-x86` | ❌ |
| `linux-x64` | ✅ |
| `linux-arm64` | ❌ |
| `linux-musl-x64` | ❌ |
| `osx-x64` | ✅ |
| `osx-arm64` | ✅ |

- `win-x86` - Native AOT is not supported for this
- `linux-arm64`, `linux-musl-x64` - will be added in a follow up PR

For the non-aot cases a self-contained executable is generated.

## Tests

To catch missing archives due to any reason on the CI build