### PR TITLE
Use CreateEmptyApplicationBuilder in Aspire.Cli

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -46,7 +46,13 @@ public class Program
 
     private static async Task<IHost> BuildApplicationAsync(string[] args)
     {
-        var builder = Host.CreateEmptyApplicationBuilder(settings: null);
+        var settings = new HostApplicationBuilderSettings
+        {
+            Configuration = new ConfigurationManager()
+        };
+        settings.Configuration.AddEnvironmentVariables();
+
+        var builder = Host.CreateEmptyApplicationBuilder(settings);
 
         // Set up settings with appropriate paths.
         var globalSettingsFilePath = GetGlobalSettingsPath();

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -46,7 +46,7 @@ public class Program
 
     private static async Task<IHost> BuildApplicationAsync(string[] args)
     {
-        var builder = Host.CreateApplicationBuilder();
+        var builder = Host.CreateEmptyApplicationBuilder(settings: null);
 
         // Set up settings with appropriate paths.
         var globalSettingsFilePath = GetGlobalSettingsPath();
@@ -55,8 +55,6 @@ public class Program
         ConfigurationHelper.RegisterSettingsFiles(builder.Configuration, workingDirectory, globalSettingsFile);
 
         await TrySetLocaleOverrideAsync(builder.Configuration);
-
-        builder.Logging.ClearProviders();
 
         // Always configure OpenTelemetry.
         builder.Logging.AddOpenTelemetry(logging => {


### PR DESCRIPTION
We are currently creating a default HostApplicationBuilder, which tries to load appsettings.json files in the CWD. This in turn is creating a FileWatcher for the CWD and all directories under it. Causing the startup of the CLI to suffer depending on the contents of the CWD.

The fix is to use an empty HostApplicationBuilder, which doesn't add appsettings.json config files by default. It also means we don't have to clear logging providers anymore, because there aren't any in an empty builder.

### Before

`strace aspire 2> out.txt` produces 120,000 kernel calls including:

```
inotify_add_watch(4, "/home/eerhardt/", IN_MODIFY|IN_ATTRIB|IN_MOVED_FROM|IN_MOVED_TO|IN_CREATE|IN_DELETE|IN_ONLYDIR|IN_EXCL_UNLINK) = 1
inotify_add_watch(4, "/home/eerhardt/git", IN_MODIFY|IN_ATTRIB|IN_MOVED_FROM|IN_MOVED_TO|IN_CREATE|IN_DELETE|IN_ONLYDIR|IN_DONT_FOLLOW|IN_EXCL_UNLINK) = 2
inotify_add_watch(4, "/home/eerhardt/git/eshop", IN_MODIFY|IN_ATTRIB|IN_MOVED_FROM|IN_MOVED_TO|IN_CREATE|IN_DELETE|IN_ONLYDIR|IN_DONT_FOLLOW|IN_EXCL_UNLINK) = 3
inotify_add_watch(4, "/home/eerhardt/git/eshop/.devcenter", IN_MODIFY|IN_ATTRIB|IN_MOVED_FROM|IN_MOVED_TO|IN_CREATE|IN_DELETE|IN_ONLYDIR|IN_DONT_FOLLOW|IN_EXCL_UNLINK) = 4
inotify_add_watch(4, "/home/eerhardt/git/eshop/.devcenter/catalog", IN_MODIFY|IN_ATTRIB|IN_MOVED_FROM|IN_MOVED_TO|IN_CREATE|IN_DELETE|IN_ONLYDIR|IN_DONT_FOLLOW|IN_EXCL_UNLINK) = 5
...
```

### After

`strace aspire 2> out.txt` produces 783 kernel calls.

Fix #9765