### PR TITLE
Possible fix for login import module exception

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Login.razor.js
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor.js
@@ -1,6 +1,6 @@
 export function validateToken(token) {
-    // Module import errors in the browser could have been caused by this function using async/await
-    // and some browsers not supporting it. Use promises instead.
+    // Module import errors in the browser could have been caused by this function using async/await and some browsers not supporting it.
+    // Use promises instead.
     var url = `/api/validatetoken?token=${encodeURIComponent(token)}`;
     return fetch(url, { method: 'POST' })
         .then(response => response.text())

--- a/src/Aspire.Dashboard/Components/Pages/Login.razor.js
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor.js
@@ -1,9 +1,8 @@
-export async function validateToken(token) {
-    try {
-        var url = `/api/validatetoken?token=${encodeURIComponent(token)}`;
-        var response = await fetch(url, { method: 'POST' });
-        return response.text();
-    } catch (ex) {
-        return `Error validating token: ${ex}`;
-    }
+export function validateToken(token) {
+    // Errors importing the module in the browser could have been caused by this function using async/await
+    // and some browsers not supporting it. Use promises instead.
+    var url = `/api/validatetoken?token=${encodeURIComponent(token)}`;
+    return fetch(url, { method: 'POST' })
+        .then(response => response.text())
+        .catch(ex => `Error validating token: ${ex}`);
 }

--- a/src/Aspire.Dashboard/Components/Pages/Login.razor.js
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor.js
@@ -1,5 +1,5 @@
 export function validateToken(token) {
-    // Errors importing the module in the browser could have been caused by this function using async/await
+    // Module import errors in the browser could have been caused by this function using async/await
     // and some browsers not supporting it. Use promises instead.
     var url = `/api/validatetoken?token=${encodeURIComponent(token)}`;
     return fetch(url, { method: 'POST' })


### PR DESCRIPTION
## Description

Telemetry shows an error on the login page. A few hundred errors occur because of failing to important a JS module.

```
Microsoft.JSInterop.JSException: Importing a module script failed. undefined
at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, Object[] args)
   at Aspire.Dashboard.Components.Pages.Login.OnAfterRenderAsync(Boolean firstRender) in /_/src/Aspire.Dashboard/Components/Pages/Login.razor.cs:line 71
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle, ComponentState owningComponentState)
```

The error isn't helpful (`undefined`) other than to indicate the error came from the browser. The only interesting thing about the JavaScript being imported is it contains a function that uses async/await.

My theory is some older browsers might throw an error because they don't support async/await in JS. Possible fix is to use promises instead. The function is very simple so using promises isn't a big downgrade.

Fixes https://github.com/dotnet/aspire/issues/9537

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
