### PR TITLE
Fix interaction provider in dashboard handling duplicate messages

### DIFF
--- a/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
+++ b/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIRECOMPUTE001
 #pragma warning disable ASPIREINTERACTION001
 
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 internal static class IDistributedApplicationBuilderExtensions
@@ -88,6 +89,8 @@ internal static class IDistributedApplicationBuilderExtensions
             var appName = multiInputResult.Canceled ? "default-app" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "Application Name")?.Value ?? "default-app");
             var appVersion = multiInputResult.Canceled ? "1.0.0" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "Application Version")?.Value ?? "1.0.0");
             var sslType = multiInputResult.Canceled ? "self-signed" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "SSL Certificate Type")?.Value ?? "self-signed");
+
+            Debugger.Launch();
 
             // Test Text input
             var envResult = await interactionService.PromptInputAsync(

--- a/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
+++ b/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
@@ -5,7 +5,6 @@
 #pragma warning disable ASPIRECOMPUTE001
 #pragma warning disable ASPIREINTERACTION001
 
-using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 internal static class IDistributedApplicationBuilderExtensions
@@ -90,7 +89,6 @@ internal static class IDistributedApplicationBuilderExtensions
             var appVersion = multiInputResult.Canceled ? "1.0.0" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "Application Version")?.Value ?? "1.0.0");
             var sslType = multiInputResult.Canceled ? "self-signed" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "SSL Certificate Type")?.Value ?? "self-signed");
 
-            Debugger.Launch();
 
             // Test Text input
             var envResult = await interactionService.PromptInputAsync(

--- a/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
+++ b/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
@@ -89,7 +89,6 @@ internal static class IDistributedApplicationBuilderExtensions
             var appVersion = multiInputResult.Canceled ? "1.0.0" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "Application Version")?.Value ?? "1.0.0");
             var sslType = multiInputResult.Canceled ? "self-signed" : (multiInputResult.Data?.FirstOrDefault(i => i.Label == "SSL Certificate Type")?.Value ?? "self-signed");
 
-
             // Test Text input
             var envResult = await interactionService.PromptInputAsync(
                 "Environment Configuration",

--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -332,11 +332,11 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
                     case WatchInteractionsResponseUpdate.KindOneofCase.MessageBox:
                     case WatchInteractionsResponseUpdate.KindOneofCase.InputsDialog:
                         if (_interactionDialogReference != null &&
-                            _interactionDialogReference.InteractionId == item.InteractionId)
+                            _interactionDialogReference.InteractionId == item.InteractionId &&
+                            _interactionDialogReference.Dialog.Instance.Content is InteractionsInputsDialogViewModel inputsVM)
                         {
                             // If the dialog is already open for this interaction, update it with the new data.
-                            var c = (InteractionsInputsDialogViewModel)_interactionDialogReference.Dialog.Instance.Content;
-                            await c.UpdateInteractionAsync(item);
+                            await inputsVM.UpdateInteractionAsync(item);
                         }
                         else
                         {

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestDialogService.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestDialogService.cs
@@ -65,14 +65,25 @@ public class TestDialogService : IDialogService
         throw new NotImplementedException();
     }
 
-    public Task<IDialogReference> ShowDialogAsync<TData>(Type dialogComponent, TData data, DialogParameters parameters) where TData : class
+    public async Task<IDialogReference> ShowDialogAsync<TData>(Type dialogComponent, TData data, DialogParameters parameters) where TData : class
     {
-        return _onShowDialog?.Invoke(data, parameters) ?? throw new InvalidOperationException("No dialog callback specified.");
+        return await RunShowDialogCallbackAsync(dialogComponent, data, parameters);
     }
 
-    public Task<IDialogReference> ShowDialogAsync<TDialog>(object data, DialogParameters parameters) where TDialog : IDialogContentComponent
+    public async Task<IDialogReference> ShowDialogAsync<TDialog>(object data, DialogParameters parameters) where TDialog : IDialogContentComponent
     {
-        return _onShowDialog?.Invoke(data, parameters) ?? throw new InvalidOperationException("No dialog callback specified.");
+        return await RunShowDialogCallbackAsync(typeof(TDialog), data, parameters);
+    }
+
+    private async Task<IDialogReference> RunShowDialogCallbackAsync(Type dialogComponent, object data, DialogParameters parameters)
+    {
+        if (_onShowDialog == null)
+        {
+            throw new InvalidOperationException("No dialog callback specified.");
+        }
+        var reference = await _onShowDialog.Invoke(data, parameters);
+        reference.Instance = new DialogInstance(dialogComponent, parameters, data);
+        return reference;
     }
 
     public Task<IDialogReference> ShowDialogAsync<TDialog>(DialogParameters parameters) where TDialog : IDialogContentComponent

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestMessageService.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestMessageService.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Tests.Shared;
+
+public class TestMessageService : IMessageService
+{
+    private readonly Func<MessageOptions, Task<Message>>? _onShowMessage;
+
+    public TestMessageService(Func<MessageOptions, Task<Message>>? onShowMessage = null)
+    {
+        _onShowMessage = onShowMessage;
+    }
+
+    public IEnumerable<Message> AllMessages { get; } = Enumerable.Empty<Message>();
+
+#pragma warning disable CS0067
+    public event Action? OnMessageItemsUpdated;
+    public event Func<Task>? OnMessageItemsUpdatedAsync;
+#pragma warning restore CS0067
+
+    public void Clear(string? section = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public int Count(string? section)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+
+    public IEnumerable<Message> MessagesToShow(int count = 5, string? section = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Remove(Message message)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Message ShowMessageBar(Action<MessageOptions> options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Message ShowMessageBar(string title)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Message ShowMessageBar(string title, MessageIntent intent)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Message ShowMessageBar(string title, MessageIntent intent, string section)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<Message> ShowMessageBarAsync(Action<MessageOptions> options)
+    {
+        var messageOptions = new MessageOptions();
+        options(messageOptions);
+
+        return _onShowMessage?.Invoke(messageOptions) ?? throw new InvalidOperationException("No dialog callback specified.");
+    }
+
+    public Task<Message> ShowMessageBarAsync(string title)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<Message> ShowMessageBarAsync(string title, MessageIntent intent)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<Message> ShowMessageBarAsync(string title, MessageIntent intent, string section)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## Description

If there is a connection error then the dashboard will reconnect and re-download all pending interactions again.

Fix is to ensure interactions are fine if message is replayed (i.e. check if notification is already displayed in message bar).

Error:

```
fail: Aspire.Hosting.Dashboard.ServiceClient.DashboardClient[0]
      Error #1 watching resources.
      Grpc.Core.RpcException: Status(StatusCode="Internal", Detail="Error reading next message. HttpProtocolException: The HTTP/2 server sent invalid data on the
connection. HTTP/2 error code 'PROTOCOL_ERROR' (0x1). (HttpProtocolError)", DebugException="System.Net.Http.HttpProtocolException: The HTTP/2 server sent invalid data
on the connection. HTTP/2 error code 'PROTOCOL_ERROR' (0x1). (HttpProtocolError)")
       ---> System.Net.Http.HttpProtocolException: The HTTP/2 server sent invalid data on the connection. HTTP/2 error code 'PROTOCOL_ERROR' (0x1). (HttpProtocolError)
         at Grpc.Net.Client.Internal.StreamExtensions.ReadMessageAsync[TResponse](Stream responseStream, GrpcCall call, Func`2 deserializer, String grpcEncoding,
Boolean singleMessage, CancellationToken cancellationToken)
         at Grpc.Net.Client.Internal.GrpcCall`2.ReadMessageAsync(Stream responseStream, String grpcEncoding, Boolean singleMessage, CancellationToken cancellationToken)
         at Grpc.Net.Client.Internal.GrpcCall`2.ReadMessageAsync(Stream responseStream, String grpcEncoding, Boolean singleMessage, CancellationToken cancellationToken)
         at Grpc.Net.Client.Internal.HttpContentClientStreamReader`2.MoveNextCore(CancellationToken cancellationToken)
         --- End of inner exception stack trace ---
         at Grpc.Net.Client.Internal.HttpContentClientStreamReader`2.MoveNextCore(CancellationToken cancellationToken)
         at Grpc.Net.Client.Internal.Retry.RetryCallBaseClientStreamReader`2.MoveNext(CancellationToken cancellationToken)
         at Grpc.Core.AsyncStreamReaderExtensions.ReadAllAsyncCore[T](IAsyncStreamReader`1 streamReader, CancellationToken cancellationToken)+MoveNext()
         at Grpc.Core.AsyncStreamReaderExtensions.ReadAllAsyncCore[T](IAsyncStreamReader`1 streamReader, CancellationToken
cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
         at Aspire.Dashboard.ServiceClient.DashboardClient.WatchInteractionsAsync(RetryContext retryContext, CancellationToken cancellationToken) in
C:\dev\git\aspire\src\Aspire.Dashboard\ServiceClient\DashboardClient.cs:line 470
         at Aspire.Dashboard.ServiceClient.DashboardClient.WatchInteractionsAsync(RetryContext retryContext, CancellationToken cancellationToken) in
C:\dev\git\aspire\src\Aspire.Dashboard\ServiceClient\DashboardClient.cs:line 470
         at Aspire.Dashboard.ServiceClient.DashboardClient.WatchWithRecoveryAsync(Func`3 action, CancellationToken cancellationToken) in
C:\dev\git\aspire\src\Aspire.Dashboard\ServiceClient\DashboardClient.cs:line 321
fail: Aspire.Hosting.Dashboard.ServiceClient.DashboardClient[0]
      Error #1 watching resources.
      Grpc.Core.RpcException: Status(StatusCode="Internal", Detail="Error reading next message. HttpProtocolException: The HTTP/2 server sent invalid data on the
connection. HTTP/2 error code 'PROTOCOL_ERROR' (0x1). (HttpProtocolError)", DebugException="System.Net.Http.HttpProtocolException: The HTTP/2 server sent invalid data
on the connection. HTTP/2 error code 'PROTOCOL_ERROR' (0x1). (HttpProtocolError)")
       ---> System.Net.Http.HttpProtocolException: The HTTP/2 server sent invalid data on the connection. HTTP/2 error code 'PROTOCOL_ERROR' (0x1). (HttpProtocolError)
         at Grpc.Net.Client.Internal.StreamExtensions.ReadMessageAsync[TResponse](Stream responseStream, GrpcCall call, Func`2 deserializer, String grpcEncoding,
Boolean singleMessage, CancellationToken cancellationToken)
         at Grpc.Net.Client.Internal.GrpcCall`2.ReadMessageAsync(Stream responseStream, String grpcEncoding, Boolean singleMessage, CancellationToken cancellationToken)
         at Grpc.Net.Client.Internal.GrpcCall`2.ReadMessageAsync(Stream responseStream, String grpcEncoding, Boolean singleMessage, CancellationToken cancellationToken)
         at Grpc.Net.Client.Internal.HttpContentClientStreamReader`2.MoveNextCore(CancellationToken cancellationToken)
         --- End of inner exception stack trace ---
         at Grpc.Net.Client.Internal.HttpContentClientStreamReader`2.MoveNextCore(CancellationToken cancellationToken)
         at Grpc.Net.Client.Internal.Retry.RetryCallBaseClientStreamReader`2.MoveNext(CancellationToken cancellationToken)
         at Grpc.Core.AsyncStreamReaderExtensions.ReadAllAsyncCore[T](IAsyncStreamReader`1 streamReader, CancellationToken cancellationToken)+MoveNext()
         at Grpc.Core.AsyncStreamReaderExtensions.ReadAllAsyncCore[T](IAsyncStreamReader`1 streamReader, CancellationToken
cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
         at Aspire.Dashboard.ServiceClient.DashboardClient.WatchResourcesAsync(RetryContext retryContext, CancellationToken cancellationToken) in
C:\dev\git\aspire\src\Aspire.Dashboard\ServiceClient\DashboardClient.cs:line 350
         at Aspire.Dashboard.ServiceClient.DashboardClient.WatchResourcesAsync(RetryContext retryContext, CancellationToken cancellationToken) in
C:\dev\git\aspire\src\Aspire.Dashboard\ServiceClient\DashboardClient.cs:line 350
         at Aspire.Dashboard.ServiceClient.DashboardClient.WatchWithRecoveryAsync(Func`3 action, CancellationToken cancellationToken) in
C:\dev\git\aspire\src\Aspire.Dashboard\ServiceClient\DashboardClient.cs:line 321
fail: Aspire.Hosting.Dashboard.Components.Interactions.InteractionsProvider[0]
      Unexpected error while watching interactions.
      System.ArgumentException: An item with the same key has already been added. Key: 1
         at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
         at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
         at System.Collections.ObjectModel.KeyedCollection`2.AddKey(TKey key, TItem item)
         at System.Collections.ObjectModel.KeyedCollection`2.InsertItem(Int32 index, TItem item)
         at Aspire.Dashboard.Components.Interactions.InteractionsProvider.WatchInteractionsAsync() in
C:\dev\git\aspire\src\Aspire.Dashboard\Components\Interactions\InteractionsProvider.cs:line 435
         at Aspire.Dashboard.Components.Interactions.InteractionsProvider.WatchInteractionsAsync() in
C:\dev\git\aspire\src\Aspire.Dashboard\Components\Interactions\InteractionsProvider.cs:line 311
         at Aspire.Dashboard.Components.Interactions.InteractionsProvider.<OnInitialized>b__35_1() in
C:\dev\git\aspire\src\Aspire.Dashboard\Components\Interactions\InteractionsProvider.cs:line 100
fail: Aspire.Hosting.Dashboard.Components.Interactions.InteractionsProvider[0]
      Unexpected error while watching interactions.
      System.ArgumentException: An item with the same key has already been added. Key: 1
         at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
         at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
         at System.Collections.ObjectModel.KeyedCollection`2.AddKey(TKey key, TItem item)
         at System.Collections.ObjectModel.KeyedCollection`2.InsertItem(Int32 index, TItem item)
         at Aspire.Dashboard.Components.Interactions.InteractionsProvider.WatchInteractionsAsync() in
C:\dev\git\aspire\src\Aspire.Dashboard\Components\Interactions\InteractionsProvider.cs:line 435
         at Aspire.Dashboard.Components.Interactions.InteractionsProvider.WatchInteractionsAsync() in
C:\dev\git\aspire\src\Aspire.Dashboard\Components\Interactions\InteractionsProvider.cs:line 311
         at Aspire.Dashboard.Components.Interactions.InteractionsProvider.<OnInitialized>b__35_1() in
C:\dev\git\aspire\src\Aspire.Dashboard\Components\Interactions\InteractionsProvider.cs:line 100
info: Aspire.Hosting.DistributedApplication[0]
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
