### PR TITLE
Force en-US for template install

### DIFF
--- a/src/Aspire.Cli/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNetCliRunner.cs
@@ -286,7 +286,12 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
 
         var exitCode = await ExecuteAsync(
             args: [.. cliArgs],
-            env: null,
+            env: new Dictionary<string, string>
+            {
+                // Force English output for consistent parsing.
+                // See NOTE: below
+                [KnownConfigNames.DotnetCliUiLanguage] = "en-US"
+            },
             workingDirectory: new DirectoryInfo(Environment.CurrentDirectory),
             backchannelCompletionSource: null,
             options: options,
@@ -591,13 +596,13 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
         using var activity = telemetry.ActivitySource.StartActivity();
 
         string[] cliArgs = ["build", projectFilePath.FullName];
-        
+
         // Always inject DOTNET_CLI_USE_MSBUILD_SERVER for apphost builds
         var env = new Dictionary<string, string>
         {
             ["DOTNET_CLI_USE_MSBUILD_SERVER"] = GetMsBuildServerValue()
         };
-        
+
         return await ExecuteAsync(
             args: cliArgs,
             env: env,


### PR DESCRIPTION
## Description

We can use `DOTNET_CLI_UI_LANGUAGE` to force the command to output english, which we then will parse. This approach is still necessary because https://github.com/dotnet/sdk/issues/47958 has not be resolved.

Fixes #10323

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
