### PR TITLE
Improve span details percentage calculation

### DIFF
--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -140,8 +140,8 @@ public sealed class SpanWaterfallViewModel
             var relativeStart = span.StartTime - traceStart;
             var rootDuration = span.Trace.Duration.TotalMilliseconds;
 
-            var leftOffset = relativeStart.TotalMilliseconds / rootDuration * 100;
-            var width = span.Duration.TotalMilliseconds / rootDuration * 100;
+            var leftOffset = CalculatePercent(relativeStart.TotalMilliseconds, rootDuration);
+            var width = CalculatePercent(span.Duration.TotalMilliseconds, rootDuration);
 
             // Figure out if the label is displayed to the left or right of the span.
             // If the label position is based on whether more than half of the span is on the left or right side of the trace.
@@ -163,7 +163,7 @@ public sealed class SpanWaterfallViewModel
                     {
                         Index = currentSpanLogIndex++,
                         LogEntry = log,
-                        LeftOffset = logRelativeStart.TotalMilliseconds / rootDuration * 100
+                        LeftOffset = CalculatePercent(logRelativeStart.TotalMilliseconds, rootDuration)
                     });
                 }
             }
@@ -191,6 +191,15 @@ public sealed class SpanWaterfallViewModel
             }
 
             return viewModel;
+        }
+
+        static double CalculatePercent(double value, double total)
+        {
+            if (total == 0)
+            {
+                return 0;
+            }
+            return value / total * 100;
         }
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -56,7 +56,7 @@ public sealed class SpanWaterfallViewModelTests
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: TelemetryTestHelpers.GetHexId("1"), parentSpanId: null, startDate: date, endDate: date));
-        var log = TelemetryTestHelpers.CreateOtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(traceId: trace.TraceId, spanId: TelemetryTestHelpers.GetHexId("1")), app1View, scope, context);
+        var log = new OtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(traceId: trace.TraceId, spanId: TelemetryTestHelpers.GetHexId("1")), app1View, scope, context);
 
         // Act
         var vm = SpanWaterfallViewModel.Create(trace, [log], new SpanWaterfallViewModel.TraceDetailState([], []));

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -5,7 +5,9 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Tests.Shared.Telemetry;
+using Google.Protobuf.Collections;
 using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry.Proto.Common.V1;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.Model;
@@ -39,6 +41,36 @@ public sealed class SpanWaterfallViewModelTests
             {
                 Assert.Equal("1-1", e.Span.SpanId);
                 Assert.Empty(e.Children);
+            });
+    }
+
+    [Fact]
+    public void Create_RootSpanZeroDuration_ZeroPercentage()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpApplication("app1", "instance", uninstrumentedPeer: false, context);
+        var app1View = new OtlpApplicationView(app1, new RepeatedField<KeyValue>());
+
+        var date = new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+        trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: TelemetryTestHelpers.GetHexId("1"), parentSpanId: null, startDate: date, endDate: date));
+        var log = TelemetryTestHelpers.CreateOtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(traceId: trace.TraceId, spanId: TelemetryTestHelpers.GetHexId("1")), app1View, scope, context);
+
+        // Act
+        var vm = SpanWaterfallViewModel.Create(trace, [log], new SpanWaterfallViewModel.TraceDetailState([], []));
+
+        // Assert
+        Assert.Collection(vm,
+            e =>
+            {
+                Assert.Equal(TelemetryTestHelpers.GetHexId("1"), e.Span.SpanId);
+                Assert.Equal(0, e.LeftOffset);
+                Assert.Equal(0, e.Width);
+
+                var spanLog = Assert.Single(e.SpanLogs);
+                Assert.Equal(0, spanLog.LeftOffset);
             });
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -55,8 +55,8 @@ public sealed class SpanWaterfallViewModelTests
         var date = new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
-        trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: TelemetryTestHelpers.GetHexId("1"), parentSpanId: null, startDate: date, endDate: date));
-        var log = new OtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(traceId: trace.TraceId, spanId: TelemetryTestHelpers.GetHexId("1")), app1View, scope, context);
+        trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "31", parentSpanId: null, startDate: date, endDate: date));
+        var log = new OtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(traceId: trace.TraceId, spanId: "1"), app1View, scope, context);
 
         // Act
         var vm = SpanWaterfallViewModel.Create(trace, [log], new SpanWaterfallViewModel.TraceDetailState([], []));
@@ -65,7 +65,7 @@ public sealed class SpanWaterfallViewModelTests
         Assert.Collection(vm,
             e =>
             {
-                Assert.Equal(TelemetryTestHelpers.GetHexId("1"), e.Span.SpanId);
+                Assert.Equal("31", e.Span.SpanId);
                 Assert.Equal(0, e.LeftOffset);
                 Assert.Equal(0, e.Width);
 

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -157,7 +157,7 @@ internal static class TelemetryTestHelpers
     {
         var span = new Span
         {
-            TraceId = ConvertHexToId(traceId),
+            TraceId = ByteString.CopyFrom(Encoding.UTF8.GetBytes(traceId)),
             SpanId = ByteString.CopyFrom(Encoding.UTF8.GetBytes(spanId)),
             ParentSpanId = parentSpanId is null ? ByteString.Empty : ByteString.CopyFrom(Encoding.UTF8.GetBytes(parentSpanId)),
             StartTimeUnixNano = DateTimeToUnixNanoseconds(startTime),
@@ -192,8 +192,8 @@ internal static class TelemetryTestHelpers
         var logRecord = new LogRecord
         {
             Body = (skipBody ?? false) ? null : new AnyValue { StringValue = message ?? "Test Value!" },
-            TraceId = (traceId != null) ? ConvertHexToId(traceId) : ByteString.CopyFrom(Convert.FromHexString("5465737454726163654964")),
-            SpanId = (spanId != null) ? ConvertHexToId(spanId) : ByteString.CopyFrom(Convert.FromHexString("546573745370616e4964")),
+            TraceId = (traceId != null) ? ByteString.CopyFrom(Encoding.UTF8.GetBytes(traceId)) : ByteString.CopyFrom(Convert.FromHexString("5465737454726163654964")),
+            SpanId = (spanId != null) ? ByteString.CopyFrom(Encoding.UTF8.GetBytes(spanId)) : ByteString.CopyFrom(Convert.FromHexString("546573745370616e4964")),
             TimeUnixNano = time != null ? DateTimeToUnixNanoseconds(time.Value) : 1000,
             ObservedTimeUnixNano = observedTime != null ? DateTimeToUnixNanoseconds(observedTime.Value) : 1000,
             SeverityNumber = severity ?? SeverityNumber.Info
@@ -339,10 +339,5 @@ internal static class TelemetryTestHelpers
             DateTimeOffset.Now.AddYears(1));
 
         return new X509Certificate2(certificate.Export(X509ContentType.Pfx));
-    }
-
-    private static ByteString ConvertHexToId(string hexString)
-    {
-        return ByteString.CopyFrom(Convert.FromHexString(hexString));
     }
 }

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -50,11 +50,6 @@ internal static class TelemetryTestHelpers
         return new OtlpScope(scope.Name, scope.Version, scope.Attributes.ToKeyValuePairs(context));
     }
 
-    public static OtlpLogEntry CreateOtlpLogEntry(LogRecord record, OtlpApplicationView app, OtlpScope scope, OtlpContext context)
-    {
-        return new OtlpLogEntry(record, app, scope, context);
-    }
-
     public static InstrumentationScope CreateScope(string? name = null, IEnumerable<KeyValuePair<string, string>>? attributes = null)
     {
         var scope = new InstrumentationScope() { Name = name ?? "TestScope" };


### PR DESCRIPTION
## Description

Spans could have zero duration. This will cause `NaN` values (floating point divide by zero), which when used in Blazor view will product `NaN%` strings.

This wouldn't break the page - the browser will ignore it - but it will avoid browser writing CSS warning.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
