### PR TITLE
Add role support to Azure AI Foundry

### DIFF
--- a/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/aspire-manifest.json
@@ -3,12 +3,12 @@
   "resources": {
     "foundry": {
       "type": "azure.bicep.v0",
-      "connectionString": "Endpoint={foundry.outputs.aiFoundryApiEndpoint};EndpointAIInference={foundry.outputs.aiFoundryApiEndpoint}models",
+      "connectionString": "Endpoint={foundry.outputs.endpoint};EndpointAIInference={foundry.outputs.aiFoundryApiEndpoint}models",
       "path": "foundry.module.bicep"
     },
     "chat": {
       "type": "value.v0",
-      "connectionString": "Endpoint={foundry.outputs.aiFoundryApiEndpoint};EndpointAIInference={foundry.outputs.aiFoundryApiEndpoint}models;DeploymentId=qwen2.5-0.5b;Model=qwen2.5-0.5b"
+      "connectionString": "Endpoint={foundry.outputs.endpoint};EndpointAIInference={foundry.outputs.aiFoundryApiEndpoint}models;DeploymentId=qwen2.5-0.5b;Model=qwen2.5-0.5b"
     },
     "webstory": {
       "type": "project.v0",
@@ -34,6 +34,15 @@
           "transport": "http",
           "external": true
         }
+      }
+    },
+    "foundry-roles": {
+      "type": "azure.bicep.v0",
+      "path": "foundry-roles.module.bicep",
+      "params": {
+        "foundry_outputs_name": "{foundry.outputs.name}",
+        "principalType": "",
+        "principalId": ""
       }
     }
   }

--- a/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/foundry-roles.module.bicep
+++ b/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/foundry-roles.module.bicep
@@ -1,0 +1,32 @@
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param foundry_outputs_name string
+
+param principalType string
+
+param principalId string
+
+resource foundry 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = {
+  name: foundry_outputs_name
+}
+
+resource foundry_CognitiveServicesUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(foundry.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')
+    principalType: principalType
+  }
+  scope: foundry
+}
+
+resource foundry_CognitiveServicesOpenAIUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(foundry.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
+    principalType: principalType
+  }
+  scope: foundry
+}

--- a/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/foundry.module.bicep
+++ b/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/foundry.module.bicep
@@ -2,7 +2,7 @@
 param location string = resourceGroup().location
 
 resource foundry 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
-  name: take('foundry${uniqueString(resourceGroup().id)}', 64)
+  name: take('foundry-${uniqueString(resourceGroup().id)}', 64)
   location: location
   identity: {
     type: 'SystemAssigned'
@@ -40,3 +40,5 @@ resource chat 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
 output aiFoundryApiEndpoint string = foundry.properties.endpoints['AI Foundry API']
 
 output endpoint string = foundry.properties.endpoint
+
+output name string = foundry.name

--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryExtensions.cs
@@ -33,7 +33,9 @@ public static class AzureAIFoundryExtensions
         builder.AddAzureProvisioning();
 
         var resource = new AzureAIFoundryResource(name, ConfigureInfrastructure);
-        return builder.AddResource(resource);
+        return builder.AddResource(resource)
+            .WithDefaultRoleAssignments(CognitiveServicesBuiltInRole.GetBuiltInRoleName,
+                CognitiveServicesBuiltInRole.CognitiveServicesUser, CognitiveServicesBuiltInRole.CognitiveServicesOpenAIUser);
     }
 
     /// <summary>
@@ -128,6 +130,37 @@ public static class AzureAIFoundryExtensions
         builder.WithHealthCheck(healthCheckKey);
 
         return builder;
+    }
+
+    /// <summary>
+    /// Assigns the specified roles to the given resource, granting it the necessary permissions
+    /// on the target Azure AI Foundry resource. This replaces the default role assignments for the resource.
+    /// </summary>
+    /// <param name="builder">The resource to which the specified roles will be assigned.</param>
+    /// <param name="target">The target Azure AI Foundry resource.</param>
+    /// <param name="roles">The built-in Cognitive Services roles to be assigned.</param>
+    /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <remarks>
+    /// <example>
+    /// Assigns the CognitiveServicesOpenAIContributor role to the 'Projects.Api' project.
+    /// <code lang="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var aiFoundry = builder.AddAzureAIFoundry("aiFoundry");
+    /// 
+    /// var api = builder.AddProject&lt;Projects.Api&gt;("api")
+    ///   .WithRoleAssignments(aiFoundry, CognitiveServicesBuiltInRole.CognitiveServicesOpenAIContributor)
+    ///   .WithReference(aiFoundry);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    public static IResourceBuilder<T> WithRoleAssignments<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<AzureAIFoundryResource> target,
+        params CognitiveServicesBuiltInRole[] roles)
+        where T : IResource
+    {
+        return builder.WithRoleAssignments(target, CognitiveServicesBuiltInRole.GetBuiltInRoleName, roles);
     }
 
     private static IResourceBuilder<AzureAIFoundryResource> WithInitializer(this IResourceBuilder<AzureAIFoundryResource> builder)
@@ -295,7 +328,6 @@ public static class AzureAIFoundryExtensions
                 },
                 (infrastructure) => new CognitiveServicesAccount(infrastructure.AspireResource.GetBicepIdentifier())
                 {
-                    Name = Take(Interpolate($"{infrastructure.AspireResource.GetBicepIdentifier()}{GetUniqueString(GetResourceGroup().Id)}"), 64),
                     Kind = "AIServices",
                     Sku = new CognitiveServicesSku()
                     {
@@ -325,6 +357,8 @@ public static class AzureAIFoundryExtensions
         {
             Value = cogServicesAccount.Properties.Endpoint
         });
+
+        infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = cogServicesAccount.Name });
 
         var resource = (AzureAIFoundryResource)infrastructure.AspireResource;
 

--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryResource.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryResource.cs
@@ -31,6 +31,11 @@ public class AzureAIFoundryResource(string name, Action<AzureResourceInfrastruct
     public BicepOutputReference Endpoint => new("endpoint", this);
 
     /// <summary>
+    /// Gets the "name" output reference for the resource.
+    /// </summary>
+    public BicepOutputReference NameOutputReference => new("name", this);
+
+    /// <summary>
     /// Gets the connection string template for the manifest for the resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
@@ -52,11 +57,6 @@ public class AzureAIFoundryResource(string name, Action<AzureResourceInfrastruct
     /// The API key to access Foundry Local
     /// </summary>
     public string? ApiKey { get; internal set; }
-
-    /// <summary>
-    /// Gets the "name" output reference for the resource.
-    /// </summary>
-    public BicepOutputReference NameOutputReference => new("name", this);
 
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAIFoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAIFoundryExtensionsTests.cs
@@ -87,7 +87,7 @@ public class AzureAIFoundryExtensionsTests
 
         var rns = app.Services.GetRequiredService<ResourceNotificationService>();
 
-        // Wait until it's not in Starting state anymore (started or failed wether the Foundry Local service is setup or not)
+        // Wait until it's not in Starting state anymore (started or failed whether the Foundry Local service is setup or not)
         await rns.WaitForResourceAsync(resource.Name, [KnownResourceStates.FailedToStart, KnownResourceStates.Running], cts.Token);
 
         var foundryManager = app.Services.GetRequiredService<FoundryLocalManager>();
@@ -136,8 +136,15 @@ public class AzureAIFoundryExtensionsTests
         var deployment1 = foundry.AddDeployment("deployment1", "gpt-4", "1.0", "OpenAI");
         var deployment2 = foundry.AddDeployment("deployment2", "Phi-4", "1.0", "Microsoft");
 
-        var manifest = await AzureManifestUtils.GetManifestWithBicep(foundry.Resource);
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        await Verify(manifest.BicepText, extension: "bicep");
+        var manifest = await AzureManifestUtils.GetManifestWithBicep(model, foundry.Resource);
+
+        var roles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "foundry-roles");
+        var rolesManifest = await AzureManifestUtils.GetManifestWithBicep(model, roles);
+
+        await Verify(manifest.BicepText, extension: "bicep")
+            .AppendContentAsFile(rolesManifest.BicepText, "bicep");
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
@@ -59,6 +59,19 @@ public class RoleAssignmentTests()
     }
 
     [Fact]
+    public Task AzureFoundrySupport()
+    {
+        return RoleAssignmentTest("ai",
+            builder =>
+            {
+                var openai = builder.AddAzureAIFoundry("ai");
+
+                builder.AddProject<Project>("api", launchProfileName: null)
+                    .WithRoleAssignments(openai, CognitiveServicesBuiltInRole.CognitiveServicesFaceRecognizer);
+            });
+    }
+
+    [Fact]
     public Task EventHubsSupport()
     {
         return RoleAssignmentTest("eventhubs",

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAIFoundryExtensionsTests.AddAzureAIFoundry_GeneratesValidBicep#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAIFoundryExtensionsTests.AddAzureAIFoundry_GeneratesValidBicep#00.verified.bicep
@@ -2,7 +2,7 @@
 param location string = resourceGroup().location
 
 resource foundry 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
-  name: take('foundry${uniqueString(resourceGroup().id)}', 64)
+  name: take('foundry-${uniqueString(resourceGroup().id)}', 64)
   location: location
   identity: {
     type: 'SystemAssigned'
@@ -59,3 +59,5 @@ resource deployment2 'Microsoft.CognitiveServices/accounts/deployments@2024-10-0
 output aiFoundryApiEndpoint string = foundry.properties.endpoints['AI Foundry API']
 
 output endpoint string = foundry.properties.endpoint
+
+output name string = foundry.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAIFoundryExtensionsTests.AddAzureAIFoundry_GeneratesValidBicep#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAIFoundryExtensionsTests.AddAzureAIFoundry_GeneratesValidBicep#01.verified.bicep
@@ -1,0 +1,32 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param foundry_outputs_name string
+
+param principalType string
+
+param principalId string
+
+resource foundry 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = {
+  name: foundry_outputs_name
+}
+
+resource foundry_CognitiveServicesUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(foundry.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')
+    principalType: principalType
+  }
+  scope: foundry
+}
+
+resource foundry_CognitiveServicesOpenAIUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(foundry.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
+    principalType: principalType
+  }
+  scope: foundry
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/RoleAssignmentTests.AzureFoundrySupport.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/RoleAssignmentTests.AzureFoundrySupport.verified.bicep
@@ -1,0 +1,20 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param ai_outputs_name string
+
+param principalId string
+
+resource ai 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = {
+  name: ai_outputs_name
+}
+
+resource ai_CognitiveServicesFaceRecognizer 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(ai.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9894cab4-e18a-44aa-828b-cb588cd6f2d7'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9894cab4-e18a-44aa-828b-cb588cd6f2d7')
+    principalType: 'ServicePrincipal'
+  }
+  scope: ai
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/RoleAssignmentTests.AzureFoundrySupport.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/RoleAssignmentTests.AzureFoundrySupport.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "api-roles-ai.module.bicep",
+  "params": {
+    "ai_outputs_name": "{ai.outputs.name}",
+    "principalId": "{api-identity.outputs.principalId}"
+  }
+}


### PR DESCRIPTION
## Description

1. Add the default roles of CognitiveServicesUser and CognitiveServicesOpenAIUser
2. Add support for developers explicitly setting the role assignments

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
