### PR TITLE
Add support for parameter description & custom input rendering

### DIFF
--- a/playground/ExternalServices/ExternalServices.AppHost/AppHost.cs
+++ b/playground/ExternalServices/ExternalServices.AppHost/AppHost.cs
@@ -6,7 +6,19 @@ using Aspire.Hosting.Yarp.Transforms;
 var builder = DistributedApplication.CreateBuilder(args);
 
 // URL value is in appsettings.json, or can be overridden by environment variable
-var externalService = builder.AddExternalService("external-service", builder.AddParameter("external-service-url"));
+var externalServiceUrl = builder.AddParameter("external-service-url")
+    .WithDescription("The URL of the external service.")
+    .WithCustomInput(p => new()
+    {
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        InputType = InputType.Text,
+#pragma warning restore ASPIREINTERACTION001
+        Value = "https://example.com",
+        Label = p.Name,
+        Placeholder = $"Enter value for {p.Name}",
+        Description = p.Description
+    });
+var externalService = builder.AddExternalService("external-service", externalServiceUrl);
 
 var nuget = builder.AddExternalService("nuget", "https://api.nuget.org/")
     .WithHttpHealthCheck(path: "/v3/index.json");

--- a/playground/ExternalServices/ExternalServices.AppHost/AppHost.cs
+++ b/playground/ExternalServices/ExternalServices.AppHost/AppHost.cs
@@ -5,7 +5,6 @@ using Aspire.Hosting.Yarp.Transforms;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-// URL value is in appsettings.json, or can be overridden by environment variable
 var externalServiceUrl = builder.AddParameter("external-service-url")
     .WithDescription("The URL of the external service.")
     .WithCustomInput(p => new()

--- a/playground/ExternalServices/ExternalServices.AppHost/appsettings.json
+++ b/playground/ExternalServices/ExternalServices.AppHost/appsettings.json
@@ -5,8 +5,5 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
-  },
-  "Parameters": {
-    "external-service-url": "https://example.com"
   }
 }

--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
@@ -29,7 +29,7 @@ var throwing = builder.AddParameter("throwing", () => throw new InvalidOperation
 var parameterFromConnectionStringConfigMissing = builder.AddConnectionString("parameterFromConnectionStringConfigMissing");
 
 var parameterWithMarkdownDescription = builder.AddParameter("markdownDescription")
-    .WithMarkdownDescription("This is a parameter with a **markdown** description.");
+    .WithDescription("This is a parameter with a **markdown** description.", enableMarkdown: true);
 
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 var parameterWithCustomInput = builder.AddParameter("customInput")

--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
@@ -29,7 +29,16 @@ var throwing = builder.AddParameter("throwing", () => throw new InvalidOperation
 var parameterFromConnectionStringConfigMissing = builder.AddConnectionString("parameterFromConnectionStringConfigMissing");
 
 var parameterWithMarkdownDescription = builder.AddParameter("markdownDescription")
-    .WithDescription("This is a parameter with a **markdown** description.", enableMarkdown: true);
+    .WithDescription("""
+        This is a parameter with a **markdown** description.
+
+        And has another paragraph.
+
+        And a list:
+        - Item 1
+        - Item 2 (and a [hyperlink](https://aka.ms/aspire))
+        - Item 3
+        """, enableMarkdown: true);
 
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 var parameterWithCustomInput = builder.AddParameter("customInput")

--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
@@ -19,13 +19,28 @@ var db = builder.AddSqlServer("sql")
                 .PublishAsConnectionString()
                 .AddDatabase("db");
 
-var insertionrows = builder.AddParameter("insertionrows");
+var insertionrows = builder.AddParameter("insertionrows")
+    .WithDescription("The number of rows to insert into the database.");
 
 var cs = builder.AddConnectionString("cs", ReferenceExpression.Create($"sql={db};rows={insertionrows}"));
 var parameterFromConnectionStringConfig = builder.AddConnectionString("parameterFromConnectionStringConfig");
 
 var throwing = builder.AddParameter("throwing", () => throw new InvalidOperationException("This is a test exception."));
 var parameterFromConnectionStringConfigMissing = builder.AddConnectionString("parameterFromConnectionStringConfigMissing");
+
+var parameterWithMarkdownDescription = builder.AddParameter("markdownDescription")
+    .WithMarkdownDescription("This is a parameter with a **markdown** description.");
+
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+var parameterWithCustomInput = builder.AddParameter("customInput")
+    .WithDescription("This parameter only accepts a number.", p => new()
+    {
+        InputType = InputType.Number,
+        Label = "Custom Input",
+        Placeholder = "Enter a number",
+        Description = p.Description,
+    });
+#pragma warning restore ASPIREINTERACTION001
 
 builder.AddProject<Projects.ParameterEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()

--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
@@ -33,7 +33,8 @@ var parameterWithMarkdownDescription = builder.AddParameter("markdownDescription
 
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 var parameterWithCustomInput = builder.AddParameter("customInput")
-    .WithDescription("This parameter only accepts a number.", p => new()
+    .WithDescription("This parameter only accepts a number.")
+    .WithCustomInput(p => new()
     {
         InputType = InputType.Number,
         Label = "Custom Input",

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -9,6 +9,7 @@
 @using Aspire.Dashboard.Components.Controls.Grid
 @using Aspire.DashboardService.Proto.V1
 @using Dialogs = Aspire.Dashboard.Resources.Dialogs
+@using Markdig
 @implements IDialogContentComponent<InteractionsInputsDialogViewModel>
 
 @inject IStringLocalizer<Dialogs> Loc
@@ -38,6 +39,9 @@
                 * Immediate value of true on text inputs ensures the value is set to the server token with every key press in textbox.
                 *@
                 var localItem = vm;
+                var descriptionId = !string.IsNullOrEmpty(localItem.Input.Description)
+                    ? $"{_elementRefs[localItem]?.Id}-description"
+                    : null;
                 <div class="interaction-input">
                     @switch (vm.Input.InputType)
                     {
@@ -47,7 +51,9 @@
                                              Label="@localItem.Input.Label"
                                              Placeholder="@localItem.Input.Placeholder"
                                              Required="localItem.Input.Required"
-                                             Immediate="true" />
+                                             Immediate="true"
+                                             aria-describedby="@descriptionId" />
+                            @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;
                         case InputType.SecretText:
@@ -58,7 +64,9 @@
                                              Required="localItem.Input.Required"
                                              TextFieldType="TextFieldType.Password"
                                              AutoComplete="one-time-code"
-                                             Immediate="true" />
+                                             Immediate="true"
+                                             aria-describedby="@descriptionId" />
+                            @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;
                         case InputType.Choice:
@@ -67,19 +75,25 @@
                                           @bind-Value="localItem.Value"
                                           Label="@localItem.Input.Label"
                                           Placeholder="@localItem.Input.Placeholder"
+                                          AriaLabel="@localItem.Input.Description"
                                           Required="localItem.Input.Required"
                                           Items="localItem.SelectOptions"
                                           OptionValue="@(vm => vm.Id)"
                                           OptionText="@(vm => vm.Name)"
                                           Height="250px"
-                                          Position="SelectPosition.Below" />
+                                          Position="SelectPosition.Below"
+                                          aria-describedby="@descriptionId" />
+                            @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;
                         case InputType.Boolean:
                             <FluentCheckbox @ref="@_elementRefs[localItem]"
                                             @bind-Value="localItem.IsChecked"
                                             Label="@localItem.Input.Label"
-                                            Placeholder="@localItem.Input.Placeholder" />
+                                            Placeholder="@localItem.Input.Placeholder"
+                                            AriaLabel="@localItem.Input.Description"
+                                            aria-describedby="@descriptionId" />
+                            @GetDescriptionContent(localItem.Input, descriptionId)
                             break;
                         case InputType.Number:
                             <FluentNumberField TValue="int?"
@@ -87,8 +101,11 @@
                                                @bind-Value="localItem.NumberValue"
                                                Label="@localItem.Input.Label"
                                                Placeholder="@localItem.Input.Placeholder"
+                                               AriaLabel="@localItem.Input.Description"
                                                Required="localItem.Input.Required"
-                                               Immediate="true" />
+                                               Immediate="true"
+                                               aria-describedby="@descriptionId" />
+                            @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.NumberValue)" />
                             break;
                         default:
@@ -115,3 +132,37 @@
         </FluentButton>
     }
 </FluentDialogFooter>
+
+@code {
+    private static readonly MarkdownPipeline s_markdownPipeline = MarkdownHelpers.CreateMarkdownPipelineBuilder().Build();
+
+    private static RenderFragment? GetDescriptionContent(InteractionInput vm, string? id)
+    {
+        @if (!string.IsNullOrEmpty(vm.Description))
+        {
+            return
+            @<div class="input-description">
+                <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="5">
+                    <div class="icon">
+                        <FluentIcon Icon="Icons.Regular.Size16.Info"
+                                    Color="Color.Accent"
+                                    Style="vertical-align: text-bottom;" />
+                    </div>
+                    <div class="text">
+                        @if (vm.EnableDescriptionMarkdown)
+                        {
+                            <div id="@id" data-markdown="true">
+                                @((MarkupString)MarkdownHelpers.ToHtml(vm.Description, s_markdownPipeline, true))
+                            </div>
+                        }
+                        else
+                        {
+                            <span id="@id" data-markdown="false">@vm.Description</span>
+                        }
+                    </div>
+                </FluentStack>
+            </div>;
+        }
+        return null;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -9,7 +9,6 @@
 @using Aspire.Dashboard.Components.Controls.Grid
 @using Aspire.DashboardService.Proto.V1
 @using Dialogs = Aspire.Dashboard.Resources.Dialogs
-@using Markdig
 @implements IDialogContentComponent<InteractionsInputsDialogViewModel>
 
 @inject IStringLocalizer<Dialogs> Loc
@@ -134,33 +133,20 @@
 </FluentDialogFooter>
 
 @code {
-    private static readonly MarkdownPipeline s_markdownPipeline = MarkdownHelpers.CreateMarkdownPipelineBuilder().Build();
-
     private static RenderFragment? GetDescriptionContent(InteractionInput vm, string? id)
     {
         @if (!string.IsNullOrEmpty(vm.Description))
         {
             return
-            @<div class="input-description">
-                <FluentStack Orientation="Orientation.Horizontal" HorizontalGap="5">
-                    <div class="icon">
-                        <FluentIcon Icon="Icons.Regular.Size16.Info"
-                                    Color="Color.Accent"
-                                    Style="vertical-align: text-bottom;" />
-                    </div>
-                    <div class="text">
-                        @if (vm.EnableDescriptionMarkdown)
-                        {
-                            <div id="@id" data-markdown="true">
-                                @((MarkupString)MarkdownHelpers.ToHtml(vm.Description, s_markdownPipeline, true))
-                            </div>
-                        }
-                        else
-                        {
-                            <span id="@id" data-markdown="false">@vm.Description</span>
-                        }
-                    </div>
-                </FluentStack>
+            @<div class="input-description" id="@id">
+                @if (vm.EnableDescriptionMarkdown)
+                {
+                    @InteractionMarkdownHelper.ToMarkupString(vm.Description)
+                }
+                else
+                {
+                    <span>@vm.Description</span>
+                }
             </div>;
         }
         return null;

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -141,7 +141,7 @@
             @<div class="input-description" id="@id">
                 @if (vm.EnableDescriptionMarkdown)
                 {
-                    @InteractionMarkdownHelper.ToMarkupString(vm.Description, suppressSurroundingParagraph: true)
+                    @InteractionMarkdownHelper.ToMarkupString(vm.Description)
                 }
                 else
                 {

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -141,7 +141,7 @@
             @<div class="input-description" id="@id">
                 @if (vm.EnableDescriptionMarkdown)
                 {
-                    @InteractionMarkdownHelper.ToMarkupString(vm.Description)
+                    @InteractionMarkdownHelper.ToMarkupString(vm.Description, suppressSurroundingParagraph: true)
                 }
                 else
                 {

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
@@ -8,11 +8,7 @@
     width: 75%;
 }
 
-.interaction-input-dialog .interaction-input ::deep .input-description .icon {
-    width: 16px;
-}
-
-.interaction-input-dialog .interaction-input ::deep .input-description .text {
-    font-style: italic;
-    font-size: 0.8rem;
+.interaction-input-dialog .interaction-input ::deep .input-description {
+    color: var(--foreground-settings-text);
+    font-size: var(--type-ramp-minus-1-font-size);
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
@@ -2,6 +2,17 @@
     width: 100%;
 }
 
-.interaction-input-dialog .interaction-input ::deep fluent-text-field, .interaction-input-dialog .interaction-input ::deep fluent-select {
+.interaction-input-dialog .interaction-input ::deep fluent-text-field,
+.interaction-input-dialog .interaction-input ::deep fluent-select,
+.interaction-input-dialog .interaction-input ::deep .input-description {
     width: 75%;
+}
+
+.interaction-input-dialog .interaction-input ::deep .input-description .icon {
+    width: 16px;
+}
+
+.interaction-input-dialog .interaction-input ::deep .input-description .text {
+    font-style: italic;
+    font-size: 0.8rem;
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
@@ -8,7 +8,14 @@
     width: 75%;
 }
 
-.interaction-input-dialog .interaction-input ::deep .input-description {
+.interaction-input-dialog .interaction-input ::deep .input-description,
+.interaction-input-dialog .interaction-input ::deep .input-description p {
     color: var(--foreground-settings-text);
     font-size: var(--type-ramp-minus-1-font-size);
+}
+
+.interaction-input-dialog .interaction-input ::deep .input-description p,
+.interaction-input-dialog .interaction-input ::deep .input-description ul,
+.interaction-input-dialog .interaction-input ::deep .input-description ol {
+    margin-bottom: 0.2em;
 }

--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -302,10 +302,7 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
             return WebUtility.HtmlEncode(item.Message);
         }
 
-        // Avoid adding paragraphs to HTML output from Markdown content unless there are multiple lines (aka multiple paragraphs).
-        var hasNewline = item.Message.Contains('\n') || item.Message.Contains('\r');
-
-        return InteractionMarkdownHelper.ToHtml(item.Message, suppressSurroundingParagraph: !hasNewline);
+        return InteractionMarkdownHelper.ToHtml(item.Message);
     }
 
     private async Task WatchInteractionsAsync()

--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -10,7 +10,6 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Aspire.DashboardService.Proto.V1;
-using Markdig;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -22,8 +21,6 @@ namespace Aspire.Dashboard.Components.Interactions;
 
 public class InteractionsProvider : ComponentBase, IAsyncDisposable
 {
-    private static readonly MarkdownPipeline s_markdownPipeline = MarkdownHelpers.CreateMarkdownPipelineBuilder().Build();
-
     internal record InteractionMessageBarReference(int InteractionId, Message Message, ComponentTelemetryContext TelemetryContext) : IDisposable
     {
         public void Dispose()
@@ -308,7 +305,7 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
         // Avoid adding paragraphs to HTML output from Markdown content unless there are multiple lines (aka multiple paragraphs).
         var hasNewline = item.Message.Contains('\n') || item.Message.Contains('\r');
 
-        return MarkdownHelpers.ToHtml(item.Message, s_markdownPipeline, suppressSurroundingParagraph: !hasNewline);
+        return InteractionMarkdownHelper.ToHtml(item.Message, suppressSurroundingParagraph: !hasNewline);
     }
 
     private async Task WatchInteractionsAsync()

--- a/src/Aspire.Dashboard/Utils/InteractionMarkdownHelper.cs
+++ b/src/Aspire.Dashboard/Utils/InteractionMarkdownHelper.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Markdig;
+using Microsoft.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Utils;
+
+public static class InteractionMarkdownHelper
+{
+    private static readonly MarkdownPipeline s_markdownPipeline = MarkdownHelpers.CreateMarkdownPipelineBuilder().Build();
+
+    public static MarkupString ToMarkupString(string markdown, bool suppressSurroundingParagraph = false)
+    {
+        return (MarkupString)ToHtml(markdown, suppressSurroundingParagraph);
+    }
+
+    public static string ToHtml(string markdown, bool suppressSurroundingParagraph = false)
+    {
+        return MarkdownHelpers.ToHtml(markdown, s_markdownPipeline, suppressSurroundingParagraph);
+    }
+}

--- a/src/Aspire.Dashboard/Utils/InteractionMarkdownHelper.cs
+++ b/src/Aspire.Dashboard/Utils/InteractionMarkdownHelper.cs
@@ -10,13 +10,16 @@ public static class InteractionMarkdownHelper
 {
     private static readonly MarkdownPipeline s_markdownPipeline = MarkdownHelpers.CreateMarkdownPipelineBuilder().Build();
 
-    public static MarkupString ToMarkupString(string markdown, bool suppressSurroundingParagraph = false)
+    public static MarkupString ToMarkupString(string markdown)
     {
-        return (MarkupString)ToHtml(markdown, suppressSurroundingParagraph);
+        return (MarkupString)ToHtml(markdown);
     }
 
-    public static string ToHtml(string markdown, bool suppressSurroundingParagraph = false)
+    public static string ToHtml(string markdown)
     {
-        return MarkdownHelpers.ToHtml(markdown, s_markdownPipeline, suppressSurroundingParagraph);
+        // Avoid adding paragraphs to HTML output from Markdown content unless there are multiple lines (aka multiple paragraphs).
+        var hasNewline = markdown.Contains('\n') || markdown.Contains('\r');
+
+        return MarkdownHelpers.ToHtml(markdown, s_markdownPipeline, !hasNewline);
     }
 }

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
@@ -32,7 +32,12 @@ public static class GitHubModelsExtensions
             Environment.GetEnvironmentVariable("GITHUB_TOKEN") ??
             throw new MissingParameterValueException($"GitHub API key parameter '{name}-gh-apikey' is missing and GITHUB_TOKEN environment variable is not set."),
             secret: true);
-
+        defaultApiKeyParameter.Resource.Description = """
+            The API key used to authenticate requests to the GitHub Models API.
+            A [fine-grained personal access token](https://github.com/settings/tokens) with the `models: read` scope is recommended.  
+            See [GitHub documentation for more details](https://docs.github.com/en/rest/models/inference).
+            """;
+        defaultApiKeyParameter.Resource.EnableDescriptionMarkup = true;
         var resource = new GitHubModelResource(name, model, organization?.Resource, defaultApiKeyParameter.Resource);
 
         defaultApiKeyParameter.WithParentRelationship(resource);

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
@@ -34,10 +34,10 @@ public static class GitHubModelsExtensions
             secret: true);
         defaultApiKeyParameter.Resource.Description = """
             The API key used to authenticate requests to the GitHub Models API.
-            A [fine-grained personal access token](https://github.com/settings/tokens) with the `models: read` scope is recommended.  
+            A [fine-grained personal access token](https://github.com/settings/tokens) with the `models: read` scope is recommended.
             See [GitHub documentation for more details](https://docs.github.com/en/rest/models/inference).
             """;
-        defaultApiKeyParameter.Resource.EnableDescriptionMarkup = true;
+        defaultApiKeyParameter.Resource.EnableDescriptionMarkdown = true;
         var resource = new GitHubModelResource(name, model, organization?.Resource, defaultApiKeyParameter.Resource);
 
         defaultApiKeyParameter.WithParentRelationship(resource);

--- a/src/Aspire.Hosting/ApplicationModel/InputGeneratorAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputGeneratorAnnotation.cs
@@ -1,11 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Hosting.ApplicationModel;
 
-#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-internal class InputGeneratorAnnotation(Func<ParameterResource, InteractionInput> inputGenerator) : IResourceAnnotation
+/// <summary>
+/// Annotation for customizing the input generation for a parameter.
+/// </summary>
+/// <param name="inputGenerator">The function that generates the input for the parameter.</param>
+[Experimental(InteractionService.DiagnosticId, UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public class InputGeneratorAnnotation(Func<ParameterResource, InteractionInput> inputGenerator) : IResourceAnnotation
 {
+    /// <summary>
+    /// Gets the function that generates the input for the parameter.
+    /// </summary>
     public Func<ParameterResource, InteractionInput> InputGenerator => inputGenerator;
 }
-#pragma warning restore ASPIREINTERACTION001

--- a/src/Aspire.Hosting/ApplicationModel/InputGeneratorAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputGeneratorAnnotation.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+internal class InputGeneratorAnnotation(Func<ParameterResource, InteractionInput> inputGenerator) : IResourceAnnotation
+{
+    public Func<ParameterResource, InteractionInput> InputGenerator => inputGenerator;
+}
+#pragma warning restore ASPIREINTERACTION001

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -86,4 +86,36 @@ public class ParameterResource : Resource, IResourceWithoutLifetime, IManifestEx
         // In publish mode, there's no WaitForValueTcs set.
         return ValueInternal;
     }
+
+    /// <summary>
+    /// Gets a description of the parameter resource.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the description should be rendered as Markdown.
+    /// </summary>
+    public bool EnableDescriptionMarkup { get; set; }
+
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    internal InteractionInput CreateInput()
+    {
+        if (this.TryGetLastAnnotation<InputGeneratorAnnotation>(out var annotation))
+        {
+            // If the annotation is present, use it to create the input.
+            return annotation.InputGenerator(this);
+        }
+
+        var input = new InteractionInput
+        {
+            InputType = Secret ? InputType.SecretText : InputType.Text,
+            Label = Name,
+            Description = Description,
+            EnableDescriptionMarkup = EnableDescriptionMarkup,
+            Placeholder = $"Enter value for {Name}",
+
+        };
+        return input;
+    }
+#pragma warning restore ASPIREINTERACTION001
 }

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -112,8 +112,7 @@ public class ParameterResource : Resource, IResourceWithoutLifetime, IManifestEx
             Label = Name,
             Description = Description,
             EnableDescriptionMarkup = EnableDescriptionMarkup,
-            Placeholder = $"Enter value for {Name}",
-
+            Placeholder = $"Enter value for {Name}"
         };
         return input;
     }

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -95,7 +95,7 @@ public class ParameterResource : Resource, IResourceWithoutLifetime, IManifestEx
     /// <summary>
     /// Gets or sets a value indicating whether the description should be rendered as Markdown.
     /// </summary>
-    public bool EnableDescriptionMarkup { get; set; }
+    public bool EnableDescriptionMarkdown { get; set; }
 
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     internal InteractionInput CreateInput()
@@ -111,7 +111,7 @@ public class ParameterResource : Resource, IResourceWithoutLifetime, IManifestEx
             InputType = Secret ? InputType.SecretText : InputType.Text,
             Label = Name,
             Description = Description,
-            EnableDescriptionMarkup = EnableDescriptionMarkup,
+            EnableDescriptionMarkdown = EnableDescriptionMarkdown,
             Placeholder = $"Enter value for {Name}"
         };
         return input;

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -129,7 +129,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                                 if (input.Description != null)
                                 {
                                     dto.Description = input.Description;
-                                    dto.EnableDescriptionMarkdown = input.EnableDescriptionMarkup;
+                                    dto.EnableDescriptionMarkdown = input.EnableDescriptionMarkdown;
                                 }
                                 if (input.Placeholder != null)
                                 {

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -126,6 +126,11 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                                 {
                                     dto.Label = input.Label;
                                 }
+                                if (input.Description != null)
+                                {
+                                    dto.Description = input.Description;
+                                    dto.EnableDescriptionMarkdown = input.EnableDescriptionMarkup;
+                                }
                                 if (input.Placeholder != null)
                                 {
                                     dto.Placeholder = input.Placeholder;

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -374,6 +374,8 @@ message InteractionInput {
     map<string, string> options = 5;
     string value = 6;
     repeated string validation_errors = 7;
+    string description = 8;
+    bool enable_description_markdown = 9;
 }
 enum MessageIntent {
     MESSAGE_INTENT_NONE = 0;

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -109,6 +109,17 @@ public sealed class InteractionInput
     public required string Label { get; init; }
 
     /// <summary>
+    /// Gets or sets the description for the input.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the description should be rendered as Markdown.
+    /// Setting this to <c>true</c> allows a description to contain Markdown elements such as links, text decoration and lists.
+    /// </summary>
+    public bool EnableDescriptionMarkup { get; init; }
+
+    /// <summary>
     /// Gets or sets the type of the input.
     /// </summary>
     public required InputType InputType { get; init; }

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -117,7 +117,7 @@ public sealed class InteractionInput
     /// Gets or sets a value indicating whether the description should be rendered as Markdown.
     /// Setting this to <c>true</c> allows a description to contain Markdown elements such as links, text decoration and lists.
     /// </summary>
-    public bool EnableDescriptionMarkup { get; init; }
+    public bool EnableDescriptionMarkdown { get; init; }
 
     /// <summary>
     /// Gets or sets the type of the input.

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -144,12 +144,7 @@ internal sealed class ParameterProcessor(
                 foreach (var parameter in unresolvedParameters)
                 {
                     // Create an input for each unresolved parameter.
-                    var input = new InteractionInput
-                    {
-                        InputType = parameter.Secret ? InputType.SecretText : InputType.Text,
-                        Label = parameter.Name,
-                        Placeholder = $"Enter value for {parameter.Name}",
-                    };
+                    var input = parameter.CreateInput();
                     resourceInputs.Add((parameter, input));
                 }
 

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -188,6 +188,20 @@ public static class ParameterResourceBuilderExtensions
     /// <param name="builder">Resource builder for the parameter.</param>
     /// <param name="createInput">Function to customize the input for the parameter.</param>
     /// <returns>Resource builder for the parameter.</returns>
+    /// <remarks>
+    /// Use this method to customize how the input field for this parameter is rendered when its value is requested, e.g.:
+    /// <code language="csharp">
+    /// builder.AddParameter("external-service-url")
+    ///     .WithCustomInput(parameter => new()
+    ///     {
+    ///         InputType = InputType.Text,
+    ///         Value = "https://example.com",
+    ///         Label = parameter.Name,
+    ///         Placeholder = $"Enter value for {parameter.Name}",
+    ///         Description = parameter.Description
+    ///     });
+    /// </code>
+    /// </remarks>
     public static IResourceBuilder<ParameterResource> WithCustomInput(this IResourceBuilder<ParameterResource> builder, Func<ParameterResource, InteractionInput> createInput)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -154,19 +154,13 @@ public static class ParameterResourceBuilderExtensions
     /// </summary>
     /// <param name="builder">Resource builder for the parameter.</param>
     /// <param name="description">The parameter description.</param>
-    /// <param name="createInput">Optional function to customize the input for the parameter.</param>
     /// <returns>Resource builder for the parameter.</returns>
-    public static IResourceBuilder<ParameterResource> WithDescription(this IResourceBuilder<ParameterResource> builder, string description, Func<ParameterResource, InteractionInput>? createInput = null)
+    public static IResourceBuilder<ParameterResource> WithDescription(this IResourceBuilder<ParameterResource> builder, string description)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(description);
 
         builder.Resource.Description = description;
-
-        if (createInput is not null)
-        {
-            builder.Resource.Annotations.Add(new InputGeneratorAnnotation(createInput));
-        }
 
         return builder;
     }
@@ -176,9 +170,8 @@ public static class ParameterResourceBuilderExtensions
     /// </summary>
     /// <param name="builder">Resource builder for the parameter.</param>
     /// <param name="description">The parameter markdown description.</param>
-    /// <param name="createInput">Optional function to customize the input for the parameter.</param>
     /// <returns>Resource builder for the parameter.</returns>
-    public static IResourceBuilder<ParameterResource> WithMarkdownDescription(this IResourceBuilder<ParameterResource> builder, string description, Func<ParameterResource, InteractionInput>? createInput = null)
+    public static IResourceBuilder<ParameterResource> WithMarkdownDescription(this IResourceBuilder<ParameterResource> builder, string description)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(description);
@@ -186,10 +179,21 @@ public static class ParameterResourceBuilderExtensions
         builder.Resource.Description = description;
         builder.Resource.EnableDescriptionMarkup = true;
 
-        if (createInput is not null)
-        {
-            builder.Resource.Annotations.Add(new InputGeneratorAnnotation(createInput));
-        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets a custom input generator function for the parameter resource.
+    /// </summary>
+    /// <param name="builder">Resource builder for the parameter.</param>
+    /// <param name="createInput">Function to customize the input for the parameter.</param>
+    /// <returns>Resource builder for the parameter.</returns>
+    public static IResourceBuilder<ParameterResource> WithCustomInput(this IResourceBuilder<ParameterResource> builder, Func<ParameterResource, InteractionInput> createInput)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(createInput);
+
+        builder.Resource.Annotations.Add(new InputGeneratorAnnotation(createInput));
 
         return builder;
     }

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -153,7 +153,10 @@ public static class ParameterResourceBuilderExtensions
     /// </summary>
     /// <param name="builder">Resource builder for the parameter.</param>
     /// <param name="description">The parameter description.</param>
-    /// <param name="enableMarkdown"></param>
+    /// <param name="enableMarkdown">
+    /// A value indicating whether the description should be rendered as Markdown.
+    /// <c>true</c> allows the description to contain Markdown elements such as links, text decoration and lists.
+    /// </param>
     /// <returns>Resource builder for the parameter.</returns>
     public static IResourceBuilder<ParameterResource> WithDescription(this IResourceBuilder<ParameterResource> builder, string description, bool enableMarkdown = false)
     {

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -148,6 +148,53 @@ public static class ParameterResourceBuilderExtensions
             });
     }
 
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    /// <summary>
+    /// Sets the description of the parameter resource.
+    /// </summary>
+    /// <param name="builder">Resource builder for the parameter.</param>
+    /// <param name="description">The parameter description.</param>
+    /// <param name="createInput">Optional function to customize the input for the parameter.</param>
+    /// <returns>Resource builder for the parameter.</returns>
+    public static IResourceBuilder<ParameterResource> WithDescription(this IResourceBuilder<ParameterResource> builder, string description, Func<ParameterResource, InteractionInput>? createInput = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(description);
+
+        builder.Resource.Description = description;
+
+        if (createInput is not null)
+        {
+            builder.Resource.Annotations.Add(new InputGeneratorAnnotation(createInput));
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets the description of the parameter resource and configures it to use markdown.
+    /// </summary>
+    /// <param name="builder">Resource builder for the parameter.</param>
+    /// <param name="description">The parameter markdown description.</param>
+    /// <param name="createInput">Optional function to customize the input for the parameter.</param>
+    /// <returns>Resource builder for the parameter.</returns>
+    public static IResourceBuilder<ParameterResource> WithMarkdownDescription(this IResourceBuilder<ParameterResource> builder, string description, Func<ParameterResource, InteractionInput>? createInput = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(description);
+
+        builder.Resource.Description = description;
+        builder.Resource.EnableDescriptionMarkup = true;
+
+        if (createInput is not null)
+        {
+            builder.Resource.Annotations.Add(new InputGeneratorAnnotation(createInput));
+        }
+
+        return builder;
+    }
+#pragma warning restore ASPIREINTERACTION001
+
     private static string GetParameterValue(ConfigurationManager configuration, string name, ParameterDefault? parameterDefault, string? configurationKey = null)
     {
         configurationKey ??= $"Parameters:{name}";

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -148,40 +148,25 @@ public static class ParameterResourceBuilderExtensions
             });
     }
 
-#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     /// <summary>
     /// Sets the description of the parameter resource.
     /// </summary>
     /// <param name="builder">Resource builder for the parameter.</param>
     /// <param name="description">The parameter description.</param>
+    /// <param name="enableMarkdown"></param>
     /// <returns>Resource builder for the parameter.</returns>
-    public static IResourceBuilder<ParameterResource> WithDescription(this IResourceBuilder<ParameterResource> builder, string description)
+    public static IResourceBuilder<ParameterResource> WithDescription(this IResourceBuilder<ParameterResource> builder, string description, bool enableMarkdown = false)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(description);
 
         builder.Resource.Description = description;
+        builder.Resource.EnableDescriptionMarkdown = enableMarkdown;
 
         return builder;
     }
 
-    /// <summary>
-    /// Sets the description of the parameter resource and configures it to use markdown.
-    /// </summary>
-    /// <param name="builder">Resource builder for the parameter.</param>
-    /// <param name="description">The parameter markdown description.</param>
-    /// <returns>Resource builder for the parameter.</returns>
-    public static IResourceBuilder<ParameterResource> WithMarkdownDescription(this IResourceBuilder<ParameterResource> builder, string description)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(description);
-
-        builder.Resource.Description = description;
-        builder.Resource.EnableDescriptionMarkup = true;
-
-        return builder;
-    }
-
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     /// <summary>
     /// Sets a custom input generator function for the parameter resource.
     /// </summary>
@@ -194,7 +179,7 @@ public static class ParameterResourceBuilderExtensions
     /// builder.AddParameter("external-service-url")
     ///     .WithCustomInput(parameter => new()
     ///     {
-    ///         InputType = InputType.Text,
+    ///         InputType = parameter.Secret ? InputType.SecretText : InputType.Text,
     ///         Value = "https://example.com",
     ///         Label = parameter.Name,
     ///         Placeholder = $"Enter value for {parameter.Name}",

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -385,4 +385,165 @@ public class AddParameterTests
         Assert.Equal(KnownResourceTypes.ConnectionString, state.ResourceType);
         Assert.Equal(KnownResourceStates.Waiting, state.State?.Text);
     }
+
+    [Fact]
+    public void ParameterWithDescription_SetsDescriptionProperty()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        // Act
+        var parameter = appBuilder.AddParameter("test")
+            .WithDescription("This is a test parameter");
+
+        // Assert
+        Assert.Equal("This is a test parameter", parameter.Resource.Description);
+        Assert.False(parameter.Resource.EnableDescriptionMarkup);
+    }
+
+    [Fact]
+    public void ParameterWithMarkdownDescription_SetsDescriptionAndMarkupProperties()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        // Act
+        var parameter = appBuilder.AddParameter("test")
+            .WithMarkdownDescription("This is a **markdown** description");
+
+        // Assert
+        Assert.Equal("This is a **markdown** description", parameter.Resource.Description);
+        Assert.True(parameter.Resource.EnableDescriptionMarkup);
+    }
+
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    [Fact]
+    public void ParameterWithDescriptionAndCustomInput_AddsInputGeneratorAnnotation()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        // Act
+        var parameter = appBuilder.AddParameter("test")
+            .WithDescription("Custom input parameter")
+            .WithCustomInput(p => new InteractionInput
+            {
+                InputType = InputType.Number,
+                Label = "Custom Label",
+                Description = p.Description,
+                EnableDescriptionMarkup = p.EnableDescriptionMarkup
+            });
+
+        // Assert
+        Assert.Equal("Custom input parameter", parameter.Resource.Description);
+        Assert.True(parameter.Resource.Annotations.OfType<InputGeneratorAnnotation>().Any());
+    }
+
+    [Fact]
+    public void ParameterCreateInput_WithoutCustomGenerator_ReturnsDefaultInput()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var parameter = appBuilder.AddParameter("test")
+            .WithDescription("Test description");
+
+        // Act
+        var input = parameter.Resource.CreateInput();
+
+        // Assert
+        Assert.Equal(InputType.Text, input.InputType);
+        Assert.Equal("test", input.Label);
+        Assert.Equal("Test description", input.Description);
+        Assert.Equal("Enter value for test", input.Placeholder);
+        Assert.False(input.EnableDescriptionMarkup);
+    }
+
+    [Fact]
+    public void ParameterCreateInput_ForSecretParameter_ReturnsSecretTextInput()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var parameter = appBuilder.AddParameter("secret", secret: true)
+            .WithDescription("Secret description");
+
+        // Act
+        var input = parameter.Resource.CreateInput();
+
+        // Assert
+        Assert.Equal(InputType.SecretText, input.InputType);
+        Assert.Equal("secret", input.Label);
+        Assert.Equal("Secret description", input.Description);
+        Assert.Equal("Enter value for secret", input.Placeholder);
+        Assert.False(input.EnableDescriptionMarkup);
+    }
+
+    [Fact]
+    public void ParameterCreateInput_WithCustomGenerator_UsesGenerator()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var parameter = appBuilder.AddParameter("test")
+            .WithDescription("Custom description")
+            .WithCustomInput(p => new InteractionInput
+            {
+                InputType = InputType.Number,
+                Label = "Custom Label",
+                Description = "Custom: " + p.Description,
+                EnableDescriptionMarkup = true,
+                Placeholder = "Enter number"
+            });
+
+        // Act
+        var input = parameter.Resource.CreateInput();
+
+        // Assert
+        Assert.Equal(InputType.Number, input.InputType);
+        Assert.Equal("Custom Label", input.Label);
+        Assert.Equal("Custom: Custom description", input.Description);
+        Assert.Equal("Enter number", input.Placeholder);
+        Assert.True(input.EnableDescriptionMarkup);
+    }
+
+    [Fact]
+    public void ParameterCreateInput_WithMarkdownDescription_SetsMarkupFlag()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var parameter = appBuilder.AddParameter("test")
+            .WithMarkdownDescription("**Bold** description");
+
+        // Act
+        var input = parameter.Resource.CreateInput();
+
+        // Assert
+        Assert.Equal("**Bold** description", input.Description);
+        Assert.True(input.EnableDescriptionMarkup);
+    }
+
+    [Fact]
+    public void ParameterWithCustomInput_AddsInputGeneratorAnnotation()
+    {
+        // Arrange
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        // Act
+        var parameter = appBuilder.AddParameter("test")
+            .WithCustomInput(p => new InteractionInput
+            {
+                InputType = InputType.Number,
+                Label = "Custom Label",
+                Description = "Custom description",
+                EnableDescriptionMarkup = false
+            });
+
+        // Assert
+        Assert.True(parameter.Resource.Annotations.OfType<InputGeneratorAnnotation>().Any());
+
+        var input = parameter.Resource.CreateInput();
+        Assert.Equal(InputType.Number, input.InputType);
+        Assert.Equal("Custom Label", input.Label);
+        Assert.Equal("Custom description", input.Description);
+        Assert.False(input.EnableDescriptionMarkup);
+    }
+#pragma warning restore ASPIREINTERACTION001
 }

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -398,7 +398,7 @@ public class AddParameterTests
 
         // Assert
         Assert.Equal("This is a test parameter", parameter.Resource.Description);
-        Assert.False(parameter.Resource.EnableDescriptionMarkup);
+        Assert.False(parameter.Resource.EnableDescriptionMarkdown);
     }
 
     [Fact]
@@ -409,11 +409,11 @@ public class AddParameterTests
 
         // Act
         var parameter = appBuilder.AddParameter("test")
-            .WithMarkdownDescription("This is a **markdown** description");
+            .WithDescription("This is a **markdown** description", enableMarkdown: true);
 
         // Assert
         Assert.Equal("This is a **markdown** description", parameter.Resource.Description);
-        Assert.True(parameter.Resource.EnableDescriptionMarkup);
+        Assert.True(parameter.Resource.EnableDescriptionMarkdown);
     }
 
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
@@ -431,7 +431,7 @@ public class AddParameterTests
                 InputType = InputType.Number,
                 Label = "Custom Label",
                 Description = p.Description,
-                EnableDescriptionMarkup = p.EnableDescriptionMarkup
+                EnableDescriptionMarkdown = p.EnableDescriptionMarkdown
             });
 
         // Assert
@@ -455,7 +455,7 @@ public class AddParameterTests
         Assert.Equal("test", input.Label);
         Assert.Equal("Test description", input.Description);
         Assert.Equal("Enter value for test", input.Placeholder);
-        Assert.False(input.EnableDescriptionMarkup);
+        Assert.False(input.EnableDescriptionMarkdown);
     }
 
     [Fact]
@@ -474,7 +474,7 @@ public class AddParameterTests
         Assert.Equal("secret", input.Label);
         Assert.Equal("Secret description", input.Description);
         Assert.Equal("Enter value for secret", input.Placeholder);
-        Assert.False(input.EnableDescriptionMarkup);
+        Assert.False(input.EnableDescriptionMarkdown);
     }
 
     [Fact]
@@ -489,7 +489,7 @@ public class AddParameterTests
                 InputType = InputType.Number,
                 Label = "Custom Label",
                 Description = "Custom: " + p.Description,
-                EnableDescriptionMarkup = true,
+                EnableDescriptionMarkdown = true,
                 Placeholder = "Enter number"
             });
 
@@ -501,7 +501,7 @@ public class AddParameterTests
         Assert.Equal("Custom Label", input.Label);
         Assert.Equal("Custom: Custom description", input.Description);
         Assert.Equal("Enter number", input.Placeholder);
-        Assert.True(input.EnableDescriptionMarkup);
+        Assert.True(input.EnableDescriptionMarkdown);
     }
 
     [Fact]
@@ -510,14 +510,14 @@ public class AddParameterTests
         // Arrange
         var appBuilder = DistributedApplication.CreateBuilder();
         var parameter = appBuilder.AddParameter("test")
-            .WithMarkdownDescription("**Bold** description");
+            .WithDescription("**Bold** description", enableMarkdown: true);
 
         // Act
         var input = parameter.Resource.CreateInput();
 
         // Assert
         Assert.Equal("**Bold** description", input.Description);
-        Assert.True(input.EnableDescriptionMarkup);
+        Assert.True(input.EnableDescriptionMarkdown);
     }
 
     [Fact]
@@ -533,7 +533,7 @@ public class AddParameterTests
                 InputType = InputType.Number,
                 Label = "Custom Label",
                 Description = "Custom description",
-                EnableDescriptionMarkup = false
+                EnableDescriptionMarkdown = false
             });
 
         // Assert
@@ -543,7 +543,7 @@ public class AddParameterTests
         Assert.Equal(InputType.Number, input.InputType);
         Assert.Equal("Custom Label", input.Label);
         Assert.Equal("Custom description", input.Description);
-        Assert.False(input.EnableDescriptionMarkup);
+        Assert.False(input.EnableDescriptionMarkdown);
     }
 #pragma warning restore ASPIREINTERACTION001
 }

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -196,7 +196,60 @@ public class InteractionServiceTests
         await CompleteInteractionAsync(interactionService, interaction.InteractionId, new InteractionCompletionState { Complete = true, State = new [] { input } });
 
         // The interaction should still be in progress due to validation error
-        Assert.False(interaction.CompletionTcs.Task.IsCompleted); 
+        Assert.False(interaction.CompletionTcs.Task.IsCompleted);
+    }
+
+    [Fact]
+    public void InteractionInput_WithDescription_SetsProperties()
+    {
+        // Arrange & Act
+        var input = new InteractionInput
+        {
+            Label = "Test Label",
+            InputType = InputType.Text,
+            Description = "Test description",
+            EnableDescriptionMarkup = false
+        };
+
+        // Assert
+        Assert.Equal("Test Label", input.Label);
+        Assert.Equal(InputType.Text, input.InputType);
+        Assert.Equal("Test description", input.Description);
+        Assert.False(input.EnableDescriptionMarkup);
+    }
+
+    [Fact]
+    public void InteractionInput_WithMarkdownDescription_SetsMarkupFlag()
+    {
+        // Arrange & Act
+        var input = new InteractionInput
+        {
+            Label = "Test Label",
+            InputType = InputType.Text,
+            Description = "**Bold** description",
+            EnableDescriptionMarkup = true
+        };
+
+        // Assert
+        Assert.Equal("**Bold** description", input.Description);
+        Assert.True(input.EnableDescriptionMarkup);
+    }
+
+    [Fact]
+    public void InteractionInput_WithNullDescription_AllowsNullValue()
+    {
+        // Arrange & Act
+        var input = new InteractionInput
+        {
+            Label = "Test Label",
+            InputType = InputType.Text,
+            Description = null,
+            EnableDescriptionMarkup = false
+        };
+
+        // Assert
+        Assert.Null(input.Description);
+        Assert.False(input.EnableDescriptionMarkup);
     }
 
     private static async Task CompleteInteractionAsync(InteractionService interactionService, int interactionId, InteractionCompletionState state)

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -208,14 +208,14 @@ public class InteractionServiceTests
             Label = "Test Label",
             InputType = InputType.Text,
             Description = "Test description",
-            EnableDescriptionMarkup = false
+            EnableDescriptionMarkdown = false
         };
 
         // Assert
         Assert.Equal("Test Label", input.Label);
         Assert.Equal(InputType.Text, input.InputType);
         Assert.Equal("Test description", input.Description);
-        Assert.False(input.EnableDescriptionMarkup);
+        Assert.False(input.EnableDescriptionMarkdown);
     }
 
     [Fact]
@@ -227,12 +227,12 @@ public class InteractionServiceTests
             Label = "Test Label",
             InputType = InputType.Text,
             Description = "**Bold** description",
-            EnableDescriptionMarkup = true
+            EnableDescriptionMarkdown = true
         };
 
         // Assert
         Assert.Equal("**Bold** description", input.Description);
-        Assert.True(input.EnableDescriptionMarkup);
+        Assert.True(input.EnableDescriptionMarkdown);
     }
 
     [Fact]
@@ -244,12 +244,12 @@ public class InteractionServiceTests
             Label = "Test Label",
             InputType = InputType.Text,
             Description = null,
-            EnableDescriptionMarkup = false
+            EnableDescriptionMarkdown = false
         };
 
         // Assert
         Assert.Null(input.Description);
-        Assert.False(input.EnableDescriptionMarkup);
+        Assert.False(input.EnableDescriptionMarkdown);
     }
 
     private static async Task CompleteInteractionAsync(InteractionService interactionService, int interactionId, InteractionCompletionState state)

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -399,11 +399,11 @@ public class ParameterProcessorTests
 
         var param1 = CreateParameterWithMissingValue("param1");
         param1.Description = "This is a test parameter";
-        param1.EnableDescriptionMarkup = false;
+        param1.EnableDescriptionMarkdown = false;
 
         var param2 = CreateParameterWithMissingValue("param2");
         param2.Description = "This parameter has **markdown** formatting";
-        param2.EnableDescriptionMarkup = true;
+        param2.EnableDescriptionMarkdown = true;
 
         List<ParameterResource> parameters = [param1, param2];
 
@@ -428,13 +428,13 @@ public class ParameterProcessorTests
         var param1Input = inputsInteraction.Inputs[0];
         Assert.Equal("param1", param1Input.Label);
         Assert.Equal("This is a test parameter", param1Input.Description);
-        Assert.False(param1Input.EnableDescriptionMarkup);
+        Assert.False(param1Input.EnableDescriptionMarkdown);
         Assert.Equal(InputType.Text, param1Input.InputType);
 
         var param2Input = inputsInteraction.Inputs[1];
         Assert.Equal("param2", param2Input.Label);
         Assert.Equal("This parameter has **markdown** formatting", param2Input.Description);
-        Assert.True(param2Input.EnableDescriptionMarkup);
+        Assert.True(param2Input.EnableDescriptionMarkdown);
         Assert.Equal(InputType.Text, param2Input.InputType);
     }
 
@@ -447,7 +447,7 @@ public class ParameterProcessorTests
 
         var secretParam = CreateParameterWithMissingValue("secretParam", secret: true);
         secretParam.Description = "This is a secret parameter";
-        secretParam.EnableDescriptionMarkup = false;
+        secretParam.EnableDescriptionMarkdown = false;
 
         List<ParameterResource> parameters = [secretParam];
         secretParam.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -468,7 +468,7 @@ public class ParameterProcessorTests
         var secretInput = inputsInteraction.Inputs[0];
         Assert.Equal("secretParam", secretInput.Label);
         Assert.Equal("This is a secret parameter", secretInput.Description);
-        Assert.False(secretInput.EnableDescriptionMarkup);
+        Assert.False(secretInput.EnableDescriptionMarkdown);
         Assert.Equal(InputType.SecretText, secretInput.InputType);
     }
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -303,7 +303,7 @@ public class ParameterProcessorTests
         var loggerService = ConsoleLoggingTestHelpers.GetResourceLoggerService();
         var interactionService = CreateInteractionService();
         var parameterProcessor = CreateParameterProcessor(
-            loggerService: loggerService, 
+            loggerService: loggerService,
             interactionService: interactionService);
         var parameterWithMissingValue = CreateParameterWithMissingValue("missingParam");
 
@@ -355,7 +355,7 @@ public class ParameterProcessorTests
         var testInteractionService = new TestInteractionService();
         var notificationService = ResourceNotificationServiceTestHelpers.Create();
         var parameterProcessor = CreateParameterProcessor(
-            notificationService: notificationService, 
+            notificationService: notificationService,
             loggerService: loggerService,
             interactionService: testInteractionService);
         var parameter = CreateParameterWithMissingValue("testParam");
@@ -388,6 +388,88 @@ public class ParameterProcessorTests
         var logEntry = logs[0];
         Assert.Contains("Parameter resource testParam has been resolved via user interaction.", logEntry.Content);
         Assert.False(logEntry.IsErrorMessage);
+    }
+
+    [Fact]
+    public async Task HandleUnresolvedParametersAsync_WithParameterDescriptions_CreatesInputsWithDescriptions()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService();
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+
+        var param1 = CreateParameterWithMissingValue("param1");
+        param1.Description = "This is a test parameter";
+        param1.EnableDescriptionMarkup = false;
+
+        var param2 = CreateParameterWithMissingValue("param2");
+        param2.Description = "This parameter has **markdown** formatting";
+        param2.EnableDescriptionMarkup = true;
+
+        List<ParameterResource> parameters = [param1, param2];
+
+        foreach (var param in parameters)
+        {
+            param.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        // Act
+        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+
+        // Wait for the message bar interaction and complete it
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
+
+        // Wait for the inputs interaction
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+
+        // Assert
+        Assert.Equal(3, inputsInteraction.Inputs.Count); // 2 parameters + 1 save option
+
+        var param1Input = inputsInteraction.Inputs[0];
+        Assert.Equal("param1", param1Input.Label);
+        Assert.Equal("This is a test parameter", param1Input.Description);
+        Assert.False(param1Input.EnableDescriptionMarkup);
+        Assert.Equal(InputType.Text, param1Input.InputType);
+
+        var param2Input = inputsInteraction.Inputs[1];
+        Assert.Equal("param2", param2Input.Label);
+        Assert.Equal("This parameter has **markdown** formatting", param2Input.Description);
+        Assert.True(param2Input.EnableDescriptionMarkup);
+        Assert.Equal(InputType.Text, param2Input.InputType);
+    }
+
+    [Fact]
+    public async Task HandleUnresolvedParametersAsync_WithSecretParameterWithDescription_CreatesSecretInput()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService();
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+
+        var secretParam = CreateParameterWithMissingValue("secretParam", secret: true);
+        secretParam.Description = "This is a secret parameter";
+        secretParam.EnableDescriptionMarkup = false;
+
+        List<ParameterResource> parameters = [secretParam];
+        secretParam.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Act
+        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+
+        // Wait for the message bar interaction and complete it
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
+
+        // Wait for the inputs interaction
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+
+        // Assert
+        Assert.Equal(2, inputsInteraction.Inputs.Count); // 1 secret parameter + 1 save option
+
+        var secretInput = inputsInteraction.Inputs[0];
+        Assert.Equal("secretParam", secretInput.Label);
+        Assert.Equal("This is a secret parameter", secretInput.Description);
+        Assert.False(secretInput.EnableDescriptionMarkup);
+        Assert.Equal(InputType.SecretText, secretInput.InputType);
     }
 
     private static ParameterProcessor CreateParameterProcessor(


### PR DESCRIPTION
## Description

Adds support for parameter descriptions and customizing input definition for parameters, e.g.:

```csharp
var externalServiceUrl = builder.AddParameter("external-service-url")
    .WithDescription("The URL of the external service.")
    .WithCustomInput(p => new()
    {
#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
        InputType = InputType.Text,
#pragma warning restore ASPIREINTERACTION001
        Value = "https://example.com",
        Label = p.Name,
        Placeholder = $"Enter value for {p.Name}",
        Description = p.Description
    });
```

<img width="759" height="504" alt="image" src="https://github.com/user-attachments/assets/a01ee1a7-f051-4660-854e-abe75361e0f2" />

Contributes to #10356 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: https://github.com/dotnet/docs-aspire/issues/4060
