### PR TITLE
Fix duplicate storage resource names

### DIFF
--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Shared\AzureRoleAssignmentUtils.cs" />
+    <Compile Include="$(SharedDir)StringComparers.cs" Link="StringComparers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -330,8 +330,15 @@ public static class AzureStorageExtensions
     public static IResourceBuilder<AzureBlobStorageResource> AddBlobService(this IResourceBuilder<AzureStorageResource> builder, [ResourceName] string? name = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        
+
         name ??= builder.Resource.Name + "-blobs";
+
+        var existingResource = builder.ApplicationBuilder.Resources.OfType<AzureBlobStorageResource>().FirstOrDefault(x => string.Equals(name, x.Name, StringComparisons.ResourceName));
+        if (existingResource != null)
+        {
+            // If the resource already exists, return it.
+            return builder.ApplicationBuilder.CreateResourceBuilder(existingResource);
+        }
 
         var resource = new AzureBlobStorageResource(name, builder.Resource);
         builder.Resource.BlobStorageResource = resource;
@@ -459,8 +466,15 @@ public static class AzureStorageExtensions
     public static IResourceBuilder<AzureTableStorageResource> AddTableService(this IResourceBuilder<AzureStorageResource> builder, [ResourceName] string? name = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        
+
         name ??= builder.Resource.Name + "-tables";
+
+        var existingResource = builder.ApplicationBuilder.Resources.OfType<AzureTableStorageResource>().FirstOrDefault(x => string.Equals(name, x.Name, StringComparisons.ResourceName));
+        if (existingResource != null)
+        {
+            // If the resource already exists, return it.
+            return builder.ApplicationBuilder.CreateResourceBuilder(existingResource);
+        }
 
         var resource = new AzureTableStorageResource(name, builder.Resource);
         return builder.ApplicationBuilder.AddResource(resource);
@@ -490,8 +504,15 @@ public static class AzureStorageExtensions
     public static IResourceBuilder<AzureQueueStorageResource> AddQueueService(this IResourceBuilder<AzureStorageResource> builder, [ResourceName] string? name = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        
+
         name ??= builder.Resource.Name + "-queues";
+
+        var existingResource = builder.ApplicationBuilder.Resources.OfType<AzureQueueStorageResource>().FirstOrDefault(x => string.Equals(name, x.Name, StringComparisons.ResourceName));
+        if (existingResource != null)
+        {
+            // If the resource already exists, return it.
+            return builder.ApplicationBuilder.CreateResourceBuilder(existingResource);
+        }
 
         var resource = new AzureQueueStorageResource(name, builder.Resource);
         builder.Resource.QueueStorageResource = resource;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -884,4 +884,50 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
 
         await Verify(manifest.BicepText, extension: "bicep");
     }
+
+    [Fact]
+    public void AddBlobServiceReturnsExistingResourceWhenNamesMatch()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+        var blobContainer = storage.AddBlobContainer("blobcontainer");
+        var blobStorageResource = builder.Resources.OfType<AzureBlobStorageResource>().FirstOrDefault();
+
+        var blobService = storage.AddBlobService();
+
+        Assert.NotNull(blobStorageResource);
+        Assert.Equal("storage-blobs", blobService.Resource.Name);
+        Assert.Equal(blobService.Resource, blobStorageResource);
+    }
+
+    [Fact]
+    public void AddQueueServiceReturnsExistingResourceWhenNamesMatch()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+        var queue = storage.AddQueue("queue");
+        var queueStorageResource = builder.Resources.OfType<AzureQueueStorageResource>().FirstOrDefault();
+
+        var queueService = storage.AddQueueService();
+
+        Assert.NotNull(queueStorageResource);
+        Assert.Equal("storage-queues", queueService.Resource.Name);
+        Assert.Equal(queueService.Resource, queueStorageResource);
+    }
+
+    [Fact]
+    public void AddTableServiceReturnsExistingResourceWhenNamesMatch()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+
+        // There is no method to add a table directly, so we create a table service with the expected name instead.
+        var tableService1 = storage.AddTableService("storage-tables");
+
+        var tableService = storage.AddTableService();
+
+        Assert.NotNull(tableService1);
+        Assert.Equal("storage-tables", tableService1.Resource.Name);
+        Assert.Equal(tableService.Resource, tableService1.Resource);
+    }
 }


### PR DESCRIPTION
## Description

When creating a blob/queue resource before adding a generic, nameless, blob/queue service two resources with the same name would be created.

Fixes https://github.com/dotnet/aspire/issues/10327

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
