### PR TITLE
get-aspire-cli: Some fixes and cleanup

### DIFF
--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -40,7 +40,7 @@ If you use [Package Source Mapping](https://learn.microsoft.com/en-us/nuget/cons
 On Windows:
 
 ```powershell
-iex "& { $(irm https://aka.ms/aspire/get/install.ps1 } -Quality dev"
+iex "& { $(irm https://aka.ms/aspire/get/install.ps1) } -Quality dev"
 ```
 
 On Linux, or macOS:

--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -40,13 +40,13 @@ If you use [Package Source Mapping](https://learn.microsoft.com/en-us/nuget/cons
 On Windows:
 
 ```powershell
-iex "& { $(irm https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.ps1) } -Quality dev"
+iex "& { $(irm https://aka.ms/aspire/get/install.ps1 } -Quality dev"
 ```
 
 On Linux, or macOS:
 
 ```sh
-curl -sSL https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.sh | bash -s -- -q dev
+curl -sSL https://aka.ms/aspire/get/install.sh | bash -s -- -q dev
 ```
 
 <!-- break between blocks -->

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -35,6 +35,7 @@ $Script:ChecksumDownloadTimeoutSec = 120
 
 # Configuration constants
 $Script:Config = @{
+    DefaultQuality = "release"
     MinimumPowerShellVersion = 4
     SupportedQualities = @("release", "staging", "dev")
     SupportedOperatingSystems = @("win", "linux", "linux-musl", "osx")
@@ -119,13 +120,13 @@ DESCRIPTION:
     Running with `-Quality staging` will download the latest staging version, or the release version if no staging is available.
     Running with `-Quality dev` will download the latest dev build from `main`.
 
-    The default quality is `release`.
+    The default quality is '$($Script:Config.DefaultQuality)'.
 
     Pass a specific version to get CLI for that version.
 
 PARAMETERS:
-    -InstallPath <string>       Directory to install the CLI (default: %USERPROFILE%\.aspire\bin on Windows, $HOME/.aspire/bin on Unix)
-    -Quality <string>           Quality to download (default: staging)
+    -InstallPath <string>       Directory to install the CLI (default: %USERPROFILE%\.aspire\bin on Windows, `$HOME/.aspire/bin on Unix)
+    -Quality <string>           Quality to download (default: $($Script:Config.DefaultQuality))
     -Version <string>           Version of the Aspire CLI to download (default: unset)
     -OS <string>                Operating system (default: auto-detect)
     -Architecture <string>      Architecture (default: auto-detect)
@@ -848,9 +849,9 @@ function Start-AspireCliInstallation {
             throw "Cannot specify both -Version and -Quality. Use -Version for a specific version or -Quality for a quality level."
         }
 
-        # Set default quality to staging if not specified and no version is provided
+        # Set default quality if not specified and no version is provided
         if ([string]::IsNullOrWhiteSpace($Version) -and [string]::IsNullOrWhiteSpace($Quality)) {
-            $Quality = "release"
+            $Quality = $Script:Config.DefaultQuality
         }
 
         # Additional parameter validation

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -154,9 +154,8 @@ EXAMPLES:
     .\get-aspire-cli.ps1 -Help
 
     # Piped execution
-    Invoke-Expression "& { `$(Invoke-RestMethod https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.ps1) }"
-    Invoke-Expression "& { `$(Invoke-RestMethod https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.ps1) } -Quality staging"
-
+    iex "& { `$(irm https://aka.ms/aspire/get/install.ps1) }"
+    iex "& { `$(irm https://aka.ms/aspire/get/install.ps1) } -Quality staging"
 "@
     if ($InvokedFromFile) { exit 0 } else { return }
 }

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -63,6 +63,50 @@ if ($PSVersionTable.PSVersion.Major -lt $Script:Config.MinimumPowerShellVersion)
     }
 }
 
+# Consolidated output function with fallback for platforms that don't support Write-Host
+function Write-Message {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Message,
+
+        [Parameter()]
+        [ValidateSet("Verbose", "Info", "Success", "Warning", "Error")]
+        [string]$Level = "Info"
+    )
+
+    $hasWriteHost = Get-Command Write-Host -ErrorAction SilentlyContinue
+
+    switch ($Level) {
+        "Verbose" {
+            if ($VerbosePreference -ne "SilentlyContinue") {
+                Write-Verbose $Message
+            }
+        }
+        "Info" {
+            if ($hasWriteHost) {
+                Write-Host $Message -ForegroundColor White
+            } else {
+                Write-Output $Message
+            }
+        }
+        "Success" {
+            if ($hasWriteHost) {
+                Write-Host $Message -ForegroundColor Green
+            } else {
+                Write-Output "SUCCESS: $Message"
+            }
+        }
+        "Warning" {
+            Write-Warning $Message
+        }
+        "Error" {
+            Write-Error $Message
+        }
+    }
+}
+
 if ($Help) {
     Write-Message @"
 Aspire CLI Download Script
@@ -115,50 +159,6 @@ EXAMPLES:
 
 "@
     if ($InvokedFromFile) { exit 0 } else { return }
-}
-
-# Consolidated output function with fallback for platforms that don't support Write-Host
-function Write-Message {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyString()]
-        [string]$Message,
-
-        [Parameter()]
-        [ValidateSet("Verbose", "Info", "Success", "Warning", "Error")]
-        [string]$Level = "Info"
-    )
-
-    $hasWriteHost = Get-Command Write-Host -ErrorAction SilentlyContinue
-
-    switch ($Level) {
-        "Verbose" {
-            if ($VerbosePreference -ne "SilentlyContinue") {
-                Write-Verbose $Message
-            }
-        }
-        "Info" {
-            if ($hasWriteHost) {
-                Write-Host $Message -ForegroundColor White
-            } else {
-                Write-Output $Message
-            }
-        }
-        "Success" {
-            if ($hasWriteHost) {
-                Write-Host $Message -ForegroundColor Green
-            } else {
-                Write-Output "SUCCESS: $Message"
-            }
-        }
-        "Warning" {
-            Write-Warning $Message
-        }
-        "Error" {
-            Write-Error $Message
-        }
-    }
 }
 
 # Helper function for PowerShell version-specific operations

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -25,6 +25,7 @@ SHOW_HELP=false
 VERBOSE=false
 KEEP_ARCHIVE=false
 DRY_RUN=false
+DEFAULT_QUALITY="release"
 
 # Function to show help
 show_help() {
@@ -39,7 +40,7 @@ DESCRIPTION:
     Running with `-Quality staging` will download the latest staging version, or the release version if no staging is available.
     Running with `-Quality dev` will download the latest dev build from `main`.
 
-    The default quality is `release`.
+    The default quality is `${DEFAULT_QUALITY}`.
 
     Pass a specific version to get CLI for that version.
 
@@ -47,7 +48,7 @@ USAGE:
     ./get-aspire-cli.sh [OPTIONS]
 
     -i, --install-path PATH     Directory to install the CLI (default: $HOME/.aspire/bin)
-    -q, --quality QUALITY       Quality to download (default: release). Supported values: dev, staging, release
+    -q, --quality QUALITY       Quality to download (default: ${DEFAULT_QUALITY}). Supported values: dev, staging, release
     --version VERSION           Version of the Aspire CLI to download (default: unset)
     --os OS                     Operating system (default: auto-detect)
     --arch ARCH                 Architecture (default: auto-detect)
@@ -701,8 +702,8 @@ fi
 
 # Initialize default values after parsing arguments
 if [[ -z "$QUALITY" ]]; then
-    # Default quality to "release" if not provided
-    QUALITY="release"
+    # Default quality if not provided
+    QUALITY="${DEFAULT_QUALITY}"
 fi
 
 # Set default install path if not provided

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -67,8 +67,8 @@ EXAMPLES:
     ./get-aspire-cli.sh --help
 
     # Piped execution (like wget <url> | bash or curl <url> | bash):
-    curl -sSL https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.sh | bash
-    curl -sSL https://github.com/dotnet/aspire/raw/refs/heads/main/eng/scripts/get-aspire-cli.sh | bash -s -- --install-path "~/bin"
+    curl -sSL https://aka.ms/aspire/get/install.sh | bash
+    curl -sSL https://aka.ms/aspire/get/install.sh | bash -s -- --install-path "~/bin"
 
 EOF
 }


### PR DESCRIPTION
- **[cli scripts] Fix ps1 -Help which failed because it called WriteMessage before it was defined in the file**
- **Update the URLs to use aka.ms links**
- **cleanup - set the default quality in one place**
