### PR TITLE
Update scripts to use the new Quality mappings to urls

### DIFF
--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -43,10 +43,22 @@ On Windows:
 iex "& { $(irm https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.ps1) }"
 ```
 
+or with arguments like:
+
+```powershell
+iex "& { $(irm https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.ps1) } -Quality staging"
+```
+
 On Linux, or macOS:
 
 ```sh
 curl -sSL https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.sh | bash
+```
+
+or with arguments like:
+
+```sh
+curl -sSL https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.sh | bash -s -- -q staging
 ```
 
 <!-- break between blocks -->

--- a/eng/scripts/README.md
+++ b/eng/scripts/README.md
@@ -23,7 +23,7 @@ Supported Quality values:
 |------------------|-------|---------------------------------------------------|-----------------------|
 | `--install-path` | `-i`  | Directory to install the CLI                      | `$HOME/.aspire/bin`   |
 | `--version`      |       | Version of the Aspire CLI to download             | `9.0`                 |
-| `--quality`      | `-q`  | Quality to download                               | `staging`               |
+| `--quality`      | `-q`  | Quality to download                               | `release`             |
 | `--os`           |       | Operating system (auto-detected if not specified) | auto-detect           |
 | `--arch`         |       | Architecture (auto-detected if not specified)     | auto-detect           |
 | `--keep-archive` | `-k`  | Keep downloaded archive files after installation  | `false`               |
@@ -36,7 +36,7 @@ Supported Quality values:
 |-----------------|---------------------------------------------------|--------------------------------------------------------------------|
 | `-InstallPath`  | Directory to install the CLI                      | `$HOME/.aspire/bin` (Unix) / `%USERPROFILE%\.aspire\bin` (Windows) |
 | `-Version`      | Version of the Aspire CLI to download             | `9.0`                                                              |
-| `-Quality`      | Quality to download                               | `staging`                                                          |
+| `-Quality`      | Quality to download                               | `release`                                                          |
 | `-OS`           | Operating system (auto-detected if not specified) | auto-detect                                                        |
 | `-Architecture` | Architecture (auto-detected if not specified)     | auto-detect                                                        |
 | `-KeepArchive`  | Keep downloaded archive files after installation  | `false`                                                            |

--- a/eng/scripts/README.md
+++ b/eng/scripts/README.md
@@ -9,11 +9,11 @@ This directory contains scripts to download and install the Aspire CLI for diffe
 
 ## Current Limitations
 
-⚠️ **Important**: Currently, only the following combination works:
-- **Version**: `9.0`
-- **Quality**: `daily`
+Supported Quality values:
 
-Other version/quality combinations are not yet available through the download URLs.
+- `dev` - builds from the `main` branch
+- `staging` - builds from the current `release` branch like `release/9.4`
+- `ga` - build for the latest GA
 
 ## Parameters
 
@@ -23,7 +23,7 @@ Other version/quality combinations are not yet available through the download UR
 |------------------|-------|---------------------------------------------------|-----------------------|
 | `--install-path` | `-i`  | Directory to install the CLI                      | `$HOME/.aspire/bin`   |
 | `--version`      |       | Version of the Aspire CLI to download             | `9.0`                 |
-| `--quality`      | `-q`  | Quality to download                               | `daily`               |
+| `--quality`      | `-q`  | Quality to download                               | `staging`               |
 | `--os`           |       | Operating system (auto-detected if not specified) | auto-detect           |
 | `--arch`         |       | Architecture (auto-detected if not specified)     | auto-detect           |
 | `--keep-archive` | `-k`  | Keep downloaded archive files after installation  | `false`               |
@@ -32,15 +32,15 @@ Other version/quality combinations are not yet available through the download UR
 
 ### PowerShell Script (`get-aspire-cli.ps1`)
 
-| Parameter       | Description                                       | Default                          |
-|-----------------|---------------------------------------------------|----------------------------------|
-| `-InstallPath`  | Directory to install the CLI                     | `$HOME/.aspire/bin` (Unix) / `%USERPROFILE%\.aspire\bin` (Windows) |
-| `-Version`      | Version of the Aspire CLI to download             | `9.0`                            |
-| `-Quality`      | Quality to download                               | `daily`                          |
-| `-OS`           | Operating system (auto-detected if not specified) | auto-detect                      |
-| `-Architecture` | Architecture (auto-detected if not specified)     | auto-detect                      |
-| `-KeepArchive`  | Keep downloaded archive files after installation  | `false`                          |
-| `-Help`         | Show help message                                 |                                  |
+| Parameter       | Description                                       | Default                                                            |
+|-----------------|---------------------------------------------------|--------------------------------------------------------------------|
+| `-InstallPath`  | Directory to install the CLI                      | `$HOME/.aspire/bin` (Unix) / `%USERPROFILE%\.aspire\bin` (Windows) |
+| `-Version`      | Version of the Aspire CLI to download             | `9.0`                                                              |
+| `-Quality`      | Quality to download                               | `staging`                                                          |
+| `-OS`           | Operating system (auto-detected if not specified) | auto-detect                                                        |
+| `-Architecture` | Architecture (auto-detected if not specified)     | auto-detect                                                        |
+| `-KeepArchive`  | Keep downloaded archive files after installation  | `false`                                                            |
+| `-Help`         | Show help message                                 |                                                                    |
 
 ## Install Path Parameter
 

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -855,7 +855,7 @@ function Start-AspireCliInstallation {
 
         # Additional parameter validation
         if (-not [string]::IsNullOrWhiteSpace($OS) -and $OS -notin $Script:Config.SupportedOperatingSystems) {
-            throw "Unsupported OS '$OS'. Supported values are: $($Script:Config.SupportedOperatingSystems -join ', '))"
+            throw "Unsupported OS '$OS'. Supported values are: $($Script:Config.SupportedOperatingSystems -join ', ')"
         }
 
         if (-not [string]::IsNullOrWhiteSpace($Architecture) -and $Architecture -notin $Script:Config.SupportedArchitectures) {

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -698,10 +698,7 @@ function Get-AspireCliUrl {
         [string]$Extension
     )
 
-    # Validate quality against supported values
-    if ($Quality -notin $Script:Config.SupportedQualities) {
-        throw "Unsupported quality '$Quality'. Supported values are: $($Script:Config.SupportedQualities -join ", ")."
-    }
+    # Validation against supported values is handled by the [ValidateSet] attribute on the $Quality parameter.
 
     if ([string]::IsNullOrWhiteSpace($Version)) {
         # When version is not set use aka.ms URLs based on quality

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -9,7 +9,7 @@ param(
     [string]$Version = "",
 
     [Parameter(HelpMessage = "Quality to download")]
-    [ValidateSet("", "ga", "staging", "dev")]
+    [ValidateSet("", "release", "staging", "dev")]
     [string]$Quality = "",
 
     [Parameter(HelpMessage = "Operating system")]
@@ -36,13 +36,13 @@ $Script:ChecksumDownloadTimeoutSec = 120
 # Configuration constants
 $Script:Config = @{
     MinimumPowerShellVersion = 4
-    SupportedQualities = @("ga", "staging", "dev")
+    SupportedQualities = @("release", "staging", "dev")
     SupportedOperatingSystems = @("win", "linux", "linux-musl", "osx")
     SupportedArchitectures = @("x64", "x86", "arm64")
     BaseUrls = @{
         "dev" = "https://aka.ms/dotnet/9/aspire/daily"
         "staging" = "https://aka.ms/dotnet/9/aspire/rc/daily"
-        "ga" = "https://aka.ms/dotnet/9/aspire/ga/daily"
+        "release" = "https://aka.ms/dotnet/9/aspire/ga/daily"
         "versioned" = "https://ci.dot.net/public/aspire"
         "versioned-checksums" = "https://ci.dot.net/public-checksums/aspire"
     }
@@ -71,8 +71,8 @@ DESCRIPTION:
     Downloads and installs the Aspire CLI for the current platform from the specified version and quality.
     Automatically updates the current session's PATH environment variable and supports GitHub Actions.
 
-    Running with `-Quality ga` download the latest GA version of the Aspire CLI for your platform and architecture.
-    Running with `-Quality staging` will download the latest staging version, or the GA version if no staging is available.
+    Running with `-Quality release` download the latest release version of the Aspire CLI for your platform and architecture.
+    Running with `-Quality staging` will download the latest staging version, or the release version if no staging is available.
     Running with `-Quality dev` will download the latest dev build from `main`.
 
     The default quality is `staging`.

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -1,8 +1,11 @@
 #!/usr/bin/env pwsh
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param(
+    [Parameter(HelpMessage = "Directory to install the CLI")]
     [string]$InstallPath = "",
+
+    [Parameter(HelpMessage = "Version of the Aspire CLI to download")]
     [string]$Version = "",
 
     [Parameter(HelpMessage = "Quality to download")]
@@ -12,14 +15,21 @@ param(
     [Parameter(HelpMessage = "Operating system")]
     [ValidateSet("", "win", "linux", "linux-musl", "osx")]
     [string]$OS = "",
+
+    [Parameter(HelpMessage = "Architecture")]
+    [ValidateSet("", "x64", "x86", "arm64")]
     [string]$Architecture = "",
+
+    [Parameter(HelpMessage = "Keep downloaded archive files and temporary directory after installation")]
     [switch]$KeepArchive,
+
+    [Parameter(HelpMessage = "Show help message")]
     [switch]$Help
 )
 
 # Global constants
 $Script:UserAgent = "get-aspire-cli.ps1/1.0"
-$Script:IsModernPowerShell = $PSVersionTable.PSVersion.Major -ge 6
+$Script:IsModernPowerShell = $PSVersionTable.PSVersion.Major -ge 6 -and $PSVersionTable.PSEdition -eq "Core"
 $Script:ArchiveDownloadTimeoutSec = 600
 $Script:ChecksumDownloadTimeoutSec = 120
 
@@ -54,16 +64,18 @@ if ($PSVersionTable.PSVersion.Major -lt $Script:Config.MinimumPowerShellVersion)
 }
 
 if ($Help) {
-    Write-Host @"
+    Write-Message @"
 Aspire CLI Download Script
 
 DESCRIPTION:
     Downloads and installs the Aspire CLI for the current platform from the specified version and quality.
     Automatically updates the current session's PATH environment variable and supports GitHub Actions.
 
-    Running this without any arguments will download the latest stable version of the Aspire CLI for your platform and architecture.
+    Running with `-Quality ga` download the latest GA version of the Aspire CLI for your platform and architecture.
     Running with `-Quality staging` will download the latest staging version, or the GA version if no staging is available.
     Running with `-Quality dev` will download the latest dev build from `main`.
+
+    The default quality is `staging`.
 
     Pass a specific version to get CLI for that version.
 
@@ -106,33 +118,56 @@ EXAMPLES:
 
 # Consolidated output function with fallback for platforms that don't support Write-Host
 function Write-Message {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [string]$Message,
-        [ValidateSet('Verbose', 'Info', 'Success', 'Warning', 'Error')]
-        [string]$Level = 'Info'
+
+        [Parameter()]
+        [ValidateSet("Verbose", "Info", "Success", "Warning", "Error")]
+        [string]$Level = "Info"
     )
 
-    try {
-        switch ($Level) {
-            'Verbose' { Write-Verbose $Message }
-            'Info' { Write-Host $Message -ForegroundColor White }
-            'Success' { Write-Host $Message -ForegroundColor Green }
-            'Warning' { Write-Host "Warning: $Message" -ForegroundColor Yellow }
-            'Error' { Write-Host "Error: $Message" -ForegroundColor Red }
+    $hasWriteHost = Get-Command Write-Host -ErrorAction SilentlyContinue
+
+    switch ($Level) {
+        "Verbose" {
+            if ($VerbosePreference -ne "SilentlyContinue") {
+                Write-Verbose $Message
+            }
         }
-    }
-    catch {
-        # Fallback for platforms that don't support Write-Host (e.g., Azure Functions)
-        $prefix = if ($Level -in @('Warning', 'Error')) { "$Level`: " } else { "" }
-        Write-Output "$prefix$Message"
+        "Info" {
+            if ($hasWriteHost) {
+                Write-Host $Message -ForegroundColor White
+            } else {
+                Write-Output $Message
+            }
+        }
+        "Success" {
+            if ($hasWriteHost) {
+                Write-Host $Message -ForegroundColor Green
+            } else {
+                Write-Output "SUCCESS: $Message"
+            }
+        }
+        "Warning" {
+            Write-Warning $Message
+        }
+        "Error" {
+            Write-Error $Message
+        }
     }
 }
 
 # Helper function for PowerShell version-specific operations
 function Invoke-WithPowerShellVersion {
+    [CmdletBinding()]
     param(
+        [Parameter(Mandatory = $true)]
         [scriptblock]$ModernAction,
+
+        [Parameter(Mandatory = $true)]
         [scriptblock]$LegacyAction
     )
 
@@ -145,146 +180,192 @@ function Invoke-WithPowerShellVersion {
 
 # Function to detect OS
 function Get-OperatingSystem {
-    Invoke-WithPowerShellVersion -ModernAction {
-        if ($IsWindows) {
-            return "win"
-        }
-        elseif ($IsLinux) {
-            try {
-                $lddOutput = & ldd --version 2>&1 | Out-String
-                return if ($lddOutput -match "musl") { "linux-musl" } else { "linux" }
-            }
-            catch { return "linux" }
-        }
-        elseif ($IsMacOS) {
-            return "osx"
-        }
-        else {
-            return "unsupported"
-        }
-    } -LegacyAction {
-        # PowerShell 5.1 and earlier - more reliable Windows detection
-        if ($env:OS -eq "Windows_NT" -or [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
-            return "win"
-        }
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
 
-        $platform = [System.Environment]::OSVersion.Platform
-        switch ($platform) {
-            { $_ -in @([System.PlatformID]::Unix, 4, 6) } { return "linux" }
-            { $_ -in @([System.PlatformID]::MacOSX, 128) } { return "osx" }
-            default { return "unsupported" }
+    try {
+        return Invoke-WithPowerShellVersion -ModernAction {
+            if ($IsWindows) {
+                return "win"
+            }
+            elseif ($IsLinux) {
+                try {
+                    $lddOutput = & ldd --version 2>&1 | Out-String
+                    return if ($lddOutput -match "musl") { "linux-musl" } else { "linux" }
+                }
+                catch { return "linux" }
+            }
+            elseif ($IsMacOS) {
+                return "osx"
+            }
+            else {
+                return "unsupported"
+            }
+        } -LegacyAction {
+            # PowerShell 5.1 and earlier - more reliable Windows detection
+            if ($env:OS -eq "Windows_NT" -or [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
+                return "win"
+            }
+
+            $platform = [System.Environment]::OSVersion.Platform
+            switch ($platform) {
+                { $_ -in @([System.PlatformID]::Unix, 4, 6) } { return "linux" }
+                { $_ -in @([System.PlatformID]::MacOSX, 128) } { return "osx" }
+                default { return "unsupported" }
+            }
         }
+    }
+    catch {
+        Write-Message "Failed to detect operating system: $($_.Exception.Message)" -Level Warning
+        return "unsupported"
     }
 }
 
-# Taken from dotnet-install.ps1 and enhanced for cross-platform support
-function Get-MachineArchitecture() {
-    Write-Message "Get-MachineArchitecture called" -Level Verbose
+# Enhanced function for cross-platform architecture detection
+function Get-MachineArchitecture {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
 
-    # On Windows PowerShell, use environment variables
-    if (-not $Script:IsModernPowerShell -or $IsWindows) {
-        # On PS x86, PROCESSOR_ARCHITECTURE reports x86 even on x64 systems.
-        # To get the correct architecture, we need to use PROCESSOR_ARCHITEW6432.
-        # PS x64 doesn't define this, so we fall back to PROCESSOR_ARCHITECTURE.
-        # Possible values: amd64, x64, x86, arm64, arm
-        if ( $null -ne $ENV:PROCESSOR_ARCHITEW6432 ) {
-            return $ENV:PROCESSOR_ARCHITEW6432
-        }
+    Write-Message "Detecting machine architecture" -Level Verbose
 
-        try {
-            if ( ((Get-CimInstance -ClassName CIM_OperatingSystem).OSArchitecture) -like "ARM*") {
-                if ( [Environment]::Is64BitOperatingSystem ) {
-                    return "arm64"
+    try {
+        # On Windows PowerShell, use environment variables
+        if (-not $Script:IsModernPowerShell -or $IsWindows) {
+            # On PS x86, PROCESSOR_ARCHITECTURE reports x86 even on x64 systems.
+            # To get the correct architecture, we need to use PROCESSOR_ARCHITEW6432.
+            # PS x64 doesn't define this, so we fall back to PROCESSOR_ARCHITECTURE.
+            # Possible values: amd64, x64, x86, arm64, arm
+            if ( $null -ne $ENV:PROCESSOR_ARCHITEW6432 ) {
+                return $ENV:PROCESSOR_ARCHITEW6432
+            }
+
+            try {
+                $osInfo = Get-CimInstance -ClassName CIM_OperatingSystem -ErrorAction Stop
+                if ($osInfo.OSArchitecture -like "ARM*") {
+                    if ([Environment]::Is64BitOperatingSystem) {
+                        return "arm64"
+                    }
+                    return "arm"
                 }
-                return "arm"
+            }
+            catch {
+                Write-Message "Failed to get CIM instance: $($_.Exception.Message)" -Level Verbose
+            }
+
+            if ( $null -ne $ENV:PROCESSOR_ARCHITECTURE ) {
+                return $ENV:PROCESSOR_ARCHITECTURE
             }
         }
-        catch {
-            # Machine doesn't support Get-CimInstance
-        }
 
-        if ($null -ne $ENV:PROCESSOR_ARCHITECTURE) {
-            return $ENV:PROCESSOR_ARCHITECTURE
-        }
-    }
-
-    # For PowerShell 6+ on Unix systems, use .NET runtime information
-    if ($Script:IsModernPowerShell) {
-        try {
-            $runtimeArch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
-            switch ($runtimeArch) {
-                'X64' { return "x64" }
-                'X86' { return "x86" }
-                'Arm64' { return "arm64" }
-                default {
-                    Write-Message "Unknown runtime architecture: $runtimeArch" -Level Verbose
-                    # Fall back to uname if available
-                    if (Get-Command uname -ErrorAction SilentlyContinue) {
-                        $unameArch = & uname -m
-                        switch ($unameArch) {
-                            { @('x86_64', 'amd64') -contains $_ } { return "x64" }
-                            { @('aarch64', 'arm64') -contains $_ } { return "arm64" }
-                            { @('i386', 'i686') -contains $_ } { return "x86" }
-                            default {
-                                Write-Message "Unknown uname architecture: $unameArch" -Level Verbose
-                                return "x64"  # Default fallback
+        # For PowerShell 6+ on Unix systems, use .NET runtime information
+        if ($Script:IsModernPowerShell) {
+            try {
+                $runtimeArch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+                switch ($runtimeArch) {
+                    "X64" { return "x64" }
+                    "X86" { return "x86" }
+                    "Arm64" { return "arm64" }
+                    default {
+                        Write-Message "Unknown runtime architecture: $runtimeArch" -Level Verbose
+                        # Fall back to uname if available
+                        if (Get-Command uname -ErrorAction SilentlyContinue) {
+                            $unameArch = & uname -m
+                            switch ($unameArch) {
+                                { @("x86_64", "amd64") -contains $_ } { return "x64" }
+                                { @("aarch64", "arm64") -contains $_ } { return "arm64" }
+                                { @("i386", "i686") -contains $_ } { return "x86" }
+                                default {
+                                    Write-Message "Unknown uname architecture: $unameArch" -Level Verbose
+                                    return "x64"  # Default fallback
+                                }
                             }
                         }
+                        return "x64"  # Default fallback
                     }
-                    return "x64"  # Default fallback
                 }
             }
+            catch {
+                Write-Message "Failed to get runtime architecture: $($_.Exception.Message)" -Level Warning
+                return "x64"  # Default fallback
+            }
         }
-        catch {
-            Write-Message "Failed to get runtime architecture: $($_.Exception.Message)" -Level Warning
-            # Final fallback - assume x64
-            return "x64"
-        }
-    }
 
-    # Final fallback for older PowerShell versions
-    return "x64"
+        # Final fallback for older PowerShell versions
+        return "x64"
+    }
+    catch {
+        Write-Message "Architecture detection failed: $($_.Exception.Message)" -Level Warning
+        return "x64"  # Safe fallback
+    }
 }
 
-# taken from dotnet-install.ps1
-function Get-CLIArchitectureFromArchitecture([string]$Architecture) {
-    Write-Message "Get-CLIArchitectureFromArchitecture called with Architecture: $Architecture" -Level Verbose
+# Convert architecture to CLI architecture format
+function Get-CLIArchitectureFromArchitecture {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Architecture
+    )
+
+    Write-Message "Converting architecture: $Architecture" -Level Verbose
 
     if ($Architecture -eq "<auto>") {
         $Architecture = Get-MachineArchitecture
     }
 
-    switch ($Architecture.ToLowerInvariant()) {
-        { ($_ -eq "amd64") -or ($_ -eq "x64") } { return "x64" }
-        { $_ -eq "x86" } { return "x86" }
-        { $_ -eq "arm64" } { return "arm64" }
-        default { throw "Architecture '$Architecture' not supported. If you think this is a bug, report it at https://github.com/dotnet/aspire/issues" }
+    $normalizedArch = $Architecture.ToLowerInvariant()
+    switch ($normalizedArch) {
+        { @("amd64", "x64") -contains $_ } {
+            return "x64"
+        }
+        { $_ -eq "x86" } {
+            return "x86"
+        }
+        { $_ -eq "arm64" } {
+            return "arm64"
+        }
+        default {
+            throw "Architecture '$Architecture' not supported. If you think this is a bug, report it at https://github.com/dotnet/aspire/issues"
+        }
     }
 }
 
 function Get-ContentTypeFromUri {
+    [CmdletBinding()]
+    [OutputType([string])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Uri,
+
+        [Parameter()]
         [int]$TimeoutSec = 60,
+
+        [Parameter()]
         [int]$OperationTimeoutSec = 30,
+
+        [Parameter()]
         [int]$MaxRetries = 5
     )
 
     try {
         Write-Message "Making HEAD request to get content type for: $Uri" -Level Verbose
-        $headResponse = Invoke-SecureWebRequest -Uri $Uri -Method 'Head' -TimeoutSec $TimeoutSec -OperationTimeoutSec $OperationTimeoutSec -MaxRetries $MaxRetries
+        $headResponse = Invoke-SecureWebRequest -Uri $Uri -Method "Head" -TimeoutSec $TimeoutSec -OperationTimeoutSec $OperationTimeoutSec -MaxRetries $MaxRetries
 
         # Extract Content-Type from response headers
         $headers = $headResponse.Headers
         if ($headers) {
             # Try common case variations and use case-insensitive lookup
-            $contentTypeKey = $headers.Keys | Where-Object { $_ -ieq 'Content-Type' } | Select-Object -First 1
+            $contentTypeKey = $headers.Keys | Where-Object { $_ -ieq "Content-Type" } | Select-Object -First 1
             if ($contentTypeKey) {
                 $value = $headers[$contentTypeKey]
                 if ($value -is [array]) {
-                    return $value -join ', '
-                } else {
+                    return $value -join ", "
+                }
+                else {
                     return $value
                 }
             }
@@ -297,14 +378,26 @@ function Get-ContentTypeFromUri {
     }
 }
 
-# Common function for web requests with centralized configuration
+# Enhanced web request function with security and reliability improvements
 function Invoke-SecureWebRequest {
+    [CmdletBinding()]
     param(
+        [Parameter(Mandatory = $true)]
         [string]$Uri,
+
+        [Parameter()]
         [string]$OutFile,
-        [string]$Method = 'Get',
+
+        [Parameter()]
+        [string]$Method = "Get",
+
+        [Parameter()]
         [int]$TimeoutSec = 60,
+
+        [Parameter()]
         [int]$OperationTimeoutSec = 30,
+
+        [Parameter()]
         [int]$MaxRetries = 5
     )
 
@@ -335,22 +428,21 @@ function Invoke-SecureWebRequest {
         UserAgent = $Script:UserAgent
     }
 
-    if ($Method -eq 'Get' -and $OutFile) {
+    if ($Method -eq "Get" -and $OutFile) {
         $requestParams.OutFile = $OutFile
     }
 
     # Add modern PowerShell parameters with graceful fallback
     if ($Script:IsModernPowerShell) {
-        @('SslProtocol', 'OperationTimeoutSeconds', 'MaximumRetryCount') | ForEach-Object {
-            $paramName = $_
-            $paramValue = switch ($paramName) {
-                'SslProtocol' { @('Tls12', 'Tls13') }
-                'OperationTimeoutSeconds' { $OperationTimeoutSec }
-                'MaximumRetryCount' { $MaxRetries }
-            }
+        $modernParams = @{
+            "SslProtocol" = @("Tls12", "Tls13")
+            "OperationTimeoutSeconds" = $OperationTimeoutSec
+            "MaximumRetryCount" = $MaxRetries
+        }
 
+        foreach ($paramName in $modernParams.Keys) {
             try {
-                $requestParams[$paramName] = $paramValue
+                $requestParams[$paramName] = $modernParams[$paramName]
             }
             catch {
                 Write-Message "$paramName parameter not available: $($_.Exception.Message)" -Level Verbose
@@ -366,22 +458,30 @@ function Invoke-SecureWebRequest {
     }
 }
 
-# Simplified file download wrapper
+# Enhanced file download wrapper with validation
 function Invoke-FileDownload {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [string]$Uri,
+
         [Parameter(Mandatory = $true)]
         [string]$OutputPath,
+
+        [Parameter()]
         [int]$TimeoutSec = 60,
+
+        [Parameter()]
         [int]$OperationTimeoutSec = 30,
+
+        [Parameter()]
         [int]$MaxRetries = 5
     )
 
     # Validate content type via HEAD request
     Write-Message "Validating content type for $Uri" -Level Verbose
     $contentType = Get-ContentTypeFromUri -Uri $Uri -TimeoutSec 60 -OperationTimeoutSec $OperationTimeoutSec -MaxRetries $MaxRetries
-    Write-Message "Detected content type: '$contentType'" -Level Verbose
+    Write-Message "Detected content type: $contentType" -Level Verbose
 
     if ($contentType -and $contentType.ToLowerInvariant().StartsWith("text/html")) {
         throw "Server returned HTML content instead of expected file. Make sure the URL is correct: $Uri"
@@ -393,14 +493,18 @@ function Invoke-FileDownload {
         Write-Message "Successfully downloaded file to: $OutputPath" -Level Verbose
     }
     catch {
-        throw "Failed to download $Uri to $OutputPath - $($_.Exception.Message)"
+        throw "Failed to download $Uri - $($_.Exception.Message)"
     }
 }
 
-# Validate the checksum of the downloaded file
+# Enhanced checksum validation with proper error handling
 function Test-FileChecksum {
+    [CmdletBinding()]
     param(
+        [Parameter(Mandatory = $true)]
         [string]$ArchiveFile,
+
+        [Parameter(Mandatory = $true)]
         [string]$ChecksumFile
     )
 
@@ -409,8 +513,8 @@ function Test-FileChecksum {
         throw "Get-FileHash cmdlet not found. Please use PowerShell 4.0 or later to validate checksums."
     }
 
-    $expectedChecksum = (Get-Content $ChecksumFile -Raw).Trim().ToLower()
-    $actualChecksum = (Get-FileHash -Path $ArchiveFile -Algorithm SHA512).Hash.ToLower()
+    $expectedChecksum = (Get-Content $ChecksumFile -Raw -ErrorAction Stop).Trim().ToLowerInvariant()
+    $actualChecksum = (Get-FileHash -Path $ArchiveFile -Algorithm SHA512 -ErrorAction Stop).Hash.ToLowerInvariant()
 
     # Compare checksums
     if ($expectedChecksum -ne $actualChecksum) {
@@ -431,6 +535,7 @@ function Expand-AspireCliArchive {
     try {
         # Create destination directory if it doesn't exist
         if (-not (Test-Path $DestinationPath)) {
+            Write-Message "Creating destination directory: $DestinationPath" -Level Verbose
             New-Item -ItemType Directory -Path $DestinationPath -Force | Out-Null
         }
 
@@ -467,10 +572,22 @@ function Expand-AspireCliArchive {
 
 # Simplified installation path determination
 function Get-InstallPath {
-    param([string]$InstallPath)
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [string]$InstallPath
+    )
 
     if (-not [string]::IsNullOrWhiteSpace($InstallPath)) {
-        return $InstallPath
+        # Validate that the path is not just whitespace and can be created
+        try {
+            $resolvedPath = [System.IO.Path]::GetFullPath($InstallPath)
+            return $resolvedPath
+        }
+        catch {
+            throw "Invalid installation path: $InstallPath - $($_.Exception.Message)"
+        }
     }
 
     # Get home directory cross-platform
@@ -498,15 +615,20 @@ function Get-InstallPath {
         throw "Unable to determine user home directory. Please specify -InstallPath parameter."
     }
 
-    return Join-Path (Join-Path $homeDirectory ".aspire") "bin"
+    $defaultPath = Join-Path (Join-Path $homeDirectory ".aspire") "bin"
+    return [System.IO.Path]::GetFullPath($defaultPath)
 }
 
 # Simplified PATH environment update
 function Update-PathEnvironment {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]$InstallPath,
+
         [Parameter(Mandatory = $true)]
+        [ValidateSet("win", "linux", "linux-musl", "osx")]
         [string]$TargetOS
     )
 
@@ -515,8 +637,10 @@ function Update-PathEnvironment {
     # Update current session PATH
     $currentPathArray = $env:PATH.Split($pathSeparator, [StringSplitOptions]::RemoveEmptyEntries)
     if ($currentPathArray -notcontains $InstallPath) {
-        $env:PATH = (@($InstallPath) + $currentPathArray) -join $pathSeparator
-        Write-Message "Added $InstallPath to PATH for current session" -Level Info
+        if ($PSCmdlet.ShouldProcess("PATH environment variable", "Add $InstallPath to current session")) {
+            $env:PATH = (@($InstallPath) + $currentPathArray) -join $pathSeparator
+            Write-Message "Added $InstallPath to PATH for current session" -Level Info
+        }
     }
 
     # Update persistent PATH for Windows
@@ -525,27 +649,30 @@ function Update-PathEnvironment {
             $userPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User)
             if (-not $userPath) { $userPath = "" }
             $userPathArray = if ($userPath) { $userPath.Split($pathSeparator, [StringSplitOptions]::RemoveEmptyEntries) } else { @() }
-
             if ($userPathArray -notcontains $InstallPath) {
-                $newUserPath = (@($InstallPath) + $userPathArray) -join $pathSeparator
-                [Environment]::SetEnvironmentVariable("PATH", $newUserPath, [EnvironmentVariableTarget]::User)
-                Write-Message "Added $InstallPath to user PATH environment variable" -Level Info
+                if ($PSCmdlet.ShouldProcess("User PATH environment variable", "Add $InstallPath")) {
+                    $newUserPath = (@($InstallPath) + $userPathArray) -join $pathSeparator
+                    [Environment]::SetEnvironmentVariable("PATH", $newUserPath, [EnvironmentVariableTarget]::User)
+                    Write-Message "Added $InstallPath to user PATH environment variable" -Level Info
+                }
             }
 
-            Write-Host ""
-            Write-Host "The aspire cli is now available for use in this and new sessions." -ForegroundColor Green
+            Write-Message "" -Level Info
+            Write-Message "The aspire cli is now available for use in this and new sessions." -Level Success
         }
         catch {
             Write-Message "Failed to update persistent PATH environment variable: $($_.Exception.Message)" -Level Warning
-            Write-Message "You may need to manually add '$InstallPath' to your PATH environment variable" -Level Info
+            Write-Message "You may need to manually add $InstallPath to your PATH environment variable" -Level Info
         }
     }
 
     # GitHub Actions support
     if ($env:GITHUB_ACTIONS -eq "true" -and $env:GITHUB_PATH) {
         try {
-            Add-Content -Path $env:GITHUB_PATH -Value $InstallPath
-            Write-Message "Added $InstallPath to GITHUB_PATH for GitHub Actions" -Level Success
+            if ($PSCmdlet.ShouldProcess("GITHUB_PATH environment variable", "Add $InstallPath to GITHUB_PATH")) {
+                Add-Content -Path $env:GITHUB_PATH -Value $InstallPath
+                Write-Message "Added $InstallPath to GITHUB_PATH for GitHub Actions" -Level Success
+            }
         }
         catch {
             Write-Message "Failed to update GITHUB_PATH: $($_.Exception.Message)" -Level Warning
@@ -553,69 +680,88 @@ function Update-PathEnvironment {
     }
 }
 
-# Function to construct the base URL for the Aspire CLI download
+# Enhanced URL construction function with configuration-based URLs
 function Get-AspireCliUrl {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
     param(
+        [Parameter()]
         [string]$Version,
+
+        [Parameter()]
         [string]$Quality,
+
+        [Parameter(Mandatory = $true)]
         [string]$RuntimeIdentifier,
-        [string]$Extension,
-        [bool]$IsChecksum = $false
+
+        [Parameter(Mandatory = $true)]
+        [string]$Extension
     )
 
-    # Default quality to "ga" if empty
-    if ([string]::IsNullOrWhiteSpace($Quality)) {
-        $Quality = "ga"
-    }
-
-    # Add .sha512 to extension if checksum is true
-    if ($IsChecksum) {
-        $Extension = "$Extension.sha512"
+    # Validate quality against supported values
+    if ($Quality -notin $Script:Config.SupportedQualities) {
+        throw "Unsupported quality '$Quality'. Supported values are: $($Script:Config.SupportedQualities -join ", ")."
     }
 
     if ([string]::IsNullOrWhiteSpace($Version)) {
         # When version is not set use aka.ms URLs based on quality
-        $baseUrl = switch ($Quality) {
-            "daily" { "https://aka.ms/dotnet/9/aspire/daily" }
-            "prerelease" { "https://aka.ms/dotnet/9/aspire/rc/daily" }
-            "ga" { "https://aka.ms/dotnet/9/aspire/ga/daily" }
-            default {
-                throw "Unsupported quality '$Quality'. Supported values are: daily, prerelease, ga."
-            }
+        $baseUrl = $Script:Config.BaseUrls[$Quality]
+        if (-not $baseUrl) {
+            throw "No base URL configured for quality: $Quality"
         }
 
-        return "$baseUrl/aspire-cli-$RuntimeIdentifier.$Extension"
-    } else {
+        $archiveFilename = "aspire-cli-$RuntimeIdentifier.$Extension"
+        $checksumFilename = "aspire-cli-$RuntimeIdentifier.$Extension.sha512"
+
+        return [PSCustomObject]@{
+            ArchiveUrl = "$baseUrl/$archiveFilename"
+            ArchiveFilename = $archiveFilename
+            ChecksumUrl = "$baseUrl/$checksumFilename"
+            ChecksumFilename = $checksumFilename
+        }
+    }
+    else {
         # When version is set, use ci.dot.net URL
-        if ($IsChecksum) {
-            # For checksum URLs, use the public-checksums URL
-            $baseUrl = "https://ci.dot.net/public-checksums/aspire"
-        } else {
-            $baseUrl = "https://ci.dot.net/public/aspire"
-        }
+        $archiveFilename = "aspire-cli-$RuntimeIdentifier-$Version.$Extension"
+        $checksumFilename = "$archiveFilename.sha512"
 
-        return "$baseUrl/$Version/aspire-cli-$RuntimeIdentifier-$Version.$Extension"
+        return [PSCustomObject]@{
+            ArchiveUrl = "$($Script:Config.BaseUrls["versioned"])/$Version/$archiveFilename"
+            ArchiveFilename = $archiveFilename
+            ChecksumUrl = "$($Script:Config.BaseUrls["versioned-checksums"])/$Version/$checksumFilename"
+            ChecksumFilename = $checksumFilename
+        }
     }
 }
 
 # Function to download and install the Aspire CLI
 function Install-AspireCli {
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([string])]
     param(
         [Parameter(Mandatory = $true)]
         [string]$InstallPath,
-        [Parameter(Mandatory = $true)]
         [string]$Version,
-        [Parameter(Mandatory = $true)]
         [string]$Quality,
         [string]$OS,
-        [string]$Architecture,
-        [switch]$KeepArchive
+        [string]$Architecture
     )
 
-    # Create a temporary directory for downloads
-    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "aspire-cli-download-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
+    # Create a temporary directory for downloads with conflict resolution
+    $tempBaseName = "aspire-cli-download-$([System.Guid]::NewGuid().ToString("N").Substring(0, 8))"
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) $tempBaseName
 
-    if (-not (Test-Path $tempDir)) {
+    # Handle potential conflicts
+    $attempt = 1
+    while (Test-Path $tempDir) {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "$tempBaseName-$attempt"
+        $attempt++
+        if ($attempt -gt 10) {
+            throw "Unable to create temporary directory after 10 attempts"
+        }
+    }
+
+    if ($PSCmdlet.ShouldProcess($InstallPath, "Create temporary directory")) {
         Write-Message "Creating temporary directory: $tempDir" -Level Verbose
         try {
             New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
@@ -634,34 +780,39 @@ function Install-AspireCli {
             throw "Unsupported operating system. Current platform: $([System.Environment]::OSVersion.Platform)"
         }
 
-        $targetArch = if ([string]::IsNullOrWhiteSpace($Architecture)) { Get-CLIArchitectureFromArchitecture '<auto>' } else { Get-CLIArchitectureFromArchitecture $Architecture }
+        $targetArch = if ([string]::IsNullOrWhiteSpace($Architecture)) { Get-CLIArchitectureFromArchitecture "<auto>" } else { Get-CLIArchitectureFromArchitecture $Architecture }
 
         # Construct the runtime identifier and URLs
         $runtimeIdentifier = "$targetOS-$targetArch"
         $extension = if ($targetOS -eq "win") { "zip" } else { "tar.gz" }
-        $url = Get-AspireCliUrl -Version $Version -Quality $Quality -RuntimeIdentifier $runtimeIdentifier -Extension $extension -IsChecksum $false
-        $checksumUrl = Get-AspireCliUrl -Version $Version -Quality $Quality -RuntimeIdentifier $runtimeIdentifier -Extension $extension -IsChecksum $true
+        $urls = Get-AspireCliUrl -Version $Version -Quality $Quality -RuntimeIdentifier $runtimeIdentifier -Extension $extension
 
-        $filename = Join-Path $tempDir "aspire-cli-$runtimeIdentifier.$extension"
-        $checksumFilename = Join-Path $tempDir "aspire-cli-$runtimeIdentifier.$extension.sha512"
+        $archivePath = Join-Path $tempDir $urls.ArchiveFilename
+        $checksumPath = Join-Path $tempDir $urls.ChecksumFilename
 
-        # Download the Aspire CLI archive
-        Write-Message "Downloading from: $url" -Level Info
-        Invoke-FileDownload -Uri $url -TimeoutSec $Script:ArchiveDownloadTimeoutSec -OutputPath $filename
+        if ($PSCmdlet.ShouldProcess($urls.ArchiveUrl, "Download CLI archive")) {
+            # Download the Aspire CLI archive
+            Write-Message "Downloading from: $($urls.ArchiveUrl)" -Level Info
+            Invoke-FileDownload -Uri $urls.ArchiveUrl -TimeoutSec $Script:ArchiveDownloadTimeoutSec -OutputPath $archivePath
+        }
 
-        # Download and test the checksum
-        Invoke-FileDownload -Uri $checksumUrl -TimeoutSec $Script:ChecksumDownloadTimeoutSec -OutputPath $checksumFilename
-        Test-FileChecksum -ArchiveFile $filename -ChecksumFile $checksumFilename
+        if ($PSCmdlet.ShouldProcess($urls.ChecksumUrl, "Download CLI archive checksum")) {
+            # Download and test the checksum
+            Invoke-FileDownload -Uri $urls.ChecksumUrl -TimeoutSec $Script:ChecksumDownloadTimeoutSec -OutputPath $checksumPath
+            Test-FileChecksum -ArchiveFile $archivePath -ChecksumFile $checksumPath
 
-        Write-Message "Successfully downloaded and validated: $filename" -Level Verbose
+            Write-Message "Successfully downloaded and validated: $($urls.ArchiveFilename)" -Level Verbose
+        }
 
-        # Unpack the archive
-        Expand-AspireCliArchive -ArchiveFile $filename -DestinationPath $InstallPath -OS $targetOS
+        if ($PSCmdlet.ShouldProcess($InstallPath, "Install CLI")) {
+            # Unpack the archive
+            Expand-AspireCliArchive -ArchiveFile $archivePath -DestinationPath $InstallPath -OS $targetOS
 
-        $cliExe = if ($targetOS -eq "win") { "aspire.exe" } else { "aspire" }
-        $cliPath = Join-Path $InstallPath $cliExe
+            $cliExe = if ($targetOS -eq "win") { "aspire.exe" } else { "aspire" }
+            $cliPath = Join-Path $InstallPath $cliExe
 
-        Write-Message "Aspire CLI successfully installed to: $cliPath" -Level Success
+            Write-Message "Aspire CLI successfully installed to: $cliPath" -Level Success
+        }
 
         # Return the target OS for the caller to use
         return $targetOS
@@ -685,26 +836,57 @@ function Install-AspireCli {
     }
 }
 
-# Main function
-function Main {
+# Main function with enhanced error handling and validation
+function Start-AspireCliInstallation {
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([int])]
+    param()
+
     try {
         # Validate that both Version and Quality are not provided
         if (-not [string]::IsNullOrWhiteSpace($Version) -and $Quality -ne "ga") {
             throw "Cannot specify both -Version and -Quality. Use -Version for a specific version or -Quality for a quality level."
         }
 
+        # Additional parameter validation
+        if (-not [string]::IsNullOrWhiteSpace($OS) -and $OS -notin $Script:Config.SupportedOperatingSystems) {
+            throw "Unsupported OS '$OS'. Supported values are: $($Script:Config.SupportedOperatingSystems -join ', '))"
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($Architecture) -and $Architecture -notin $Script:Config.SupportedArchitectures) {
+            throw "Unsupported Architecture $Architecture. Supported values are: $($Script:Config.SupportedArchitectures -join ", ")"
+        }
+
         # Determine the installation path
-        $InstallPath = Get-InstallPath -InstallPath $InstallPath
+        $resolvedInstallPath = Get-InstallPath -InstallPath $InstallPath
+
+        # Ensure the installation directory exists
+        if (-not (Test-Path $resolvedInstallPath)) {
+            Write-Message "Creating installation directory: $resolvedInstallPath" -Level Info
+            if ($PSCmdlet.ShouldProcess($resolvedInstallPath, "Create installation directory")) {
+                try {
+                    New-Item -ItemType Directory -Path $resolvedInstallPath -Force | Out-Null
+                }
+                catch {
+                    throw "Failed to create installation directory: $resolvedInstallPath - $($_.Exception.Message)"
+                }
+            }
+        }
 
         # Download and install the Aspire CLI
-        $targetOS = Install-AspireCli -InstallPath $InstallPath -Version $Version -Quality $Quality -OS $OS -Architecture $Architecture -KeepArchive:$KeepArchive
+        $targetOS = Install-AspireCli -InstallPath $resolvedInstallPath -Version $Version -Quality $Quality -OS $OS -Architecture $Architecture
 
         # Update PATH environment variables
-        Update-PathEnvironment -InstallPath $InstallPath -TargetOS $targetOS
+        Update-PathEnvironment -InstallPath $resolvedInstallPath -TargetOS $targetOS
     }
     catch {
-        Write-Message $_.Exception.Message -Level Error
-        throw
+        # Display clean error message without stack trace
+        Write-Message "Error: $($_.Exception.Message)" -Level Error
+        if ($InvokedFromFile) {
+            exit 1
+        } else {
+            return 1
+        }
     }
 }
 
@@ -715,12 +897,20 @@ try {
         Set-StrictMode -Off
     }
 
-    Main
+    Start-AspireCliInstallation
     $exitCode = 0
 }
 catch {
-    Write-Error $_
+    # Display clean error message without stack trace
+    Write-Message "Error: $($_.Exception.Message)" -Level Error
     $exitCode = 1
 }
 
-if ($InvokedFromFile) { exit $exitCode } else { if ($exitCode -ne 0) { return $exitCode } }
+if ($InvokedFromFile) {
+    exit $exitCode
+}
+else {
+    if ($exitCode -ne 0) {
+        return $exitCode
+    }
+}

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -75,7 +75,7 @@ DESCRIPTION:
     Running with `-Quality staging` will download the latest staging version, or the release version if no staging is available.
     Running with `-Quality dev` will download the latest dev build from `main`.
 
-    The default quality is `staging`.
+    The default quality is `release`.
 
     Pass a specific version to get CLI for that version.
 
@@ -850,7 +850,7 @@ function Start-AspireCliInstallation {
 
         # Set default quality to staging if not specified and no version is provided
         if ([string]::IsNullOrWhiteSpace($Version) -and [string]::IsNullOrWhiteSpace($Quality)) {
-            $Quality = "staging"
+            $Quality = "release"
         }
 
         # Additional parameter validation

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -111,6 +111,7 @@ EXAMPLES:
 
     # Piped execution
     Invoke-Expression "& { `$(Invoke-RestMethod https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.ps1) }"
+    Invoke-Expression "& { `$(Invoke-RestMethod https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.ps1) } -Quality staging"
 
 "@
     if ($InvokedFromFile) { exit 0 } else { return }

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -694,17 +694,17 @@ if [[ "$SHOW_HELP" == true ]]; then
     exit 0
 fi
 
-# Initialize default values after parsing arguments
-if [[ -z "$QUALITY" ]]; then
-    # Default quality to "staging" if not provided
-    QUALITY="staging"
-fi
-
 # Validate that both Version and Quality are not provided
 if [[ -n "$VERSION" && -n "$QUALITY" ]]; then
     say_error "Cannot specify both --version and --quality. Use --version for a specific version or --quality for a quality level."
     say_info "Use --help for usage information."
     exit 1
+fi
+
+# Initialize default values after parsing arguments
+if [[ -z "$QUALITY" ]]; then
+    # Default quality to "staging" if not provided
+    QUALITY="staging"
 fi
 
 # Set default install path if not provided

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -694,7 +694,7 @@ if [[ "$SHOW_HELP" == true ]]; then
     exit 0
 fi
 
-# Validate that both Version and Quality are not provided
+# Validate that both --version and --quality are not provided together
 if [[ -n "$VERSION" && -n "$QUALITY" ]]; then
     say_error "Cannot specify both --version and --quality. Use --version for a specific version or --quality for a quality level."
     say_info "Use --help for usage information."

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -32,11 +32,14 @@ show_help() {
 Aspire CLI Download Script
 
 DESCRIPTION:
-    Downloads and unpacks the Aspire CLI for the current platform from the specified version and quality.
+    Downloads and installs the Aspire CLI for the current platform from the specified version and quality.
+    Automatically updates the current session's PATH environment variable and supports GitHub Actions.
 
-    Running this without any arguments will download the latest stable version of the Aspire CLI for your platform and architecture.
-    Running with `-q staging` will download the latest staging version, or the GA version if no staging is available.
-    Running with `-q dev` will download the latest daily build from `main`.
+    Running with `-Quality release` download the latest release version of the Aspire CLI for your platform and architecture.
+    Running with `-Quality staging` will download the latest staging version, or the release version if no staging is available.
+    Running with `-Quality dev` will download the latest dev build from `main`.
+
+    The default quality is `staging`.
 
     Pass a specific version to get CLI for that version.
 
@@ -44,7 +47,7 @@ USAGE:
     ./get-aspire-cli.sh [OPTIONS]
 
     -i, --install-path PATH     Directory to install the CLI (default: $HOME/.aspire/bin)
-    -q, --quality QUALITY       Quality to download (default: staging). Supported values: dev, staging, ga
+    -q, --quality QUALITY       Quality to download (default: staging). Supported values: dev, staging, release
     --version VERSION           Version of the Aspire CLI to download (default: unset)
     --os OS                     Operating system (default: auto-detect)
     --arch ARCH                 Architecture (default: auto-detect)
@@ -582,11 +585,11 @@ construct_aspire_cli_url() {
             staging)
                 base_url="https://aka.ms/dotnet/9/aspire/rc/daily"
                 ;;
-            ga)
+            release)
                 base_url="https://aka.ms/dotnet/9/aspire/ga/daily"
                 ;;
             *)
-                say_error "Unsupported quality '$quality'. Supported values are: dev, staging, ga."
+                say_error "Unsupported quality '$quality'. Supported values are: dev, staging, release."
                 return 1
                 ;;
         esac

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -15,10 +15,10 @@ readonly GREEN='\033[0;32m'
 readonly YELLOW='\033[1;33m'
 readonly RESET='\033[0m'
 
-# Default values
+# Variables (defaults set after parsing arguments)
 INSTALL_PATH=""
 VERSION=""
-QUALITY="ga"
+QUALITY=""
 OS=""
 ARCH=""
 SHOW_HELP=false
@@ -34,8 +34,8 @@ DESCRIPTION:
     Downloads and unpacks the Aspire CLI for the current platform from the specified version and quality.
 
     Running this without any arguments will download the latest stable version of the Aspire CLI for your platform and architecture.
-    Running with `-q prerelease` will download the latest prerelease version, or the GA version if no prerelease is available.
-    Running with `-q daily` will download the latest daily build from `main`.
+    Running with `-q staging` will download the latest staging version, or the GA version if no staging is available.
+    Running with `-q dev` will download the latest daily build from `main`.
 
     Pass a specific version to get CLI for that version.
 
@@ -43,7 +43,7 @@ USAGE:
     ./get-aspire-cli.sh [OPTIONS]
 
     -i, --install-path PATH     Directory to install the CLI (default: $HOME/.aspire/bin)
-    -q, --quality QUALITY       Quality to download (default: ga). Supported values: daily, prerelease, ga
+    -q, --quality QUALITY       Quality to download (default: staging). Supported values: dev, staging, ga
     --version VERSION           Version of the Aspire CLI to download (default: unset)
     --os OS                     Operating system (default: auto-detect)
     --arch ARCH                 Architecture (default: auto-detect)
@@ -54,7 +54,7 @@ USAGE:
 EXAMPLES:
     ./get-aspire-cli.sh
     ./get-aspire-cli.sh --install-path "~/bin"
-    ./get-aspire-cli.sh --quality "prerelease"
+    ./get-aspire-cli.sh --quality "staging"
     ./get-aspire-cli.sh --version "9.5.0-preview.1.25366.3"
     ./get-aspire-cli.sh --os "linux" --arch "x64"
     ./get-aspire-cli.sh --keep-archive
@@ -537,9 +537,9 @@ construct_aspire_cli_url() {
     local base_url
     local filename
 
-    # Default quality to "ga" if empty
+    # Default quality to "staging" if empty
     if [[ -z "$quality" ]]; then
-        quality="ga"
+        quality="staging"
     fi
 
     # Add .sha512 to extension if checksum is true
@@ -550,17 +550,17 @@ construct_aspire_cli_url() {
     if [[ -z "$version" ]]; then
         # When version is not set use aka.ms URLs based on quality
         case "$quality" in
-            daily)
+            dev)
                 base_url="https://aka.ms/dotnet/9/aspire/daily"
                 ;;
-            prerelease)
+            staging)
                 base_url="https://aka.ms/dotnet/9/aspire/rc/daily"
                 ;;
             ga)
                 base_url="https://aka.ms/dotnet/9/aspire/ga/daily"
                 ;;
             *)
-                say_error "Unsupported quality '$quality'. Supported values are: daily, prerelease, ga."
+                say_error "Unsupported quality '$quality'. Supported values are: dev, staging, ga."
                 return 1
                 ;;
         esac

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -39,7 +39,7 @@ DESCRIPTION:
     Running with `-Quality staging` will download the latest staging version, or the release version if no staging is available.
     Running with `-Quality dev` will download the latest dev build from `main`.
 
-    The default quality is `staging`.
+    The default quality is `release`.
 
     Pass a specific version to get CLI for that version.
 
@@ -47,7 +47,7 @@ USAGE:
     ./get-aspire-cli.sh [OPTIONS]
 
     -i, --install-path PATH     Directory to install the CLI (default: $HOME/.aspire/bin)
-    -q, --quality QUALITY       Quality to download (default: staging). Supported values: dev, staging, release
+    -q, --quality QUALITY       Quality to download (default: release). Supported values: dev, staging, release
     --version VERSION           Version of the Aspire CLI to download (default: unset)
     --os OS                     Operating system (default: auto-detect)
     --arch ARCH                 Architecture (default: auto-detect)
@@ -566,11 +566,6 @@ construct_aspire_cli_url() {
     local base_url
     local filename
 
-    # Default quality to "staging" if empty
-    if [[ -z "$quality" ]]; then
-        quality="staging"
-    fi
-
     # Add .sha512 to extension if checksum is true
     if [[ "$checksum" == "true" ]]; then
         extension="${extension}.sha512"
@@ -706,8 +701,8 @@ fi
 
 # Initialize default values after parsing arguments
 if [[ -z "$QUALITY" ]]; then
-    # Default quality to "staging" if not provided
-    QUALITY="staging"
+    # Default quality to "release" if not provided
+    QUALITY="release"
 fi
 
 # Set default install path if not provided

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -24,6 +24,7 @@ ARCH=""
 SHOW_HELP=false
 VERBOSE=false
 KEEP_ARCHIVE=false
+DRY_RUN=false
 
 # Function to show help
 show_help() {
@@ -48,6 +49,7 @@ USAGE:
     --os OS                     Operating system (default: auto-detect)
     --arch ARCH                 Architecture (default: auto-detect)
     -k, --keep-archive          Keep downloaded archive files and temporary directory after installation
+    --dry-run                   Show what would be done without actually performing any actions
     -v, --verbose               Enable verbose output
     -h, --help                  Show this help message
 
@@ -58,6 +60,7 @@ EXAMPLES:
     ./get-aspire-cli.sh --version "9.5.0-preview.1.25366.3"
     ./get-aspire-cli.sh --os "linux" --arch "x64"
     ./get-aspire-cli.sh --keep-archive
+    ./get-aspire-cli.sh --dry-run
     ./get-aspire-cli.sh --help
 
     # Piped execution (like wget <url> | bash or curl <url> | bash):
@@ -120,6 +123,10 @@ parse_args() {
                 KEEP_ARCHIVE=true
                 shift
                 ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
             -v|--verbose)
                 VERBOSE=true
                 shift
@@ -156,7 +163,6 @@ say_info() {
     echo -e "$1" >&2
 }
 
-# Function to detect OS
 detect_os() {
     local uname_s
     uname_s=$(uname -s)
@@ -208,7 +214,6 @@ get_cli_architecture_from_architecture() {
     esac
 }
 
-# Function to detect architecture
 detect_architecture() {
     local uname_m
     uname_m=$(uname -m)
@@ -301,6 +306,11 @@ download_file() {
     local validate_content_type="${5:-true}"
     local use_temp_file="${6:-true}"
 
+    if [[ "$DRY_RUN" == true ]]; then
+        say_info "[DRY RUN] Would download $url"
+        return 0
+    fi
+
     local target_file="$output_path"
     if [[ "$use_temp_file" == true ]]; then
         target_file="${output_path}.tmp"
@@ -326,7 +336,7 @@ download_file() {
         say_verbose "Successfully downloaded file to: $output_path"
         return 0
     else
-        say_error "Failed to download $url to $output_path"
+        say_error "Failed to download $url"
         return 1
     fi
 }
@@ -335,6 +345,11 @@ download_file() {
 validate_checksum() {
     local archive_file="$1"
     local checksum_file="$2"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        say_info "[DRY RUN] Would validate checksum of $archive_file using $checksum_file"
+        return 0
+    fi
 
     # Determine the checksum command to use
     local checksum_cmd=""
@@ -379,6 +394,11 @@ install_archive() {
     local archive_file="$1"
     local destination_path="$2"
     local os="$3"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        say_info "[DRY RUN] Would install archive $archive_file to $destination_path"
+        return 0
+    fi
 
     say_verbose "Installing archive to: $destination_path"
 
@@ -425,6 +445,12 @@ add_to_path()
     local config_file="$1"
     local bin_path="$2"
     local command="$3"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        say_info "[DRY RUN] Would check if $bin_path is already in \$PATH"
+        say_info "[DRY RUN] Would add '$command' to $config_file if not already present"
+        return 0
+    fi
 
     if [[ ":$PATH:" == *":$bin_path:"* ]]; then
         say_info "Path $bin_path already exists in \$PATH, skipping addition"
@@ -641,7 +667,9 @@ download_and_install_archive() {
         return 1
     fi
 
-    say_verbose "Successfully downloaded and validated: $filename"
+    if [[ "$DRY_RUN" != true ]]; then
+        say_verbose "Successfully downloaded and validated: $filename"
+    fi
 
     # Install the archive
     if ! install_archive "$filename" "$INSTALL_PATH" "$os"; then
@@ -661,14 +689,19 @@ download_and_install_archive() {
 # Parse command line arguments
 parse_args "$@"
 
-# Show help if requested
 if [[ "$SHOW_HELP" == true ]]; then
     show_help
     exit 0
 fi
 
+# Initialize default values after parsing arguments
+if [[ -z "$QUALITY" ]]; then
+    # Default quality to "staging" if not provided
+    QUALITY="staging"
+fi
+
 # Validate that both Version and Quality are not provided
-if [[ -n "$VERSION" && "$QUALITY" != "ga" ]]; then
+if [[ -n "$VERSION" && -n "$QUALITY" ]]; then
     say_error "Cannot specify both --version and --quality. Use --version for a specific version or --quality for a quality level."
     say_info "Use --help for usage information."
     exit 1
@@ -683,12 +716,21 @@ else
 fi
 
 # Create a temporary directory for downloads
-temp_dir=$(mktemp -d -t aspire-cli-download-XXXXXXXX)
-say_verbose "Creating temporary directory: $temp_dir"
+if [[ "$DRY_RUN" == true ]]; then
+    temp_dir="/tmp/aspire-cli-dry-run"
+else
+    temp_dir=$(mktemp -d -t aspire-cli-download-XXXXXXXX)
+    say_verbose "Creating temporary directory: $temp_dir"
+fi
 
 # Cleanup function for temporary directory
 cleanup() {
     # shellcheck disable=SC2317  # Function is called via trap
+    if [[ "$DRY_RUN" == true ]]; then
+        # No cleanup needed in dry-run mode
+        return 0
+    fi
+
     if [[ -n "${temp_dir:-}" ]] && [[ -d "$temp_dir" ]]; then
         if [[ "$KEEP_ARCHIVE" != true ]]; then
             say_verbose "Cleaning up temporary files..."
@@ -710,8 +752,12 @@ fi
 # Handle GitHub Actions environment
 if [[ -n "${GITHUB_ACTIONS:-}" ]] && [[ "${GITHUB_ACTIONS}" == "true" ]]; then
     if [[ -n "${GITHUB_PATH:-}" ]]; then
-        echo "$INSTALL_PATH" >> "$GITHUB_PATH"
-        say_verbose "Added $INSTALL_PATH to \$GITHUB_PATH"
+        if [[ "$DRY_RUN" == true ]]; then
+            say_info "[DRY RUN] Would add $INSTALL_PATH to \$GITHUB_PATH"
+        else
+            echo "$INSTALL_PATH" >> "$GITHUB_PATH"
+            say_verbose "Added $INSTALL_PATH to \$GITHUB_PATH"
+        fi
     fi
 fi
 
@@ -720,5 +766,9 @@ add_to_shell_profile "$INSTALL_PATH" "$INSTALL_PATH_UNEXPANDED"
 
 # Add to current session PATH, if the path is not already in PATH
 if [[ ":$PATH:" != *":$INSTALL_PATH:"* ]]; then
-    export PATH="$INSTALL_PATH:$PATH"
+    if [[ "$DRY_RUN" == true ]]; then
+        say_info "[DRY RUN] Would add $INSTALL_PATH to PATH"
+    else
+        export PATH="$INSTALL_PATH:$PATH"
+    fi
 fi


### PR DESCRIPTION
## Key Changes

### 1. **Quality Level Behavior**
- **`dev`**: Downloads latest development builds from the `main` branch
- **`staging`**: Downloads release candidate builds (rc/daily)  
- **`ga`**: Downloads generally available release builds (ga/daily)
- **Default**: `staging` quality is used when no quality is specified

### 2. **Updated URL Mappings for Quality Levels**
- **PowerShell Script (`get-aspire-cli.ps1`)**:
  - `dev` quality now maps to: `https://aka.ms/dotnet/9/aspire/daily`
  - `staging` quality now maps to: `https://aka.ms/dotnet/9/aspire/rc/daily` 
  - `ga` quality now maps to: `https://aka.ms/dotnet/9/aspire/ga/daily`

- **Bash Script (`get-aspire-cli.sh`)**:
  - Updated with corresponding URL mappings to match PowerShell script
  - Consistent quality-to-URL mapping across both script implementations

### 3. **Support for -WhatIf and --dry-run**
- This will be useful for testing

### 4. **Code Quality Improvements**
The code has been made more idiomatic in many ways:
- Better PowerShell coding practices and conventions
- Improved error handling patterns
- Enhanced cross-platform compatibility
- More robust parameter validation
- Cleaner function organization and separation of concerns
