### PR TITLE
Fix parameter substitution in GitHub Models

### DIFF
--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
@@ -10,6 +10,8 @@ namespace Aspire.Hosting.GitHub.Models;
 /// </summary>
 public class GitHubModelResource : Resource, IResourceWithConnectionString, IResourceWithoutLifetime
 {
+    internal ParameterResource DefaultKeyParameter { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="GitHubModelResource"/> class.
     /// </summary>
@@ -21,7 +23,7 @@ public class GitHubModelResource : Resource, IResourceWithConnectionString, IRes
     {
         Model = model;
         Organization = organization;
-        Key = key;
+        Key = DefaultKeyParameter = key;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
@@ -86,7 +86,7 @@ public static class GitHubModelsExtensions
         }
 
         // Remove the existing parameter if it's the default one
-        if (builder.Resource.Key.Name == $"{builder.Resource.Name}-gh-apikey")
+        if (builder.Resource.DefaultKeyParameter == builder.Resource.Key)
         {
             builder.ApplicationBuilder.Resources.Remove(builder.Resource.Key);
         }

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
@@ -85,8 +85,11 @@ public static class GitHubModelsExtensions
             throw new ArgumentException("The API key parameter must be marked as secret. Use AddParameter with secret: true when creating the parameter.", nameof(apiKey));
         }
 
-        // Remove the existing API key parameter
-        builder.ApplicationBuilder.Resources.Remove(builder.Resource.Key);
+        // Remove the existing parameter if it's the default one
+        if (builder.Resource.Key.Name == $"{builder.Resource.Name}-gh-apikey")
+        {
+            builder.ApplicationBuilder.Resources.Remove(builder.Resource.Key);
+        }
 
         builder.Resource.Key = apiKey.Resource;
 

--- a/tests/Aspire.Hosting.GitHub.Models.Tests/GitHubModelsExtensionTests.cs
+++ b/tests/Aspire.Hosting.GitHub.Models.Tests/GitHubModelsExtensionTests.cs
@@ -255,6 +255,26 @@ public class GitHubModelsExtensionTests
     }
 
     [Fact]
+    public void WithApiKeyCalledTwiceOnlyRemovesDefaultParameter()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var github = builder.AddGitHubModel("github", "openai/gpt-4o-mini");
+
+        Assert.NotNull(builder.Resources.FirstOrDefault(r => r.Name == "github-gh-apikey"));
+
+        github.WithApiKey(builder.AddParameter("secret-key1", secret: true));
+
+        Assert.Null(builder.Resources.FirstOrDefault(r => r.Name == "github-gh-apikey"));
+        Assert.NotNull(builder.Resources.FirstOrDefault(r => r.Name == "secret-key1"));
+
+        github.WithApiKey(builder.AddParameter("secret-key2", secret: true));
+
+        Assert.NotNull(builder.Resources.FirstOrDefault(r => r.Name == "secret-key1"));
+        Assert.NotNull(builder.Resources.FirstOrDefault(r => r.Name == "secret-key2"));
+    }
+
+    [Fact]
     public void WithHealthCheckAddsHealthCheckAnnotation()
     {
         using var builder = TestDistributedApplicationBuilder.Create();


### PR DESCRIPTION
## Description

When calling the method twice the parameter may be removed by mistake.

Fixes https://github.com/dotnet/aspire/pull/10424#pullrequestreview-3020954727

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
