### PR TITLE
get-aspire-cli.ps1: Prepend the installation path to PATH instead of

### DIFF
--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -478,7 +478,7 @@ function Update-PathEnvironment {
     # Update current session PATH
     $currentPathArray = $env:PATH.Split($pathSeparator, [StringSplitOptions]::RemoveEmptyEntries)
     if ($currentPathArray -notcontains $InstallPath) {
-        $env:PATH = ($currentPathArray + @($InstallPath)) -join $pathSeparator
+        $env:PATH = (@($InstallPath) + $currentPathArray) -join $pathSeparator
         Write-Message "Added $InstallPath to PATH for current session" -Level Info
     }
 
@@ -490,7 +490,7 @@ function Update-PathEnvironment {
             $userPathArray = if ($userPath) { $userPath.Split($pathSeparator, [StringSplitOptions]::RemoveEmptyEntries) } else { @() }
 
             if ($userPathArray -notcontains $InstallPath) {
-                $newUserPath = ($userPathArray + @($InstallPath)) -join $pathSeparator
+                $newUserPath = (@($InstallPath) + $userPathArray) -join $pathSeparator
                 [Environment]::SetEnvironmentVariable("PATH", $newUserPath, [EnvironmentVariableTarget]::User)
                 Write-Message "Added $InstallPath to user PATH environment variable" -Level Info
             }


### PR DESCRIPTION
.. appending it at the end. This way it will take precedence over the
cli installed as a dotnet tool.

Suggested by @ damianedwards
