### PR TITLE
[backport 9.4] `aspire exec` fixes

### DIFF
--- a/src/Aspire.Cli/Commands/ExecCommand.cs
+++ b/src/Aspire.Cli/Commands/ExecCommand.cs
@@ -67,6 +67,11 @@ internal class ExecCommand : BaseCommand
         startResourceOption.Description = ExecCommandStrings.StartTargetResourceArgumentDescription;
         Options.Add(startResourceOption);
 
+        // only for --help output
+        var commandOption = new Option<string>("--");
+        commandOption.Description = ExecCommandStrings.CommandArgumentDescription;
+        Options.Add(commandOption);
+
         TreatUnmatchedTokensAsErrors = false;
     }
 

--- a/src/Aspire.Cli/Resources/ExecCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ExecCommandStrings.Designer.cs
@@ -61,7 +61,22 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Run an Aspire app host to execute a command against the resource. (Preview).
+        ///   Looks up a localized string similar to The command to execute in the target resource&apos;s context. Commands can be specified directly after options or after a -- separator..
+        /// </summary>
+        internal static string CommandArgumentDescription {
+            get {
+                return ResourceManager.GetString("CommandArgumentDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource&apos;s environment. (Preview)
+        ///
+        ///Examples:
+        ///  aspire exec --resource api dotnet build
+        ///  aspire exec --resource api -- dotnet test --logger console
+        ///  aspire exec --start-resource worker pwsh -c &quot;Get-Process&quot;
+        ///    .
         /// </summary>
         internal static string Description {
             get {
@@ -70,7 +85,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to parse command..
+        ///   Looks up a localized string similar to Failed to parse the command. Ensure the command is specified after all options or after the -- separator..
         /// </summary>
         internal static string FailedToParseCommand {
             get {
@@ -79,7 +94,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The path to the Aspire app host project file..
+        ///   Looks up a localized string similar to The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory..
         /// </summary>
         internal static string ProjectArgumentDescription {
             get {
@@ -88,7 +103,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name of the target resource to start and execute the command against..
+        ///   Looks up a localized string similar to The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running..
         /// </summary>
         internal static string StartTargetResourceArgumentDescription {
             get {
@@ -97,7 +112,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name of the target resource to execute the command against..
+        ///   Looks up a localized string similar to The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready..
         /// </summary>
         internal static string TargetResourceArgumentDescription {
             get {
@@ -106,7 +121,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Target resource is not specified..
+        ///   Looks up a localized string similar to Target resource is not specified. Use --resource or --start-resource to specify the target..
         /// </summary>
         internal static string TargetResourceNotSpecified {
             get {

--- a/src/Aspire.Cli/Resources/ExecCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ExecCommandStrings.Designer.cs
@@ -94,6 +94,15 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Command is not specified..
+        /// </summary>
+        internal static string NoCommandSpecified {
+            get {
+                return ResourceManager.GetString("NoCommandSpecified", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory..
         /// </summary>
         internal static string ProjectArgumentDescription {

--- a/src/Aspire.Cli/Resources/ExecCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ExecCommandStrings.resx
@@ -118,21 +118,30 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>Run an Aspire app host to execute a command against the resource. (Preview)</value>
+    <value>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </value>
   </data>
   <data name="ProjectArgumentDescription" xml:space="preserve">
-    <value>The path to the Aspire app host project file.</value>
+    <value>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</value>
   </data>
   <data name="StartTargetResourceArgumentDescription" xml:space="preserve">
-    <value>The name of the target resource to start and execute the command against.</value>
+    <value>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</value>
   </data>
   <data name="TargetResourceArgumentDescription" xml:space="preserve">
-    <value>The name of the target resource to execute the command against.</value>
+    <value>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</value>
   </data>
   <data name="TargetResourceNotSpecified" xml:space="preserve">
-    <value>Target resource is not specified.</value>
+    <value>Target resource is not specified. Use --resource or --start-resource to specify the target.</value>
   </data>
   <data name="FailedToParseCommand" xml:space="preserve">
-    <value>Failed to parse command.</value>
+    <value>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</value>
+  </data>
+  <data name="CommandArgumentDescription" xml:space="preserve">
+    <value>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/ExecCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ExecCommandStrings.resx
@@ -144,4 +144,7 @@ Examples:
   <data name="CommandArgumentDescription" xml:space="preserve">
     <value>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</value>
   </data>
+  <data name="NoCommandSpecified" xml:space="preserve">
+    <value>Command is not specified.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.cs.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.cs.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.de.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.de.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.es.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.es.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.fr.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.fr.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.it.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.it.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ja.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ja.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ko.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ko.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pl.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pl.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pt-BR.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.pt-BR.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ru.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.ru.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.tr.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.tr.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hans.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hans.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hant.xlf
@@ -2,34 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExecCommandStrings.resx">
     <body>
+      <trans-unit id="CommandArgumentDescription">
+        <source>The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</source>
+        <target state="new">The command to execute in the target resource's context. Commands can be specified directly after options or after a -- separator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
-        <source>Run an Aspire app host to execute a command against the resource. (Preview)</source>
-        <target state="new">Run an Aspire app host to execute a command against the resource. (Preview)</target>
+        <source>Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </source>
+        <target state="new">Execute commands in the context of an Aspire application resource. Starts the AppHost, waits for resources to initialize, then runs the specified command in the target resource's environment. (Preview)
+
+Examples:
+  aspire exec --resource api dotnet build
+  aspire exec --resource api -- dotnet test --logger console
+  aspire exec --start-resource worker pwsh -c "Get-Process"
+    </target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToParseCommand">
-        <source>Failed to parse command.</source>
-        <target state="new">Failed to parse command.</target>
+        <source>Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</source>
+        <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
-        <source>The path to the Aspire app host project file.</source>
-        <target state="new">The path to the Aspire app host project file.</target>
+        <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
+        <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartTargetResourceArgumentDescription">
-        <source>The name of the target resource to start and execute the command against.</source>
-        <target state="new">The name of the target resource to start and execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will only be executed after the target resource has successfully started and is running.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceArgumentDescription">
-        <source>The name of the target resource to execute the command against.</source>
-        <target state="new">The name of the target resource to execute the command against.</target>
+        <source>The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</source>
+        <target state="new">The name of the target resource to execute the command against. The command will be executed as soon as the AppHost starts, without waiting for the resource to be ready.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetResourceNotSpecified">
-        <source>Target resource is not specified.</source>
-        <target state="new">Target resource is not specified.</target>
+        <source>Target resource is not specified. Use --resource or --start-resource to specify the target.</source>
+        <target state="new">Target resource is not specified. Use --resource or --start-resource to specify the target.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ExecCommandStrings.zh-Hant.xlf
@@ -29,6 +29,11 @@ Examples:
         <target state="new">Failed to parse the command. Ensure the command is specified after all options or after the -- separator.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCommandSpecified">
+        <source>Command is not specified.</source>
+        <target state="new">Command is not specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</source>
         <target state="new">The path to the Aspire AppHost project file. If not specified, searches for a project file in the current directory.</target>

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -194,7 +194,7 @@ internal class BackchannelLogEntry
     public required string CategoryName { get; set; }
 }
 
-internal struct CommandOutput
+internal class CommandOutput
 {
     public required string Text { get; init; }
     public bool IsErrorMessage { get; init; }

--- a/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 using RootCommand = Aspire.Cli.Commands.RootCommand;
 
 namespace Aspire.Cli.Tests.Commands;

--- a/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Cli.Commands;
+using System.CommandLine;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
+using RootCommand = Aspire.Cli.Commands.RootCommand;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -25,7 +25,10 @@ public class ExecCommandTests
         var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("exec --help");
+        var commandLineConfiguration = new CommandLineConfiguration(command);
+        commandLineConfiguration.Output = new TestOutputTextWriter(_outputHelper);
+
+        var result = command.Parse("exec --help", commandLineConfiguration);
 
         var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
         Assert.Equal(ExitCodeConstants.Success, exitCode);

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -246,18 +246,29 @@ internal sealed class CliServiceCollectionTestOptions
     };
 }
 
-internal sealed class TestOutputTextWriter(ITestOutputHelper outputHelper) : TextWriter
+internal sealed class TestOutputTextWriter : TextWriter
 {
+    private readonly ITestOutputHelper _outputHelper;
+
+    public TestOutputTextWriter(ITestOutputHelper outputHelper) : this(outputHelper, null)
+    {
+    }
+
+    public TestOutputTextWriter(ITestOutputHelper outputHelper, IFormatProvider? formatProvider) : base(formatProvider)
+    {
+        _outputHelper = outputHelper;
+    }
+
     public override Encoding Encoding => Encoding.UTF8;
 
     public override void WriteLine(string? message)
     {
-        outputHelper.WriteLine(message!);
+        _outputHelper.WriteLine(message!);
     }
 
     public override void Write(string? message)
     {
-        outputHelper.Write(message!);
+        _outputHelper.Write(message!);
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -249,6 +249,7 @@ internal sealed class CliServiceCollectionTestOptions
 internal sealed class TestOutputTextWriter : TextWriter
 {
     private readonly ITestOutputHelper _outputHelper;
+    public List<string> Logs { get; } = new List<string>();
 
     public TestOutputTextWriter(ITestOutputHelper outputHelper) : this(outputHelper, null)
     {
@@ -264,11 +265,19 @@ internal sealed class TestOutputTextWriter : TextWriter
     public override void WriteLine(string? message)
     {
         _outputHelper.WriteLine(message!);
+        if (message is not null)
+        {
+            Logs.Add(message);
+        }
     }
 
     public override void Write(string? message)
     {
         _outputHelper.Write(message!);
+        if (message is not null)
+        {
+            Logs.Add(message);
+        }
     }
 
 }


### PR DESCRIPTION
This is a cherry-pick from `main` to `release/9.4` of the following PRs (and issues they are fixing):
| issue | PR |
| --- | --- |
| #10596 | https://github.com/dotnet/aspire/pull/10625 |
| #10594 | https://github.com/dotnet/aspire/pull/10598 |
| #10591 & #10592 | https://github.com/dotnet/aspire/pull/10606 |

#10625 is a very important fix to backport, because it fixes the behavior in AOT Aspire.Cli.
Others are minor improvements for `aspire exec --help`, and fail-fast and argument validation scenario improvements.

