### PR TITLE
Put DeployCommand behind a feature flag

### DIFF
--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -88,7 +88,13 @@ internal sealed class RootCommand : BaseRootCommand
         Subcommands.Add(addCommand);
         Subcommands.Add(publishCommand);
         Subcommands.Add(configCommand);
-        Subcommands.Add(deployCommand);
+
+        // Only add the deploy command if the feature flag is enabled
+        if (featureFlags.IsFeatureEnabled(KnownFeatures.DeployCommandEnabled, defaultValue: false))
+        {
+            Subcommands.Add(deployCommand);
+        }
+
         Subcommands.Add(execCommand);
     }
 }

--- a/src/Aspire.Cli/KnownFeatures.cs
+++ b/src/Aspire.Cli/KnownFeatures.cs
@@ -9,4 +9,5 @@ internal static class KnownFeatures
     public static string FeaturePrefix => "features";
     public static string UpdateNotificationsEnabled => "updateNotificationsEnabled";
     public static string MinimumSdkCheckEnabled => "minimumSdkCheckEnabled";
+    public static string DeployCommandEnabled => "deployCommandEnabled";
 }

--- a/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
@@ -93,7 +93,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         var json = await File.ReadAllTextAsync(settingsPath);
         var settings = JsonNode.Parse(json)?.AsObject();
         Assert.NotNull(settings);
-        
+
         Assert.True(settings["foo"] is JsonObject);
         var fooObject = settings["foo"]!.AsObject();
         Assert.True(fooObject["bar"] is JsonObject);
@@ -109,7 +109,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
-        
+
         // First set a primitive value
         var result1 = command.Parse("config set foo primitive");
         var exitCode1 = await result1.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
@@ -125,7 +125,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         var json = await File.ReadAllTextAsync(settingsPath);
         var settings = JsonNode.Parse(json)?.AsObject();
         Assert.NotNull(settings);
-        
+
         Assert.True(settings["foo"] is JsonObject);
         var fooObject = settings["foo"]!.AsObject();
         Assert.Equal("nested", fooObject["bar"]?.ToString());
@@ -245,7 +245,7 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         var json = await File.ReadAllTextAsync(settingsPath);
         var settings = JsonNode.Parse(json)?.AsObject();
         Assert.NotNull(settings);
-        
+
         // The deep object should be completely removed since it became empty
         Assert.False(settings.ContainsKey("deep"));
     }
@@ -340,19 +340,5 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
         // Check the feature flag
         var featureFlags = provider.GetRequiredService<IFeatures>();
         Assert.False(featureFlags.IsFeatureEnabled("testFeature", defaultValue: true));
-    }
-
-    [Fact]
-    public void DeployCommand_IsAlwaysAvailable()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
-        var provider = services.BuildServiceProvider();
-
-        var rootCommand = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
-        
-        // Check that deploy command is always available
-        var hasDeployCommand = rootCommand.Subcommands.Any(cmd => cmd.Name == "deploy");
-        Assert.True(hasDeployCommand);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
@@ -18,7 +18,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
     {
         using var tempRepo = TemporaryWorkspace.Create(outputHelper);
 
-        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options => options.EnabledFeatures = [KnownFeatures.DeployCommandEnabled]);
         var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
@@ -36,6 +36,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         // Arrange
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
+            options.EnabledFeatures = [KnownFeatures.DeployCommandEnabled];
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner
@@ -69,7 +70,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
-
+            options.EnabledFeatures = [KnownFeatures.DeployCommandEnabled];
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner
@@ -103,7 +104,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
-
+            options.EnabledFeatures = new[] { KnownFeatures.DeployCommandEnabled };
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner
@@ -137,7 +138,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
-
+            options.EnabledFeatures = [KnownFeatures.DeployCommandEnabled];
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner
@@ -201,7 +202,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
-
+            options.EnabledFeatures = [KnownFeatures.DeployCommandEnabled];
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner
@@ -256,6 +257,38 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
 
         // Assert
         Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public void DeployCommand_WhenFeatureFlagDisabled_IsNotAvailable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+
+        // Check that the deploy command is not available in the subcommands
+        var deployCommand = command.Subcommands.FirstOrDefault(c => c.Name == "deploy");
+        Assert.Null(deployCommand);
+    }
+
+    [Fact]
+    public void DeployCommand_WhenFeatureFlagEnabled_IsAvailable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(
+            workspace,
+            outputHelper,
+            options => options.EnabledFeatures = [KnownFeatures.DeployCommandEnabled]
+        );
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+
+        // Check that the deploy command is available in the subcommands
+        var deployCommand = command.Subcommands.FirstOrDefault(c => c.Name == "deploy");
+        Assert.NotNull(deployCommand);
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
@@ -104,7 +104,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
         {
             options.ProjectLocatorFactory = (sp) => new TestProjectLocator();
-            options.EnabledFeatures = new[] { KnownFeatures.DeployCommandEnabled };
+            options.EnabledFeatures = [KnownFeatures.DeployCommandEnabled];
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner

--- a/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
@@ -97,6 +97,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.EnabledFeatures = [KnownFeatures.DeployCommandEnabled];
             options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
             {
                 CheckAsyncCallback = _ => false // SDK not installed


### PR DESCRIPTION
Put the DeployCommand behind a feature flag until a built-in deployer is available.