### PR TITLE
[release/9.4] Add purple styling for default values in CLI prompts (#10474)

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -51,6 +51,7 @@ internal class ConsoleInteractionService : IInteractionService
         {
             prompt.DefaultValue(defaultValue);
             prompt.ShowDefaultValue();
+            prompt.DefaultValueStyle(new Style(Color.Fuchsia));
         }
 
         if (validator is not null)


### PR DESCRIPTION
Backport of #10474 to release/9.4

## Customer Impact

More purple makes people happy of course.

## Testing

## Risk

## Regression?
