### PR TITLE
Simplify GH Models API keys experience

### DIFF
--- a/playground/GitHubModelsEndToEnd/GitHubModelsEndToEnd.AppHost/Program.cs
+++ b/playground/GitHubModelsEndToEnd/GitHubModelsEndToEnd.AppHost/Program.cs
@@ -6,10 +6,6 @@ builder.AddAzureContainerAppEnvironment("env");
 
 var chat = builder.AddGitHubModel("chat", "openai/gpt-4o-mini");
 
-// To set the GitHub Models API key define the value for the following parameter in User Secrets.
-// Alternatively, you can set the environment variable GITHUB_TOKEN and comment the line below.
-chat.WithApiKey(builder.AddParameter("github-api-key", secret: true));
-
 builder.AddProject<Projects.GitHubModelsEndToEnd_WebStory>("webstory")
        .WithExternalHttpEndpoints()
        .WithReference(chat).WaitFor(chat);

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
@@ -16,10 +16,12 @@ public class GitHubModelResource : Resource, IResourceWithConnectionString, IRes
     /// <param name="name">The name of the resource.</param>
     /// <param name="model">The model name.</param>
     /// <param name="organization">The organization.</param>
-    public GitHubModelResource(string name, string model, ParameterResource? organization) : base(name)
+    /// <param name="key">The key parameter.</param>
+    public GitHubModelResource(string name, string model, ParameterResource? organization, ParameterResource key) : base(name)
     {
         Model = model;
         Organization = organization;
+        Key = key;
     }
 
     /// <summary>
@@ -39,10 +41,9 @@ public class GitHubModelResource : Resource, IResourceWithConnectionString, IRes
     /// Gets or sets the API key (PAT or GitHub App minted token) for accessing GitHub Models.
     /// </summary>
     /// <remarks>
-    /// If not set, the value will be retrieved from the environment variable GITHUB_TOKEN.
     /// The token must have the <code>models: read</code> permission if using a fine-grained PAT or GitHub App minted token.
     /// </remarks>
-    public ParameterResource Key { get; set; } = new ParameterResource("github-api-key", p => Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? string.Empty, secret: true);
+    public ParameterResource Key { get; internal set; }
 
     /// <summary>
     /// Gets the connection string expression for the GitHub Models resource.

--- a/src/Aspire.Hosting.GitHub.Models/README.md
+++ b/src/Aspire.Hosting.GitHub.Models/README.md
@@ -24,10 +24,7 @@ Then, in the _AppHost.cs_ file of `AppHost`, add a GitHub Model resource and con
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
-var apiKey = builder.AddParameter("github-api-key", secret: true);
-
-var chat = builder.AddGitHubModel("chat", "openai/gpt-4o-mini")
-                  .WithApiKey(apiKey);
+var chat = builder.AddGitHubModel("chat", "openai/gpt-4o-mini");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(chat);
@@ -49,10 +46,23 @@ The GitHub Model resource can be configured with the following options:
 
 ### API Key
 
-The API key can be configured using a parameter:
+The API key can be set as a configuration value using the default name `{resource_name}-gh-apikey` or the `GITHUB_TOKEN` environment variable.
+
+Then in user secrets:
+
+```json
+{
+    "Parameters": 
+    {
+        "chat-gh-apikey": "YOUR_GITHUB_TOKEN_HERE"
+    }
+}
+```
+
+Furthermore, the API key can be configured using a custom parameter:
 
 ```csharp
-var apiKey = builder.AddParameter("github-api-key", secret: true);
+var apiKey = builder.AddParameter("my-api-key", secret: true);
 var chat = builder.AddGitHubModel("chat", "openai/gpt-4o-mini")
                   .WithApiKey(apiKey);
 ```
@@ -63,16 +73,9 @@ Then in user secrets:
 {
     "Parameters": 
     {
-        "github-api-key": "YOUR_GITHUB_TOKEN_HERE"
+        "my-api-key": "YOUR_GITHUB_TOKEN_HERE"
     }
 }
-```
-
-Or directly as a string (not recommended for production):
-
-```csharp
-var chat = builder.AddGitHubModel("chat", "openai/gpt-4o-mini")
-                  .WithApiKey("your-api-key-here");
 ```
 
 ## Available Models

--- a/tests/Aspire.Hosting.GitHub.Models.Tests/GitHubModelsExtensionTests.cs
+++ b/tests/Aspire.Hosting.GitHub.Models.Tests/GitHubModelsExtensionTests.cs
@@ -12,6 +12,7 @@ public class GitHubModelsExtensionTests
     public void AddGitHubModelAddsResourceWithCorrectName()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
 
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini");
 
@@ -20,9 +21,23 @@ public class GitHubModelsExtensionTests
     }
 
     [Fact]
+    public void AddGitHubModelCreatesDefaultApiKeyParameter()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var github = builder.AddGitHubModel("mymodel", "openai/gpt-4o-mini");
+
+        // Verify that the API key parameter exists and follows the naming pattern
+        Assert.NotNull(github.Resource.Key);
+        Assert.Equal("mymodel-gh-apikey", github.Resource.Key.Name);
+        Assert.True(github.Resource.Key.Secret);
+    }
+
+    [Fact]
     public void AddGitHubModelUsesCorrectEndpoint()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
 
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini");
 
@@ -34,6 +49,7 @@ public class GitHubModelsExtensionTests
     public void ConnectionStringExpressionIsCorrectlyFormatted()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
 
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini");
 
@@ -72,7 +88,7 @@ public class GitHubModelsExtensionTests
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini");
 
         Assert.NotNull(github.Resource.Key);
-        Assert.Equal("github-api-key", github.Resource.Key.Name);
+        Assert.Equal("github-gh-apikey", github.Resource.Key.Name);
         Assert.True(github.Resource.Key.Secret);
     }
 
@@ -80,6 +96,7 @@ public class GitHubModelsExtensionTests
     public void AddGitHubModelWithoutOrganization()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
 
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini");
 
@@ -93,6 +110,7 @@ public class GitHubModelsExtensionTests
 
         var orgParameter = builder.AddParameter("github-org");
         builder.Configuration["Parameters:github-org"] = "myorg";
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
 
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini", orgParameter);
 
@@ -108,6 +126,7 @@ public class GitHubModelsExtensionTests
 
         var orgParameter = builder.AddParameter("github-org");
         builder.Configuration["Parameters:github-org"] = "myorg";
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
 
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini", orgParameter);
 
@@ -127,6 +146,7 @@ public class GitHubModelsExtensionTests
 
         var orgParameter = builder.AddParameter("github-org");
         builder.Configuration["Parameters:github-org"] = "myorg";
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
 
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini", orgParameter);
 
@@ -141,6 +161,7 @@ public class GitHubModelsExtensionTests
     public void ConnectionStringExpressionWithoutOrganization()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
 
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini");
 
@@ -160,21 +181,31 @@ public class GitHubModelsExtensionTests
         var orgParameter = builder.AddParameter("github-org");
         builder.Configuration["Parameters:github-org"] = "myorg";
 
-        var resource = new GitHubModelResource("test", "openai/gpt-4o-mini", orgParameter.Resource);
+        var apiKeyParameter = builder.AddParameter("github-api-key", secret: true);
+        builder.Configuration["Parameters:github-api-key"] = "test-key";
+
+        var resource = new GitHubModelResource("test", "openai/gpt-4o-mini", orgParameter.Resource, apiKeyParameter.Resource);
 
         Assert.Equal("test", resource.Name);
         Assert.Equal("openai/gpt-4o-mini", resource.Model);
         Assert.Equal(orgParameter.Resource, resource.Organization);
+        Assert.Equal(apiKeyParameter.Resource, resource.Key);
     }
 
     [Fact]
     public void GitHubModelResourceConstructorWithNullOrganization()
     {
-        var resource = new GitHubModelResource("test", "openai/gpt-4o-mini", null);
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var apiKeyParameter = builder.AddParameter("github-api-key", secret: true);
+        builder.Configuration["Parameters:github-api-key"] = "test-key";
+
+        var resource = new GitHubModelResource("test", "openai/gpt-4o-mini", null, apiKeyParameter.Resource);
 
         Assert.Equal("test", resource.Name);
         Assert.Equal("openai/gpt-4o-mini", resource.Model);
         Assert.Null(resource.Organization);
+        Assert.Equal(apiKeyParameter.Resource, resource.Key);
     }
 
     [Fact]
@@ -185,7 +216,10 @@ public class GitHubModelsExtensionTests
         var orgParameter = builder.AddParameter("github-org");
         builder.Configuration["Parameters:github-org"] = "myorg";
 
-        var resource = new GitHubModelResource("test", "openai/gpt-4o-mini", null);
+        var apiKeyParameter = builder.AddParameter("github-api-key", secret: true);
+        builder.Configuration["Parameters:github-api-key"] = "test-key";
+
+        var resource = new GitHubModelResource("test", "openai/gpt-4o-mini", null, apiKeyParameter.Resource);
         Assert.Null(resource.Organization);
 
         resource.Organization = orgParameter.Resource;
@@ -193,9 +227,38 @@ public class GitHubModelsExtensionTests
     }
 
     [Fact]
+    public void WithApiKeyThrowsIfParameterIsNotSecret()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
+
+        var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini");
+        var apiKey = builder.AddParameter("non-secret-key"); // Not marked as secret
+
+        var exception = Assert.Throws<ArgumentException>(() => github.WithApiKey(apiKey));
+        Assert.Contains("The API key parameter must be marked as secret", exception.Message);
+    }
+
+    [Fact]
+    public void WithApiKeySucceedsIfParameterIsSecret()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
+
+        var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini");
+        var apiKey = builder.AddParameter("secret-key", secret: true);
+
+        // This should not throw
+        var result = github.WithApiKey(apiKey);
+        Assert.NotNull(result);
+        Assert.Equal(apiKey.Resource, github.Resource.Key);
+    }
+
+    [Fact]
     public void WithHealthCheckAddsHealthCheckAnnotation()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
+        builder.Configuration["Parameters:github-gh-apikey"] = "test-api-key";
 
         var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini").WithHealthCheck();
 


### PR DESCRIPTION
## Description

Defines a default child API key parameter with the name `{resource}gh-apikey`. Ensures API keys are set as secrets.

Fixes https://github.com/dotnet/aspire/issues/10331

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
