### PR TITLE
Improve display of error log entries on trace details

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -228,13 +228,14 @@
                                                         var eventName = StructureLogsDetailsViewModel.GetEventName(item.LogEntry, StructuredLogsLoc);
                                                         var isSelected = SelectedData?.LogEntryViewModel?.LogEntry.InternalId == item.LogEntry.InternalId;
                                                         var htmlTooltip = item.Index < 500;
+                                                        var buttonColor = item.LogEntry.IsError ? "var(--error)" : spanColor;
 
                                                         <button id="@buttonId"
                                                                 title="@(!htmlTooltip ? $"{eventName} - {item.LogEntry.Scope.Name}" : string.Empty)"
                                                                 aria-label="@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails)]"
-                                                                class="@($"span-log-entry-button {(isSelected ? "span-log-entry-selected" : null)}")"
+                                                                class="@($"span-log-entry-button {(isSelected ? "span-log-entry-selected" : null)} {(item.LogEntry.IsError ? "span-log-entry-error" : null)}")"
                                                                 data-span-color="@spanColor"
-                                                                style="@($"left: {@item.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)}%; --span-color: {spanColor}")"
+                                                                style="@($"left: {@item.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)}%; --button-color: {buttonColor};")"
                                                                 @onclick="@(() => ToggleSpanLogsAsync(item.LogEntry))"
                                                                 @onclick:stopPropagation="true">
                                                         </button>
@@ -245,7 +246,7 @@
                                                         *@
                                                         @if (htmlTooltip)
                                                         {
-                                                            <FluentTooltip Anchor="@buttonId" MaxWidth="400px">
+                                                            <FluentTooltip Anchor="@buttonId" MaxWidth="350px">
                                                                 <div class="log-tooltip-title-container">
                                                                     <span class="log-tooltip-title">@eventName</span> <span class="log-tooltip-subtitle">@item.LogEntry.Scope.Name</span><br />
                                                                 </div>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -284,7 +284,11 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     private string GetRowClass(SpanWaterfallViewModel viewModel)
     {
         // Test with id rather than the object reference because the data and view model objects are recreated on trace updates.
-        if (viewModel.Span.SpanId == SelectedData?.SpanViewModel?.Span.SpanId)
+        if (SelectedData?.SpanViewModel is { } selectedSpan && selectedSpan.Span.SpanId == viewModel.Span.SpanId)
+        {
+            return "selected-row";
+        }
+        else if (SelectedData?.LogEntryViewModel is { } selectedLog && viewModel.SpanLogs.Any(l => l.LogEntry.InternalId == selectedLog.LogEntry.InternalId))
         {
             return "selected-row";
         }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -221,6 +221,18 @@
     background: color-mix(in srgb, var(--button-color), white 50%);
 }
 
+::deep .span-log-entry-error {
+    opacity: 1;
+    /* Error log entries appear above non-error log entries */
+    z-index: 1;
+    background: color-mix(in srgb, var(--button-color), white 15%);
+    border-color: color-mix(in srgb, var(--button-color), black 50%);
+}
+
+::deep .span-log-entry-error:hover {
+    background: color-mix(in srgb, var(--button-color), white 30%);
+}
+
 ::deep .span-log-entry-selected {
     opacity: 1;
     background: color-mix(in srgb, var(--button-color), white 50%);
@@ -228,10 +240,8 @@
     height: 20px;
 }
 
-::deep .span-log-entry-error {
-    opacity: 1;
-    /* Error log entries appear above non-error log entries */
-    z-index: 1;
+::deep .span-log-entry-selected.span-log-entry-error {
+    background: color-mix(in srgb, var(--button-color), white 30%);
 }
 
 ::deep .log-tooltip-title {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -212,25 +212,31 @@
     align-self: center;
     opacity: 0.8;
     transform: translateX(-50%);
-    background: color-mix(in srgb, var(--span-color), white 30%);
-    border-color: color-mix(in srgb, var(--span-color), black 50%);
+    background: color-mix(in srgb, var(--button-color), white 30%);
+    border-color: color-mix(in srgb, var(--button-color), black 50%);
 }
 
 ::deep .span-log-entry-button:hover {
     opacity: 1;
-    background: color-mix(in srgb, var(--span-color), white 50%);
+    background: color-mix(in srgb, var(--button-color), white 50%);
 }
 
 ::deep .span-log-entry-selected {
     opacity: 1;
-    background: color-mix(in srgb, var(--span-color), white 50%);
+    background: color-mix(in srgb, var(--button-color), white 50%);
     width: 20px;
     height: 20px;
 }
 
+::deep .span-log-entry-error {
+    opacity: 1;
+    /* Error log entries appear above non-error log entries */
+    z-index: 1;
+}
+
 ::deep .log-tooltip-title {
     font-weight: bold;
-    font-size: 16px;
+    font-size: 15px;
 }
 
 ::deep .log-tooltip-subtitle {
@@ -243,7 +249,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    margin-bottom: 8px;
+    margin-bottom: 4px;
     margin-top: 4px;
 }
 
@@ -251,6 +257,7 @@
     margin-bottom: 0;
     width: 100%;
     table-layout: fixed;
+    font-size: 12px;
 }
 
 ::deep.log-tooltip-table td:nth-child(1) {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogLevelColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogLevelColumnDisplay.razor
@@ -4,11 +4,11 @@
 @using Aspire.Dashboard.Resources
 @using Microsoft.Extensions.Logging
 
-@if (LogEntry.Severity is LogLevel.Error or LogLevel.Critical)
+@if (LogEntry.IsError)
 {
     <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="severity-icon"/>
 }
-else if (LogEntry.Severity is LogLevel.Warning)
+else if (LogEntry.IsWarning)
 {
     <FluentIcon Icon="Icons.Filled.Size16.Warning" Color="Color.Warning" Class="severity-icon"/>
 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -24,6 +24,8 @@ public class OtlpLogEntry
     public OtlpApplicationView ApplicationView { get; }
     public OtlpScope Scope { get; }
     public long InternalId { get; }
+    public bool IsError => Severity is LogLevel.Error or LogLevel.Critical;
+    public bool IsWarning => Severity is LogLevel.Warning;
 
     public OtlpLogEntry(LogRecord record, OtlpApplicationView logApp, OtlpScope scope, OtlpContext context)
     {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -368,7 +368,7 @@ public sealed class TelemetryRepository : IDisposable
                         // For log entries error and above, increment the unviewed count if there are no read log subscriptions for the application.
                         // We don't increment the count if there are active read subscriptions because the count will be quickly decremented when the subscription callback is run.
                         // Notifying the user there are errors and then immediately clearing the notification is confusing.
-                        if (logEntry.Severity >= LogLevel.Error)
+                        if (logEntry.IsError)
                         {
                             if (!_logSubscriptions.Any(s => s.SubscriptionType == SubscriptionType.Read && (s.ApplicationKey == applicationView.ApplicationKey || s.ApplicationKey == null)))
                             {


### PR DESCRIPTION
## Description

* Errors logs have a different color and they have a z-index to appear above other non-error log entries.
* Tweak sizes in tooltip
* Select row when log entry is selected.

<img width="1464" height="825" alt="image" src="https://github.com/user-attachments/assets/ecb02a81-d483-437c-845f-e87a9b73b234" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
