### PR TITLE
Implement RFC6761 reserved DNS names handling

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/Resolver/DnsResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/Resolver/DnsResolver.cs
@@ -978,7 +978,7 @@ internal sealed partial class DnsResolver : IDnsResolver, IDisposable
         }
     }
 
-    enum ReservedNameType
+    private enum ReservedNameType
     {
         None,
         Localhost,


### PR DESCRIPTION
## Description

The Managed DNS implementation correctly special-cased "localhost" and resolved to loopback without contacting DNS server, but the authoritative RFC 6761 requires the same for subdomains as well (e.g. service.localhost). Ths PR fills the gap, including the other special-cased name "invalid".

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
