### PR TITLE
Change CompleteInteractionAsync answers to object

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostBackchannel.cs
@@ -20,7 +20,7 @@ internal interface IAppHostBackchannel
     Task ConnectAsync(string socketPath, CancellationToken cancellationToken);
     IAsyncEnumerable<PublishingActivity> GetPublishingActivitiesAsync(CancellationToken cancellationToken);
     Task<string[]> GetCapabilitiesAsync(CancellationToken cancellationToken);
-    Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken);
+    Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
     IAsyncEnumerable<CommandOutput> ExecAsync(CancellationToken cancellationToken);
 }
 
@@ -182,7 +182,7 @@ internal sealed class AppHostBackchannel(ILogger<AppHostBackchannel> logger, Asp
         return capabilities;
     }
 
-    public async Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken)
+    public async Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken)
     {
         using var activity = telemetry.ActivitySource.StartActivity();
         var rpc = await _rpcTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
@@ -23,6 +23,7 @@ namespace Aspire.Cli.Backchannel;
 [JsonSerializable(typeof(MessageFormatterEnumerableTracker.EnumeratorResults<PublishingActivity>))]
 [JsonSerializable(typeof(RequestId))]
 [JsonSerializable(typeof(IEnumerable<DisplayLineState>))]
+[JsonSerializable(typeof(PublishingPromptInputAnswer[]))]
 [JsonSerializable(typeof(ValidationResult))]
 [JsonSerializable(typeof(IAsyncEnumerable<CommandOutput>))]
 [JsonSerializable(typeof(MessageFormatterEnumerableTracker.EnumeratorResults<CommandOutput>))]

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -432,7 +432,7 @@ internal abstract class PublishCommandBase : BaseCommand
         }
 
         // Handle multiple inputs
-        var results = new string?[inputs.Count];
+        var answers = new PublishingPromptInputAnswer[inputs.Count];
         for (var i = 0; i < inputs.Count; i++)
         {
             var input = inputs[i];
@@ -456,11 +456,14 @@ internal abstract class PublishCommandBase : BaseCommand
                 result = input.Value;
             }
 
-            results[i] = result;
+            answers[i] = new PublishingPromptInputAnswer
+            {
+                Value = result
+            };
         }
 
         // Send all results as an array
-        await backchannel.CompletePromptResponseAsync(activity.Data.Id, results, cancellationToken);
+        await backchannel.CompletePromptResponseAsync(activity.Data.Id, answers, cancellationToken);
     }
 
     private async Task<string?> HandleSingleInputAsync(PublishingPromptInput input, string promptText, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -198,7 +198,7 @@ internal class AppHostRpcTarget(
     }
 #pragma warning restore CA1822
 
-    public async Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken = default)
+    public async Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken = default)
     {
         await activityReporter.CompleteInteractionAsync(promptId, answers, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -205,3 +205,8 @@ internal struct CommandOutput
 
     public int? ExitCode { get; init; }
 }
+
+internal class PublishingPromptInputAnswer
+{
+    public string? Value { get; set; }
+}

--- a/src/Aspire.Hosting/Publishing/PublishingActivityReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityReporter.cs
@@ -311,7 +311,7 @@ internal sealed class PublishingActivityReporter : IPublishingActivityReporter, 
         }
     }
 
-    internal async Task CompleteInteractionAsync(string promptId, string?[]? responses, CancellationToken cancellationToken = default)
+    internal async Task CompleteInteractionAsync(string promptId, PublishingPromptInputAnswer[]? responses, CancellationToken cancellationToken = default)
     {
         if (int.TryParse(promptId, CultureInfo.InvariantCulture, out var interactionId))
         {
@@ -325,7 +325,7 @@ internal sealed class PublishingActivityReporter : IPublishingActivityReporter, 
                         {
                             for (var i = 0; i < Math.Min(inputsInfo.Inputs.Count, responses.Length); i++)
                             {
-                                inputsInfo.Inputs[i].Value = responses[i] ?? "";
+                                inputsInfo.Inputs[i].Value = responses[i].Value ?? "";
                             }
                         }
 

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -61,7 +61,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("text-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("production", completedPrompt.Answers[0]);
+        Assert.Equal("production", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -107,7 +107,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("secret-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("SecurePassword123!", completedPrompt.Answers[0]);
+        Assert.Equal("SecurePassword123!", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -160,7 +160,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("choice-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("us-east-1", completedPrompt.Answers[0]);
+        Assert.Equal("us-east-1", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -206,7 +206,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("bool-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("true", completedPrompt.Answers[0]);
+        Assert.Equal("true", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -252,7 +252,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("number-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("3", completedPrompt.Answers[0]);
+        Assert.Equal("3", completedPrompt.Answers[0].Value);
     }
 
     [Fact]
@@ -321,13 +321,13 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Equal(3, promptBackchannel.CompletedPrompts.Count);
 
         Assert.Equal("text-prompt-1", promptBackchannel.CompletedPrompts[0].PromptId);
-        Assert.Equal("MyTestApp", promptBackchannel.CompletedPrompts[0].Answers[0]);
+        Assert.Equal("MyTestApp", promptBackchannel.CompletedPrompts[0].Answers[0].Value);
 
         Assert.Equal("choice-prompt-1", promptBackchannel.CompletedPrompts[1].PromptId);
-        Assert.Equal("prod", promptBackchannel.CompletedPrompts[1].Answers[0]);
+        Assert.Equal("prod", promptBackchannel.CompletedPrompts[1].Answers[0].Value);
 
         Assert.Equal("bool-prompt-1", promptBackchannel.CompletedPrompts[2].PromptId);
-        Assert.Equal("true", promptBackchannel.CompletedPrompts[2].Answers[0]);
+        Assert.Equal("true", promptBackchannel.CompletedPrompts[2].Answers[0].Value);
     }
 
     [Fact]
@@ -408,10 +408,10 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("multi-input-prompt-1", completedPrompt.PromptId);
         Assert.Equal(4, completedPrompt.Answers.Length);
-        Assert.Equal("Server=localhost;Database=MyApp;", completedPrompt.Answers[0]);
-        Assert.Equal("secret-api-key-12345", completedPrompt.Answers[1]);
-        Assert.Equal("staging", completedPrompt.Answers[2]);
-        Assert.Equal("true", completedPrompt.Answers[3]);
+        Assert.Equal("Server=localhost;Database=MyApp;", completedPrompt.Answers[0].Value);
+        Assert.Equal("secret-api-key-12345", completedPrompt.Answers[1].Value);
+        Assert.Equal("staging", completedPrompt.Answers[2].Value);
+        Assert.Equal("true", completedPrompt.Answers[3].Value);
     }
 
     [Fact]
@@ -458,7 +458,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("text-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("development", completedPrompt.Answers[0]);
+        Assert.Equal("development", completedPrompt.Answers[0].Value);
 
         // Verify that the PromptForStringAsync was called with the default value
         var promptCalls = consoleService.StringPromptCalls;
@@ -512,7 +512,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Single(promptBackchannel.CompletedPrompts);
         var completedPrompt = promptBackchannel.CompletedPrompts[0];
         Assert.Equal("text-prompt-1", completedPrompt.PromptId);
-        Assert.Equal("development", completedPrompt.Answers[0]);
+        Assert.Equal("development", completedPrompt.Answers[0].Value);
 
         // Verify that the PromptForStringAsync was called with the default value
         var promptCalls = consoleService.StringPromptCalls;
@@ -608,7 +608,7 @@ internal sealed class TestPromptBackchannel : IAppHostBackchannel
         _completionSource.SetResult();
     }
 
-    public Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken)
+    public Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken)
     {
         CompletedPrompts.Add(new PromptCompletion(promptId, answers));
         if (_promptCompletionSources.TryGetValue(promptId, out var completionSource))
@@ -647,7 +647,7 @@ internal sealed class TestPromptBackchannel : IAppHostBackchannel
 // Data structures for tracking prompts
 internal sealed record PromptInputData(string Label, string InputType, bool IsRequired, IReadOnlyList<KeyValuePair<string, string>>? Options = null, string? Value = null, IReadOnlyList<string>? ValidationErrors = null);
 internal sealed record PromptData(string PromptId, IReadOnlyList<PromptInputData> Inputs, string Message, string? Title = null);
-internal sealed record PromptCompletion(string PromptId, string?[] Answers);
+internal sealed record PromptCompletion(string PromptId, PublishingPromptInputAnswer[] Answers);
 
 // Enhanced TestConsoleInteractionService that tracks interaction types
 [SuppressMessage("Usage", "ASPIREINTERACTION001:Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostBackchannel.cs
@@ -226,7 +226,7 @@ internal sealed class TestAppHostBackchannel : IAppHostBackchannel
         }
     }
 
-    public Task CompletePromptResponseAsync(string promptId, string?[] answers, CancellationToken cancellationToken)
+    public Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
     }

--- a/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PublishingActivityReporterTests.cs
@@ -481,7 +481,7 @@ public class PublishingActivityReporterTests
         Assert.Equal("text-label", input.Label);
         Assert.Equal("Text", input.InputType);
 
-        var responses = new string[] { "user-response" };
+        var responses = new PublishingPromptInputAnswer[] { new PublishingPromptInputAnswer { Value = "user-response" } };
 
         // Act
         await reporter.CompleteInteractionAsync(promptId, responses, CancellationToken.None).DefaultTimeout();


### PR DESCRIPTION
## Description

Change `CompletePromptResponseAsync` answers to object array instead of a string array so new properties can be added to an answer.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
