### PR TITLE
Use different names for persistent and session scoped networks

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -441,6 +441,11 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     /// <returns>The normalized application name with invalid characters removed.</returns>
     private static string NormalizeApplicationName(string applicationName)
     {
+        if (string.IsNullOrEmpty(applicationName))
+        {
+            return applicationName;
+        }
+
         applicationName = ApplicationNameRegex().Match(applicationName) switch
         {
             Match { Success: true } match => match.Groups["name"].Value,

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -433,7 +433,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     }
 
     /// <summary>
-    /// Normalizes the application name for use in physical container resource names.
+    /// Normalizes the application name for use in physical container resource names (only guaranteed valid as a suffix).
     /// Removes the ".AppHost" suffix if present and takes only characters that are valid in resource names.
     /// Invalid characters are simply omitted from the name as the result doesn't need to be identical.
     /// </summary>
@@ -455,24 +455,12 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         var normalizedName = new StringBuilder();
         for (var i = 0; i < applicationName.Length; i++)
         {
-            if (normalizedName.Length == 0)
+            if ((applicationName[i] is >= 'a' and <= 'z') ||
+                (applicationName[i] is >= 'A' and <= 'Z') ||
+                (applicationName[i] is >= '0' and <= '9') ||
+                (applicationName[i] is '_' or '-' or '.'))
             {
-                if ((applicationName[i] is >= 'a' and <= 'z') ||
-                    (applicationName[i] is >= 'A' and <= 'Z') ||
-                    (applicationName[i] is >= '0' and <= '9'))
-                {
-                    normalizedName.Append(applicationName[i]);
-                }
-            }
-            else
-            {
-                if ((applicationName[i] is >= 'a' and <= 'z') ||
-                    (applicationName[i] is >= 'A' and <= 'Z') ||
-                    (applicationName[i] is >= '0' and <= '9') ||
-                    (applicationName[i] is '_' or '-' or '.'))
-                {
-                    normalizedName.Append(applicationName[i]);
-                }
+                normalizedName.Append(applicationName[i]);
             }
         }
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -13,6 +13,8 @@ using k8s.Models;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Polly;
@@ -1242,6 +1244,7 @@ public class DcpExecutorTests
 
     private static DcpExecutor CreateAppExecutor(
         DistributedApplicationModel distributedAppModel,
+        IHostEnvironment? hostEnvironment = null,
         IConfiguration? configuration = null,
         IKubernetesService? kubernetesService = null,
         DcpOptions? dcpOptions = null,
@@ -1268,6 +1271,7 @@ public class DcpExecutorTests
             NullLogger<DcpExecutor>.Instance,
             NullLogger<DistributedApplication>.Instance,
             distributedAppModel,
+            hostEnvironment ?? new TestHostEnvironment(),
             kubernetesService ?? new TestKubernetesService(),
             configuration,
             new Hosting.Eventing.DistributedApplicationEventing(),
@@ -1281,6 +1285,14 @@ public class DcpExecutorTests
             new TestDcpDependencyCheckService(),
             new DcpNameGenerator(configuration, Options.Create(dcpOptions)),
             events ?? new DcpExecutorEvents());
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string ApplicationName { get; set; } = default!;
+        public IFileProvider ContentRootFileProvider { get; set; } = default!;
+        public string ContentRootPath { get; set; } = default!;
+        public string EnvironmentName { get; set; } = default!;
     }
 
     private sealed class TestProject : IProjectMetadata


### PR DESCRIPTION
## Description

Update the default network names to reflect the resource lifetime (persistent vs. session scoped) as well as appending a normalized version of the application name (with `.AppHost` removed if present).

Persistent networks will be named `aspire-persistent-network-<hash>-<ApplicationName>`, while session scoped networks will be named `aspire-session-network-<randomid>-<ApplicationName>`. This should make it more clear whether a network resource is intentionally persistent or a leaked resource from a failed cleanup, as well as making it easier to identify which application a network belongs to if you work with multiple Aspire based projects.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
