### PR TITLE
Update FluentUI to 4.12.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,8 +88,8 @@
     <PackageVersion Include="Markdig" Version="0.41.3" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.1.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.9" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.11.9" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.12.1" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.12.1" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
     <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.2" />
     <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -129,6 +129,7 @@
                                                     ItemSize="46"
                                                     ItemsProvider="@GetData"
                                                     ResizableColumns="true"
+                                                    ResizeColumnOnAllRows="false"
                                                     GridTemplateColumns="@_manager.GetGridTemplateColumns()"
                                                     RowClass="@(r => GetRowClass(r.Resource))"
                                                     Loading="_isLoading"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -126,6 +126,7 @@
                                                 GenerateHeader="GenerateHeaderOption.Sticky"
                                                 ItemSize="46"
                                                 ResizableColumns="true"
+                                                ResizeColumnOnAllRows="false"
                                                 ItemsProvider="@GetData"
                                                 TGridItem="OtlpLogEntry"
                                                 GridTemplateColumns="@_manager.GetGridTemplateColumns()"

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -79,6 +79,7 @@
     margin-right: 0.25rem;
     white-space: nowrap;
     grid-row: 1;
+    text-align: left;
 }
 
 ::deep .span-name-container {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -84,6 +84,7 @@
                                     GenerateHeader="GenerateHeaderOption.Sticky"
                                     ItemSize="46"
                                     ResizableColumns="true"
+                                    ResizeColumnOnAllRows="false"
                                     ItemsProvider="@GetData"
                                     TGridItem="OtlpTrace"
                                     GridTemplateColumns="@_manager.GetGridTemplateColumns()"


### PR DESCRIPTION
Update to latest FluentUI. Data grids default to allowing resize on all rows. Disable in primary page grids: resources, structured logs, traces. Left enabled in details grids.