### PR TITLE
Made changes to how parameter.Value works

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -106,7 +106,7 @@ internal sealed class BicepProvisioner(
         if (BicepUtilities.GetExistingResourceGroup(resource) is { } existingResourceGroup)
         {
             var existingResourceGroupName = existingResourceGroup is ParameterResource parameterResource
-                ? parameterResource.Value
+                ? (await parameterResource.GetValueAsync(cancellationToken).ConfigureAwait(false))!
                 : (string)existingResourceGroup;
             var response = await context.Subscription.GetResourceGroups().GetAsync(existingResourceGroupName, cancellationToken).ConfigureAwait(false);
             resourceGroup = response.Value;

--- a/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
@@ -73,7 +73,7 @@ public static class NatsBuilderExtensions
                 AuthOpts = new()
                 {
                     Username = await nats.UserNameReference.GetValueAsync(ct).ConfigureAwait(false),
-                    Password = nats.PasswordParameter!.Value,
+                    Password = await nats.PasswordParameter!.GetValueAsync(ct).ConfigureAwait(false),
                 }
             };
 

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -158,14 +158,14 @@ public static class RedisBuilderExtensions
                                       .WithHttpEndpoint(targetPort: 8081, name: "http")
                                       .ExcludeFromManifest();
 
-            builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(resource, (e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(resource, async (e, ct) =>
             {
                 var redisInstances = builder.ApplicationBuilder.Resources.OfType<RedisResource>();
 
                 if (!redisInstances.Any())
                 {
                     // No-op if there are no Redis resources present.
-                    return Task.CompletedTask;
+                    return;
                 }
 
                 var hostsVariableBuilder = new StringBuilder();
@@ -177,14 +177,13 @@ public static class RedisBuilderExtensions
                     var hostString = $"{(hostsVariableBuilder.Length > 0 ? "," : string.Empty)}{redisInstance.Name}:{redisInstance.Name}:{redisInstance.PrimaryEndpoint.TargetPort}:0";
                     if (redisInstance.PasswordParameter is not null)
                     {
-                        hostString += $":{redisInstance.PasswordParameter.Value}";
+                        var password = await redisInstance.PasswordParameter.GetValueAsync(ct).ConfigureAwait(false);
+                        hostString += $":{password}";
                     }
                     hostsVariableBuilder.Append(hostString);
                 }
 
                 resourceBuilder.WithEnvironment("REDIS_HOSTS", hostsVariableBuilder.ToString());
-
-                return Task.CompletedTask;
             });
 
             configureContainer?.Invoke(resourceBuilder);
@@ -244,7 +243,7 @@ public static class RedisBuilderExtensions
                         context.EnvironmentVariables.Add($"RI_REDIS_ALIAS{counter}", redisInstance.Name);
                         if (redisInstance.PasswordParameter is not null)
                         {
-                            context.EnvironmentVariables.Add($"RI_REDIS_PASSWORD{counter}", redisInstance.PasswordParameter.Value);
+                            context.EnvironmentVariables.Add($"RI_REDIS_PASSWORD{counter}", redisInstance.PasswordParameter);
                         }
 
                         counter++;

--- a/src/Aspire.Hosting/ExternalServiceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExternalServiceBuilderExtensions.cs
@@ -185,7 +185,7 @@ public static class ExternalServiceBuilderExtensions
         {
             var uri = builder.Resource.Uri;
 
-            // OK accessing the paramter here synchronously as this should only activate once the resource is running
+            // OK accessing the parameter here synchronously as this should only activate once the resource is running
 
             if (uri is null && !Uri.TryCreate(builder.Resource.UrlParameter?.Value, UriKind.Absolute, out uri)
                 || (uri?.Scheme != "http" && uri?.Scheme != "https"))

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -62,7 +62,7 @@ internal sealed class ParameterProcessor(
     {
         try
         {
-            var value = parameterResource.Value ?? "";
+            var value = parameterResource.ValueInternal ?? "";
 
             await notificationService.PublishUpdateAsync(parameterResource, s =>
             {


### PR DESCRIPTION
## Description

This was found while dogfooding the latest build with async parameter resolution. We were using ParameterResource.Value is *many* places and as a result those places did not properly wait for values to be resolved before continuing, they just failed. Now ParameterResource.Value calls `ParameterResource.GetValueAsync(...).GetAwaiter().GetResult()`, which is not great, but is consistent. We need the sync and async versions to work exactly the same way to avoid inconsistent state. 

There's a risk with introducing deadlocks with this change for people that were using .Value before. ~I'm working through tests now to make sure that does not happen in practice.~ 👍🏾  If the Value is accessed before the TCS is set then it will throw an exception like it did before. 

- Value now blocks (sync over async) waiting for value resolution if WaitForValueTcs is set.
- Made GetValueAsync on ParameterResource public.
- Changed most code outside of tests to use GetValueAsync instead of Value

Fixes #10352

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
