### PR TITLE
Ensure all YARP env vars are strings

### DIFF
--- a/src/Aspire.Hosting.Yarp/YarpEnvConfigGenerator.cs
+++ b/src/Aspire.Hosting.Yarp/YarpEnvConfigGenerator.cs
@@ -36,7 +36,7 @@ internal class YarpEnvConfigGenerator
     {
         if (IsSimple(obj))
         {
-            environmentVariables.Add(prefix, obj);
+            environmentVariables.Add(prefix, obj.ToString() ?? "");
         }
         else if (obj is IReadOnlyDictionary<string, string> dict)
         {
@@ -74,7 +74,7 @@ internal class YarpEnvConfigGenerator
                 {
                     if ((sslProtocols & protocol) == protocol)
                     {
-                        environmentVariables.Add($"{prefix}__{counter}", protocol);
+                        environmentVariables.Add($"{prefix}__{counter}", protocol.ToString());
                         counter++;
                     }
                 }

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpConfigGeneratorTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpConfigGeneratorTests.cs
@@ -243,6 +243,23 @@ public class YarpConfigGeneratorTests()
     }
 
     [Fact]
+    public void EnsureAllEnvVarsAreStrings()
+    {
+        var variables = new Dictionary<string, object>();
+        var builder = TestDistributedApplicationBuilder.Create();
+
+        YarpEnvConfigGenerator.PopulateEnvVariables(
+            variables,
+            _validRoutes.Select(r => new YarpRoute(r)).ToList(),
+            _validClusters.Select(c => new YarpCluster(c, c.Destinations!.First().Value.Address)).ToList());
+
+        foreach (var variable in variables)
+        {
+            Assert.IsType<string>(variable.Value);
+        }
+    }
+
+    [Fact]
     [RequiresDocker]
     public async Task GenerateEnvVariablesConfigurationDockerCompose()
     {


### PR DESCRIPTION
## Description

There are expectations in other integrations that primitive environment variables are serialized to strings and not random objects like enums and bools.

Fix #10432