### PR TITLE
[release/9.4] Backport 10453 (remove obsolete RPC API)

### DIFF
--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -110,11 +110,6 @@ internal class AppHostRpcTarget(
         return Task.CompletedTask;
     }
 
-    public Task<DashboardUrlsState> GetDashboardUrlsAsync()
-    {
-        return GetDashboardUrlsAsync(CancellationToken.None);
-    }
-
     public async Task<DashboardUrlsState> GetDashboardUrlsAsync(CancellationToken cancellationToken)
     {
         if (!options.DashboardEnabled)


### PR DESCRIPTION
Backport of #10453 to release/9.4

## Customer Impact

None, just removing an API we don't need anymore.

## Testing

Existing tests work.

## Risk

Low.

## Regression?
