### PR TITLE
aspire-cli: Fix linux-arm64 and linux-musl-x64 to produce tarballs and not zip files

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -32,18 +32,35 @@
       <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.zip" />
       <_ArchiveFiles Include="$(ArtifactsPackagesDir)\**\aspire-cli-*.tar.gz" />
 
+      <!-- Extract RID from each archive file -->
+      <_ArchiveFilesWithRid Include="@(_ArchiveFiles)">
+        <!-- Extract the rid from filenames like aspire-cli-linux-x64-9.0-dev.tar.gz and aspire-cli-linux-arm64-9.4.0-preview.1.25358.11.zip -->
+        <ExtractedRid>$([System.Text.RegularExpressions.Regex]::Match(%(_ArchiveFiles.FileName), 'aspire-cli-(.*)-\d+.*').Groups[1].Value)</ExtractedRid>
+      </_ArchiveFilesWithRid>
+
       <_CliPackProjects Include="$(RepoRoot)eng\clipack\Aspire.Cli.*.csproj" />
       <_ExpectedRids Include="@(_CliPackProjects->'%(Filename)'->Replace('Aspire.Cli.', ''))" />
 
-      <!-- Extract the rid from filenames like aspire-cli-linux-x64-9.0-dev.tar.gz and aspire-cli-linux-arm64-9.4.0-preview.1.25358.11.zip -->
-      <_FoundRidInCliArchiveFile Include="$([System.Text.RegularExpressions.Regex]::Match(%(_ArchiveFiles.FileName), 'aspire-cli-(.*)-\d+.*').Groups[1].Value)" />
-
-      <_MissingRids Include="@(_ExpectedRids)" Exclude="@(_FoundRidInCliArchiveFile)" />
-      <_UnexpectedRids Include="@(_FoundRidInCliArchiveFile)" Exclude="@(_ExpectedRids)" />
+      <_MissingRids Include="@(_ExpectedRids)" Exclude="@(_ArchiveFilesWithRid -> '%(ExtractedRid)')" />
+      <_UnexpectedRids Include="@(_ArchiveFilesWithRid -> '%(ExtractedRid)')" Exclude="@(_ExpectedRids)" />
     </ItemGroup>
 
     <Warning Condition="@(_UnexpectedRids->Count()) > 0" Text="Found unexpected CLI archives for @(_UnexpectedRids, ',') . These are all the cli archives found - @(_ArchiveFiles, ', ')" />
     <Error Condition="@(_MissingRids->Count()) > 0" Text="Missing CLI archive(s) for runtime identifiers: @(_MissingRids, ', '). These are all the cli archives found - @(_ArchiveFiles, ', ')" />
+
+    <!-- Validate aspire-cli archive file extensions match expected format for each RID -->
+    <ItemGroup>
+      <!-- Check Windows RIDs (should have .zip extension) -->
+      <_WindowsArchiveFiles Include="@(_ArchiveFilesWithRid)" Condition="$([System.String]::new('%(ExtractedRid)').StartsWith('win-'))" />
+      <_InvalidWindowsArchiveFiles Include="@(_WindowsArchiveFiles)" Condition="!$([System.String]::new('%(Extension)').Equals('.zip'))" />
+
+      <!-- Check non-Windows RIDs (should have .tar.gz extension) -->
+      <_NonWindowsArchiveFiles Include="@(_ArchiveFilesWithRid)" Condition="!$([System.String]::new('%(ExtractedRid)').StartsWith('win-'))" />
+      <_InvalidNonWindowsArchiveFiles Include="@(_NonWindowsArchiveFiles)" Condition="!$([System.String]::new('%(FileName)%(Extension)').EndsWith('.tar.gz'))" />
+    </ItemGroup>
+
+    <Error Condition="@(_InvalidWindowsArchiveFiles->Count()) > 0" Text="Windows aspire-cli archives must have .zip extension. Invalid files: @(_InvalidWindowsArchiveFiles, ', ')" />
+    <Error Condition="@(_InvalidNonWindowsArchiveFiles->Count()) > 0" Text="Non-Windows aspire-cli archives must have .tar.gz extension. Invalid files: @(_InvalidNonWindowsArchiveFiles, ', ')" />
 
     <!--
       For blob items for the Dashboard, we want to make sure that the version we get back is not stable, even when the repo is producing stable versions.

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -3,8 +3,8 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
 
     <ArchiveName>aspire-cli-$(CliRuntime)</ArchiveName>
-    <ArchiveFormat Condition="'$(ArchiveFormat)' == '' and $(CliRuntime.StartsWith('win-'))">zip</ArchiveFormat>
-    <ArchiveFormat Condition="'$(ArchiveFormat)' == ''">tar.gz</ArchiveFormat>
+    <ArchiveFormat Condition="$(CliRuntime.StartsWith('win-'))">zip</ArchiveFormat>
+    <ArchiveFormat Condition="!$(CliRuntime.StartsWith('win-'))">tar.gz</ArchiveFormat>
 
     <!-- PublishNativeAot is explicitly set to false in the projects for cases where we don't want to AOT at all.
          For the rest, publish native AOT if running on the target platfrom -->

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -134,6 +134,8 @@ extends:
           agentOs: linux
           targetRidsForSameOS:
             - linux-x64
+            - linux-arm64
+            - linux-musl-x64
           # no need to sign ELF binaries on linux
           codeSign: false
           teamName: $(_TeamName)
@@ -222,8 +224,6 @@ extends:
                     - win-arm64
                     # non-aot - single file builds
                     - win-x86
-                    - linux-arm64
-                    - linux-musl-x64
 
       - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
         - template: /eng/common/templates-official/job/onelocbuild.yml@self
@@ -232,4 +232,3 @@ extends:
             LclPackageId: 'LCL-JUNO-PROD-ASPIRE'
             MirrorRepo: aspire
             MirrorBranch: main
-


### PR DESCRIPTION
## What?:

The `aspire-cli` archives for `linux-arm64`, and `linux-musl-x64` are expected be tarballs. But `.zip` files are produced.

## Why?

- We produce `linux-arm64` archives on a Windows azdo agent. And the
Archives targets defaults to `.zip` Windows. Even though we set that
property in `Common.projitems` it does not take effect as it is imported
after the props files.
- Fixing the above though runs into a new issue where `tar` fails on Windows (https://github.com/dotnet/arcade/issues/15982)
- So the final fix is to build these on linux agents too, to get the correct tarballs.

## Tests

These archives don't have any explicit tests. And Arcade does not fail the build when tar fails. So we add msbuild based checks to ensure that we get the expected archives with the expected extensions.

Contributes to https://github.com/dotnet/aspire/issues/10288