### PR TITLE
Add server validation of interaction inputs

### DIFF
--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -127,8 +127,8 @@ internal static class InteractionCommands
                var numberOfPeopleInput = new InteractionInput { InputType = InputType.Number, Label = "Number of people", Placeholder = "Enter number of people", Value = "2", Required = true };
                var inputs = new List<InteractionInput>
                {
-                   new InteractionInput { InputType = InputType.Text, Label = "Name", Placeholder = "Enter name", Required = true },
-                   new InteractionInput { InputType = InputType.SecretText, Label = "Password", Placeholder = "Enter password", Required = true },
+                   new InteractionInput { InputType = InputType.Text, Label = "Name", Placeholder = "Enter name", Required = true, MaxLength = 50 },
+                   new InteractionInput { InputType = InputType.SecretText, Label = "Password", Placeholder = "Enter password", Required = true, MaxLength = 20 },
                    dinnerInput,
                    numberOfPeopleInput,
                    new InteractionInput { InputType = InputType.Boolean, Label = "Remember me", Placeholder = "What does this do?", Required = true },

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -270,7 +270,8 @@
     <Compile Include="$(SharedDir)ConsoleLogs\LogEntry.cs" Link="Utils\ConsoleLogs\LogEntry.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\LogPauseViewModel.cs" Link="Utils\ConsoleLogs\LogPauseViewModel.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\TimestampParser.cs" Link="Utils\ConsoleLogs\TimestampParser.cs" />
-    <Compile Include="..\Shared\KnownUrls.cs" Link="Utils\KnownUrls.cs" />
+    <Compile Include="$(SharedDir)KnownUrls.cs" Link="Utils\KnownUrls.cs" />
+    <Compile Include="$(SharedDir)InteractionHelpers.cs" Link="Utils\InteractionHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -51,7 +51,7 @@
                                              Required="localItem.Input.Required"
                                              Immediate="true"
                                              aria-describedby="@descriptionId"
-                                             Maxlength="@GetMaxLength(localItem)" />
+                                             Maxlength="@InteractionHelpers.GetMaxLength(localItem.Input.MaxLength)" />
                             @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;
@@ -69,7 +69,7 @@
                                              AutoComplete="one-time-code"
                                              Immediate="true"
                                              aria-describedby="@descriptionId"
-                                             Maxlength="@GetMaxLength(localItem)" />
+                                             Maxlength="@InteractionHelpers.GetMaxLength(localItem.Input.MaxLength)" />
                             @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -33,10 +33,6 @@
         <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
             @foreach (var vm in _inputDialogInputViewModels)
             {
-                @*
-                * AutoComplete value of one-time-code on password input prevents the browser asking to save the value.
-                * Immediate value of true on text inputs ensures the value is set to the server token with every key press in textbox.
-                *@
                 var localItem = vm;
                 var descriptionId = !string.IsNullOrEmpty(localItem.Input.Description)
                     ? $"{_elementRefs[localItem]?.Id}-description"
@@ -45,6 +41,9 @@
                     @switch (vm.Input.InputType)
                     {
                         case InputType.Text:
+                            @*
+                            * Immediate value of true on text input ensures the value is set to the server token with every key press in textbox.
+                            *@
                             <FluentTextField @ref="@_elementRefs[localItem]"
                                              @bind-Value="localItem.Value"
                                              Label="@localItem.Input.Label"
@@ -52,11 +51,15 @@
                                              Required="localItem.Input.Required"
                                              Immediate="true"
                                              aria-describedby="@descriptionId"
-                                             Maxlength="@MaxTextLength" />
+                                             Maxlength="@GetMaxLength(localItem)" />
                             @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;
                         case InputType.SecretText:
+                            @*
+                            * AutoComplete value of one-time-code on password input prevents the browser asking to save the value.
+                            * Immediate value of true on text input ensures the value is set to the server token with every key press in textbox.
+                            *@
                             <FluentTextField @ref="@_elementRefs[localItem]"
                                              @bind-Value="localItem.Value"
                                              Label="@localItem.Input.Label"
@@ -66,7 +69,7 @@
                                              AutoComplete="one-time-code"
                                              Immediate="true"
                                              aria-describedby="@descriptionId"
-                                             Maxlength="@MaxTextLength" />
+                                             Maxlength="@GetMaxLength(localItem)" />
                             @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -51,7 +51,8 @@
                                              Placeholder="@localItem.Input.Placeholder"
                                              Required="localItem.Input.Required"
                                              Immediate="true"
-                                             aria-describedby="@descriptionId" />
+                                             aria-describedby="@descriptionId"
+                                             Maxlength="@MaxTextLength" />
                             @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;
@@ -64,7 +65,8 @@
                                              TextFieldType="TextFieldType.Password"
                                              AutoComplete="one-time-code"
                                              Immediate="true"
-                                             aria-describedby="@descriptionId" />
+                                             aria-describedby="@descriptionId"
+                                             Maxlength="@MaxTextLength" />
                             @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
@@ -24,7 +24,7 @@ public partial class InteractionsInputDialog
     private ValidationMessageStore _validationMessages = default!;
     private List<InputViewModel> _inputDialogInputViewModels = default!;
     private Dictionary<InputViewModel, FluentComponentBase?> _elementRefs = default!;
-    
+
     protected override void OnInitialized()
     {
         _editContext = new EditContext(Content);

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
@@ -11,6 +11,8 @@ namespace Aspire.Dashboard.Components.Dialogs;
 
 public partial class InteractionsInputDialog
 {
+    internal const int MaxTextLength = 8000;
+
     [Parameter]
     public InteractionsInputsDialogViewModel Content { get; set; } = default!;
 
@@ -22,7 +24,7 @@ public partial class InteractionsInputDialog
     private ValidationMessageStore _validationMessages = default!;
     private List<InputViewModel> _inputDialogInputViewModels = default!;
     private Dictionary<InputViewModel, FluentComponentBase?> _elementRefs = default!;
-
+    
     protected override void OnInitialized()
     {
         _editContext = new EditContext(Content);

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
@@ -11,8 +11,6 @@ namespace Aspire.Dashboard.Components.Dialogs;
 
 public partial class InteractionsInputDialog
 {
-    internal const int MaxTextLength = 8000;
-
     [Parameter]
     public InteractionsInputsDialogViewModel Content { get; set; } = default!;
 
@@ -170,15 +168,5 @@ public partial class InteractionsInputDialog
     private async Task CancelAsync()
     {
         await Dialog.CancelAsync();
-    }
-
-    private static int GetMaxLength(InputViewModel inputModel)
-    {
-        if (inputModel.Input.MaxLength == 0)
-        {
-            return MaxTextLength;
-        }
-
-        return inputModel.Input.MaxLength;
     }
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
@@ -171,4 +171,14 @@ public partial class InteractionsInputDialog
     {
         await Dialog.CancelAsync();
     }
+
+    private static int GetMaxLength(InputViewModel inputModel)
+    {
+        if (inputModel.Input.MaxLength == 0)
+        {
+            return MaxTextLength;
+        }
+
+        return inputModel.Input.MaxLength;
+    }
 }

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -42,6 +42,7 @@
     <Compile Include="$(SharedDir)PortAllocator.cs" Link="Publishing\PortAllocator.cs" />
     <Compile Include="$(SharedDir)OverloadResolutionPriorityAttribute.cs" Link="Utils\OverloadResolutionPriorityAttribute.cs" />
     <Compile Include="$(SharedDir)PackageUpdateHelpers.cs" Link="Utils\PackageUpdateHelpers.cs" />
+    <Compile Include="$(SharedDir)InteractionHelpers.cs" Link="Utils\InteractionHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -143,6 +143,10 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                                 {
                                     dto.Options.Add(input.Options.ToDictionary());
                                 }
+                                if (input.MaxLength != null)
+                                {
+                                    dto.MaxLength = input.MaxLength.Value;
+                                }
                                 dto.ValidationErrors.AddRange(input.ValidationErrors);
                                 return dto;
                             }).ToList();

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -376,6 +376,7 @@ message InteractionInput {
     repeated string validation_errors = 7;
     string description = 8;
     bool enable_description_markdown = 9;
+    int32 max_length = 10;
 }
 enum MessageIntent {
     MESSAGE_INTENT_NONE = 0;

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -103,6 +103,8 @@ public interface IInteractionService
 [Experimental(InteractionService.DiagnosticId, UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class InteractionInput
 {
+    internal const int MaxTextLength = 8000;
+
     /// <summary>
     /// Gets or sets the label for the input.
     /// </summary>

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -103,8 +103,6 @@ public interface IInteractionService
 [Experimental(InteractionService.DiagnosticId, UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class InteractionInput
 {
-    internal const int MaxTextLength = 8000;
-
     /// <summary>
     /// Gets or sets the label for the input.
     /// </summary>
@@ -145,6 +143,23 @@ public sealed class InteractionInput
     /// Gets or sets the placeholder text for the input.
     /// </summary>
     public string? Placeholder { get; set; }
+
+    /// <summary>
+    /// gets or sets the maximum length for text inputs.
+    /// </summary>
+    public int? MaxLength
+    {
+        get => field;
+        set
+        {
+            if (value is { } v)
+            {
+                ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(v, 0);
+            }
+
+            field = value;
+        }
+    }
 
     internal List<string> ValidationErrors { get; } = [];
 }

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -264,9 +264,11 @@ internal class InteractionService : IInteractionService
                         {
                             case InputType.Text:
                             case InputType.SecretText:
-                                if (value.Length > InteractionInput.MaxTextLength)
+                                var maxLength = InteractionHelpers.GetMaxLength(input.MaxLength);
+
+                                if (value.Length > maxLength)
                                 {
-                                    context.AddValidationError(input, $"Value length exceeds {InteractionInput.MaxTextLength} characters.");
+                                    context.AddValidationError(input, $"Value length exceeds {maxLength} characters.");
                                 }
                                 break;
                             case InputType.Choice:

--- a/src/Shared/InteractionHelpers.cs
+++ b/src/Shared/InteractionHelpers.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Aspire;
+
+internal static class InteractionHelpers
+{
+    // Chosen to balance between being long enough for most normal use but provides a default limit
+    // to prevent possible abuse of interactions API.
+    public const int DefaultMaxLength = 8000;
+
+    public static int GetMaxLength(int? configuredInputLength)
+    {
+        // An unconfigured max length uses the default.
+        if (configuredInputLength is null || configuredInputLength == 0)
+        {
+            return DefaultMaxLength;
+        }
+
+        return configuredInputLength.Value;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -282,6 +282,45 @@ public class InteractionServiceTests
             error => Assert.Equal("Value must be a valid boolean.", error));
     }
 
+    [Theory]
+    [InlineData(InputType.Text, null)]
+    [InlineData(InputType.Text, 1)]
+    [InlineData(InputType.Text, 10)]
+    [InlineData(InputType.Text, InteractionHelpers.DefaultMaxLength)]
+    [InlineData(InputType.SecretText, 10)]
+    public async Task PromptInputsAsync_TextExceedsLimit_ReturnErrors(InputType inputType, int? maxLength)
+    {
+        await TextExceedsLimitCoreAsync(inputType, maxLength, success: true);
+        await TextExceedsLimitCoreAsync(inputType, maxLength, success: false);
+
+        static async Task TextExceedsLimitCoreAsync(InputType inputType, int? maxLength, bool success)
+        {
+            var interactionService = CreateInteractionService();
+
+            var input = new InteractionInput { Label = "Value", InputType = inputType, MaxLength = maxLength };
+            var resultTask = interactionService.PromptInputAsync("Please provide", "please", input);
+
+            var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+            var resolvedMaxLength = InteractionHelpers.GetMaxLength(maxLength);
+
+            input.Value = new string('!', success ? resolvedMaxLength : resolvedMaxLength + 1);
+            await CompleteInteractionAsync(interactionService, interaction.InteractionId, new InteractionCompletionState { Complete = true, State = new[] { input } });
+
+            if (!success)
+            {
+                // The interaction should still be in progress due to invalid data
+                Assert.False(interaction.CompletionTcs.Task.IsCompleted);
+
+                Assert.Collection(input.ValidationErrors,
+                    error => Assert.Equal($"Value length exceeds {resolvedMaxLength} characters.", error));
+            }
+            else
+            {
+                Assert.True(interaction.CompletionTcs.Task.IsCompletedSuccessfully);
+            }
+        }
+    }
+
     [Fact]
     public void InteractionInput_WithDescription_SetsProperties()
     {
@@ -333,6 +372,36 @@ public class InteractionServiceTests
         // Assert
         Assert.Null(input.Description);
         Assert.False(input.EnableDescriptionMarkdown);
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData(1, false)]
+    [InlineData(int.MaxValue, false)]
+    [InlineData(0, true)]
+    [InlineData(-1, true)]
+    [InlineData(int.MinValue, true)]
+    public void InteractionInput_WithLengths_ErrorOnInvalid(int? length, bool invalid)
+    {
+        // Arrange & Act
+        if (invalid)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => SetLength(length));
+        }
+        else
+        {
+            SetLength(length);
+        }
+
+        static void SetLength(int? length)
+        {
+            var input = new InteractionInput
+            {
+                Label = "Test Label",
+                InputType = InputType.Text,
+                MaxLength = length
+            };
+        }
     }
 
     private static async Task CompleteInteractionAsync(InteractionService interactionService, int interactionId, InteractionCompletionState state)


### PR DESCRIPTION
## Description

Validate interaction service input matches what is expected:

- Required inputs have a value
- Number inputs are a number
- Boolean inputs are a boolean
- Choice inputs are one of the options
- Give text inputs a configurable max length. Default value of 8000 should be large enough for any normal usage. ~Could add configuration for a custom length in the future~

The dashboard or CLI shouldn't send these values, UI logic should prevent that from happening, but server should double check.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
