### PR TITLE
Optimize trace detail page performance

### DIFF
--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -28,14 +28,14 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
     {
         public void Dispose()
         {
-            TelemetryContext?.Dispose();
+            TelemetryContext.Dispose();
         }
     }
     internal record InteractionDialogReference(int InteractionId, IDialogReference Dialog, ComponentTelemetryContext TelemetryContext) : IDisposable
     {
         public void Dispose()
         {
-            TelemetryContext?.Dispose();
+            TelemetryContext.Dispose();
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -261,9 +261,22 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             _tracesSubscription?.Dispose();
             _tracesSubscription = TelemetryRepository.OnNewTraces(_trace.FirstSpan.Source.ApplicationKey, SubscriptionType.Read, () => InvokeAsync(async () =>
             {
-                UpdateDetailViewData();
-                await InvokeAsync(StateHasChanged);
-                await _dataGrid.SafeRefreshDataAsync();
+                if (_trace == null)
+                {
+                    return;
+                }
+
+                // Only update trace if required.
+                if (TelemetryRepository.HasUpdatedTrace(_trace))
+                {
+                    UpdateDetailViewData();
+                    StateHasChanged();
+                    await _dataGrid.SafeRefreshDataAsync();
+                }
+                else
+                {
+                    Logger.LogTrace("Trace '{TraceId}' is unchanged.", TraceId);
+                }
             }));
         }
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -42,12 +42,18 @@ public class OtlpSpan
     public OtlpScope Scope { get; }
     public TimeSpan Duration => EndTime - StartTime;
 
-    public OtlpApplication? UninstrumentedPeer { get; internal set; }
+    public OtlpApplication? UninstrumentedPeer { get => _uninstrumentedPeer; init => _uninstrumentedPeer = value; }
 
     public IEnumerable<OtlpSpan> GetChildSpans() => GetChildSpans(this, Trace.Spans);
     public static IEnumerable<OtlpSpan> GetChildSpans(OtlpSpan parentSpan, OtlpSpanCollection spans) => spans.Where(s => s.ParentSpanId == parentSpan.SpanId);
 
     private string? _cachedDisplaySummary;
+    private OtlpApplication? _uninstrumentedPeer;
+
+    public void SetUninstrumentedPeer(OtlpApplication? peer)
+    {
+        _uninstrumentedPeer = peer;
+    }
 
     public OtlpSpan? GetParentSpan()
     {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -771,14 +771,14 @@ public sealed class TelemetryRepository : IDisposable
 
         try
         {
-            var lastestTrace = GetTraceUnsynchronized(trace.TraceId);
-            if (lastestTrace == null)
+            var latestTrace = GetTraceUnsynchronized(trace.TraceId);
+            if (latestTrace == null)
             {
                 // Trace must have been removed. Technically there is an update (nothing).
                 return true;
             }
 
-            return lastestTrace.LastUpdatedDate > trace.LastUpdatedDate;
+            return latestTrace.LastUpdatedDate > trace.LastUpdatedDate;
         }
         finally
         {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -817,7 +817,7 @@ public sealed class TelemetryRepository : IDisposable
 
     private OtlpTrace? GetTraceAndCloneUnsynchronized(string traceId)
     {
-        Debug.Assert(_tracesLock.IsReadLockHeld || _tracesLock.IsWriteLockHeld, $"Must get lock before calling {nameof(GetTraceUnsynchronized)}.");
+        Debug.Assert(_tracesLock.IsReadLockHeld || _tracesLock.IsWriteLockHeld, $"Must get lock before calling {nameof(GetTraceAndCloneUnsynchronized)}.");
 
         var trace = GetTraceUnsynchronized(traceId);
 
@@ -828,6 +828,7 @@ public sealed class TelemetryRepository : IDisposable
     {
         Debug.Assert(_tracesLock.IsReadLockHeld || _tracesLock.IsWriteLockHeld, $"Must get lock before calling {nameof(GetSpanAndCloneUnsynchronized)}.");
 
+        // Trace and its spans are cloned here.
         var trace = GetTraceAndCloneUnsynchronized(traceId);
         if (trace != null)
         {

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -22,7 +22,7 @@ public sealed class SpanWaterfallViewModelTests
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
 
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc)));
@@ -82,7 +82,7 @@ public sealed class SpanWaterfallViewModelTests
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
 
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc), kind: OtlpSpanKind.Client, attributes: [KeyValuePair.Create("http.url", "http://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag"), KeyValuePair.Create("server.address", "localhost")]));
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "2", parentSpanId: null, startDate: new DateTime(2001, 2, 1, 1, 1, 2, DateTimeKind.Utc), kind: OtlpSpanKind.Client));
@@ -115,7 +115,7 @@ public sealed class SpanWaterfallViewModelTests
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
         var app = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
 
         // Create a span with an attribute that simulates uninstrumented peer
@@ -156,7 +156,7 @@ public sealed class SpanWaterfallViewModelTests
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         var parentSpan = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "parent", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc));
         var childSpan = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "child", parentSpanId: "parent", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc));
@@ -178,7 +178,7 @@ public sealed class SpanWaterfallViewModelTests
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         var parentSpan = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "parent", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc));
         var childSpan = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "child", parentSpanId: "parent", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc));

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -53,7 +53,7 @@ public sealed class SpanWaterfallViewModelTests
         var app1View = new OtlpApplicationView(app1, new RepeatedField<KeyValue>());
 
         var date = new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "31", parentSpanId: null, startDate: date, endDate: date));
         var log = new OtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(traceId: trace.TraceId, spanId: "1"), app1View, scope, context);

--- a/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
@@ -17,7 +17,7 @@ public sealed class TraceHelpersTests
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
 
@@ -39,7 +39,7 @@ public sealed class TraceHelpersTests
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "1-2", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
@@ -66,7 +66,7 @@ public sealed class TraceHelpersTests
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
@@ -94,7 +94,7 @@ public sealed class TraceHelpersTests
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
         var app3 = new OtlpApplication("app3", "instance", uninstrumentedPeer: false, context);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc)));
@@ -128,7 +128,7 @@ public sealed class TraceHelpersTests
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
         var app2 = new OtlpApplication("app2", "instance", uninstrumentedPeer: false, context);
         var app3 = new OtlpApplication("app3", "instance", uninstrumentedPeer: true, context);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc), uninstrumentedPeer: app3));

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
@@ -19,7 +19,7 @@ public class OtlpSpanTests
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
         var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
-        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
 
         var span = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime,


### PR DESCRIPTION
## Description

Trace detail page is updated when new trace data is received. This is so the currently viewed trace is updated with new spans.

However a lot of the time it is unnessary. Other traces are being updated, but the trace detail page is still updated with unchanged data. This PR adds a check to see whether the currently viewed trace has changed or not and skips updating the page if it hasn't.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
