### PR TITLE
Add runtime information to dashboard exception telemetry

### DIFF
--- a/src/Aspire.Dashboard/Telemetry/TelemetryLoggerProvider.cs
+++ b/src/Aspire.Dashboard/Telemetry/TelemetryLoggerProvider.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Utils;
+
 namespace Aspire.Dashboard.Telemetry;
 
 /// <summary>
@@ -58,7 +60,8 @@ public sealed class TelemetryLoggerProvider : ILoggerProvider
                         {
                             [TelemetryPropertyKeys.ExceptionType] = new AspireTelemetryProperty(exception.GetType().FullName!),
                             [TelemetryPropertyKeys.ExceptionMessage] = new AspireTelemetryProperty(exception.Message),
-                            [TelemetryPropertyKeys.ExceptionStackTrace] = new AspireTelemetryProperty(exception.StackTrace ?? string.Empty)
+                            [TelemetryPropertyKeys.ExceptionStackTrace] = new AspireTelemetryProperty(exception.StackTrace ?? string.Empty),
+                            [TelemetryPropertyKeys.ExceptionRuntimeVersion] = new AspireTelemetryProperty(VersionHelpers.RuntimeVersion?.ToString() ?? string.Empty),
                         }
                     );
                 }

--- a/src/Aspire.Dashboard/Telemetry/TelemetryPropertyKeys.cs
+++ b/src/Aspire.Dashboard/Telemetry/TelemetryPropertyKeys.cs
@@ -30,6 +30,7 @@ public static class TelemetryPropertyKeys
     public const string ExceptionType = AspireDashboardPropertyPrefix + "Exception.Type";
     public const string ExceptionMessage = AspireDashboardPropertyPrefix + "Exception.Message";
     public const string ExceptionStackTrace = AspireDashboardPropertyPrefix + "Exception.StackTrace";
+    public const string ExceptionRuntimeVersion = AspireDashboardPropertyPrefix + "Exception.RuntimeVersion";
 
     // Resources properties
     public const string ResourceTypes = AspireDashboardPropertyPrefix + "Resource.Types";

--- a/src/Aspire.Dashboard/Utils/VersionHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/VersionHelpers.cs
@@ -8,25 +8,27 @@ namespace Aspire.Dashboard.Utils;
 
 public static class VersionHelpers
 {
-    private static readonly Lazy<Version?> s_cachedRuntimeVersion = new Lazy<Version?>(GetRuntimeVersion);
+    private static readonly Lazy<string?> s_cachedRuntimeVersion = new Lazy<string?>(GetRuntimeVersion);
 
     public static string? DashboardDisplayVersion { get; } = typeof(VersionHelpers).Assembly.GetDisplayVersion();
 
-    public static Version? RuntimeVersion => s_cachedRuntimeVersion.Value;
+    public static string? RuntimeVersion => s_cachedRuntimeVersion.Value;
 
-    private static Version? GetRuntimeVersion()
+    private static string? GetRuntimeVersion()
     {
         var description = RuntimeInformation.FrameworkDescription;
 
-        // Examples: ".NET 8.0.3", ".NET 7.0.16", ".NET Core 3.1.32"
-        var parts = description.Split(' ');
-        if (parts.Length >= 2)
+        // Example inputs:
+        // ".NET 8.0.3"
+        // ".NET Core 3.1.32"
+        // ".NET Framework 4.8.9032.0"
+
+        int lastSpace = description.LastIndexOf(' ');
+        if (lastSpace >= 0 && lastSpace < description.Length - 1)
         {
-            if (Version.TryParse(parts[1], out var v))
-            {
-                return v;
-            }
+            return description.Substring(lastSpace + 1);
         }
+
         return null;
     }
 }

--- a/src/Aspire.Dashboard/Utils/VersionHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/VersionHelpers.cs
@@ -8,7 +8,7 @@ namespace Aspire.Dashboard.Utils;
 
 public static class VersionHelpers
 {
-    private static readonly Lazy<Version?> s_cachedRuntimeVersion = new Lazy<Version?>(static () => GetRuntimeVersion());
+    private static readonly Lazy<Version?> s_cachedRuntimeVersion = new Lazy<Version?>(GetRuntimeVersion);
 
     public static string? DashboardDisplayVersion { get; } = typeof(VersionHelpers).Assembly.GetDisplayVersion();
 

--- a/src/Aspire.Dashboard/Utils/VersionHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/VersionHelpers.cs
@@ -1,11 +1,32 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using Aspire.Dashboard.Extensions;
 
 namespace Aspire.Dashboard.Utils;
 
 public static class VersionHelpers
 {
+    private static readonly Lazy<Version?> s_cachedRuntimeVersion = new Lazy<Version?>(static () => GetRuntimeVersion());
+
     public static string? DashboardDisplayVersion { get; } = typeof(VersionHelpers).Assembly.GetDisplayVersion();
+
+    public static Version? RuntimeVersion => s_cachedRuntimeVersion.Value;
+
+    private static Version? GetRuntimeVersion()
+    {
+        var description = RuntimeInformation.FrameworkDescription;
+
+        // Examples: ".NET 8.0.3", ".NET 7.0.16", ".NET Core 3.1.32"
+        var parts = description.Split(' ');
+        if (parts.Length >= 2)
+        {
+            if (Version.TryParse(parts[1], out var v))
+            {
+                return v;
+            }
+        }
+        return null;
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/VersionHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/VersionHelpersTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.RegularExpressions;
 using Aspire.Dashboard.Utils;
 using Xunit;
 
@@ -8,10 +9,15 @@ namespace Aspire.Dashboard.Tests;
 
 public class VersionHelpersTests
 {
+    // Accepts versions like 8.0.3, 9.0.0-preview.6.24224.1
+    private static readonly Regex s_versionRegex = new Regex(@"^\d+\.\d+\.\d+(-[A-Za-z0-9\.\-]+)?$");
+
     [Fact]
-    public void RuntimeVersion_ReturnsValue()
+    public void RuntimeVersion_ReturnsValidVersionString()
     {
-        Assert.NotNull(VersionHelpers.RuntimeVersion);
-        Assert.True(VersionHelpers.RuntimeVersion.Major >= 8);
+        var version = VersionHelpers.RuntimeVersion;
+
+        Assert.False(string.IsNullOrWhiteSpace(version), "Version should not be null or empty");
+        Assert.Matches(s_versionRegex, version);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/VersionHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/VersionHelpersTests.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Utils;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class VersionHelpersTests
+{
+    [Fact]
+    public void RuntimeVersion_ReturnsValue()
+    {
+        Assert.NotNull(VersionHelpers.RuntimeVersion);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/VersionHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/VersionHelpersTests.cs
@@ -12,5 +12,6 @@ public class VersionHelpersTests
     public void RuntimeVersion_ReturnsValue()
     {
         Assert.NotNull(VersionHelpers.RuntimeVersion);
+        Assert.True(VersionHelpers.RuntimeVersion.Major >= 8);
     }
 }


### PR DESCRIPTION
## Description

Include runtime information on error telemetry in case an error is related to the version of .NET we're running on.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
