### PR TITLE
Use proxied endpoints for aspire dashboard

### DIFF
--- a/src/Aspire.Dashboard/Properties/launchSettings.json
+++ b/src/Aspire.Dashboard/Properties/launchSettings.json
@@ -2,6 +2,10 @@
   "profiles": {
     "Aspire.Dashboard": {
       "commandName": "Project",
+      "launchBrowser": true
+    },
+    "Aspire.Dashboard.Test": {
+      "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
+using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -12,16 +13,15 @@ using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Devcontainers.Codespaces;
+using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
+using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.AspNetCore.Http;
-using Aspire.Hosting.Eventing;
-using Aspire.Hosting.Utils;
-using System.Net.Sockets;
 
 namespace Aspire.Hosting.Dashboard;
 

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -11,15 +11,17 @@ using Aspire.Dashboard.ConsoleLogs;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
-using Aspire.Hosting.Devcontainers;
 using Aspire.Hosting.Devcontainers.Codespaces;
 using Aspire.Hosting.Lifecycle;
-using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Http;
+using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Utils;
+using System.Net.Sockets;
 
 namespace Aspire.Hosting.Dashboard;
 
@@ -33,10 +35,8 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
                                              ILoggerFactory loggerFactory,
                                              DcpNameGenerator nameGenerator,
                                              IHostApplicationLifetime hostApplicationLifetime,
-                                             CodespacesUrlRewriter codespaceUrlRewriter,
-                                             IOptions<CodespacesOptions> codespacesOptions,
-                                             IOptions<DevcontainersOptions> devcontainersOptions,
-                                             DevcontainerSettingsWriter settingsWriter
+                                             IDistributedApplicationEventing eventing,
+                                             CodespacesUrlRewriter codespaceUrlRewriter
                                              ) : IDistributedApplicationLifecycleHook, IAsyncDisposable
 {
     private static readonly HashSet<string> s_suppressAutomaticConfigurationCopy = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -138,26 +138,67 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
         dashboardResource.Annotations.Add(new ExcludeLifecycleCommandsAnnotation());
 
         // Remove endpoint annotations because we are directly configuring
-        // the dashboard app (it doesn't go through the proxy!).
+        // the dashboard app.
         var endpointAnnotations = dashboardResource.Annotations.OfType<EndpointAnnotation>().ToList();
         foreach (var endpointAnnotation in endpointAnnotations)
         {
             dashboardResource.Annotations.Remove(endpointAnnotation);
         }
 
-        if (codespacesOptions.Value.IsCodespace || devcontainersOptions.Value.IsDevcontainer)
+        // Add the dashboard endpoints as non-proxied
+        var options = dashboardOptions.Value;
+
+        var dashboardUrls = options.DashboardUrl;
+        var otlpGrpcEndpointUrl = options.OtlpGrpcEndpointUrl;
+        var otlpHttpEndpointUrl = options.OtlpHttpEndpointUrl;
+
+        eventing.Subscribe<ResourceReadyEvent>(dashboardResource, (context, resource) =>
         {
-            // We need to print out the url so that dotnet watch can launch the dashboard
-            // technically this is too early
-            if (StringUtils.TryGetUriFromDelimitedString(dashboardOptions.Value.DashboardUrl, ";", out var firstDashboardUrl))
+            var browserToken = options.DashboardToken;
+
+            if (!StringUtils.TryGetUriFromDelimitedString(dashboardUrls, ";", out var firstDashboardUrl))
             {
-                settingsWriter.AddPortForward(
-                                firstDashboardUrl.ToString(),
-                                firstDashboardUrl.Port,
-                                firstDashboardUrl.Scheme,
-                                $"aspire-dashboard-{firstDashboardUrl.Scheme}",
-                                openBrowser: true);
+                return Task.CompletedTask;
             }
+
+            var dashboardUrl = codespaceUrlRewriter.RewriteUrl(firstDashboardUrl.ToString());
+
+            distributedApplicationLogger.LogInformation("Now listening on: {DashboardUrl}", dashboardUrl.TrimEnd('/'));
+
+            if (!string.IsNullOrEmpty(browserToken))
+            {
+                LoggingHelpers.WriteDashboardUrl(distributedApplicationLogger, dashboardUrl, browserToken, isContainer: false);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        foreach (var d in dashboardUrls?.Split(';', StringSplitOptions.RemoveEmptyEntries) ?? [])
+        {
+            var address = BindingAddress.Parse(d);
+
+            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: address.Scheme, port: address.Port, isProxied: true)
+            {
+                TargetHost = address.Host
+            });
+        }
+
+        if (otlpGrpcEndpointUrl != null)
+        {
+            var address = BindingAddress.Parse(otlpGrpcEndpointUrl);
+            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: "otlp-grpc", uriScheme: address.Scheme, port: address.Port, isProxied: true, transport: "http2")
+            {
+                TargetHost = address.Host
+            });
+        }
+
+        if (otlpHttpEndpointUrl != null)
+        {
+            var address = BindingAddress.Parse(otlpHttpEndpointUrl);
+            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: "otlp-http", uriScheme: address.Scheme, port: address.Port, isProxied: true)
+            {
+                TargetHost = address.Host
+            });
         }
 
         var showDashboardResources = configuration.GetBool(KnownConfigNames.ShowDashboardResources, KnownConfigNames.Legacy.ShowDashboardResources);
@@ -211,16 +252,12 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
         var resourceServiceUrl = await dashboardEndpointProvider.GetResourceServiceUriAsync(context.CancellationToken).ConfigureAwait(false);
 
         context.EnvironmentVariables["ASPNETCORE_ENVIRONMENT"] = environment;
-        context.EnvironmentVariables[DashboardConfigNames.DashboardFrontendUrlName.EnvVarName] = options.DashboardUrl;
         context.EnvironmentVariables[DashboardConfigNames.ResourceServiceUrlName.EnvVarName] = resourceServiceUrl;
-        if (options.OtlpGrpcEndpointUrl != null)
-        {
-            context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpGrpcUrlName.EnvVarName] = options.OtlpGrpcEndpointUrl;
-        }
+
+        PopulateDashboardUrls(context);
+
         if (options.OtlpHttpEndpointUrl != null)
         {
-            context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpHttpUrlName.EnvVarName] = options.OtlpHttpEndpointUrl;
-
             // Use explicitly defined allowed origins if configured.
             var allowedOrigins = configuration.GetString(KnownConfigNames.DashboardCorsAllowedOrigins, KnownConfigNames.Legacy.DashboardCorsAllowedOrigins);
 
@@ -316,6 +353,50 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
         if (!string.IsNullOrEmpty(browserToken))
         {
             LoggingHelpers.WriteDashboardUrl(distributedApplicationLogger, dashboardUrl, browserToken, isContainer: false);
+        }
+    }
+
+    private static void PopulateDashboardUrls(EnvironmentCallbackContext context)
+    {
+        var dashboardResource = (IResourceWithEndpoints)context.Resource;
+
+        // We want to resolve the "target" URL for the dashboard to listen on.
+        static ReferenceExpression GetTargetUrlExpression(EndpointReference e) =>
+            ReferenceExpression.Create($"{e.Property(EndpointProperty.Scheme)}://{e.EndpointAnnotation.TargetHost}:{e.Property(EndpointProperty.TargetPort)}");
+
+        var otlpGrpc = dashboardResource.GetEndpoint("otlp-grpc");
+
+        if (otlpGrpc.Exists)
+        {
+            context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpGrpcUrlName.EnvVarName] = GetTargetUrlExpression(otlpGrpc);
+        }
+
+        var otlpHttp = dashboardResource.GetEndpoint("otlp-http");
+
+        if (otlpHttp.Exists)
+        {
+            context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpHttpUrlName.EnvVarName] = GetTargetUrlExpression(otlpHttp);
+        }
+
+        var aspnetCoreUrls = new ReferenceExpressionBuilder();
+        var first = true;
+
+        // Turn http and https endpoints into a single ASPNETCORE_URLS environment variable.
+        foreach (var e in dashboardResource.GetEndpoints().Where(e => e.EndpointName is "http" or "https"))
+        {
+            if (!first)
+            {
+                aspnetCoreUrls.AppendLiteral(";");
+            }
+
+            aspnetCoreUrls.Append($"{e.Property(EndpointProperty.Scheme)}://{e.EndpointAnnotation.TargetHost}:{e.Property(EndpointProperty.TargetPort)}");
+            first = false;
+        }
+
+        if (!aspnetCoreUrls.IsEmpty)
+        {
+            // Combine into a single expression
+            context.EnvironmentVariables[DashboardConfigNames.DashboardFrontendUrlName.EnvVarName] = aspnetCoreUrls.Build();
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Channels;
 using Aspire.Hosting.ConsoleLogs;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
-using Aspire.Hosting.Devcontainers;
 using Aspire.Hosting.Devcontainers.Codespaces;
 using Aspire.Hosting.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
@@ -170,8 +169,10 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
 
         var envVars = new Dictionary<string, object>();
 
+        var dashboardResource = new ExecutableResource("aspire-dashboard", "dashboard.exe", ".");
+
         // Act
-        await hook.ConfigureEnvironmentVariables(new EnvironmentCallbackContext(new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run), environmentVariables: envVars));
+        await hook.ConfigureEnvironmentVariables(new EnvironmentCallbackContext(new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run), environmentVariables: envVars, resource: dashboardResource));
 
         // Assert
         Assert.Equal("true", envVars.Single(e => e.Key == "ASPIRE_DASHBOARD_PURPLE_MONKEY_DISHWASHER").Value);
@@ -183,14 +184,11 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
         IConfiguration configuration,
         ILoggerFactory? loggerFactory = null,
         IOptions<CodespacesOptions>? codespacesOptions = null,
-        IOptions<DevcontainersOptions>? devcontainersOptions = null,
         IOptions<DashboardOptions>? dashboardOptions = null
         )
     {
         codespacesOptions ??= Options.Create(new CodespacesOptions());
-        devcontainersOptions ??= Options.Create(new DevcontainersOptions());
         dashboardOptions ??= Options.Create(new DashboardOptions { DashboardPath = "test.dll" });
-        var settingsWriter = new DevcontainerSettingsWriter(NullLogger<DevcontainerSettingsWriter>.Instance, codespacesOptions, devcontainersOptions);
         var rewriter = new CodespacesUrlRewriter(codespacesOptions);
 
         return new DashboardLifecycleHook(
@@ -204,10 +202,8 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
             loggerFactory ?? NullLoggerFactory.Instance,
             new DcpNameGenerator(configuration, Options.Create(new DcpOptions())),
             new TestHostApplicationLifetime(),
-            rewriter,
-            codespacesOptions,
-            devcontainersOptions,
-            settingsWriter
+            new Hosting.Eventing.DistributedApplicationEventing(),
+            rewriter
             );
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -549,11 +549,11 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
     {
         foreach (var endpoint in dashboard.Annotations.OfType<EndpointAnnotation>())
         {
-            if (endpoint.Name == "otlp-grpc")
+            if (endpoint.Name == DashboardLifecycleHook.OtlpGrpcEndpointName)
             {
                 endpoint.AllocatedEndpoint = new(endpoint, "localhost", otlpGrpcPort, targetPortExpression: otlpGrpcPort.ToString());
             }
-            else if (endpoint.Name == "otlp-http")
+            else if (endpoint.Name == DashboardLifecycleHook.OtlpHttpEndpointName)
             {
                 endpoint.AllocatedEndpoint = new(endpoint, "localhost", otlpHttpPort, targetPortExpression: otlpHttpPort.ToString());
             }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -104,6 +104,8 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         var dashboard = Assert.Single(model.Resources);
 
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5003);
+
         Assert.Same(container.Resource, dashboard);
 
         var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout())
@@ -114,7 +116,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
             e =>
             {
                 Assert.Equal(KnownConfigNames.DashboardOtlpGrpcEndpointUrl, e.Key);
-                Assert.Equal("http://localhost", e.Value);
+                Assert.Equal("http://localhost:5001", e.Value);
             },
             e =>
             {
@@ -129,7 +131,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
             e =>
             {
                 Assert.Equal(KnownConfigNames.AspNetCoreUrls, e.Key);
-                Assert.Equal("http://localhost", e.Value);
+                Assert.Equal("http://localhost:5003", e.Value);
             },
             e =>
             {
@@ -214,6 +216,8 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         var dashboard = Assert.Single(model.Resources);
 
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5000);
+
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.Equal("BrowserToken", config.Single(e => e.Key == DashboardConfigNames.DashboardFrontendAuthModeName.EnvVarName).Value);
@@ -251,6 +255,8 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         var dashboard = Assert.Single(model.Resources);
 
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5000);
+
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.Equal("Unsecured", config.Single(e => e.Key == DashboardConfigNames.DashboardFrontendAuthModeName.EnvVarName).Value);
@@ -284,6 +290,8 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var dashboard = Assert.Single(model.Resources);
+
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5000);
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
@@ -326,6 +334,8 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         var dashboard = Assert.Single(model.Resources, r => r.Name == "aspire-dashboard");
 
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5003);
+
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, app.Services).DefaultTimeout();
 
         var expectedAllowedOrigins = !string.IsNullOrEmpty(explicitCorsAllowedOrigins) ? explicitCorsAllowedOrigins : "http://localhost:8081,http://localhost:58080";
@@ -364,6 +374,8 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var dashboard = Assert.Single(model.Resources, r => r.Name == "aspire-dashboard");
+
+        SetDashboardAllocatedEndpoints(dashboard, otlpGrpcPort: 5001, otlpHttpPort: 5002, httpPort: 5003);
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, app.Services).DefaultTimeout();
 
@@ -531,6 +543,25 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("aspire-dashboard", dashboard.Name);
         Assert.Same(ManifestPublishingCallbackAnnotation.Ignore, annotation);
         Assert.Null(manifest);
+    }
+
+    static void SetDashboardAllocatedEndpoints(IResource dashboard, int otlpGrpcPort, int otlpHttpPort, int httpPort)
+    {
+        foreach (var endpoint in dashboard.Annotations.OfType<EndpointAnnotation>())
+        {
+            if (endpoint.Name == "otlp-grpc")
+            {
+                endpoint.AllocatedEndpoint = new(endpoint, "localhost", otlpGrpcPort, targetPortExpression: otlpGrpcPort.ToString());
+            }
+            else if (endpoint.Name == "otlp-http")
+            {
+                endpoint.AllocatedEndpoint = new(endpoint, "localhost", otlpHttpPort, targetPortExpression: otlpHttpPort.ToString());
+            }
+            else if (endpoint.Name == "http")
+            {
+                endpoint.AllocatedEndpoint = new(endpoint, "localhost", httpPort, targetPortExpression: httpPort.ToString());
+            }
+        }
     }
 
     private sealed class DashboardProject : IProjectMetadata


### PR DESCRIPTION
## Description

Today we directly bind the dashboard endpoints to fixed ports from the launch profile. This means if the dashboard shutdown is slow, users may end up with ports conflicts. Using DCP proxies, we bind to random ports and dcp will retry the proxy binding on failure giving ample time for the dashboard to shutdown.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
