### PR TITLE
Change Azure OpenAI to use CognitiveServicesOpenAIUser role by default

### DIFF
--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai-roles.module.bicep
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai-roles.module.bicep
@@ -11,11 +11,11 @@ resource openai 'Microsoft.CognitiveServices/accounts@2024-10-01' existing = {
   name: openai_outputs_name
 }
 
-resource openai_CognitiveServicesOpenAIContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(openai.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442'))
+resource openai_CognitiveServicesOpenAIUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(openai.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'))
   properties: {
     principalId: principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442')
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
     principalType: principalType
   }
   scope: openai

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -97,7 +97,7 @@ public static class AzureOpenAIExtensions
         var resource = new AzureOpenAIResource(name, configureInfrastructure);
         return builder.AddResource(resource)
             .WithDefaultRoleAssignments(CognitiveServicesBuiltInRole.GetBuiltInRoleName,
-                CognitiveServicesBuiltInRole.CognitiveServicesOpenAIContributor);
+                CognitiveServicesBuiltInRole.CognitiveServicesOpenAIUser);
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/tests/Aspire.Hosting.Azure.Tests/AzureOpenAIExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureOpenAIExtensionsTests.cs
@@ -93,11 +93,11 @@ public class AzureOpenAIExtensionsTests(ITestOutputHelper output)
               name: openai_outputs_name
             }
 
-            resource openai_CognitiveServicesOpenAIContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-              name: guid(openai.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442'))
+            resource openai_CognitiveServicesOpenAIUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+              name: guid(openai.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'))
               properties: {
                 principalId: principalId
-                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442')
+                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd')
                 principalType: principalType
               }
               scope: openai

--- a/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/RoleAssignmentTests.cs
@@ -54,7 +54,7 @@ public class RoleAssignmentTests()
                 var openai = builder.AddAzureOpenAI("openai");
 
                 builder.AddProject<Project>("api", launchProfileName: null)
-                    .WithRoleAssignments(openai, CognitiveServicesBuiltInRole.CognitiveServicesOpenAIUser);
+                    .WithRoleAssignments(openai, CognitiveServicesBuiltInRole.CognitiveServicesOpenAIUser, CognitiveServicesBuiltInRole.CognitiveServicesFaceRecognizer);
             });
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/RoleAssignmentTests.OpenAISupport.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/RoleAssignmentTests.OpenAISupport.verified.bicep
@@ -18,3 +18,13 @@ resource openai_CognitiveServicesOpenAIUser 'Microsoft.Authorization/roleAssignm
   }
   scope: openai
 }
+
+resource openai_CognitiveServicesFaceRecognizer 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(openai.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9894cab4-e18a-44aa-828b-cb588cd6f2d7'))
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9894cab4-e18a-44aa-828b-cb588cd6f2d7')
+    principalType: 'ServicePrincipal'
+  }
+  scope: openai
+}


### PR DESCRIPTION
## Description

The CognitiveServicesOpenAIContributor role is too permissive as it allows an app to modify deployments (i.e. models). Instead we should be defaulting to CognitiveServicesOpenAIUser which allows the app to do inference, but not modify the resources.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
    - https://github.com/dotnet/docs-aspire/issues/3936
