### PR TITLE
Share more package checking code between CLI and app host

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -48,6 +48,7 @@
     <Compile Include="$(SharedDir)CircularBuffer.cs" Link="Utils\CircularBuffer.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="StringComparers.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting\Backchannel\BackchannelDataTypes.cs" Link="Backchannel\CliBackchannelDataTypes.cs" />
+    <Compile Include="$(SharedDir)PackageUpdateHelpers.cs" Link="Utils\PackageUpdateHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Semver;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Commands;
 

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Diagnostics;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Utils;
 
@@ -29,7 +30,9 @@ internal abstract class BaseCommand : Command
                     // but we'll only wait so long before we get details back about updates
                     // being available (it should already be in the cache for longer running
                     // commands and some commands will opt out entirely)
-                    var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                    var cts = !Debugger.IsAttached
+                        ? new CancellationTokenSource(TimeSpan.FromSeconds(10))
+                        : new CancellationTokenSource();
                     await updateNotifier.NotifyIfUpdateAvailableAsync(currentDirectory, cancellationToken: cts.Token);
                 }
                 catch

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -12,6 +12,8 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Utils;
 using Spectre.Console;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
+
 namespace Aspire.Cli.Commands;
 
 internal sealed class NewCommand : BaseCommand

--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -11,9 +11,11 @@ using Aspire.Cli.Backchannel;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Hosting;
+using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli;
 
@@ -716,37 +718,10 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
                 return (ExitCodeConstants.FailedToAddPackage, null);
             }
 
-            var foundPackages = new List<NuGetPackage>();
             try
             {
-                using var document = JsonDocument.Parse(stdout);
-
-                var searchResultsArray = document.RootElement.GetProperty("searchResult");
-
-                foreach (var sourceResult in searchResultsArray.EnumerateArray())
-                {
-                    var source = sourceResult.GetProperty("sourceName").GetString();
-                    var sourcePackagesArray = sourceResult.GetProperty("packages");
-
-                    foreach (var packageResult in sourcePackagesArray.EnumerateArray())
-                    {
-                        var id = packageResult.GetProperty("id").GetString();
-
-                        // var version = prerelease switch {
-                        //     true => packageResult.GetProperty("version").GetString(),
-                        //     false => packageResult.GetProperty("latestVersion").GetString()
-                        // };
-
-                        var version = packageResult.GetProperty("latestVersion").GetString();
-
-                        foundPackages.Add(new NuGetPackage
-                        {
-                            Id = id!,
-                            Version = version!,
-                            Source = source!
-                        });
-                    }
-                }
+                var foundPackages = PackageUpdateHelpers.ParsePackageSearchResults(stdout);
+                return (result, foundPackages.ToArray());
             }
             catch (JsonException ex)
             {
@@ -754,14 +729,6 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
                 return (ExitCodeConstants.FailedToAddPackage, null);
             }
 
-            return (result, foundPackages.ToArray());
         }
     }
-}
-
-internal class NuGetPackage
-{
-    public string Id { get; set; } = string.Empty;
-    public string Version { get; set; } = string.Empty;
-    public string Source { get; set; } = string.Empty;
 }

--- a/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using Aspire.Cli.Telemetry;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.NuGet;
 

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Resources;
+using Aspire.Shared;
 
 namespace Aspire.Cli.Utils;
 
@@ -9,13 +10,6 @@ internal static class VersionHelper
 {
     public static string GetDefaultTemplateVersion()
     {
-        // Write some code that gets the informational assembly version of the current assembly and returns it as a string.
-        var assembly = typeof(VersionHelper).Assembly;
-        var informationalVersion = assembly
-            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
-            .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
-            .FirstOrDefault()?.InformationalVersion;
-
-        return informationalVersion ?? throw new InvalidOperationException(ErrorStrings.UnableToRetrieveAssemblyVersion);
+        return PackageUpdateHelpers.GetCurrentAssemblyVersion() ?? throw new InvalidOperationException(ErrorStrings.UnableToRetrieveAssemblyVersion);
     }
 }

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -41,6 +41,7 @@
     <Compile Include="$(SharedDir)LaunchProfiles\*.cs" />
     <Compile Include="$(SharedDir)PortAllocator.cs" Link="Publishing\PortAllocator.cs" />
     <Compile Include="$(SharedDir)OverloadResolutionPriorityAttribute.cs" Link="Utils\OverloadResolutionPriorityAttribute.cs" />
+    <Compile Include="$(SharedDir)PackageUpdateHelpers.cs" Link="Utils\PackageUpdateHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -241,7 +241,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddHostedService<DistributedApplicationLifecycle>();
         _innerBuilder.Services.AddHostedService<DistributedApplicationRunner>();
         _innerBuilder.Services.AddHostedService<VersionCheckService>();
-        _innerBuilder.Services.AddSingleton<IVersionFetcher, VersionFetcher>();
+        _innerBuilder.Services.AddSingleton<IPackageFetcher, PackageFetcher>();
         _innerBuilder.Services.AddSingleton(options);
         _innerBuilder.Services.AddSingleton<ResourceNotificationService>();
         _innerBuilder.Services.AddSingleton<ResourceLoggerService>();

--- a/src/Aspire.Hosting/VersionChecking/IPackageFetcher.cs
+++ b/src/Aspire.Hosting/VersionChecking/IPackageFetcher.cs
@@ -5,7 +5,7 @@ using Aspire.Shared;
 
 namespace Aspire.Hosting.VersionChecking;
 
-internal interface IVersionFetcher
+internal interface IPackageFetcher
 {
-    Task<List<NuGetPackage>> TryFetchVersionsAsync(string appHostDirectory, CancellationToken cancellationToken);
+    Task<List<NuGetPackage>> TryFetchPackagesAsync(string appHostDirectory, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Hosting/VersionChecking/IVersionFetcher.cs
+++ b/src/Aspire.Hosting/VersionChecking/IVersionFetcher.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Semver;
+using Aspire.Shared;
 
 namespace Aspire.Hosting.VersionChecking;
 
 internal interface IVersionFetcher
 {
-    Task<SemVersion?> TryFetchLatestVersionAsync(string appHostDirectory, CancellationToken cancellationToken);
+    Task<List<NuGetPackage>> TryFetchVersionsAsync(string appHostDirectory, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Hosting/VersionChecking/Package.cs
+++ b/src/Aspire.Hosting/VersionChecking/Package.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace Aspire.Hosting.VersionChecking;
-
-internal record Package(string Id, string LatestVersion);

--- a/src/Aspire.Hosting/VersionChecking/PackageFetcher.cs
+++ b/src/Aspire.Hosting/VersionChecking/PackageFetcher.cs
@@ -8,18 +8,18 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.VersionChecking;
 
-internal sealed class VersionFetcher : IVersionFetcher
+internal sealed class PackageFetcher : IPackageFetcher
 {
     public const string PackageId = "Aspire.Hosting.AppHost";
 
-    private readonly ILogger<VersionFetcher> _logger;
+    private readonly ILogger<PackageFetcher> _logger;
 
-    public VersionFetcher(ILogger<VersionFetcher> logger)
+    public PackageFetcher(ILogger<PackageFetcher> logger)
     {
         _logger = logger;
     }
 
-    public async Task<List<NuGetPackage>> TryFetchVersionsAsync(string appHostDirectory, CancellationToken cancellationToken)
+    public async Task<List<NuGetPackage>> TryFetchPackagesAsync(string appHostDirectory, CancellationToken cancellationToken)
     {
         var outputJson = new StringBuilder();
         var spec = new ProcessSpec("dotnet")

--- a/src/Aspire.Hosting/VersionChecking/PackageFetcher.cs
+++ b/src/Aspire.Hosting/VersionChecking/PackageFetcher.cs
@@ -12,6 +12,10 @@ internal sealed class PackageFetcher : IPackageFetcher
 {
     public const string PackageId = "Aspire.Hosting.AppHost";
 
+    // Limit the number of packages fetched per search to avoid overwhelming the output. This should never happen unless there is a bug in the API.
+    // Package search returns the latest version per source and few packages will match "Aspire.Hosting.AppHost" search string.
+    private const int SearchPageSize = 1000;
+
     private readonly ILogger<PackageFetcher> _logger;
 
     public PackageFetcher(ILogger<PackageFetcher> logger)
@@ -24,7 +28,7 @@ internal sealed class PackageFetcher : IPackageFetcher
         var outputJson = new StringBuilder();
         var spec = new ProcessSpec("dotnet")
         {
-            Arguments = $"package search {PackageId} --format json",
+            Arguments = $"package search {PackageId} --format json --prerelease --take {SearchPageSize}",
             ThrowOnNonZeroReturnCode = false,
             InheritEnv = true,
             OnOutputData = output =>

--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -3,8 +3,10 @@
 
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -28,7 +30,7 @@ internal sealed class VersionCheckService : BackgroundService
     private readonly IVersionFetcher _versionFetcher;
     private readonly DistributedApplicationExecutionContext _executionContext;
     private readonly TimeProvider _timeProvider;
-    private readonly SemVersion _appHostVersion;
+    private readonly SemVersion? _appHostVersion;
 
     public VersionCheckService(IInteractionService interactionService, ILogger<VersionCheckService> logger,
         IConfiguration configuration, DistributedApplicationOptions options, IVersionFetcher versionFetcher,
@@ -42,9 +44,7 @@ internal sealed class VersionCheckService : BackgroundService
         _executionContext = executionContext;
         _timeProvider = timeProvider;
 
-        var version = typeof(VersionCheckService).Assembly.GetName().Version!;
-        var patch = version.Build > 0 ? version.Build : 0;
-        _appHostVersion = new SemVersion(version.Major, version.Minor, patch);
+        _appHostVersion = PackageUpdateHelpers.GetCurrentPackageVersion();
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -53,6 +53,12 @@ internal sealed class VersionCheckService : BackgroundService
         {
             // Don't check version if there is no way to prompt that information to the user.
             // Or app is being run during a publish.
+            return;
+        }
+
+        if (_appHostVersion == null)
+        {
+            _logger.LogDebug("App host version is not available, skipping version check.");
             return;
         }
 
@@ -72,6 +78,8 @@ internal sealed class VersionCheckService : BackgroundService
 
     private async Task CheckForLatestAsync(CancellationToken cancellationToken)
     {
+        Debug.Assert(_appHostVersion != null);
+
         var now = _timeProvider.GetUtcNow();
         var checkForLatestVersion = true;
         if (_configuration[LastCheckDateKey] is string checkDateString &&
@@ -90,7 +98,9 @@ internal sealed class VersionCheckService : BackgroundService
             var appHostDirectory = _configuration["AppHost:Directory"]!;
 
             SecretsStore.TrySetUserSecret(_options.Assembly, LastCheckDateKey, now.ToString("o", CultureInfo.InvariantCulture));
-            latestVersion = await _versionFetcher.TryFetchLatestVersionAsync(appHostDirectory, cancellationToken).ConfigureAwait(false);
+            var packages = await _versionFetcher.TryFetchVersionsAsync(appHostDirectory, cancellationToken).ConfigureAwait(false);
+
+            latestVersion = PackageUpdateHelpers.GetNewerVersion(_appHostVersion, packages);
         }
 
         if (TryGetConfigVersion(KnownLatestVersionKey, out var storedKnownLatestVersion))

--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -27,20 +27,20 @@ internal sealed class VersionCheckService : BackgroundService
     private readonly ILogger<VersionCheckService> _logger;
     private readonly IConfiguration _configuration;
     private readonly DistributedApplicationOptions _options;
-    private readonly IVersionFetcher _versionFetcher;
+    private readonly IPackageFetcher _packageFetcher;
     private readonly DistributedApplicationExecutionContext _executionContext;
     private readonly TimeProvider _timeProvider;
     private readonly SemVersion? _appHostVersion;
 
     public VersionCheckService(IInteractionService interactionService, ILogger<VersionCheckService> logger,
-        IConfiguration configuration, DistributedApplicationOptions options, IVersionFetcher versionFetcher,
+        IConfiguration configuration, DistributedApplicationOptions options, IPackageFetcher packageFetcher,
         DistributedApplicationExecutionContext executionContext, TimeProvider timeProvider)
     {
         _interactionService = interactionService;
         _logger = logger;
         _configuration = configuration;
         _options = options;
-        _versionFetcher = versionFetcher;
+        _packageFetcher = packageFetcher;
         _executionContext = executionContext;
         _timeProvider = timeProvider;
 
@@ -98,7 +98,7 @@ internal sealed class VersionCheckService : BackgroundService
             var appHostDirectory = _configuration["AppHost:Directory"]!;
 
             SecretsStore.TrySetUserSecret(_options.Assembly, LastCheckDateKey, now.ToString("o", CultureInfo.InvariantCulture));
-            var packages = await _versionFetcher.TryFetchVersionsAsync(appHostDirectory, cancellationToken).ConfigureAwait(false);
+            var packages = await _packageFetcher.TryFetchPackagesAsync(appHostDirectory, cancellationToken).ConfigureAwait(false);
 
             latestVersion = PackageUpdateHelpers.GetNewerVersion(_appHostVersion, packages);
         }

--- a/src/Aspire.Hosting/VersionChecking/VersionFetcher.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionFetcher.cs
@@ -2,16 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
-using System.Text.Json;
 using Aspire.Hosting.Dcp.Process;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
-using Semver;
 
 namespace Aspire.Hosting.VersionChecking;
 
 internal sealed class VersionFetcher : IVersionFetcher
 {
-    private const string PackageId = "Aspire.Hosting.AppHost";
+    public const string PackageId = "Aspire.Hosting.AppHost";
 
     private readonly ILogger<VersionFetcher> _logger;
 
@@ -20,7 +19,7 @@ internal sealed class VersionFetcher : IVersionFetcher
         _logger = logger;
     }
 
-    public async Task<SemVersion?> TryFetchLatestVersionAsync(string appHostDirectory, CancellationToken cancellationToken)
+    public async Task<List<NuGetPackage>> TryFetchVersionsAsync(string appHostDirectory, CancellationToken cancellationToken)
     {
         var outputJson = new StringBuilder();
         var spec = new ProcessSpec("dotnet")
@@ -52,61 +51,15 @@ internal sealed class VersionFetcher : IVersionFetcher
             if (processResult.ExitCode != 0)
             {
                 _logger.LogDebug("The dotnet CLI call to check for latest version failed with exit code {ExitCode}.", processResult.ExitCode);
-                return null;
+                return [];
             }
         }
 
-        return GetLatestVersion(outputJson.ToString());
-    }
-
-    internal static SemVersion? GetLatestVersion(string outputJson)
-    {
-        var packages = ParseOutput(outputJson);
-        var versions = new List<SemVersion>();
-        foreach (var package in packages)
-        {
-            // Filter packages to only consider "Aspire.Hosting.AppHost".
-            // Although the CLI command 'dotnet package search Aspire.Hosting.AppHost --format json' 
-            // should already limit results according to NuGet search syntax 
-            // (https://learn.microsoft.com/en-us/nuget/consume-packages/finding-and-choosing-packages#search-syntax),
-            // we add this extra check for robustness in case the CLI output includes unexpected packages.
-            if (package.Id == PackageId &&
-                SemVersion.TryParse(package.LatestVersion, out var version) &&
-                !version.IsPrerelease)
-            {
-                versions.Add(version);
-            }
-        }
-
-        return versions.OrderDescending(SemVersion.PrecedenceComparer).FirstOrDefault();
-    }
-
-    private static List<Package> ParseOutput(string outputJson)
-    {
-        var packages = new List<Package>();
-
-        using var document = JsonDocument.Parse(outputJson);
-        var root = document.RootElement;
-
-        if (root.TryGetProperty("searchResult", out var searchResults))
-        {
-            foreach (var result in searchResults.EnumerateArray())
-            {
-                if (result.TryGetProperty("packages", out var packagesArray))
-                {
-                    foreach (var pkg in packagesArray.EnumerateArray())
-                    {
-                        var id = pkg.GetProperty("id").GetString();
-                        var latestVersion = pkg.GetProperty("latestVersion").GetString();
-                        if (id != null && latestVersion != null)
-                        {
-                            packages.Add(new Package(id, latestVersion));
-                        }
-                    }
-                }
-            }
-        }
-
-        return packages;
+        // Filter packages to only consider "Aspire.Hosting.AppHost".
+        // Although the CLI command 'dotnet package search Aspire.Hosting.AppHost --format json' 
+        // should already limit results according to NuGet search syntax 
+        // (https://learn.microsoft.com/en-us/nuget/consume-packages/finding-and-choosing-packages#search-syntax),
+        // we add this extra check for robustness in case the CLI output includes unexpected packages.
+        return PackageUpdateHelpers.ParsePackageSearchResults(outputJson.ToString(), PackageId);
     }
 }

--- a/src/Shared/PackageUpdateHelpers.cs
+++ b/src/Shared/PackageUpdateHelpers.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Semver;
+#if CLI
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
+#else
+using NuGetPackage = Aspire.Shared.NuGetPackage;
+#endif
+
+namespace Aspire.Shared;
+
+#if CLI
+internal class NuGetPackageCli
+#else
+internal class NuGetPackage
+#endif
+{
+    public string Id { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+    public string Source { get; set; } = string.Empty;
+}
+
+internal static class PackageUpdateHelpers
+{
+    public static SemVersion? GetCurrentPackageVersion()
+    {
+        try
+        {
+            var versionString = GetCurrentAssemblyVersion();
+            if (versionString == null)
+            {
+                return null;
+            }
+
+            // Remove any build metadata (e.g., +sha.12345) for comparison
+            var cleanVersionString = versionString.Split('+')[0];
+            return SemVersion.Parse(cleanVersionString, SemVersionStyles.Strict);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static string? GetCurrentAssemblyVersion()
+    {
+        // Write some code that gets the informational assembly version of the current assembly and returns it as a string.
+        var assembly = typeof(PackageUpdateHelpers).Assembly;
+        var informationalVersion = assembly
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+            .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+            .FirstOrDefault()?.InformationalVersion;
+
+        return informationalVersion;
+    }
+
+    public static SemVersion? GetNewerVersion(SemVersion currentVersion, IEnumerable<NuGetPackage> availablePackages)
+    {
+        SemVersion? newestStable = null;
+        SemVersion? newestPrerelease = null;
+
+        foreach (var package in availablePackages)
+        {
+            if (SemVersion.TryParse(package.Version, SemVersionStyles.Strict, out var version))
+            {
+                if (version.IsPrerelease)
+                {
+                    newestPrerelease = newestPrerelease is null || SemVersion.PrecedenceComparer.Compare(version, newestPrerelease) > 0 ? version : newestPrerelease;
+                }
+                else
+                {
+                    newestStable = newestStable is null || SemVersion.PrecedenceComparer.Compare(version, newestStable) > 0 ? version : newestStable;
+                }
+            }
+        }
+
+        // Apply notification rules
+        if (currentVersion.IsPrerelease)
+        {
+            // Rule 1: If using a prerelease version where the version is lower than the latest stable version, prompt to upgrade
+            if (newestStable is not null && SemVersion.PrecedenceComparer.Compare(currentVersion, newestStable) < 0)
+            {
+                return newestStable;
+            }
+
+            // Rule 2: If using a prerelease version and there is a newer prerelease version, prompt to upgrade
+            if (newestPrerelease is not null && SemVersion.PrecedenceComparer.Compare(currentVersion, newestPrerelease) < 0)
+            {
+                return newestPrerelease;
+            }
+        }
+        else
+        {
+            // Rule 3: If using a stable version and there is a newer stable version, prompt to upgrade
+            if (newestStable is not null && SemVersion.PrecedenceComparer.Compare(currentVersion, newestStable) < 0)
+            {
+                return newestStable;
+            }
+        }
+
+        return null;
+    }
+
+    public static List<NuGetPackage> ParsePackageSearchResults(string stdout, string? packageId = null)
+    {
+        var foundPackages = new List<NuGetPackage>();
+
+        using var document = JsonDocument.Parse(stdout);
+        if (!document.RootElement.TryGetProperty("searchResult", out var searchResultsArray))
+        {
+            return [];
+        }
+
+        foreach (var sourceResult in searchResultsArray.EnumerateArray())
+        {
+            var source = sourceResult.GetProperty("sourceName").GetString()!;
+            var sourcePackagesArray = sourceResult.GetProperty("packages");
+
+            foreach (var packageResult in sourcePackagesArray.EnumerateArray())
+            {
+                var id = packageResult.GetProperty("id").GetString()!;
+
+                var version = packageResult.GetProperty("latestVersion").GetString()!;
+
+                if (packageId == null || id == packageId)
+                {
+                    foundPackages.Add(new NuGetPackage
+                    {
+                        Id = id,
+                        Version = version,
+                        Source = source
+                    });
+                }
+            }
+        }
+
+        return foundPackages;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Commands;
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -9,6 +9,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Commands;
 

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.NuGet;
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Utils;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.TestServices;
 

--- a/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Semver;
 using Xunit;
+using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Utils;
 

--- a/tests/Aspire.Hosting.Tests/VersionChecking/PackageUpdateHelpersTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/PackageUpdateHelpersTests.cs
@@ -1,13 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.VersionChecking;
+using Aspire.Shared;
 using Semver;
 using Xunit;
 
 namespace Aspire.Hosting.Tests.VersionChecking;
 
-public class VersionFetcherTests
+public class PackageUpdateHelpersTests
 {
     [Fact]
     public void GetLatestVersion_MultipleVersions_LatestVersion()
@@ -50,7 +50,8 @@ public class VersionFetcherTests
             """;
 
         // Act
-        var latestVersion = VersionFetcher.GetLatestVersion(json);
+        var packages = PackageUpdateHelpers.ParsePackageSearchResults(json, "Aspire.Hosting.AppHost");
+        var latestVersion = PackageUpdateHelpers.GetNewerVersion(new SemVersion(1), packages);
 
         // Assert
         Assert.Equal(new SemVersion(19, 0, 0), latestVersion);
@@ -97,10 +98,59 @@ public class VersionFetcherTests
             """;
 
         // Act
-        var latestVersion = VersionFetcher.GetLatestVersion(json);
+        var packages = PackageUpdateHelpers.ParsePackageSearchResults(json, "Aspire.Hosting.AppHost");
+        var latestVersion = PackageUpdateHelpers.GetNewerVersion(new SemVersion(1), packages);
 
         // Assert
         Assert.Equal(new SemVersion(9, 3, 1), latestVersion);
+    }
+
+    [Fact]
+    public void GetLatestVersion_HasPrerelease_UsePrerelease()
+    {
+        // Arrange
+        var json = """
+            {
+              "version": 2,
+              "problems": [],
+              "searchResult": [
+                {
+                  "sourceName": "feed1",
+                  "packages": [
+                    {
+                      "id": "Aspire.Hosting.AppHost",
+                      "latestVersion": "0.4.1"
+                    }
+                  ]
+                },
+                {
+                  "sourceName": "feed2",
+                  "packages": [
+                    {
+                      "id": "Aspire.Hosting.AppHost",
+                      "latestVersion": "19.0.0-pre1"
+                    }
+                  ]
+                },
+                {
+                  "sourceName": "feed3",
+                  "packages": [
+                    {
+                      "id": "Aspire.Hosting.AppHost",
+                      "latestVersion": "9.3.1"
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        // Act
+        var packages = PackageUpdateHelpers.ParsePackageSearchResults(json, "Aspire.Hosting.AppHost");
+        var latestVersion = PackageUpdateHelpers.GetNewerVersion(new SemVersion(10, prerelease: ["dev"]), packages);
+
+        // Assert
+        Assert.Equal(new SemVersion(19, 0, 0, prerelease: ["pre1"]), latestVersion);
     }
 
     [Fact]
@@ -110,7 +160,8 @@ public class VersionFetcherTests
         var json = "{}";
 
         // Act
-        var latestVersion = VersionFetcher.GetLatestVersion(json);
+        var packages = PackageUpdateHelpers.ParsePackageSearchResults(json, "Aspire.Hosting.AppHost");
+        var latestVersion = PackageUpdateHelpers.GetNewerVersion(new SemVersion(1), packages);
 
         // Assert
         Assert.Null(latestVersion);
@@ -157,7 +208,8 @@ public class VersionFetcherTests
             """;
 
         // Act
-        var latestVersion = VersionFetcher.GetLatestVersion(json);
+        var packages = PackageUpdateHelpers.ParsePackageSearchResults(json, "Aspire.Hosting.AppHost");
+        var latestVersion = PackageUpdateHelpers.GetNewerVersion(new SemVersion(1), packages);
 
         // Assert
         Assert.Equal(new SemVersion(9, 0, 0), latestVersion);

--- a/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
@@ -21,15 +21,15 @@ public class VersionCheckServiceTests
         // Arrange
         var interactionService = new TestInteractionService();
         var configurationManager = new ConfigurationManager();
-        var versionTcs = new TaskCompletionSource<List<NuGetPackage>>();
-        var versionFetcher = new TestPackageFetcher(versionTcs.Task);
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
         var options = new DistributedApplicationOptions();
-        var service = CreateVersionCheckService(interactionService: interactionService, packageFetcher: versionFetcher, configuration: configurationManager, options: options);
+        var service = CreateVersionCheckService(interactionService: interactionService, packageFetcher: packageFetcher, configuration: configurationManager, options: options);
 
         // Act
         _ = service.StartAsync(CancellationToken.None);
 
-        versionTcs.TrySetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = "100.0.0" }]);
+        packagesTcs.TrySetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = "100.0.0" }]);
 
         var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         interaction.CompletionTcs.TrySetResult(InteractionResult.Ok(true));
@@ -37,7 +37,7 @@ public class VersionCheckServiceTests
         await service.ExecuteTask!.DefaultTimeout();
 
         // Assert
-        Assert.True(versionFetcher.FetchCalled);
+        Assert.True(packageFetcher.FetchCalled);
     }
 
     [Fact]
@@ -50,9 +50,9 @@ public class VersionCheckServiceTests
         {
             [KnownConfigNames.VersionCheckDisabled] = "true"
         });
-        var versionFetcher = new TestPackageFetcher();
+        var packageFetcher = new TestPackageFetcher();
         var options = new DistributedApplicationOptions();
-        var service = CreateVersionCheckService(interactionService: interactionService, packageFetcher: versionFetcher, configuration: configurationManager, options: options);
+        var service = CreateVersionCheckService(interactionService: interactionService, packageFetcher: packageFetcher, configuration: configurationManager, options: options);
 
         // Act
         _ = service.StartAsync(CancellationToken.None);
@@ -60,7 +60,7 @@ public class VersionCheckServiceTests
         await service.ExecuteTask!.DefaultTimeout();
 
         // Assert
-        Assert.False(versionFetcher.FetchCalled);
+        Assert.False(packageFetcher.FetchCalled);
     }
 
     [Fact]
@@ -78,11 +78,11 @@ public class VersionCheckServiceTests
             [VersionCheckService.LastCheckDateKey] = lastCheckDate.ToString("o", CultureInfo.InvariantCulture)
         });
 
-        var versionTcs = new TaskCompletionSource<List<NuGetPackage>>();
-        var versionFetcher = new TestPackageFetcher(versionTcs.Task);
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
         var service = CreateVersionCheckService(
             interactionService: interactionService,
-            packageFetcher: versionFetcher,
+            packageFetcher: packageFetcher,
             configuration: configurationManager,
             timeProvider: timeProvider);
 
@@ -94,7 +94,7 @@ public class VersionCheckServiceTests
         interactionService.Interactions.Writer.Complete();
 
         // Assert
-        Assert.False(versionFetcher.FetchCalled);
+        Assert.False(packageFetcher.FetchCalled);
         Assert.False(interactionService.Interactions.Reader.TryRead(out var _));
     }
 
@@ -114,11 +114,11 @@ public class VersionCheckServiceTests
             [VersionCheckService.KnownLatestVersionKey] = "100.0.0"
         });
 
-        var versionTcs = new TaskCompletionSource<List<NuGetPackage>>();
-        var versionFetcher = new TestPackageFetcher(versionTcs.Task);
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
         var service = CreateVersionCheckService(
             interactionService: interactionService,
-            packageFetcher: versionFetcher,
+            packageFetcher: packageFetcher,
             configuration: configurationManager,
             timeProvider: timeProvider);
 
@@ -131,7 +131,7 @@ public class VersionCheckServiceTests
         await service.ExecuteTask!.DefaultTimeout();
 
         // Assert
-        Assert.False(versionFetcher.FetchCalled);
+        Assert.False(packageFetcher.FetchCalled);
     }
 
     [Fact]
@@ -140,21 +140,21 @@ public class VersionCheckServiceTests
         // Arrange
         var interactionService = new TestInteractionService();
         var configurationManager = new ConfigurationManager();
-        var versionTcs = new TaskCompletionSource<List<NuGetPackage>>();
-        var versionFetcher = new TestPackageFetcher(versionTcs.Task);
-        var service = CreateVersionCheckService(interactionService: interactionService, packageFetcher: versionFetcher, configuration: configurationManager);
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
+        var service = CreateVersionCheckService(interactionService: interactionService, packageFetcher: packageFetcher, configuration: configurationManager);
 
         // Act
         _ = service.StartAsync(CancellationToken.None);
 
-        versionTcs.SetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = "0.1.0" }]);
+        packagesTcs.SetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = "0.1.0" }]);
 
         await service.ExecuteTask!.DefaultTimeout();
 
         interactionService.Interactions.Writer.Complete();
 
         // Assert
-        Assert.True(versionFetcher.FetchCalled);
+        Assert.True(packageFetcher.FetchCalled);
 
         Assert.False(interactionService.Interactions.Reader.TryRead(out var _));
     }
@@ -169,21 +169,21 @@ public class VersionCheckServiceTests
         {
             [VersionCheckService.IgnoreVersionKey] = "100.0.0"
         });
-        var versionTcs = new TaskCompletionSource<List<NuGetPackage>>();
-        var versionFetcher = new TestPackageFetcher(versionTcs.Task);
-        var service = CreateVersionCheckService(interactionService: interactionService, packageFetcher: versionFetcher, configuration: configurationManager);
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
+        var service = CreateVersionCheckService(interactionService: interactionService, packageFetcher: packageFetcher, configuration: configurationManager);
 
         // Act
         _ = service.StartAsync(CancellationToken.None);
 
-        versionTcs.SetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = "100.0.0" }]);
+        packagesTcs.SetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = "100.0.0" }]);
 
         await service.ExecuteTask!.DefaultTimeout();
 
         interactionService.Interactions.Writer.Complete();
 
         // Assert
-        Assert.True(versionFetcher.FetchCalled);
+        Assert.True(packageFetcher.FetchCalled);
 
         Assert.False(interactionService.Interactions.Reader.TryRead(out var _));
     }


### PR DESCRIPTION
## Description

Share and reuse CLI version checking logic with app host.

Note that there are issues sharing internal types between CLI and app host because CLI tests references both and gets duplicate type errors. Fixed by customizing a type name between projects.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
