### PR TITLE
Refactor async task handling to use WaitAsync for cancellation support

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -789,7 +789,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         var containersTask = CreateContainersAsync(toCreate.Where(ar => ar.DcpResource is Container), cancellationToken);
         var executablesTask = CreateExecutablesAsync(toCreate.Where(ar => ar.DcpResource is Executable), cancellationToken);
 
-        await Task.WhenAll(containersTask, executablesTask).ConfigureAwait(false);
+        await Task.WhenAll(containersTask, executablesTask).WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private void AddAllocatedEndpointInfo(IEnumerable<AppResource> resources)
@@ -1084,10 +1084,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             var tasks = new List<Task>();
             foreach (var group in executableResources.GroupBy(e => e.ModelResource))
             {
-                tasks.Add(CreateResourceExecutablesAsyncCore(group.Key, group, cancellationToken));
+                tasks.Add(Task.Run(() => CreateResourceExecutablesAsyncCore(group.Key, group, cancellationToken), cancellationToken));
             }
 
-            return Task.WhenAll(tasks);
+            return Task.WhenAll(tasks).WaitAsync(cancellationToken);
         }
         finally
         {
@@ -1097,9 +1097,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
     private async Task CreateExecutableAsync(AppResource er, ILogger resourceLogger, CancellationToken cancellationToken)
     {
-        // Force async execution
-        await Task.Yield();
-
         if (er.DcpResource is not Executable exe)
         {
             throw new InvalidOperationException($"Expected an Executable resource, but got {er.DcpResource.Kind} instead");
@@ -1338,10 +1335,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     }
                 }
 
-                tasks.Add(CreateContainerAsyncCore(cr, cancellationToken));
+                tasks.Add(Task.Run(() => CreateContainerAsyncCore(cr, cancellationToken), cancellationToken));
             }
 
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            await Task.WhenAll(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -1351,9 +1348,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
     private async Task CreateContainerAsync(AppResource cr, ILogger resourceLogger, CancellationToken cancellationToken)
     {
-        // Force async execution
-        await Task.Yield();
-
         await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResource.Metadata.Name)).ConfigureAwait(false);
 
         var dcpContainerResource = (Container)cr.DcpResource;

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1084,6 +1084,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             var tasks = new List<Task>();
             foreach (var group in executableResources.GroupBy(e => e.ModelResource))
             {
+                // Force this to be async so that blocking code does not stop other executables from being created.
                 tasks.Add(Task.Run(() => CreateResourceExecutablesAsyncCore(group.Key, group, cancellationToken), cancellationToken));
             }
 
@@ -1335,6 +1336,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     }
                 }
 
+                // Force this to be async so that blocking code does not stop other containers from being created.
                 tasks.Add(Task.Run(() => CreateContainerAsyncCore(cr, cancellationToken), cancellationToken));
             }
 


### PR DESCRIPTION
## Description

If there's a blocking API call in the creation of the service it will block ctrl + c. This is because we assume that the cancellation token will be respected but that is not the case with these blocking APIs. This changes the logic so that WhenAll will yield if the token is fired.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
