### PR TITLE
Add quotation marks in dashboard around arguments with spaces in them

### DIFF
--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -126,6 +126,10 @@ builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice")
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
 #endif
 
+builder.AddExecutable("executableWithSingleArg", "dotnet", Environment.CurrentDirectory, "--version");
+builder.AddExecutable("executableWithSingleEscapedArg", "dotnet", Environment.CurrentDirectory, "one two");
+builder.AddExecutable("executableWithMultipleArgs", "dotnet", Environment.CurrentDirectory, "--version", "one two");
+
 IResourceBuilder<IResource>? previousResourceBuilder = null;
 
 for (var i = 0; i < 3; i++)

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -20,13 +20,11 @@
             {
                 if (launchArgument.IsShown)
                 {
-                    if (launchArgument.Value.Contains(' '))
+                    <span class="subtext">@FormatValue(launchArgument.Value)</span>
+
+                    static string FormatValue(string value)
                     {
-                        <span class="subtext">&nbsp;"@launchArgument.Value"</span>
-                    }
-                    else
-                    {
-                        <span class="subtext">&nbsp;@launchArgument.Value</span>
+                        return " " + (value.Contains(' ') ? $"\"{value}\"" : value);
                     }
                 }
                 else

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -1,5 +1,4 @@
-﻿@using Aspire.Dashboard.Model
-@using Aspire.Dashboard.Resources
+﻿@using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils
 
 @inject IStringLocalizer<Columns> Loc
@@ -21,7 +20,14 @@
             {
                 if (launchArgument.IsShown)
                 {
-                    <span class="subtext">&nbsp;@launchArgument.Value</span>
+                    if (launchArgument.Value.Contains(' '))
+                    {
+                        <span class="subtext">&nbsp;"@launchArgument.Value"</span>
+                    }
+                    else
+                    {
+                        <span class="subtext">&nbsp;@launchArgument.Value</span>
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Description

Before:
<img width="834" height="218" alt="image" src="https://github.com/user-attachments/assets/9b683d3f-0aa3-4f9a-b2de-6331e61fb2a2" /> 

After:
<img width="834" height="218" alt="image" src="https://github.com/user-attachments/assets/91068d9b-b795-442a-99c3-245aa001eaa7" />


Fixes #10048

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No, included playground resource examples for this
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
