### PR TITLE
fix: aspire exec fails in AOT for `CommandOutput` serialization

### DIFF
--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -194,7 +194,7 @@ internal class BackchannelLogEntry
     public required string CategoryName { get; set; }
 }
 
-internal struct CommandOutput
+internal class CommandOutput
 {
     public required string Text { get; init; }
     public bool IsErrorMessage { get; init; }


### PR DESCRIPTION
## Description

> ❌  An unexpected error occurred: Deserializing JSON-RPC result to type IAsyncEnumerable`1 failed with
NotSupportedException: 'StreamJsonRpc.SystemTextJsonFormatter+AsyncEnumerableConverter+Converter`1[
Aspire.Cli.Backchannel.CommandOutput]' is missing native code or metadata. This can happen for code that is not
compatible with trimming or AOT. Inspect and fix trimming and AOT related warnings that were generated when the app was
published. For more information see https://aka.ms/nativeaot-compatibility

Fixes #10596