### PR TITLE
Update dependencies from https://github.com/microsoft/usvc-apiserver build 0.15.18

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.15.16">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.15.18">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>0a08d73648db3334215b703de0c04aaa3688508e</Sha>
+      <Sha>1000964000870157d5a7337d4723dbf15cc23725</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.15.16">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.15.18">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>0a08d73648db3334215b703de0c04aaa3688508e</Sha>
+      <Sha>1000964000870157d5a7337d4723dbf15cc23725</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.15.16">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.15.18">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>0a08d73648db3334215b703de0c04aaa3688508e</Sha>
+      <Sha>1000964000870157d5a7337d4723dbf15cc23725</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.15.16">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.15.18">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>0a08d73648db3334215b703de0c04aaa3688508e</Sha>
+      <Sha>1000964000870157d5a7337d4723dbf15cc23725</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.15.16">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.15.18">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>0a08d73648db3334215b703de0c04aaa3688508e</Sha>
+      <Sha>1000964000870157d5a7337d4723dbf15cc23725</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.15.16">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.15.18">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>0a08d73648db3334215b703de0c04aaa3688508e</Sha>
+      <Sha>1000964000870157d5a7337d4723dbf15cc23725</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.15.16">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.15.18">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>0a08d73648db3334215b703de0c04aaa3688508e</Sha>
+      <Sha>1000964000870157d5a7337d4723dbf15cc23725</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.15.16">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.15.18">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>0a08d73648db3334215b703de0c04aaa3688508e</Sha>
+      <Sha>1000964000870157d5a7337d4723dbf15cc23725</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="9.7.0">
       <Uri>https://github.com/dotnet/extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,14 +28,14 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.15.16</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.15.16</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.15.16</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.15.16</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.15.16</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindows386Version>0.15.16</MicrosoftDeveloperControlPlanewindows386Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.15.16</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.15.16</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.15.18</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.15.18</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.15.18</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.15.18</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.15.18</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindows386Version>0.15.18</MicrosoftDeveloperControlPlanewindows386Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.15.18</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.15.18</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>10.0.0-beta.25351.1</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>10.0.0-beta.25351.1</MicrosoftDotNetXUnitV3ExtensionsVersion>


### PR DESCRIPTION
Updating to DCP version 0.15.18.

@karolz-ms and @danegsta, can either of you help with adding some info here on what the payload is fixing and risk?
