### PR TITLE
Update contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,7 @@ To run tests, use the build script:
 
 ```bash
 ./build.sh --test  # Linux/macOS
-./build.cmd --test # Windows
+./build.cmd -test # Windows
 ```
 
 ### Quarantined Tests


### PR DESCRIPTION
updated test

## Description

Updated contributing.md to specify how to test the aspire code, noting that the necessary flag to test on windows is `-test` not `--test` The screenshot below shows how `--test` fails with `Uknown Switch` vs `-test` that works like expected 
<img width="895" height="494" alt="image" src="https://github.com/user-attachments/assets/d31fa792-eff2-4453-b949-40fbba2485d8" />


Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
