### PR TITLE
Force async execution of resource startup

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1097,6 +1097,9 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
     private async Task CreateExecutableAsync(AppResource er, ILogger resourceLogger, CancellationToken cancellationToken)
     {
+        // Force async execution
+        await Task.Yield();
+
         if (er.DcpResource is not Executable exe)
         {
             throw new InvalidOperationException($"Expected an Executable resource, but got {er.DcpResource.Kind} instead");
@@ -1348,6 +1351,9 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
     private async Task CreateContainerAsync(AppResource cr, ILogger resourceLogger, CancellationToken cancellationToken)
     {
+        // Force async execution
+        await Task.Yield();
+
         await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResource.Metadata.Name)).ConfigureAwait(false);
 
         var dcpContainerResource = (Container)cr.DcpResource;


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspire/pull/10354

- Previously we didn't preemptively dispatch to the threadpool per resource on startup. That causes issues blocking other resource's startup because of a single blocking call. This change dispatching preemptively before creating the dcp resource.

Reproduced while dogfooding the community toolkit with 9.4 builds. Verified this fix on the same build.

Hanging stack:

<img width="228" height="775" alt="hangstack" src="https://github.com/user-attachments/assets/9eaf26b6-7ff9-474c-a2e3-bf16c800db8b" />

