### PR TITLE
Template name strings, default prompts, and template version selection changes.

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -127,7 +127,7 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
     public virtual async Task<bool> PromptToUsePrereleaseTemplates(CancellationToken cancellationToken)
     {
         return await interactionService.PromptForSelectionAsync(
-            "Use pre-release templates?",
+            NewCommandStrings.PromptToUsePrereleaseTemplates,
             [false, true],
             (s) => s ? TemplatingStrings.Yes : TemplatingStrings.No,
             cancellationToken

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -158,7 +158,7 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
         return await interactionService.PromptForSelectionAsync(
             NewCommandStrings.SelectAProjectTemplate,
             validTemplates,
-            t => $"{t.Name} ({t.Description})",
+            t => t.Description,
             cancellationToken
         );
     }

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -115,6 +115,7 @@ internal sealed class NewCommand : BaseCommand
 
 internal interface INewCommandPrompter
 {
+    Task<bool> PromptToUsePrereleaseTemplates(CancellationToken cancellationToken);
     Task<NuGetPackage> PromptForTemplatesVersionAsync(IEnumerable<NuGetPackage> candidatePackages, CancellationToken cancellationToken);
     Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken);
     Task<string> PromptForProjectNameAsync(string defaultName, CancellationToken cancellationToken);
@@ -123,6 +124,16 @@ internal interface INewCommandPrompter
 
 internal class NewCommandPrompter(IInteractionService interactionService) : INewCommandPrompter
 {
+    public virtual async Task<bool> PromptToUsePrereleaseTemplates(CancellationToken cancellationToken)
+    {
+        return await interactionService.PromptForSelectionAsync(
+            "Use pre-release templates?",
+            [false, true],
+            (s) => s ? TemplatingStrings.Yes : TemplatingStrings.No,
+            cancellationToken
+            );
+    }
+
     public virtual async Task<NuGetPackage> PromptForTemplatesVersionAsync(IEnumerable<NuGetPackage> candidatePackages, CancellationToken cancellationToken)
     {
         return await interactionService.PromptForSelectionAsync(

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Utils;
+using Semver;
 using Spectre.Console;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
@@ -115,7 +116,6 @@ internal sealed class NewCommand : BaseCommand
 
 internal interface INewCommandPrompter
 {
-    Task<bool> PromptToUsePrereleaseTemplates(CancellationToken cancellationToken);
     Task<NuGetPackage> PromptForTemplatesVersionAsync(IEnumerable<NuGetPackage> candidatePackages, CancellationToken cancellationToken);
     Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken);
     Task<string> PromptForProjectNameAsync(string defaultName, CancellationToken cancellationToken);
@@ -124,24 +124,58 @@ internal interface INewCommandPrompter
 
 internal class NewCommandPrompter(IInteractionService interactionService) : INewCommandPrompter
 {
-    public virtual async Task<bool> PromptToUsePrereleaseTemplates(CancellationToken cancellationToken)
-    {
-        return await interactionService.PromptForSelectionAsync(
-            NewCommandStrings.PromptToUsePrereleaseTemplates,
-            [false, true],
-            (s) => s ? TemplatingStrings.Yes : TemplatingStrings.No,
-            cancellationToken
-            );
-    }
-
     public virtual async Task<NuGetPackage> PromptForTemplatesVersionAsync(IEnumerable<NuGetPackage> candidatePackages, CancellationToken cancellationToken)
     {
-        return await interactionService.PromptForSelectionAsync(
-            NewCommandStrings.SelectATemplateVersion,
-            candidatePackages,
-            (p) => $"{p.Version} ({p.Source})",
-            cancellationToken
-            );
+        var packagesGroupedByReleaseStatus = candidatePackages.GroupBy(p => SemVersion.Parse(p.Version).IsPrerelease ? "Prerelease" : "Released");
+        var releasedGroup = packagesGroupedByReleaseStatus.FirstOrDefault(g => g.Key == "Released");
+        var prereleaseGroup = packagesGroupedByReleaseStatus.FirstOrDefault(g => g.Key == "Prerelease");
+
+        var selections = new List<(string SelectionText, Func<Task<NuGetPackage>> PackageSelector)>();
+
+        foreach (var releasedPackage in releasedGroup ?? Enumerable.Empty<NuGetPackage>())
+        {
+            selections.Add(($"{releasedPackage.Version} ({releasedPackage.Source})", () => Task.FromResult(releasedPackage!)));
+        }
+
+        if (releasedGroup is not null && prereleaseGroup is not null)
+        {
+            // If we have prerelease packages (and there are released packages) we
+            // want to show a sub-menu option which we will use to prompt the user.
+            // To make this work the first prompt returns a function which is invoke
+            // which will either return the package or trigger another prompt for
+            // sub-packages. This is the sub-prompt logic.
+            selections.Add((NewCommandStrings.UsePrereleaseTemplates, async () =>
+            {
+                return await interactionService.PromptForSelectionAsync(
+                     NewCommandStrings.SelectATemplateVersion,
+                     prereleaseGroup,
+                     (p) => $"{p.Version} ({p.Source})",
+                     cancellationToken
+                     );
+            }
+            ));
+        }
+        else if (prereleaseGroup is not null)
+        {
+            // Fallback behavior if we happen to have NuGet feeds configured such
+            // that we only have access to prerelease template packages - in this
+            // case we just want to display them rather than having a special
+            // expander menu.
+            foreach (var prereleasePackage in prereleaseGroup)
+            {
+                selections.Add(($"{prereleasePackage.Version} ({prereleasePackage.Source})", () => Task.FromResult(prereleasePackage)));
+            }
+        }
+
+        var selection = await interactionService.PromptForSelectionAsync(
+                    NewCommandStrings.SelectATemplateVersion,
+                    selections,
+                    s => s.SelectionText,
+                    cancellationToken
+                    );
+
+        var package = await selection.PackageSelector();
+        return package;
     }
 
     public virtual async Task<string> PromptForOutputPath(string path, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -104,5 +104,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("SelectAProjectTemplate", resourceCulture);
             }
         }
+        
+        public static string PromptToUsePrereleaseTemplates {
+            get {
+                return ResourceManager.GetString("PromptToUsePrereleaseTemplates", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -81,8 +81,16 @@ namespace Aspire.Cli.Resources {
             }
         }
         
-        public static string EnterTheOutputPath {
+        public static string UsePrereleaseTemplates {
             get {
+                return ResourceManager.GetString("UsePrereleaseTemplates", resourceCulture);
+            }
+        }
+        
+        public static string EnterTheOutputPath
+        {
+            get
+            {
                 return ResourceManager.GetString("EnterTheOutputPath", resourceCulture);
             }
         }

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -128,7 +128,7 @@
     <value>Enter the output path:</value>
   </data>
   <data name="EnterTheProjectName" xml:space="preserve">
-    <value>Enter the project name:</value>
+    <value>Enter the project name</value>
   </data>
   <data name="InvalidProjectName" xml:space="preserve">
     <value>Invalid project name.</value>

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -124,6 +124,9 @@
   <data name="SelectATemplateVersion" xml:space="preserve">
     <value>Select a template version:</value>
   </data>
+  <data name="UsePrereleaseTemplates" xml:space="preserve">
+    <value>(use pre-release templates)</value>
+  </data>
   <data name="EnterTheOutputPath" xml:space="preserve">
     <value>Enter the output path:</value>
   </data>
@@ -135,8 +138,5 @@
   </data>
   <data name="SelectAProjectTemplate" xml:space="preserve">
     <value>Select a project template:</value>
-  </data>
-  <data name="PromptToUsePrereleaseTemplates" xml:space="preserve">
-    <value>Use pre-release templates?</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -136,4 +136,7 @@
   <data name="SelectAProjectTemplate" xml:space="preserve">
     <value>Select a project template:</value>
   </data>
+  <data name="PromptToUsePrereleaseTemplates" xml:space="preserve">
+    <value>Use pre-release templates?</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -92,9 +92,19 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("AspireXUnit_Description", resourceCulture);
             }
         }
+
+        public static string IntegrationTestsTemplate_Description
+        {
+            get
+            {
+                return ResourceManager.GetString("IntegrationTestsTemplate_Description", resourceCulture);
+            }
+        }
         
-        public static string UseRedisCache_Prompt {
-            get {
+        public static string UseRedisCache_Prompt
+        {
+            get
+            {
                 return ResourceManager.GetString("UseRedisCache_Prompt", resourceCulture);
             }
         }

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -177,9 +177,9 @@ namespace Aspire.Cli.Resources {
             }
         }
         
-        public static string GettingLatestTemplates {
+        public static string GettingTemplates {
             get {
-                return ResourceManager.GetString("GettingLatestTemplates", resourceCulture);
+                return ResourceManager.GetString("GettingTemplates", resourceCulture);
             }
         }
         

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -183,8 +183,8 @@
   <data name="EnterXUnitVersion_Description" xml:space="preserve">
     <value>The version of xUnit.net to use for the test project.</value>
   </data>
-  <data name="GettingLatestTemplates" xml:space="preserve">
-    <value>Getting latest templates...</value>
+  <data name="GettingTemplates" xml:space="preserve">
+    <value>Getting templates...</value>
   </data>
   <data name="TemplateInstallationFailed" xml:space="preserve">
     <value>The template installation failed with exit code {0}. For more information run with --debug switch.</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -121,25 +121,25 @@
     <value>At least one template factory must be provided.</value>
   </data>
   <data name="AspireStarter_Description" xml:space="preserve">
-    <value>Aspire Starter App</value>
+    <value>Sample starter with frontend and backend services</value>
   </data>
   <data name="AspireEmpty_Description" xml:space="preserve">
-    <value>Aspire Empty App</value>
+    <value>Empty apphost with Service Defaults project</value>
   </data>
   <data name="AspireAppHost_Description" xml:space="preserve">
-    <value>Aspire App Host</value>
+    <value>Apphost project only</value>
   </data>
   <data name="AspireServiceDefaults_Description" xml:space="preserve">
-    <value>Aspire Service Defaults</value>
+    <value>Service Defaults project only</value>
   </data>
   <data name="AspireMSTest_Description" xml:space="preserve">
-    <value>Aspire Test Project (MSTest)</value>
+    <value>Test Project (MSTest) only</value>
   </data>
   <data name="AspireNUnit_Description" xml:space="preserve">
-    <value>Aspire Test Project (NUnit)</value>
+    <value>Test Project (NUnit) only</value>
   </data>
   <data name="AspireXUnit_Description" xml:space="preserve">
-    <value>Aspire Test Project (xUnit)</value>
+    <value>Test Project (xUnit) only</value>
   </data>
   <data name="UseRedisCache_Prompt" xml:space="preserve">
     <value>Use Redis Cache</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -124,13 +124,13 @@
     <value>Starter template</value>
   </data>
   <data name="AspireEmpty_Description" xml:space="preserve">
-    <value>Empty apphost</value>
+    <value>Apphost and service defaults</value>
   </data>
   <data name="AspireAppHost_Description" xml:space="preserve">
     <value>Apphost only</value>
   </data>
   <data name="AspireServiceDefaults_Description" xml:space="preserve">
-    <value>Service Defaults only</value>
+    <value>Service defaults only</value>
   </data>
   <data name="AspireMSTest_Description" xml:space="preserve">
     <value>MSTest</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -121,16 +121,16 @@
     <value>At least one template factory must be provided.</value>
   </data>
   <data name="AspireStarter_Description" xml:space="preserve">
-    <value>Sample starter with frontend and backend services</value>
+    <value>Starter template</value>
   </data>
   <data name="AspireEmpty_Description" xml:space="preserve">
-    <value>Empty apphost with Service Defaults project</value>
+    <value>Empty apphost</value>
   </data>
   <data name="AspireAppHost_Description" xml:space="preserve">
-    <value>Apphost project only</value>
+    <value>Apphost only</value>
   </data>
   <data name="AspireServiceDefaults_Description" xml:space="preserve">
-    <value>Service Defaults project only</value>
+    <value>Service Defaults only</value>
   </data>
   <data name="AspireMSTest_Description" xml:space="preserve">
     <value>MSTest</value>
@@ -142,7 +142,7 @@
     <value>xUnit</value>
   </data>
   <data name="IntegrationTestsTemplate_Description" xml:space="preserve">
-    <value>Integration tests template</value>
+    <value>Integration tests only</value>
   </data>
   <data name="UseRedisCache_Prompt" xml:space="preserve">
     <value>Use Redis Cache</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -124,13 +124,13 @@
     <value>Starter template</value>
   </data>
   <data name="AspireEmpty_Description" xml:space="preserve">
-    <value>Apphost and service defaults</value>
+    <value>AppHost and service defaults</value>
   </data>
   <data name="AspireAppHost_Description" xml:space="preserve">
-    <value>Apphost only</value>
+    <value>AppHost</value>
   </data>
   <data name="AspireServiceDefaults_Description" xml:space="preserve">
-    <value>Service defaults only</value>
+    <value>Service defaults</value>
   </data>
   <data name="AspireMSTest_Description" xml:space="preserve">
     <value>MSTest</value>
@@ -142,7 +142,7 @@
     <value>xUnit</value>
   </data>
   <data name="IntegrationTestsTemplate_Description" xml:space="preserve">
-    <value>Integration tests only</value>
+    <value>Integration tests</value>
   </data>
   <data name="UseRedisCache_Prompt" xml:space="preserve">
     <value>Use Redis Cache</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -133,13 +133,16 @@
     <value>Service Defaults project only</value>
   </data>
   <data name="AspireMSTest_Description" xml:space="preserve">
-    <value>Test Project (MSTest) only</value>
+    <value>MSTest</value>
   </data>
   <data name="AspireNUnit_Description" xml:space="preserve">
-    <value>Test Project (NUnit) only</value>
+    <value>NUnit</value>
   </data>
   <data name="AspireXUnit_Description" xml:space="preserve">
-    <value>Test Project (xUnit) only</value>
+    <value>xUnit</value>
+  </data>
+  <data name="IntegrationTestsTemplate_Description" xml:space="preserve">
+    <value>Integration tests template</value>
   </data>
   <data name="UseRedisCache_Prompt" xml:space="preserve">
     <value>Use Redis Cache</value>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Výstupní cesta pro projekt</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Vyberte šablonu projektu:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">Zadejte název projektu:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">Zadejte název projektu:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Výstupní cesta pro projekt</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Vyberte šablonu projektu:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">Zdroj NuGet, který se má použít pro šablony projektu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">Projektnamen eingeben:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">Projektnamen eingeben:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Der Ausgabepfad für das Projekt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Projektvorlage auswählen:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Der Ausgabepfad für das Projekt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Projektvorlage auswählen:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">Die NuGet-Quelle, die für die Projektvorlagen verwendet werden soll.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -32,11 +32,6 @@
         <target state="translated">La ruta de salida del proyecto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Seleccione una plantilla de proyecto:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">El origen de NuGet que se va a usar para las plantillas de proyecto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">La ruta de salida del proyecto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Seleccione una plantilla de proyecto:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">Escriba el nombre del proyecto:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">Escriba el nombre del proyecto:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Le chemin de sortie du projet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Sélectionnez un modèle de projet :</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">Entrez le nom du projet :</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">Entrez le nom du projet :</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Le chemin de sortie du projet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Sélectionnez un modèle de projet :</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">La source NuGet à utiliser pour les modèles de projet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Percorso di output per il progetto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Selezionare un modello di progetto:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">Immetti il nome del progetto:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">Immetti il nome del progetto:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Percorso di output per il progetto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Selezionare un modello di progetto:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">Origine NuGet da utilizzare per i modelli di progetto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -32,11 +32,6 @@
         <target state="translated">プロジェクトの出力パス。</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">プロジェクト テンプレートを選択してください:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">プロジェクト テンプレートに使用する NuGet ソース。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">プロジェクト名を入力してください:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">プロジェクト名を入力してください:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">プロジェクトの出力パス。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">プロジェクト テンプレートを選択してください:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -32,11 +32,6 @@
         <target state="translated">프로젝트의 출력 경로입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">프로젝트 템플릿 선택:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">프로젝트 템플릿에 사용할 NuGet 소스입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">프로젝트의 출력 경로입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">프로젝트 템플릿 선택:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">프로젝트 이름 입력:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">프로젝트 이름 입력:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Ścieżka wyjściowa projektu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Wybierz szablon projektu:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">Źródło NuGet, które ma być używane dla szablonów projektu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Ścieżka wyjściowa projektu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Wybierz szablon projektu:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">Wprowadź nazwę projektu:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">Wprowadź nazwę projektu:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -32,11 +32,6 @@
         <target state="translated">O caminho de saída para o projeto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Selecione um modelo de projeto:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">A origem do NuGet a ser usada para os modelos de projeto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">Insira o nome do projeto:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">Insira o nome do projeto:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">O caminho de saída para o projeto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Selecione um modelo de projeto:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Выходной путь для проекта.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Выберите шаблон проекта:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Выходной путь для проекта.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Выберите шаблон проекта:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">Источник NuGet для использования в шаблонах проекта.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">Введите имя проекта:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">Введите имя проекта:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Projenin çıkış yolu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Bir proje şablonu seçin:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">Proje şablonları için kullanılacak NuGet kaynağı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">Proje adını girin:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">Proje adını girin:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Projenin çıkış yolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">Bir proje şablonu seçin:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">输入项目名称:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">输入项目名称:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -32,11 +32,6 @@
         <target state="translated">项目的输出路径。</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">选择项目模板:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">要用于项目模板的 NuGet 源。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">项目的输出路径。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">选择项目模板:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -32,11 +32,6 @@
         <target state="translated">專案的輸出路徑。</target>
         <note />
       </trans-unit>
-      <trans-unit id="PromptToUsePrereleaseTemplates">
-        <source>Use pre-release templates?</source>
-        <target state="new">Use pre-release templates?</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">選取專案範本:</target>
@@ -50,6 +45,11 @@
       <trans-unit id="SourceArgumentDescription">
         <source>The NuGet source to use for the project templates.</source>
         <target state="translated">要用於專案範本的 NuGet 來源。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsePrereleaseTemplates">
+        <source>(use pre-release templates)</source>
+        <target state="new">(use pre-release templates)</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionArgumentDescription">

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">專案的輸出路徑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PromptToUsePrereleaseTemplates">
+        <source>Use pre-release templates?</source>
+        <target state="new">Use pre-release templates?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a project template:</source>
         <target state="translated">選取專案範本:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnterTheProjectName">
-        <source>Enter the project name:</source>
-        <target state="translated">輸入專案名稱:</target>
+        <source>Enter the project name</source>
+        <target state="needs-review-translation">輸入專案名稱:</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidProjectName">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Testovací projekt Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Testovací projekt Aspire (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Testovací projekt Aspire (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Hostitel aplikací Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Prázdná aplikace Aspire</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Výchozí nastavení služby Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Úvodní aplikace Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Hostitel aplikací Aspire</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Hostitel aplikací Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Prázdná aplikace Aspire</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Prázdná aplikace Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Testovací projekt Aspire (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Testovací projekt Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Testovací projekt Aspire (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Testovací projekt Aspire (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Výchozí nastavení služby Aspire</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Výchozí nastavení služby Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Úvodní aplikace Aspire</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Úvodní aplikace Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Testovací projekt Aspire (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Testovací projekt Aspire (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Hostitel aplikací Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Prázdná aplikace Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Výchozí nastavení služby Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -62,9 +62,9 @@
         <target state="translated">Zadat verzi xUnit.net, která se má použít</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">Získávají se nejnovější šablony...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Prázdná aplikace Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Výchozí nastavení služby Aspire</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="de" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Aspire-App-Host</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Leere Aspire-App</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Standardwerte für den Aspire-Dienst</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="de" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Aspire-App-Host</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Leere Aspire-App</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Standardwerte für den Aspire-Dienst</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Aspire Starter-App</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Aspire-Testprojekt (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Aspire-Testprojekt (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Aspire-Testprojekt (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="de" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Aspire-App-Host</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Aspire-App-Host</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Leere Aspire-App</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Leere Aspire-App</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Aspire-Testprojekt (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Aspire-Testprojekt (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Aspire-Testprojekt (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Aspire-Testprojekt (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Standardwerte für den Aspire-Dienst</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Standardwerte für den Aspire-Dienst</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Aspire Starter-App</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Aspire Starter-App</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Aspire-Testprojekt (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Aspire-Testprojekt (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -62,9 +62,9 @@
         <target state="translated">Geben Sie die zu verwendende xUnit.net-Version ein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">Die neuesten Vorlagen werden abgerufen...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Leere Aspire-App</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Standardwerte für den Aspire-Dienst</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Proyecto de prueba de Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Proyecto de prueba de Aspire (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Proyecto de prueba de Aspire (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Aplicación vacía de Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Valores predeterminados del servicio de Aspire</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="es" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Host de aplicaciones de Aspire</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Host de aplicaciones de Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Aplicación vacía de Aspire</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Aplicación vacía de Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Proyecto de prueba de Aspire (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Proyecto de prueba de Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Proyecto de prueba de Aspire (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Proyecto de prueba de Aspire (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Valores predeterminados del servicio de Aspire</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Valores predeterminados del servicio de Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Aplicación de inicio de Aspire</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Aplicación de inicio de Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Proyecto de prueba de Aspire (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Proyecto de prueba de Aspire (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="es" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Host de aplicaciones de Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Aplicación vacía de Aspire</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Valores predeterminados del servicio de Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Aplicación de inicio de Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="es" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Host de aplicaciones de Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Aplicación vacía de Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Valores predeterminados del servicio de Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -62,9 +62,9 @@
         <target state="translated">Introduzca la versión de xUnit.net que se va a usar</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">Obteniendo las plantillas más recientes...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Application vide Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Paramètres par défaut du service Aspire</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Hôte d’application Aspire</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Hôte d’application Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Application vide Aspire</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Application vide Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Projet de test Aspire (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Projet de test Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Projet de test Aspire (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Projet de test Aspire (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Paramètres par défaut du service Aspire</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Paramètres par défaut du service Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Application de démarrage Aspire</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Application de démarrage Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Projet de test Aspire (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Projet de test Aspire (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -62,9 +62,9 @@
         <target state="translated">Entrez la version de xUnit.net à utiliser</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">Récupération des derniers modèles...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Hôte d’application Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Application vide Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Paramètres par défaut du service Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Hôte d’application Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Application vide Aspire</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Paramètres par défaut du service Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Application de démarrage Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Projet de test Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Projet de test Aspire (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Projet de test Aspire (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Progetto di test di Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Progetto di test Aspire (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Progetto di test di Aspire (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="it" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Host delle app Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">App vuota Aspire</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Impostazioni predefinite del servizio Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">App Starter Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="it" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Host delle app Aspire</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Host delle app Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">App vuota Aspire</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">App vuota Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Progetto di test di Aspire (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Progetto di test di Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Progetto di test Aspire (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Progetto di test Aspire (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Impostazioni predefinite del servizio Aspire</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Impostazioni predefinite del servizio Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">App Starter Aspire</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">App Starter Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Progetto di test di Aspire (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Progetto di test di Aspire (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -62,9 +62,9 @@
         <target state="translated">Immettere la versione xUnit.net da usare</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">Recupero dei modelli più recenti in corso...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="it" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Host delle app Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">App vuota Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Impostazioni predefinite del servizio Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">App vuota Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Impostazioni predefinite del servizio Aspire</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Aspire の空のアプリ</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Aspire サービスの既定</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Aspire アプリ ホスティング プロセス</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Aspire の空のアプリ</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Aspire サービスの既定</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Aspire アプリ ホスティング プロセス</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Aspire の空のアプリ</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Aspire サービスの既定</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Aspire スターター アプリ</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -62,9 +62,9 @@
         <target state="translated">使用する xUnit.net バージョンを入力</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">最新のテンプレートを取得しています...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Aspire アプリ ホスティング プロセス</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Aspire アプリ ホスティング プロセス</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Aspire の空のアプリ</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Aspire の空のアプリ</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Aspire テスト プロジェクト (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Aspire テスト プロジェクト (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Aspire テスト プロジェクト (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Aspire テスト プロジェクト (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Aspire サービスの既定</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Aspire サービスの既定</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Aspire スターター アプリ</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Aspire スターター アプリ</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Aspire テスト プロジェクト (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Aspire テスト プロジェクト (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Aspire テスト プロジェクト (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Aspire テスト プロジェクト (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Aspire テスト プロジェクト (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Aspire 빈 앱</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Aspire 서비스 기본값</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Aspire 테스트 프로젝트(MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Aspire 테스트 프로젝트(NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Aspire 테스트 프로젝트(xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -62,9 +62,9 @@
         <target state="translated">사용할 xUnit.net 버전을 입력하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">최신 템플릿을 가져오는 중...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Aspire 앱 호스트</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Aspire 빈 앱</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Aspire 서비스 기본값</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Aspire 시작 앱</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Aspire 앱 호스트</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Aspire 앱 호스트</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Aspire 빈 앱</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Aspire 빈 앱</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Aspire 테스트 프로젝트(MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Aspire 테스트 프로젝트(MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Aspire 테스트 프로젝트(NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Aspire 테스트 프로젝트(NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Aspire 서비스 기본값</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Aspire 서비스 기본값</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Aspire 시작 앱</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Aspire 시작 앱</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Aspire 테스트 프로젝트(xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Aspire 테스트 프로젝트(xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Aspire 앱 호스트</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Aspire 빈 앱</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Aspire 서비스 기본값</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Pusta aplikacja Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Domyślne ustawienia usługi Aspire</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -62,9 +62,9 @@
         <target state="translated">Wprowadź wersję xUnit.net do użycia</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">Trwa pobieranie najnowszych szablonów...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Host aplikacji Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Pusta aplikacja Aspire</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Domyślne ustawienia usługi Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Aplikacja startowa Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Host aplikacji Aspire</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Host aplikacji Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Pusta aplikacja Aspire</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Pusta aplikacja Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Projekt testowy Aspire (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Projekt testowy Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Projekt testowy Aspire (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Projekt testowy Aspire (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Domyślne ustawienia usługi Aspire</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Domyślne ustawienia usługi Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Aplikacja startowa Aspire</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Aplikacja startowa Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Projekt testowy Aspire (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Projekt testowy Aspire (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Host aplikacji Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Pusta aplikacja Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Domyślne ustawienia usługi Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Projekt testowy Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Projekt testowy Aspire (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Projekt testowy Aspire (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Aplicativo Aspire Vazio</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Padrões do Serviço Do Azure</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Projeto de Teste Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Projeto de Teste Aspire (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Projeto de Teste Aspire (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Host de Aplicativo Aspire</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Host de Aplicativo Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Aplicativo Aspire Vazio</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Aplicativo Aspire Vazio</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Projeto de Teste Aspire (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Projeto de Teste Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Projeto de Teste Aspire (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Projeto de Teste Aspire (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Padrões do Serviço Do Azure</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Padrões do Serviço Do Azure</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Aplicativo Inicial Aspire</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Aplicativo Inicial Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Projeto de Teste Aspire (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Projeto de Teste Aspire (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -62,9 +62,9 @@
         <target state="translated">Digite a versão do xUnit.net a ser usada</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">Obtendo modelos mais recentes...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Host de Aplicativo Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Aplicativo Aspire Vazio</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Padrões do Serviço Do Azure</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Host de Aplicativo Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Aplicativo Aspire Vazio</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Padrões do Serviço Do Azure</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Aplicativo Inicial Aspire</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Тестовый проект Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Тестовый проект Aspire (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Тестовый проект Aspire (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Пустое приложение Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Параметры службы Aspire по умолчанию</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Хост приложений Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Пустое приложение Aspire</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Параметры службы Aspire по умолчанию</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Приложение Aspire для начинающих</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -62,9 +62,9 @@
         <target state="translated">Укажите версию xUnit.net, которую следует использовать</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">Производится получение последних шаблонов...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Хост приложений Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Пустое приложение Aspire</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Параметры службы Aspire по умолчанию</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Хост приложений Aspire</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Хост приложений Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Пустое приложение Aspire</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Пустое приложение Aspire</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Тестовый проект Aspire (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Тестовый проект Aspire (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Тестовый проект Aspire (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Тестовый проект Aspire (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Параметры службы Aspire по умолчанию</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Параметры службы Aspire по умолчанию</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Приложение Aspire для начинающих</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Приложение Aspire для начинающих</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Тестовый проект Aspire (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Тестовый проект Aspire (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -62,9 +62,9 @@
         <target state="translated">Kullanılacak xUnit.net sürümünü girin</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">En son şablonlar alınıyor...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Aspire Test Projesi (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Aspire Test Projesi (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Aspire Test Projesi (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Aspire Boş Uygulama</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Aspire Hizmet Varsayılanları</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Aspire Uygulama Ana İşlemi</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Aspire Boş Uygulama</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Aspire Hizmet Varsayılanları</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Aspire Uygulama Ana İşlemi</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Aspire Boş Uygulama</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Aspire Hizmet Varsayılanları</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Aspire Başlangıç Uygulaması</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Aspire Uygulama Ana İşlemi</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Aspire Uygulama Ana İşlemi</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Aspire Boş Uygulama</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Aspire Boş Uygulama</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Aspire Test Projesi (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Aspire Test Projesi (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Aspire Test Projesi (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Aspire Test Projesi (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Aspire Hizmet Varsayılanları</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Aspire Hizmet Varsayılanları</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Aspire Başlangıç Uygulaması</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Aspire Başlangıç Uygulaması</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Aspire Test Projesi (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Aspire Test Projesi (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Aspire 应用主机</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Aspire 空应用</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Aspire 服务默认值</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -62,9 +62,9 @@
         <target state="translated">输入要使用的 xUnit.net 版本</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">正在获取最新模板...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Aspire 应用主机</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Aspire 应用主机</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Aspire 空应用</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Aspire 空应用</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Aspire 测试项目(MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Aspire 测试项目(MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Aspire 测试项目(NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Aspire 测试项目(NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Aspire 服务默认值</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Aspire 服务默认值</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Aspire 入门应用</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Aspire 入门应用</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Aspire 测试项目(xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Aspire 测试项目(xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Aspire 测试项目(MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Aspire 测试项目(NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Aspire 测试项目(xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Aspire 应用主机</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Aspire 空应用</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Aspire 服务默认值</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Aspire 入门应用</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Aspire 空应用</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Aspire 服务默认值</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -62,9 +62,9 @@
         <target state="translated">輸入要使用的 xUnit.net 版本</target>
         <note />
       </trans-unit>
-      <trans-unit id="GettingLatestTemplates">
-        <source>Getting latest templates...</source>
-        <target state="translated">正在取得最新的範本...</target>
+      <trans-unit id="GettingTemplates">
+        <source>Getting templates...</source>
+        <target state="new">Getting templates...</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost project only</source>
+        <source>Apphost only</source>
         <target state="needs-review-translation">Aspire 應用程式主機</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost with Service Defaults project</source>
+        <source>Empty apphost</source>
         <target state="needs-review-translation">Aspire 空白應用程式</target>
         <note />
       </trans-unit>
@@ -23,12 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults project only</source>
+        <source>Service Defaults only</source>
         <target state="needs-review-translation">Aspire 服務預設值</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Sample starter with frontend and backend services</source>
+        <source>Starter template</source>
         <target state="needs-review-translation">Aspire 入門應用程式</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests template</source>
-        <target state="new">Integration tests template</target>
+        <source>Integration tests only</source>
+        <target state="new">Integration tests only</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -3,38 +3,38 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Aspire App Host</source>
-        <target state="translated">Aspire 應用程式主機</target>
+        <source>Apphost project only</source>
+        <target state="needs-review-translation">Aspire 應用程式主機</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Aspire Empty App</source>
-        <target state="translated">Aspire 空白應用程式</target>
+        <source>Empty apphost with Service Defaults project</source>
+        <target state="needs-review-translation">Aspire 空白應用程式</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Aspire Test Project (MSTest)</source>
-        <target state="translated">Aspire 測試專案 (MSTest)</target>
+        <source>Test Project (MSTest) only</source>
+        <target state="needs-review-translation">Aspire 測試專案 (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Aspire Test Project (NUnit)</source>
-        <target state="translated">Aspire 測試專案 (NUnit)</target>
+        <source>Test Project (NUnit) only</source>
+        <target state="needs-review-translation">Aspire 測試專案 (NUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Aspire Service Defaults</source>
-        <target state="translated">Aspire 服務預設值</target>
+        <source>Service Defaults project only</source>
+        <target state="needs-review-translation">Aspire 服務預設值</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireStarter_Description">
-        <source>Aspire Starter App</source>
-        <target state="translated">Aspire 入門應用程式</target>
+        <source>Sample starter with frontend and backend services</source>
+        <target state="needs-review-translation">Aspire 入門應用程式</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Aspire Test Project (xUnit)</source>
-        <target state="translated">Aspire 測試專案 (xUnit)</target>
+        <source>Test Project (xUnit) only</source>
+        <target state="needs-review-translation">Aspire 測試專案 (xUnit)</target>
         <note />
       </trans-unit>
       <trans-unit id="AtLeastOneTemplateFactoryMustBeProvided">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -13,12 +13,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireMSTest_Description">
-        <source>Test Project (MSTest) only</source>
+        <source>MSTest</source>
         <target state="needs-review-translation">Aspire 測試專案 (MSTest)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireNUnit_Description">
-        <source>Test Project (NUnit) only</source>
+        <source>NUnit</source>
         <target state="needs-review-translation">Aspire 測試專案 (NUnit)</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireXUnit_Description">
-        <source>Test Project (xUnit) only</source>
+        <source>xUnit</source>
         <target state="needs-review-translation">Aspire 測試專案 (xUnit)</target>
         <note />
       </trans-unit>
@@ -65,6 +65,11 @@
       <trans-unit id="GettingTemplates">
         <source>Getting templates...</source>
         <target state="new">Getting templates...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntegrationTestsTemplate_Description">
+        <source>Integration tests template</source>
+        <target state="new">Integration tests template</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -3,12 +3,12 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../TemplatingStrings.resx">
     <body>
       <trans-unit id="AspireAppHost_Description">
-        <source>Apphost only</source>
+        <source>AppHost</source>
         <target state="needs-review-translation">Aspire 應用程式主機</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Apphost and service defaults</source>
+        <source>AppHost and service defaults</source>
         <target state="needs-review-translation">Aspire 空白應用程式</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service defaults only</source>
+        <source>Service defaults</source>
         <target state="needs-review-translation">Aspire 服務預設值</target>
         <note />
       </trans-unit>
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IntegrationTestsTemplate_Description">
-        <source>Integration tests only</source>
-        <target state="new">Integration tests only</target>
+        <source>Integration tests</source>
+        <target state="new">Integration tests</target>
         <note />
       </trans-unit>
       <trans-unit id="No">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -8,7 +8,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">
-        <source>Empty apphost</source>
+        <source>Apphost and service defaults</source>
         <target state="needs-review-translation">Aspire 空白應用程式</target>
         <note />
       </trans-unit>
@@ -23,7 +23,7 @@
         <note />
       </trans-unit>
       <trans-unit id="AspireServiceDefaults_Description">
-        <source>Service Defaults only</source>
+        <source>Service defaults only</source>
         <target state="needs-review-translation">Aspire 服務預設值</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -319,19 +319,9 @@ internal class DotNetTemplateFactory(IInteractionService interactionService, IDo
 
             if (candidatePackages.Any(p => SemVersion.Parse(p.Version).IsPrerelease))
             {
-                var usePrereleaseResponse = await interactionService.PromptForSelectionAsync(
-                    "Use pre-release templates?",
-                    [TemplatingStrings.No, TemplatingStrings.Yes],
-                    choice => choice,
-                    cancellationToken: cancellationToken
-                    );
+                var usePrerelease = await prompter.PromptToUsePrereleaseTemplates(cancellationToken);
 
-                candidatePackages = usePrereleaseResponse switch
-                {
-                    var choice when string.Equals(choice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput) => candidatePackages.Where(p => SemVersion.Parse(p.Version).IsPrerelease),
-                    var choice when string.Equals(choice, TemplatingStrings.No, StringComparisons.CliInputOrOutput) => candidatePackages.Where(p => !SemVersion.Parse(p.Version).IsPrerelease),
-                    _ => throw new InvalidOperationException("Unexpected choice for pre-release templates.")
-                };
+                candidatePackages = candidatePackages.Where(p => SemVersion.Parse(p.Version).IsPrerelease == usePrerelease);
             }
 
             if (!candidatePackages.Any())

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -329,11 +329,6 @@ internal class DotNetTemplateFactory(IInteractionService interactionService, IDo
                 throw new EmptyChoicesException(TemplatingStrings.NoTemplateVersionsFound);
             }
 
-            if (candidatePackages.Count() == 1)
-            {
-                return candidatePackages.First().Version;
-            }
-
             var orderedCandidatePackages = candidatePackages.OrderByDescending(p => SemVersion.Parse(p.Version), SemVersion.PrecedenceComparer);
             var selectedPackage = await prompter.PromptForTemplatesVersionAsync(orderedCandidatePackages, cancellationToken);
             return selectedPackage.Version;

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -338,13 +338,6 @@ internal class DotNetTemplateFactory(IInteractionService interactionService, IDo
                 () => nuGetPackageCache.GetTemplatePackagesAsync(workingDirectory, prerelease, source, cancellationToken)
                 );
 
-            if (candidatePackages.Any(p => SemVersion.Parse(p.Version).IsPrerelease))
-            {
-                var usePrerelease = await prompter.PromptToUsePrereleaseTemplates(cancellationToken);
-
-                candidatePackages = candidatePackages.Where(p => SemVersion.Parse(p.Version).IsPrerelease == usePrerelease);
-            }
-
             if (!candidatePackages.Any())
             {
                 throw new EmptyChoicesException(TemplatingStrings.NoTemplateVersionsFound);

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -98,7 +98,7 @@ internal class DotNetTemplateFactory(IInteractionService interactionService, IDo
         var useRedisCache = result.GetValue<bool?>("--use-redis-cache");
         if (!useRedisCache.HasValue)
         {
-            useRedisCache = await interactionService.PromptForSelectionAsync(TemplatingStrings.UseRedisCache_Prompt, [TemplatingStrings.No, TemplatingStrings.Yes], choice => choice, cancellationToken) switch
+            useRedisCache = await interactionService.PromptForSelectionAsync(TemplatingStrings.UseRedisCache_Prompt, [TemplatingStrings.Yes, TemplatingStrings.No], choice => choice, cancellationToken) switch
             {
                 var choice when string.Equals(choice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput) => true,
                 var choice when string.Equals(choice, TemplatingStrings.No, StringComparisons.CliInputOrOutput) => false,

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -213,6 +213,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                     return promptedPackages.First();
                 };
 
+                prompter.PromptToUsePrereleaseTemplatesCallback = () =>
+                {
+                    // Simulate user choosing to use pre-release templates.
+                    return false;
+                };
+
                 return prompter;
             };
 
@@ -261,7 +267,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.NotNull(promptedPackages);
         Assert.Collection(
             promptedPackages,
-            package => Assert.Equal("9.4.0-preview.1234", package.Version),
             package => Assert.Equal("9.3.0", package.Version),
             package => Assert.Equal("9.2.0", package.Version)
         );
@@ -582,10 +587,20 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
 internal sealed class TestNewCommandPrompter(IInteractionService interactionService) : NewCommandPrompter(interactionService)
 {
+    public Func<bool>? PromptToUsePrereleaseTemplatesCallback { get; set; }
     public Func<IEnumerable<NuGetPackage>, NuGetPackage>? PromptForTemplatesVersionCallback { get; set; }
     public Func<ITemplate[], ITemplate>? PromptForTemplateCallback { get; set; }
     public Func<string, string>? PromptForProjectNameCallback { get; set; }
     public Func<string, string>? PromptForOutputPathCallback { get; set; }
+
+    public override Task<bool> PromptToUsePrereleaseTemplates(CancellationToken cancellationToken)
+    {
+        return PromptToUsePrereleaseTemplatesCallback switch
+        {
+            { } callback => Task.FromResult(callback()),
+            _ => Task.FromResult(false) // Default to not using pre-release templates.
+        };
+    }
 
     public override Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken)
     {

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -261,6 +261,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.NotNull(promptedPackages);
         Assert.Collection(
             promptedPackages,
+            package => Assert.Equal("9.4.0-preview.1234", package.Version),
             package => Assert.Equal("9.3.0", package.Version),
             package => Assert.Equal("9.2.0", package.Version)
         );

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -213,12 +213,6 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                     return promptedPackages.First();
                 };
 
-                prompter.PromptToUsePrereleaseTemplatesCallback = () =>
-                {
-                    // Simulate user choosing to use pre-release templates.
-                    return false;
-                };
-
                 return prompter;
             };
 
@@ -587,20 +581,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
 internal sealed class TestNewCommandPrompter(IInteractionService interactionService) : NewCommandPrompter(interactionService)
 {
-    public Func<bool>? PromptToUsePrereleaseTemplatesCallback { get; set; }
     public Func<IEnumerable<NuGetPackage>, NuGetPackage>? PromptForTemplatesVersionCallback { get; set; }
     public Func<ITemplate[], ITemplate>? PromptForTemplateCallback { get; set; }
     public Func<string, string>? PromptForProjectNameCallback { get; set; }
     public Func<string, string>? PromptForOutputPathCallback { get; set; }
-
-    public override Task<bool> PromptToUsePrereleaseTemplates(CancellationToken cancellationToken)
-    {
-        return PromptToUsePrereleaseTemplatesCallback switch
-        {
-            { } callback => Task.FromResult(callback()),
-            _ => Task.FromResult(false) // Default to not using pre-release templates.
-        };
-    }
 
     public override Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Description

This PR changes the `aspire new` experience so that when we select a template we choose from a descriptive name instead of the underlying template name:


https://github.com/user-attachments/assets/026e8b26-b269-49ba-9ff3-c559ac1856e9



## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
