### PR TITLE
Match name with ResourceCommandService

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -38,7 +38,7 @@ public class ResourceCommandService
     /// For example, if a resource named <c>cache</c> has multiple replicas, then specifing <c>cache</c> won't return a match.
     /// </para>
     /// </remarks>
-    /// <param name="resourceId">The resource id. This id can either exactly match the unique id of the resource or the displayed resource name if the resource name doesn't have duplicas (i.e. replicas).</param>
+    /// <param name="resourceId">The resource id. This id can either exactly match the unique id of the resource or the displayed resource name if the resource name doesn't have duplicates (i.e. replicas).</param>
     /// <param name="commandName">The command name.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The <see cref="ExecuteCommandResult" /> indicates command success or failure.</returns>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -25,7 +25,20 @@ public class ResourceCommandService
     /// <summary>
     /// Execute a command for the specified resource.
     /// </summary>
-    /// <param name="resourceId">The id of the resource.</param>
+    /// <remarks>
+    /// <para>
+    /// A resource id can be either the unique id of the resource or the displayed resource name.
+    /// </para>
+    /// <para>
+    /// Projects, executables and containers typically have a unique id that combines the display name and a unique suffix. For example, a resource named <c>cache</c> could have a resource id of <c>cache-abcdwxyz</c>.
+    /// This id is used to uniquely identify the resource in the app host.
+    /// </para>
+    /// <para>
+    /// The resource name can be also be used to retrieve the resource state, but it must be unique. If there are multiple resources with the same name, then this method will not return a match.
+    /// For example, if a resource named <c>cache</c> has multiple replicas, then specifing <c>cache</c> won't return a match.
+    /// </para>
+    /// </remarks>
+    /// <param name="resourceId">The resource id. This id can either exactly match the unique id of the resource or the displayed resource name if the resource name doesn't have duplicas (i.e. replicas).</param>
     /// <param name="commandName">The command name.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The <see cref="ExecuteCommandResult" /> indicates command success or failure.</returns>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -447,7 +447,7 @@ public class ResourceNotificationService : IDisposable
     /// For example, if a resource named <c>cache</c> has multiple replicas, then specifing <c>cache</c> won't return a match.
     /// </para>
     /// </remarks>
-    /// <param name="resourceId">The resource id. This id can either exactly match the unique id of the resource or the displayed resource name if the resource name doesn't have duplicas (i.e. replicas).</param>
+    /// <param name="resourceId">The resource id. This id can either exactly match the unique id of the resource or the displayed resource name if the resource name doesn't have duplicates (i.e. replicas).</param>
     /// <param name="resourceEvent">When this method returns, contains the <see cref="ResourceEvent"/> for the specified resource id, if found; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if specified resource id was found; otherwise, <see langword="false"/>.</returns>
     public bool TryGetCurrentState(string resourceId, [NotNullWhen(true)] out ResourceEvent? resourceEvent)

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -38,8 +38,8 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithAnnotation(new DcpInstancesAnnotation([
-            new DcpInstance("myResource", "abcdwxyz", 0),
-            new DcpInstance("myResource", "efghwxyz", 1)
+            new DcpInstance("myResource-abcdwxyz", "abcdwxyz", 0),
+            new DcpInstance("myResource-efghwxyz", "efghwxyz", 1)
             ]));
 
         var app = builder.Build();
@@ -82,7 +82,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
 
         var custom = builder.AddResource(new CustomResource("myResource"));
         custom.WithAnnotation(new DcpInstancesAnnotation([
-            new DcpInstance("myResource", "abcdwxyz", 0)
+            new DcpInstance("myResource-abcdwxyz", "abcdwxyz", 0)
             ]));
         custom.WithCommand(name: "mycommand",
                 displayName: "My command",

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -31,6 +31,29 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task ExecuteCommandAsync_ResourceNameMultipleMatches_Failure()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("myResource", "abcdwxyz", 0),
+            new DcpInstance("myResource", "efghwxyz", 1)
+            ]));
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        // Act
+        var result = await app.ResourceCommands.ExecuteCommandAsync("myResource", "NotFound");
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("Resource 'myResource' not found.", result.ErrorMessage);
+    }
+
+    [Fact]
     public async Task ExecuteCommandAsync_NoMatchingCommand_Failure()
     {
         // Arrange
@@ -47,6 +70,43 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
         // Assert
         Assert.False(result.Success);
         Assert.Equal("Command 'NotFound' not available for resource 'myResource'.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ExecuteCommandAsync_ResourceNameMultipleMatches_Success()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var commandResourcesChannel = Channel.CreateUnbounded<string>();
+
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("myResource", "abcdwxyz", 0)
+            ]));
+        custom.WithCommand(name: "mycommand",
+                displayName: "My command",
+                executeCommand: async e =>
+                {
+                    await commandResourcesChannel.Writer.WriteAsync(e.ResourceName);
+                    return new ExecuteCommandResult { Success = true };
+                });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        // Act
+        var result = await app.ResourceCommands.ExecuteCommandAsync("myResource", "mycommand");
+        commandResourcesChannel.Writer.Complete();
+
+        // Assert
+        Assert.True(result.Success);
+
+        var resolvedResourceNames = custom.Resource.GetResolvedResourceNames().ToList();
+        await foreach (var resourceName in commandResourcesChannel.Reader.ReadAllAsync().DefaultTimeout())
+        {
+            Assert.True(resolvedResourceNames.Remove(resourceName));
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Description

`ResourceCommandService.ExecuteCommandAsync(string, ...)` takes a resourceId and matches to the resource with that resourceId. That includes the suffix for DCP resources, e.g. `cache-sfsdfsdf`. This could be confusing as people often only think about the resource name, e.g. `cache`.

PR improves XML docs for API. It also allows the method to match on resource name if there are no replicas.

Fixes https://github.com/dotnet/aspire/issues/10224

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
