### PR TITLE
Fire ResourceEndpointsAllocatedEvent event once for each logical app model resource

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -784,9 +784,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         // Fire the endpoints allocated event for all DCP managed resources with endpoints.
         foreach (var resource in toCreate.Select(r => r.ModelResource).OfType<IResourceWithEndpoints>())
         {
+            // Ensure we fire the event only once for each app model resource. There may be multiple physical replicas of
+            // the same app model resource which can result in the event being fired multiple times.
             if (allocatedResources.Add(resource.Name))
             {
-                // Replicas can result in the endpoints allocated event being fired multiple times for the same logical resource.
                 var resourceEvent = new ResourceEndpointsAllocatedEvent(resource, _executionContext.ServiceProvider);
                 await _distributedApplicationEventing.PublishAsync(resourceEvent, EventDispatchBehavior.NonBlockingConcurrent, cancellationToken).ConfigureAwait(false);
             }

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -236,18 +236,19 @@ internal sealed class ApplicationOrchestrator
                     // is bound to all interfaces (0.0.0.0, ::, etc.) we use the machine name as the additional
                     // address. If bound to a *.localhost address, we add the originally declared *.localhost address
                     // as an additional URL.
-                    var additionalUrl = (allocatedEndpoint.BindingMode, endpoint.TargetHost) switch
+                    var additionalUrl = allocatedEndpoint.BindingMode switch
                     {
                         // The allocated address doesn't match the original target host, so include the target host as
                         // an additional URL.
-                        (EndpointBindingMode.SingleAddress, var host) when !allocatedEndpoint.Address.Equals(endpoint.TargetHost, StringComparison.OrdinalIgnoreCase) => new ResourceUrlAnnotation
+                        EndpointBindingMode.SingleAddress when !allocatedEndpoint.Address.Equals(endpoint.TargetHost, StringComparison.OrdinalIgnoreCase) => new ResourceUrlAnnotation
                         {
                             Url = $"{allocatedEndpoint.UriScheme}://{endpoint.TargetHost}:{allocatedEndpoint.Port}",
                             Endpoint = endpointReference,
                         },
-                        // For other single address bindings, don't include an additional URL.
-                        (EndpointBindingMode.SingleAddress, _) => null,
-                        // All other cases are binding to multiple interfaces, so add the machine name as an additional URL.
+                        // For other single address bindings ("localhost", specific IP), don't include an additional URL.
+                        EndpointBindingMode.SingleAddress => null,
+                        // All other cases are binding to some set of all interfaces (IPv4, IPv6, or both), so add the machine
+                        // name as an additional URL.
                         _ => new ResourceUrlAnnotation
                         {
                             Url = $"{allocatedEndpoint.UriScheme}://{Environment.MachineName}:{allocatedEndpoint.Port}",

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -258,7 +258,7 @@ internal sealed class ApplicationOrchestrator
 
                     if (additionalUrl is not null)
                     {
-                        if (!existingUrls.Any(existingUrl => existingUrl.Url.Equals(additionalUrl.Url, StringComparison.OrdinalIgnoreCase) && existingUrl.Endpoint?.EndpointName == url.Endpoint?.EndpointName))
+                        if (!existingUrls.Any(existingUrl => existingUrl.Url.Equals(additionalUrl.Url, StringComparison.OrdinalIgnoreCase) && existingUrl.Endpoint?.EndpointName == additionalUrl.Endpoint?.EndpointName))
                         {
                             urls.Add(additionalUrl);
                         }

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -202,6 +202,12 @@ internal sealed class ApplicationOrchestrator
     private async Task ProcessResourceUrlCallbacks(IResource resource, CancellationToken cancellationToken)
     {
         var urls = new List<ResourceUrlAnnotation>();
+        var existingUrls = new List<ResourceUrlAnnotation>();
+
+        if (resource.TryGetUrls(out var existingAnnotations))
+        {
+            existingUrls.AddRange(existingAnnotations);
+        }
 
         // Project endpoints to URLs
         if (resource.TryGetEndpoints(out var endpoints) && resource is IResourceWithEndpoints resourceWithEndpoints)
@@ -212,31 +218,52 @@ internal sealed class ApplicationOrchestrator
                 Debug.Assert(endpoint.AllocatedEndpoint is not null, "Endpoint should be allocated at this point as we're calling this from ResourceEndpointsAllocatedEvent handler.");
                 if (endpoint.AllocatedEndpoint is { } allocatedEndpoint)
                 {
+                    // The allocated endpoint is used for service discovery and is the primary URL displayed to
+                    // the user. In general, if valid for a particular service binding, the allocated endpoint
+                    // will be "localhost" as that's a valid address for the .NET developer certificate. However,
+                    // if a service is bound to a specific IP address, the allocated endpoint will be that same IP
+                    // address.
                     var endpointReference = new EndpointReference(resourceWithEndpoints, endpoint);
                     var url = new ResourceUrlAnnotation { Url = allocatedEndpoint.UriString, Endpoint = endpointReference };
-                    urls.Add(url);
-                    if (allocatedEndpoint.BindingMode != EndpointBindingMode.SingleAddress && (endpoint.TargetHost is not "localhost" or "127.0.0.1"))
+
+                    if (!existingUrls.Any(existingUrl => existingUrl.Url.Equals(url.Url, StringComparison.OrdinalIgnoreCase) && existingUrl.Endpoint?.EndpointName == url.Endpoint?.EndpointName))
                     {
-                        // Endpoint is listening on multiple addresses so add another URL based on the declared target hostname
-                        // For endpoints targeting all external addresses (IPv4 0.0.0.0 or IPv6 ::) use the machine name
-                        var address = endpoint.TargetHost is "0.0.0.0" or "::" ? Environment.MachineName : endpoint.TargetHost;
-                        url = new ResourceUrlAnnotation { Url = $"{allocatedEndpoint.UriScheme}://{address}:{allocatedEndpoint.Port}", Endpoint = endpointReference };
                         urls.Add(url);
                     }
-                    else if (endpoint.TargetHost.Length > 10 && endpoint.TargetHost.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
+
+                    // In the case that a service is bound to multiple addresses or a *.localhost address, we generate
+                    // additional URLs to indicate to the user other ways their service can be reached. If the service
+                    // is bound to all interfaces (0.0.0.0, ::, etc.) we use the machine name as the additional
+                    // address. If bound to a *.localhost address, we add the originally declared *.localhost address
+                    // as an additional URL.
+                    var additionalUrl = (allocatedEndpoint.BindingMode, endpoint.TargetHost) switch
                     {
-                        // Add the originally declared *.localhost URL
-                        url = new ResourceUrlAnnotation { Url = $"{allocatedEndpoint.UriScheme}://{endpoint.TargetHost}:{allocatedEndpoint.Port}", Endpoint = endpointReference };
-                        urls.Add(url);
+                        // The allocated address doesn't match the original target host, so include the target host as
+                        // an additional URL.
+                        (EndpointBindingMode.SingleAddress, var host) when !allocatedEndpoint.Address.Equals(endpoint.TargetHost, StringComparison.OrdinalIgnoreCase) => new ResourceUrlAnnotation
+                        {
+                            Url = $"{allocatedEndpoint.UriScheme}://{endpoint.TargetHost}:{allocatedEndpoint.Port}",
+                            Endpoint = endpointReference,
+                        },
+                        // For other single address bindings, don't include an additional URL.
+                        (EndpointBindingMode.SingleAddress, _) => null,
+                        // All other cases are binding to multiple interfaces, so add the machine name as an additional URL.
+                        _ => new ResourceUrlAnnotation
+                        {
+                            Url = $"{allocatedEndpoint.UriScheme}://{Environment.MachineName}:{allocatedEndpoint.Port}",
+                            Endpoint = endpointReference,
+                        },
+                    };
+
+                    if (additionalUrl is not null)
+                    {
+                        if (!existingUrls.Any(existingUrl => existingUrl.Url.Equals(additionalUrl.Url, StringComparison.OrdinalIgnoreCase) && existingUrl.Endpoint?.EndpointName == url.Endpoint?.EndpointName))
+                        {
+                            urls.Add(additionalUrl);
+                        }
                     }
                 }
             }
-        }
-
-        if (resource.TryGetUrls(out var existingUrls))
-        {
-            // Static URLs added to the resource via WithUrl(string name, string url), i.e. not callback-based
-            urls.AddRange(existingUrls);
         }
 
         // Run the URL callbacks
@@ -249,17 +276,6 @@ internal sealed class ApplicationOrchestrator
             foreach (var callback in callbacks)
             {
                 await callback.Callback(urlsCallbackContext).ConfigureAwait(false);
-            }
-        }
-
-        // Clear existing URLs
-        if (existingUrls is not null)
-        {
-            var existing = existingUrls.ToArray();
-            for (var i = existing.Length - 1; i >= 0; i--)
-            {
-                var url = existing[i];
-                resource.Annotations.Remove(url);
             }
         }
 

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -389,6 +389,52 @@ public class WithUrlsTests
     }
 
     [Fact]
+    public async Task ExpectedNumberOfUrlsForReplicatedResource()
+    {
+        // This test creates a single project resource with a custom URL and
+        // a replica count of 3. It then checks that the number of URLs
+        // generated isn't impacted by the number of replicas.
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var servicea = builder.AddProject<Projects.ServiceA>("servicea")
+            .WithUrl("https://example.com/project")
+            .WithReplicas(3);
+
+        var app = await builder.BuildAsync();
+
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        var cts = new CancellationTokenSource();
+        var projectRunning = false;
+
+        var watchTask = Task.Run(async () =>
+        {
+            await foreach (var notification in rns.WatchAsync(cts.Token).WithCancellation(cts.Token))
+            {
+                if (!projectRunning && notification.Snapshot.State == KnownResourceStates.Running)
+                {
+                    projectRunning = true;
+                    Assert.Equal(2, notification.Snapshot.Urls.Length);
+                    Assert.Collection(notification.Snapshot.Urls,
+                        url => Assert.StartsWith("http://localhost:", url.Url), // The default project URL
+                        url => Assert.Equal("https://example.com/project", url.Url) // Static URL
+                    );
+                    break;
+                }
+            }
+        });
+
+        await app.StartAsync();
+
+        await app.ResourceNotifications.WaitForResourceAsync(servicea.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        await watchTask.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        cts.Cancel();
+
+        await app.StopAsync();
+
+    }
+
+    [Fact]
     public async Task UrlsAreInExpectedStateForResourcesGivenTheirLifecycle()
     {
         using var builder = TestDistributedApplicationBuilder.Create();


### PR DESCRIPTION
## Description

Prevent duplicating URLs in the dashboard for resources with replicas.

We were firing ResourceEndpointsAllocatedEvent once for each replica instead of once for the logical app model resource. Additionally, ProcessResourceUrlCallbacks wasn't idempotent and would result in the same endpoint URLs being added every time it was called.

Fixes #10529