### PR TITLE
Fix AddBlobs and AddBlobContainer when using default name

### DIFF
--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Shared\AzureRoleAssignmentUtils.cs" />
+    <Compile Include="$(SharedDir)StringComparers.cs" Link="StringComparers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -338,6 +338,13 @@ public static class AzureStorageExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
+        if (string.Equals(name, builder.Resource.Name + "-blobs", StringComparisons.ResourceName))
+        {
+            // If the name is the default name, use the GetBlobService method instead so we keep
+            // track of the default resource.
+            return GetBlobService(builder);
+        }
+
         return CreateBlobService(builder, name);
     }
 
@@ -469,6 +476,13 @@ public static class AzureStorageExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
+
+        if (string.Equals(name, builder.Resource.Name + "-queues", StringComparisons.ResourceName))
+        {
+            // If the name is the default name, use the GetQueueService method instead so we keep
+            // track of the default resource.
+            return GetQueueService(builder);
+        }
 
         return CreateQueueService(builder, name);
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -824,6 +824,60 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
         Assert.Equal(expectedTableManifest, tableManifest.ToString());
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddBlobsReturnsExistingResourceWhenNamesMatch(bool addContainerFirst)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+
+        if (addContainerFirst)
+        {
+            storage.AddBlobContainer("blobcontainer");
+        }
+
+        var blobService = storage.AddBlobs("storage-blobs");
+
+        if (!addContainerFirst)
+        {
+            storage.AddBlobContainer("blobcontainer");
+        }
+
+        var blobStorageResource = builder.Resources.OfType<AzureBlobStorageResource>().Single();
+
+        Assert.NotNull(blobStorageResource);
+        Assert.Equal("storage-blobs", blobService.Resource.Name);
+        Assert.Equal(blobService.Resource, blobStorageResource);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddQueuesServiceReturnsExistingResourceWhenNamesMatch(bool addQueueFirst)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var storage = builder.AddAzureStorage("storage");
+
+        if (addQueueFirst)
+        {
+            storage.AddQueue("queue");
+        }
+
+        var queueService = storage.AddQueues("storage-queues");
+
+        if (!addQueueFirst)
+        {
+            storage.AddQueue("queue");
+        }
+
+        var queueStorageResource = builder.Resources.OfType<AzureQueueStorageResource>().Single();
+
+        Assert.NotNull(queueStorageResource);
+        Assert.Equal("storage-queues", queueService.Resource.Name);
+        Assert.Equal(queueService.Resource, queueStorageResource);
+    }
+
     [Fact]
     public void RunAsEmulatorAppliesEmulatorResourceAnnotation()
     {


### PR DESCRIPTION
## Description

When calling both AddBlobContainer and `.AddBlobs("{storageName}-blobs")`, an exception is thrown because a duplicate resource is trying to be added.

The fix is to check for the default name in AddBlobs and AddQueues and return the same resource that is used in AddBlobContainer and AddQueue.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
