### PR TITLE
Add missing end quote for Outputs declaration

### DIFF
--- a/eng/ReplaceText.targets
+++ b/eng/ReplaceText.targets
@@ -59,7 +59,7 @@
   <Target Name="_ProcessTextReplacementFiles"
     DependsOnTargets="GatherTextReplacementValues"
     Inputs="$(MSBuildAllProjects);@(_TextReplacementFile)"
-    Outputs="@(_TextReplacementFile->'%(_TextReplacementIntermediateFile))"
+    Outputs="@(_TextReplacementFile->'%(_TextReplacementIntermediateFile)')"
     >
     <ReplaceText
         Input="%(_TextReplacementFile.Identity)"


### PR DESCRIPTION
The `_ProcessTextReplacementFiles` target specifies an invalid expression in its `Outputs` attribute leading to MSBuild not properly checking the output and always rebuilding this target. This was found while prototyping a new set of functionality in MSBuild that is more strict about input and output declarations and failed on this.