### PR TITLE
Fix ShowDismiss setting not being used with message boxs or confirmations

### DIFF
--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -165,11 +165,11 @@ internal static class InteractionCommands
 
                return CommandResults.Success();
            })
-           .WithCommand("dismiss-interaction", "Dismiss interaction tests", executeCommand: async commandContext =>
+           .WithCommand("dismiss-interaction", "Dismiss interaction tests", executeCommand: commandContext =>
            {
                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
 
-               DoThing(nameof(IInteractionService.PromptNotificationAsync), (showDismiss, title) =>
+               RunInteractionWithDismissValues(nameof(IInteractionService.PromptNotificationAsync), (showDismiss, title) =>
                {
                    return interactionService.PromptNotificationAsync(
                        title: title,
@@ -177,7 +177,7 @@ internal static class InteractionCommands
                        options: new NotificationInteractionOptions { ShowDismiss = showDismiss },
                        cancellationToken: commandContext.CancellationToken);
                });
-               DoThing(nameof(IInteractionService.PromptConfirmationAsync), (showDismiss, title) =>
+               RunInteractionWithDismissValues(nameof(IInteractionService.PromptConfirmationAsync), (showDismiss, title) =>
                {
                    return interactionService.PromptConfirmationAsync(
                        title: title,
@@ -185,7 +185,7 @@ internal static class InteractionCommands
                        options: new MessageBoxInteractionOptions { ShowDismiss = showDismiss },
                        cancellationToken: commandContext.CancellationToken);
                });
-               DoThing(nameof(IInteractionService.PromptMessageBoxAsync), (showDismiss, title) =>
+               RunInteractionWithDismissValues(nameof(IInteractionService.PromptMessageBoxAsync), (showDismiss, title) =>
                {
                    return interactionService.PromptMessageBoxAsync(
                        title: title,
@@ -193,7 +193,7 @@ internal static class InteractionCommands
                        options: new MessageBoxInteractionOptions { ShowDismiss = showDismiss },
                        cancellationToken: commandContext.CancellationToken);
                });
-               DoThing(nameof(IInteractionService.PromptInputAsync), (showDismiss, title) =>
+               RunInteractionWithDismissValues(nameof(IInteractionService.PromptInputAsync), (showDismiss, title) =>
                {
                    return interactionService.PromptInputAsync(
                        title: title,
@@ -204,9 +204,7 @@ internal static class InteractionCommands
                        cancellationToken: commandContext.CancellationToken);
                });
 
-               await Task.Yield();
-
-               return CommandResults.Success();
+               return Task.FromResult(CommandResults.Success());
            })
            .WithCommand("many-values", "Many values", executeCommand: async commandContext =>
            {
@@ -246,8 +244,9 @@ internal static class InteractionCommands
         return resource;
     }
 
-    static void DoThing(string title, Func<bool?, string, Task> action)
+    private static void RunInteractionWithDismissValues(string title, Func<bool?, string, Task> action)
     {
+        // Don't wait for interactions to complete, i.e. await tasks.
         _ = action(null, $"{title} - ShowDismiss = null");
         _ = action(true, $"{title} - ShowDismiss = true");
         _ = action(false, $"{title} - ShowDismiss = false");

--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -165,6 +165,49 @@ internal static class InteractionCommands
 
                return CommandResults.Success();
            })
+           .WithCommand("dismiss-interaction", "Dismiss interaction tests", executeCommand: async commandContext =>
+           {
+               var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
+
+               DoThing(nameof(IInteractionService.PromptNotificationAsync), (showDismiss, title) =>
+               {
+                   return interactionService.PromptNotificationAsync(
+                       title: title,
+                       message: string.Empty,
+                       options: new NotificationInteractionOptions { ShowDismiss = showDismiss },
+                       cancellationToken: commandContext.CancellationToken);
+               });
+               DoThing(nameof(IInteractionService.PromptConfirmationAsync), (showDismiss, title) =>
+               {
+                   return interactionService.PromptConfirmationAsync(
+                       title: title,
+                       message: string.Empty,
+                       options: new MessageBoxInteractionOptions { ShowDismiss = showDismiss },
+                       cancellationToken: commandContext.CancellationToken);
+               });
+               DoThing(nameof(IInteractionService.PromptMessageBoxAsync), (showDismiss, title) =>
+               {
+                   return interactionService.PromptMessageBoxAsync(
+                       title: title,
+                       message: string.Empty,
+                       options: new MessageBoxInteractionOptions { ShowDismiss = showDismiss },
+                       cancellationToken: commandContext.CancellationToken);
+               });
+               DoThing(nameof(IInteractionService.PromptInputAsync), (showDismiss, title) =>
+               {
+                   return interactionService.PromptInputAsync(
+                       title: title,
+                       message: string.Empty,
+                       inputLabel: "Input",
+                       placeHolder: "Enter input",
+                       options: new InputsDialogInteractionOptions { ShowDismiss = showDismiss },
+                       cancellationToken: commandContext.CancellationToken);
+               });
+
+               await Task.Yield();
+
+               return CommandResults.Success();
+           })
            .WithCommand("many-values", "Many values", executeCommand: async commandContext =>
            {
                var interactionService = commandContext.ServiceProvider.GetRequiredService<IInteractionService>();
@@ -201,6 +244,13 @@ internal static class InteractionCommands
            });
 
         return resource;
+    }
+
+    static void DoThing(string title, Func<bool?, string, Task> action)
+    {
+        _ = action(null, $"{title} - ShowDismiss = null");
+        _ = action(true, $"{title} - ShowDismiss = true");
+        _ = action(false, $"{title} - ShowDismiss = false");
     }
 }
 

--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -560,7 +560,7 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
             DialogType = DialogType.MessageBox,
             Alignment = HorizontalAlignment.Center,
             Title = content.Title,
-            ShowDismiss = false,
+            ShowDismiss = parameters.ShowDismiss,
             PrimaryAction = parameters.PrimaryAction,
             SecondaryAction = parameters.SecondaryAction,
             Width = parameters.Width,

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -342,7 +342,7 @@ public class InteractionOptions
     public bool? ShowSecondaryButton { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether show the dismiss button in the header.
+    /// Gets or sets a value indicating whether show the dismiss button.
     /// </summary>
     public bool? ShowDismiss { get; set; }
 


### PR DESCRIPTION
## Description

`ShowDismiss` setting wasn't be applied to message boxes.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
