### PR TITLE
update `Azure.Provisioning.Storage` to `1.1.2`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.SignalR" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.Sql" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="1.1.1" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="1.1.2" />
     <PackageVersion Include="Azure.Provisioning.WebPubSub" Version="1.1.0" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.4" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.2" />

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -102,6 +102,13 @@ public static class AzureStorageExtensions
                 }
             }
 
+            if (azureResource.TableStorageResource is not null)
+            {
+                var tableService = azureResource.TableStorageResource.ToProvisioningEntity();
+                tableService.Parent = storageAccount;
+                infrastructure.Add(tableService);
+            }
+
             infrastructure.Add(new ProvisioningOutput("blobEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.BlobUri });
             infrastructure.Add(new ProvisioningOutput("queueEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.QueueUri });
             infrastructure.Add(new ProvisioningOutput("tableEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.TableUri });
@@ -463,6 +470,8 @@ public static class AzureStorageExtensions
         name ??= builder.Resource.Name + "-tables";
 
         var resource = new AzureTableStorageResource(name, builder.Resource);
+        builder.Resource.TableStorageResource = resource;
+
         return builder.ApplicationBuilder.AddResource(resource);
     }
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
@@ -25,6 +25,7 @@ public class AzureStorageResource(string name, Action<AzureResourceInfrastructur
 
     internal AzureBlobStorageResource? BlobStorageResource { get; set; }
     internal AzureQueueStorageResource? QueueStorageResource { get; set; }
+    internal AzureTableStorageResource? TableStorageResource { get; set; }
 
     internal List<AzureBlobStorageContainerResource> BlobContainers { get; } = [];
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureTableStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureTableStorageResource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Azure.Provisioning;
 
 namespace Aspire.Hosting.Azure;
 
@@ -39,5 +40,15 @@ public class AzureTableStorageResource(string name, AzureStorageResource storage
             // Injected to support Aspire client integration for Azure Storage Tables.
             target[$"{AzureStorageResource.TablesConnectionKeyPrefix}__{connectionName}__ServiceUri"] = Parent.TableEndpoint; // Updated for consistency
         }
+    }
+
+    /// <summary>
+    /// Converts the current instance to a provisioning entity.
+    /// </summary>
+    /// <returns>A <see cref="global::Azure.Provisioning.Storage.TableService"/> instance.</returns>
+    internal global::Azure.Provisioning.Storage.TableService ToProvisioningEntity()
+    {
+        global::Azure.Provisioning.Storage.TableService service = new(Infrastructure.NormalizeBicepIdentifier(Name));
+        return service;
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaPublishMode.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaPublishMode.verified.bicep
@@ -34,6 +34,7 @@ resource queue 'Microsoft.Storage/storageAccounts/queueServices@2024-01-01' = {
 }
 
 resource table 'Microsoft.Storage/storageAccounts/tableServices@2024-01-01' = {
+  name: 'default'
   parent: storage
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaPublishMode.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddAzureStorageViaPublishMode.verified.bicep
@@ -33,6 +33,10 @@ resource queue 'Microsoft.Storage/storageAccounts/queueServices@2024-01-01' = {
   parent: storage
 }
 
+resource table 'Microsoft.Storage/storageAccounts/tableServices@2024-01-01' = {
+  parent: storage
+}
+
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddMultipleStorageServiceGeneratesSingleResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddMultipleStorageServiceGeneratesSingleResource.verified.bicep
@@ -52,6 +52,7 @@ resource queue2 'Microsoft.Storage/storageAccounts/queueServices/queues@2024-01-
 }
 
 resource tableService2 'Microsoft.Storage/storageAccounts/tableServices@2024-01-01' = {
+  name: 'default'
   parent: storage
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddMultipleStorageServiceGeneratesSingleResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.AddMultipleStorageServiceGeneratesSingleResource.verified.bicep
@@ -51,6 +51,10 @@ resource queue2 'Microsoft.Storage/storageAccounts/queueServices/queues@2024-01-
   parent: queueService2
 }
 
+resource tableService2 'Microsoft.Storage/storageAccounts/tableServices@2024-01-01' = {
+  parent: storage
+}
+
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
@@ -41,6 +41,10 @@ resource myqueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2024-01
   parent: myqueues
 }
 
+resource mytables 'Microsoft.Storage/storageAccounts/tableServices@2024-01-01' = {
+  parent: storage
+}
+
 output blobEndpoint string = storage.properties.primaryEndpoints.blob
 
 output queueEndpoint string = storage.properties.primaryEndpoints.queue

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureStorageExtensionsTests.ResourceNamesBicepValid.verified.bicep
@@ -42,6 +42,7 @@ resource myqueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2024-01
 }
 
 resource mytables 'Microsoft.Storage/storageAccounts/tableServices@2024-01-01' = {
+  name: 'default'
   parent: storage
 }
 


### PR DESCRIPTION
## Description

This PR bumps `Azure.Provisioning.Storage` to `1.1.2` which fixes https://github.com/Azure/azure-sdk-for-net/issues/51210

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
