### PR TITLE
Throw if container runtime is unhealthy during image build

### DIFF
--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -154,7 +154,7 @@ internal sealed class ResourceContainerImageBuilder(
                         cancellationToken).ConfigureAwait(false);
 
                     await step.CompleteAsync("Building container images failed", CompletionState.CompletedWithError, cancellationToken).ConfigureAwait(false);
-                    return;
+                    throw new InvalidOperationException("Container runtime is not running or is unhealthy.");
                 }
 
                 await task.SucceedAsync(

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
@@ -381,4 +381,51 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         Assert.Equal("/custom/path", options.OutputPath);
         Assert.Equal(ContainerTargetPlatform.LinuxArm64, options.TargetPlatform);
     }
+
+    [Fact]
+    public async Task BuildImageAsync_ThrowsInvalidOperationException_WhenDockerRuntimeNotAvailable()
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
+
+        builder.Services.AddLogging(logging =>
+        {
+            logging.AddFakeLogging();
+            logging.AddXunit(output);
+        });
+
+        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", new UnhealthyMockContainerRuntime());
+
+        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var container = builder.AddDockerfile("container", tempContextPath, tempDockerfilePath);
+
+        using var app = builder.Build();
+
+        using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
+        var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageBuilder>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            imageBuilder.BuildImagesAsync([container.Resource], options: null, cts.Token));
+
+        Assert.Equal("Container runtime is not running or is unhealthy.", exception.Message);
+
+        var collector = app.Services.GetFakeLogCollector();
+        var logs = collector.GetSnapshot();
+
+        Assert.Contains(logs, log => log.Message.Contains("Container runtime is not running or is unhealthy. Cannot build container images."));
+    }
+
+    private sealed class UnhealthyMockContainerRuntime : IContainerRuntime
+    {
+        public string Name => "MockDocker";
+
+        public Task<bool> CheckIfRunningAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task BuildImageAsync(string contextPath, string dockerfilePath, string imageName, ContainerBuildOptions? options, CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("This mock runtime should not be used for building images.");
+        }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/dotnet/aspire/issues/10156.

Before:

<img width="1440" height="1631" alt="image" src="https://github.com/user-attachments/assets/6cedfd8e-3909-4caa-a4fd-833cfb6ea1ad" />

After:

<img width="1440" height="773" alt="image" src="https://github.com/user-attachments/assets/9ff3f329-a1fd-453a-8888-3d153e0f82b3" />


