### PR TITLE
Fix telemetry opt out

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
@@ -34,7 +34,7 @@ internal class ConfigureDefaultDashboardOptions(IConfiguration configuration, IO
         options.AspNetCoreEnvironment = configuration["ASPNETCORE_ENVIRONMENT"] ?? "Production";
 
         options.TelemetryOptOut = bool.TryParse(configuration["ASPIRE_DASHBOARD_TELEMETRY_OPTOUT"], out var telemetryOptOut)
-            ? !telemetryOptOut
+            ? telemetryOptOut
             : null;
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardOptionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardOptionsTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dashboard;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Tests.Dashboard;
+
+public class DashboardOptionsTests
+{
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("purplemonkeydishwasher", null)]
+    [InlineData(null, null)]
+    public void TelemetryOptOut_ConfiguredCorrectly(string? configurationValue, bool? expectedValue)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            { "ASPIRE_DASHBOARD_TELEMETRY_OPTOUT", configurationValue },
+            { "ASPNETCORE_ENVIRONMENT", "Development" },
+            { KnownConfigNames.AspNetCoreUrls, "http://localhost:8080" },
+            { KnownConfigNames.DashboardOtlpGrpcEndpointUrl, "http://localhost:4317" }
+        });
+
+        using var app = builder.Build();
+        var dashboardOptions = app.Services.GetRequiredService<IOptions<DashboardOptions>>().Value;
+        Assert.Equal(expectedValue, dashboardOptions.TelemetryOptOut);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardOptionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardOptionsTests.cs
@@ -13,6 +13,7 @@ public class DashboardOptionsTests
     [Theory]
     [InlineData("true", true)]
     [InlineData("false", false)]
+    [InlineData("", null)]
     [InlineData("purplemonkeydishwasher", null)]
     [InlineData(null, null)]
     public void TelemetryOptOut_ConfiguredCorrectly(string? configurationValue, bool? expectedValue)


### PR DESCRIPTION
## Description

Telemetry opt out was incorrectly being inverted.

Fixes https://github.com/dotnet/aspire/issues/10569

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
