### PR TITLE
chore: aspire exec report error when executable failed to start

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -14,7 +14,7 @@ internal class ConsoleInteractionService : IInteractionService
     private static readonly Style s_exitCodeMessageStyle = new Style(foreground: Color.RoyalBlue1, background: null, decoration: Decoration.None);
     private static readonly Style s_infoMessageStyle = new Style(foreground: Color.Green, background: null, decoration: Decoration.None);
     private static readonly Style s_waitingMessageStyle = new Style(foreground: Color.Yellow, background: null, decoration: Decoration.None);
-    private static readonly Style s_errorMessageStyle = new Style(foreground: Color.Black, background: null, decoration: Decoration.Bold);
+    private static readonly Style s_errorMessageStyle = new Style(foreground: Color.Red, background: null, decoration: Decoration.Bold);
 
     private readonly IAnsiConsole _ansiConsole;
 
@@ -120,6 +120,7 @@ internal class ConsoleInteractionService : IInteractionService
                 "waiting" => s_waitingMessageStyle,
                 "running" => s_infoMessageStyle,
                 "exitCode" => s_exitCodeMessageStyle,
+                "failedToStart" => s_errorMessageStyle,
                 _ => s_infoMessageStyle
             };
 

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -86,6 +86,14 @@
       "environmentVariables": {
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
+    },
+    "exec-nonexisting-command": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "exec --project ../../../../../playground/DatabaseMigration/DatabaseMigration.AppHost/DatabaseMigration.AppHost.csproj --resource api -- randomnonexistingcommand builddoit",
+      "environmentVariables": {
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
     }
   }
 }

--- a/tests/Aspire.Cli.Tests/E2E/ExecTests.cs
+++ b/tests/Aspire.Cli.Tests/E2E/ExecTests.cs
@@ -92,6 +92,26 @@ public class ExecTests(ITestOutputHelper output)
 
     [Fact]
     [RequiresDocker]
+    public async Task Exec_NonExistingCommand_ShouldProduceLogs()
+    {
+        string[] args = [
+            "--operation", "run",
+            "--project", DatabaseMigrationsAppHostProjectPath,
+            "--resource", "api",
+                         // not existing command. Executable should fail without start basically
+            "--command", "\"randombuildcommand doit\"",
+            "--postgres"
+        ];
+
+        var app = await BuildAppAsync(args);
+        var logs = await ExecAndCollectLogsAsync(app);
+
+        Assert.True(logs.Count > 0, "No logs were produced during the exec operation.");
+        Assert.Contains(logs, x => x.Text.Contains("Aspire exec failed to start"));
+    }
+
+    [Fact]
+    [RequiresDocker]
     public async Task Exec_DotnetHelp_ShouldProduceLogs()
     {
         string[] args = [


### PR DESCRIPTION
## Description

Aspire exec today does not show anything if executable resource failed to start. We also dont report a non-zero exit code, meaning there is no user info existing and nobody can understand what happened.

This PR covers this scenario and adds a separate message reported to user if resource failed to start. I also report an artificial exitcode `-1` to demonstrate that `aspire exec` finished non-successfully. 

<img width="809" alt="image" src="https://github.com/user-attachments/assets/1576f162-feff-4155-a0a3-48e92e1a584f" />

Fixes #10263 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
