### PR TITLE
Add links between telemetry and resources in grid values

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
@@ -206,7 +206,7 @@ public partial class PlotlyChart : ChartBase
         [JSInvokable]
         public async Task ViewSpan(string traceId, string spanId)
         {
-            var available = await MetricsHelpers.WaitForSpanToBeAvailableAsync(
+            var available = await TraceLinkHelpers.WaitForSpanToBeAvailableAsync(
                 traceId,
                 spanId,
                 _plotlyChart.TelemetryRepository.GetSpan,

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -23,7 +23,12 @@
             else
             {
                 @ContentBeforeValue
-                if (ValueTemplate is not null)
+                if (ComponentMetadata is not null)
+                {
+                    <DynamicComponent Type="@ComponentMetadata.Type"
+                                      Parameters="@BuildComponentParameters()" />
+                }
+                else if (ValueTemplate is not null)
                 {
                     @ValueTemplate(Value)
                 }

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
@@ -4,11 +4,12 @@
 using System.Net;
 using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.ConsoleLogs;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
-using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 using Microsoft.JSInterop;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -92,6 +93,9 @@ public partial class GridValue
     [Parameter]
     public bool ContainsSecret { get; set; }
 
+    [Parameter]
+    public ComponentMetadata? ComponentMetadata { get; set; }
+
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; set; }
 
@@ -106,6 +110,7 @@ public partial class GridValue
     private readonly string _cellTextId = $"celltext-{Guid.NewGuid():N}";
     private string? _value;
     private string? _formattedValue;
+    private Dictionary<string, object>? _componentParameters;
 
     protected override void OnInitialized()
     {
@@ -156,5 +161,23 @@ public partial class GridValue
     private async Task OpenTextVisualizerAsync()
     {
         await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, ValueDescription, ValueToVisualize ?? Value ?? string.Empty, IsMasked || ContainsSecret);
+    }
+
+    private Dictionary<string, object> BuildComponentParameters()
+    {
+        _componentParameters ??= [];
+
+        if (ComponentMetadata?.Parameters != null)
+        {
+            foreach (var parameter in ComponentMetadata.Parameters)
+            {
+                _componentParameters[parameter.Key] = parameter.Value;
+            }
+        }
+
+        _componentParameters["Value"] = Value ?? string.Empty;
+        _componentParameters["HighlightText"] = HighlightText ?? string.Empty;
+
+        return _componentParameters;
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -34,7 +34,8 @@
                        IsMasked="@context.IsValueMasked"
                        IsMaskedChanged="(isMasked) => OnIsValueMaskedChanged(context, isMasked)"
                        TextVisualizerTitle="@context.Name"
-                       ValueToVisualize="@(context.ValueToVisualize ?? context.Value)" />
+                       ValueToVisualize="@(context.ValueToVisualize ?? context.Value)"
+                       ComponentMetadata="@GetComponentMetadata(context)"/>
             @ExtraValueContent(context)
         </AspireTemplateColumn>
     </FluentDataGrid>

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -142,6 +143,9 @@ public partial class PropertyGrid<TItem> where TItem : IPropertyGridItem
     [Parameter]
     public string? Class { get; set; }
 
+    [Parameter]
+    public Dictionary<string, ComponentMetadata>? ValueComponents { get; set; }
+
     private ColumnResizeLabels _resizeLabels = ColumnResizeLabels.Default;
     private ColumnSortLabels _sortLabels = ColumnSortLabels.Default;
 
@@ -160,5 +164,15 @@ public partial class PropertyGrid<TItem> where TItem : IPropertyGridItem
         item.IsValueMasked = isValueMasked;
 
         await IsValueMaskedChanged.InvokeAsync(item);
+    }
+
+    private ComponentMetadata? GetComponentMetadata(TItem item)
+    {
+        if (ValueComponents is null)
+        {
+            return null;
+        }
+        ValueComponents.TryGetValue(item.Key as string ?? item.Name, out var metadata);
+        return metadata;
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/LogLevelValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/LogLevelValue.razor
@@ -1,0 +1,12 @@
+﻿@using Aspire.Dashboard.Utils
+
+@if (LogEntry.IsError)
+{
+    <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="severity-icon" />
+}
+else if (LogEntry.IsWarning)
+{
+    <FluentIcon Icon="Icons.Filled.Size16.Warning" Color="Color.Warning" Class="severity-icon" />
+}
+
+<FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/LogLevelValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/LogLevelValue.razor.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+using Microsoft.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Controls.PropertyValues;
+
+public partial class LogLevelValue
+{
+    [Parameter, EditorRequired]
+    public required string Value { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string HighlightText { get; set; }
+
+    [Parameter, EditorRequired]
+    public required OtlpLogEntry LogEntry { get; set; }
+}

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceHealthStateValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceHealthStateValue.razor
@@ -1,0 +1,12 @@
+﻿@using Aspire.Dashboard.Otlp.Model
+@using Aspire.Dashboard.Utils
+
+@if (_icon != null)
+{
+    <FluentIcon Width="16px"
+                Class="severity-icon"
+                Color="@_color"
+                Value="@_icon" />
+}
+
+<FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceHealthStateValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceHealthStateValue.razor.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Controls.PropertyValues;
+
+public partial class ResourceHealthStateValue
+{
+    private Icon? _icon;
+    private Color _color;
+
+    [Parameter, EditorRequired]
+    public required string Value { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string HighlightText { get; set; }
+
+    [Parameter, EditorRequired]
+    public required ResourceViewModel Resource { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        (_icon, _color) = ResourceIconHelpers.GetHealthStatusIcon(Resource.HealthStatus);
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameButtonValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameButtonValue.razor
@@ -1,0 +1,13 @@
+﻿@using Aspire.Dashboard.Utils
+
+@if (_resourceIcon != null)
+{
+    @* Only display a button if dashboard client is enabled and a matching resource can be found. *@
+    <FluentButton OnClick="OnClickAsync" Appearance="Appearance.Lightweight" Class="button-hyperlink" IconStart="_resourceIcon">
+        <FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />
+    </FluentButton>
+}
+else
+{
+    <FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />
+}

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameButtonValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameButtonValue.razor.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Controls.PropertyValues;
+
+public partial class ResourceNameButtonValue
+{
+    [Parameter, EditorRequired]
+    public required string Value { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string HighlightText { get; set; }
+
+    [Parameter, EditorRequired]
+    public required OtlpApplication Resource { get; set; }
+
+    [Inject]
+    public required NavigationManager NavigationManager { get; init; }
+
+    [Inject]
+    public required IDashboardClient DashboardClient { get; init; }
+
+    private ResourceViewModel? _resource;
+    private Icon? _resourceIcon;
+
+    protected override void OnParametersSet()
+    {
+        _resourceIcon = null;
+
+        if (DashboardClient.IsEnabled)
+        {
+            _resource = DashboardClient.GetResource(Resource.ApplicationKey.ToString());
+            if (_resource != null)
+            {
+                _resourceIcon = ResourceIconHelpers.GetIconForResource(_resource, IconSize.Size16, IconVariant.Regular);
+            }
+        }
+    }
+
+    private Task OnClickAsync()
+    {
+        Debug.Assert(_resource != null, "Should only get here if there is a matched resource.");
+
+        NavigationManager.NavigateTo(DashboardUrls.ResourcesUrl(_resource.Name));
+        return Task.CompletedTask;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameValue.razor
@@ -1,0 +1,12 @@
+﻿@using Aspire.Dashboard.Otlp.Model
+@using Aspire.Dashboard.Utils
+
+@* Do this to trim significant whitespace so there isn't a space added between icon and text *@
+@{
+    <FluentIcon Width="16px"
+                Class="resource-icon"
+                Color="Color.Custom"
+                CustomColor="@ColorGenerator.Instance.GetColorHexByKey(FormatName(Resource))"
+                Value="@ResourceIconHelpers.GetIconForResource(Resource, IconSize.Size16)" />
+}
+<FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameValue.razor.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Controls.PropertyValues;
+
+public partial class ResourceNameValue
+{
+    [Parameter, EditorRequired]
+    public required string Value { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string HighlightText { get; set; }
+
+    [Parameter, EditorRequired]
+    public required ResourceViewModel Resource { get; set; }
+
+    [Parameter, EditorRequired]
+    public required Func<ResourceViewModel, string> FormatName { get; set; }
+}

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceStateValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceStateValue.razor
@@ -1,0 +1,9 @@
+﻿@using Aspire.Dashboard.Utils
+
+@* Do this to trim significant whitespace so there isn't a space added between icon and text *@
+@{
+    <FluentIcon Value="@_stateViewModel.Icon"
+                Color="@_stateViewModel.Color"
+                Class="severity-icon" />
+}
+<FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceStateValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceStateValue.razor.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Resources;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace Aspire.Dashboard.Components.Controls.PropertyValues;
+
+public partial class ResourceStateValue
+{
+    private ResourceStateViewModel _stateViewModel = null!;
+
+    [Parameter, EditorRequired]
+    public required string Value { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string HighlightText { get; set; }
+
+    [Parameter, EditorRequired]
+    public required ResourceViewModel Resource { get; set; }
+
+    [Inject]
+    public required IDashboardClient DashboardClient { get; init; }
+
+    [Inject]
+    public required IStringLocalizer<Columns> Loc { get; init; }
+
+    protected override void OnParametersSet()
+    {
+        _stateViewModel = ResourceStateViewModel.GetStateViewModel(Resource, Loc);
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanIdButtonValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanIdButtonValue.razor
@@ -1,0 +1,5 @@
+﻿@using Aspire.Dashboard.Utils
+
+<FluentButton OnClick="OnClickAsync" Appearance="Appearance.Lightweight" Class="button-hyperlink" IconStart="new Icons.Regular.Size16.GanttChart()">
+    <FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />
+</FluentButton>

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanIdButtonValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanIdButtonValue.razor.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Controls.PropertyValues;
+
+public partial class SpanIdButtonValue
+{
+    [Parameter, EditorRequired]
+    public required string Value { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string HighlightText { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string TraceId { get; set; }
+
+    [Inject]
+    public required IDialogService DialogService { get; init; }
+
+    [Inject]
+    public required TelemetryRepository TelemetryRepository { get; init; }
+
+    [Inject]
+    public required IStringLocalizer<Resources.Dialogs> Loc { get; init; }
+
+    [Inject]
+    public required NavigationManager NavigationManager { get; init; }
+
+    private async Task OnClickAsync()
+    {
+        var available = await TraceLinkHelpers.WaitForSpanToBeAvailableAsync(
+            traceId: TraceId,
+            spanId: Value,
+            getSpan: TelemetryRepository.GetSpan,
+            DialogService,
+            InvokeAsync,
+            Loc,
+            CancellationToken.None).ConfigureAwait(false);
+
+        if (available)
+        {
+            NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(TraceId, spanId: Value));
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanStatusValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanStatusValue.razor
@@ -1,0 +1,8 @@
+﻿@using Aspire.Dashboard.Utils
+
+@if (Span.Status == Otlp.Model.OtlpSpanStatusCode.Error)
+{
+    <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="severity-icon" />
+}
+
+<FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanStatusValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanStatusValue.razor.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+using Microsoft.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Controls.PropertyValues;
+
+public partial class SpanStatusValue
+{
+    [Parameter, EditorRequired]
+    public required string Value { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string HighlightText { get; set; }
+
+    [Parameter, EditorRequired]
+    public required OtlpSpan Span { get; set; }
+}

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/TraceIdButtonValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/TraceIdButtonValue.razor
@@ -1,0 +1,5 @@
+﻿@using Aspire.Dashboard.Utils
+
+<FluentButton OnClick="OnClickAsync" Appearance="Appearance.Lightweight" Class="button-hyperlink" IconStart="new Icons.Regular.Size16.GanttChart()">
+    <FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />
+</FluentButton>

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/TraceIdButtonValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/TraceIdButtonValue.razor.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Utils;
+using Microsoft.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Controls.PropertyValues;
+
+public partial class TraceIdButtonValue
+{
+    [Parameter, EditorRequired]
+    public required string Value { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string HighlightText { get; set; }
+
+    [Parameter]
+    public EventCallback OnClick { get; set; }
+
+    [Inject]
+    public required NavigationManager NavigationManager { get; init; }
+
+    private async Task OnClickAsync()
+    {
+        if (OnClick.HasDelegate)
+        {
+            await OnClick.InvokeAsync();
+        }
+        else
+        {
+            NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(Value));
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -50,12 +50,12 @@
                         @FilteredResourceProperties.Count()
                     </FluentBadge>
                 </div>
-                <PropertyGrid
-                    TItem="DisplayedResourcePropertyViewModel"
-                    Items="@FilteredResourceProperties"
-                    IsValueMaskedChanged="@OnValueMaskedChanged"
-                    HighlightText="@_filter"
-                    GridTemplateColumns="1fr 1.5fr" />
+                <PropertyGrid TItem="DisplayedResourcePropertyViewModel"
+                              Items="@FilteredResourceProperties"
+                              IsValueMaskedChanged="@OnValueMaskedChanged"
+                              HighlightText="@_filter"
+                              GridTemplateColumns="1fr 1.5fr"
+                              ValueComponents="_valueComponents" />
             </FluentAccordionItem>
             <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsUrlsHeader)]" Expanded="@_isUrlsExpanded">
                 <div slot="end">
@@ -241,14 +241,7 @@
                                 }
                                 else
                                 {
-                                    // Browse the icon library at: https://aka.ms/fluentui-system-icons
-                                    (Icon? icon, Color color) = context.HealthStatus switch
-                                    {
-                                        HealthStatus.Healthy => ((Icon)new Icons.Filled.Size16.Heart(), Color.Success),
-                                        HealthStatus.Degraded => (new Icons.Filled.Size16.HeartBroken(), Color.Warning),
-                                        HealthStatus.Unhealthy => (new Icons.Filled.Size16.HeartBroken(), Color.Error),
-                                        _ => (new Icons.Regular.Size16.CircleHint(), Color.Info)
-                                    };
+                                    (Icon? icon, Color color) = ResourceIconHelpers.GetHealthStatusIcon(context.HealthStatus);
 
                                     <FluentIcon Value="@icon" Color="@color" Class="severity-icon"/>
                                 }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using Aspire.Dashboard.Components.Controls.PropertyValues;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Telemetry;
@@ -101,6 +102,7 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
     private string _filter = "";
     private bool? _isMaskAllChecked;
     private bool _dataChanged;
+    private Dictionary<string, ComponentMetadata>? _valueComponents;
 
     private bool IsMaskAllChecked
     {
@@ -145,6 +147,25 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                     item.IsValueMasked = !_unmaskedItemNames.Contains(item.Name);
                 }
             }
+
+            _valueComponents = new Dictionary<string, ComponentMetadata>
+            {
+                [KnownProperties.Resource.State] = new ComponentMetadata
+                {
+                    Type = typeof(ResourceStateValue),
+                    Parameters = { ["Resource"] = _resource }
+                },
+                [KnownProperties.Resource.DisplayName] = new ComponentMetadata
+                {
+                    Type = typeof(ResourceNameValue),
+                    Parameters = { ["Resource"] = _resource, ["FormatName"] = (ResourceViewModel r) => ResourceViewModel.GetResourceName(r, ResourceByName) }
+                },
+                [KnownProperties.Resource.HealthState] = new ComponentMetadata
+                {
+                    Type = typeof(ResourceHealthStateValue),
+                    Parameters = { ["Resource"] = _resource }
+                },
+            };
         }
 
         UpdateTelemetryProperties();

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -39,7 +39,8 @@
                 <PropertyGrid TItem="TelemetryPropertyViewModel"
                               Items="@FilteredItems"
                               GridTemplateColumns="1fr 2fr"
-                              HighlightText="@_filter" />
+                              HighlightText="@_filter"
+                              ValueComponents="_valueComponents" />
             </FluentAccordionItem>
             <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsContextHeader)]" Expanded="true">
                 <div slot="end">
@@ -50,7 +51,8 @@
                 <PropertyGrid TItem="TelemetryPropertyViewModel"
                               Items="@FilteredContextItems"
                               GridTemplateColumns="1fr 2fr"
-                              HighlightText="@_filter" />
+                              HighlightText="@_filter"
+                              ValueComponents="@_valueComponents" />
             </FluentAccordionItem>
             <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsResourceHeader)]" Expanded="true">
                 <div slot="end">
@@ -61,7 +63,8 @@
                 <PropertyGrid TItem="TelemetryPropertyViewModel"
                               Items="@FilteredResourceItems"
                               GridTemplateColumns="1fr 2fr"
-                              HighlightText="@_filter" />
+                              HighlightText="@_filter"
+                              ValueComponents="@_valueComponents" />
             </FluentAccordionItem>
             <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsEventsHeader)]" Expanded="@_isSpanEventsExpanded">
                 <div slot="end">

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Components.Controls.PropertyValues;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
@@ -18,6 +19,9 @@ public partial class SpanDetails : IDisposable
 {
     [Parameter, EditorRequired]
     public required SpanDetailsViewModel ViewModel { get; set; }
+
+    [Parameter, EditorRequired]
+    public required EventCallback CloseCallback { get; set; }
 
     [Inject]
     public required IDialogService DialogService { get; init; }
@@ -61,6 +65,7 @@ public partial class SpanDetails : IDisposable
     private List<TelemetryPropertyViewModel> _contextAttributes = null!;
     private bool _dataChanged;
     private SpanDetailsViewModel? _viewModel;
+    private Dictionary<string, ComponentMetadata>? _valueComponents;
 
     private ColumnResizeLabels _resizeLabels = ColumnResizeLabels.Default;
     private ColumnSortLabels _sortLabels = ColumnSortLabels.Default;
@@ -99,19 +104,43 @@ public partial class SpanDetails : IDisposable
             {
                 _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "Version", Key = KnownSourceFields.VersionField, Value = _viewModel.Span.Scope.Version });
             }
-            if (!string.IsNullOrEmpty(_viewModel.Span.ParentSpanId))
-            {
-                _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "ParentId", Key = KnownTraceFields.ParentIdField, Value = _viewModel.Span.ParentSpanId });
-            }
             if (!string.IsNullOrEmpty(_viewModel.Span.TraceId))
             {
                 _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "TraceId", Key = KnownTraceFields.TraceIdField, Value = _viewModel.Span.TraceId });
+            }
+            if (!string.IsNullOrEmpty(_viewModel.Span.ParentSpanId))
+            {
+                _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "ParentId", Key = KnownTraceFields.ParentIdField, Value = _viewModel.Span.ParentSpanId });
             }
 
             // Collapse details sections when they have no data.
             _isSpanEventsExpanded = _viewModel.Span.Events.Any();
             _isSpanLinksExpanded = _viewModel.Span.Links.Any();
             _isSpanBacklinksExpanded = _viewModel.Span.BackLinks.Any();
+
+            _valueComponents = new Dictionary<string, ComponentMetadata>
+            {
+                [KnownTraceFields.TraceIdField] = new ComponentMetadata
+                {
+                    Type = typeof(TraceIdButtonValue),
+                    Parameters = { ["OnClick"] = CloseCallback }
+                },
+                [KnownTraceFields.ParentIdField] = new ComponentMetadata
+                {
+                    Type = typeof(SpanIdButtonValue),
+                    Parameters = { ["TraceId"] = _viewModel.Span.TraceId }
+                },
+                [KnownResourceFields.ServiceNameField] = new ComponentMetadata
+                {
+                    Type = typeof(ResourceNameButtonValue),
+                    Parameters = { ["Resource"] = _viewModel.Span.Source.Application }
+                },
+                [KnownTraceFields.StatusField] = new ComponentMetadata
+                {
+                    Type = typeof(SpanStatusValue),
+                    Parameters = { ["Span"] = _viewModel.Span }
+                },
+            };
         }
     }
 
@@ -130,7 +159,7 @@ public partial class SpanDetails : IDisposable
 
     public async Task OnViewDetailsAsync(SpanLinkViewModel linkVM)
     {
-        var available = await MetricsHelpers.WaitForSpanToBeAvailableAsync(
+        var available = await TraceLinkHelpers.WaitForSpanToBeAvailableAsync(
             traceId: linkVM.TraceId,
             spanId: linkVM.SpanId,
             getSpan: TelemetryRepository.GetSpan,

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
@@ -30,7 +30,8 @@
                 <PropertyGrid TItem="TelemetryPropertyViewModel"
                               Items="@FilteredItems"
                               GridTemplateColumns="1fr 2fr"
-                              HighlightText="@_filter" />
+                              HighlightText="@_filter"
+                              ValueComponents="@_valueComponents" />
             </FluentAccordionItem>
             <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.StructuredLogsDetailsContextHeader)]" Expanded="true">
                 <div slot="end">
@@ -41,7 +42,8 @@
                 <PropertyGrid TItem="TelemetryPropertyViewModel"
                               Items="@FilteredContextItems"
                               GridTemplateColumns="1fr 2fr"
-                              HighlightText="@_filter" />
+                              HighlightText="@_filter"
+                              ValueComponents="@_valueComponents" />
             </FluentAccordionItem>
             @if (_exceptionAttributes.Count > 0)
             {
@@ -66,7 +68,8 @@
                 <PropertyGrid TItem="TelemetryPropertyViewModel"
                               Items="@FilteredResourceItems"
                               GridTemplateColumns="1fr 2fr"
-                              HighlightText="@_filter" />
+                              HighlightText="@_filter"
+                              ValueComponents="@_valueComponents" />
             </FluentAccordionItem>
         </FluentAccordion>
     </div>

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Components.Controls.PropertyValues;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
@@ -14,6 +15,9 @@ public partial class StructuredLogDetails : IDisposable
 {
     [Parameter, EditorRequired]
     public required StructureLogsDetailsViewModel ViewModel { get; set; }
+
+    [Parameter]
+    public EventCallback CloseCallback { get; set; }
 
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
@@ -40,6 +44,7 @@ public partial class StructuredLogDetails : IDisposable
     private string _filter = "";
     private bool _dataChanged;
     private StructureLogsDetailsViewModel? _viewModel;
+    private Dictionary<string, ComponentMetadata>? _valueComponents;
 
     private List<TelemetryPropertyViewModel> _logEntryAttributes = null!;
     private List<TelemetryPropertyViewModel> _contextAttributes = null!;
@@ -70,7 +75,7 @@ public partial class StructuredLogDetails : IDisposable
 
             _contextAttributes =
             [
-                new TelemetryPropertyViewModel { Name ="Category", Key = KnownStructuredLogFields.CategoryField, Value = _viewModel.LogEntry.Scope.Name }
+                new TelemetryPropertyViewModel { Name = "Category", Key = KnownStructuredLogFields.CategoryField, Value = _viewModel.LogEntry.Scope.Name }
             ];
             MoveAttributes(attributes, _contextAttributes, a => a.Name is "event.name" or "logrecord.event.id" or "logrecord.event.name");
             if (HasTelemetryBaggage(_viewModel.LogEntry.TraceId))
@@ -80,10 +85,6 @@ public partial class StructuredLogDetails : IDisposable
             if (HasTelemetryBaggage(_viewModel.LogEntry.SpanId))
             {
                 _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "SpanId", Key = KnownStructuredLogFields.SpanIdField, Value = _viewModel.LogEntry.SpanId });
-            }
-            if (HasTelemetryBaggage(_viewModel.LogEntry.ParentId))
-            {
-                _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "ParentId", Key = KnownStructuredLogFields.ParentIdField, Value = _viewModel.LogEntry.ParentId });
             }
 
             _exceptionAttributes = [];
@@ -95,6 +96,30 @@ public partial class StructuredLogDetails : IDisposable
                 new TelemetryPropertyViewModel { Name = "Message", Key = KnownStructuredLogFields.MessageField, Value = _viewModel.LogEntry.Message },
                 .. attributes,
             ];
+
+            _valueComponents = new Dictionary<string, ComponentMetadata>
+            {
+                [KnownStructuredLogFields.TraceIdField] = new ComponentMetadata
+                {
+                    Type = typeof(TraceIdButtonValue),
+                    Parameters = { ["OnClick"] = CloseCallback }
+                },
+                [KnownStructuredLogFields.SpanIdField] = new ComponentMetadata
+                {
+                    Type = typeof(SpanIdButtonValue),
+                    Parameters = { ["TraceId"] = _viewModel.LogEntry.TraceId }
+                },
+                [KnownResourceFields.ServiceNameField] = new ComponentMetadata
+                {
+                    Type = typeof(ResourceNameButtonValue),
+                    Parameters = { ["Resource"] = _viewModel.LogEntry.ApplicationView.Application }
+                },
+                [KnownStructuredLogFields.LevelField] = new ComponentMetadata
+                {
+                    Type = typeof(LogLevelValue),
+                    Parameters = { ["LogEntry"] = _viewModel.LogEntry }
+                },
+            };
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor.cs
@@ -36,7 +36,7 @@ public partial class ExemplarsDialog : IDisposable
 
     public async Task OnViewDetailsAsync(ChartExemplar exemplar)
     {
-        var available = await MetricsHelpers.WaitForSpanToBeAvailableAsync(
+        var available = await TraceLinkHelpers.WaitForSpanToBeAvailableAsync(
             traceId: exemplar.TraceId,
             spanId: exemplar.SpanId,
             getSpan: TelemetryRepository.GetSpan,

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -297,11 +297,11 @@
                     <Details>
                         @if (context?.SpanViewModel is { } spanVm)
                         {
-                            <SpanDetails ViewModel="spanVm" />
+                            <SpanDetails ViewModel="spanVm" CloseCallback="() => ClearSelectedSpanAsync(causedByUserAction: true)" />
                         }
                         else if (context?.LogEntryViewModel is { } logEntryVm)
                         {
-                            <StructuredLogDetails ViewModel="logEntryVm" />
+                            <StructuredLogDetails ViewModel="logEntryVm" CloseCallback="() => ClearSelectedSpanAsync(causedByUserAction: true)" />
                         }
                     </Details>
                 </SummaryDetailsView>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -167,7 +167,7 @@
 ::deep .span-overview-container {
     height: 24px;
     display: inline-flex;
-    align-items: center;
+    align-items: baseline;
 }
 
 ::deep .trace-header {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -7,16 +7,17 @@
 @inject IStringLocalizer<Columns> Loc
 
 <span class="resource-name-container">
-    <FluentIcon Width="16px"
-                Class="resource-icon"
-                Color="Color.Custom"
-                CustomColor="@ColorGenerator.Instance.GetColorHexByKey(FormatName(Resource))"
-                Value="@ResourceIconHelpers.GetIconForResource(Resource, IconSize.Size16)" />
-
-    <span class="resource-name-text">
-        <FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)" />
-    </span>
-
+    @* Do this to trim significant whitespace so there isn't a space added between icon and text *@
+    @{
+        <FluentIcon Width="16px"
+                    Class="resource-icon"
+                    Color="Color.Custom"
+                    CustomColor="@ColorGenerator.Instance.GetColorHexByKey(FormatName(Resource))"
+                    Value="@ResourceIconHelpers.GetIconForResource(Resource, IconSize.Size16)" />
+    }
+    @{
+        <span class="resource-name-text"><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)" /></span>
+    }
     @if (Resource.Properties.TryGetValue(KnownProperties.Container.Lifetime, out var value) &&
         value.Value.HasStringValue &&
         StringComparer.Ordinal.Equals(value.Value.StringValue, KnownContainerLifetimes.Persistent))

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -7,11 +7,12 @@
 }
 
 <div class="state-column-cell">
-
-    <FluentIcon Value="@vm.Icon"
-                Color="@vm.Color"
-                Class="severity-icon" />
-
+    @* Do this to trim significant whitespace so there isn't a space added between icon and text *@
+    @{
+        <FluentIcon Value="@vm.Icon"
+                    Color="@vm.Color"
+                    Class="severity-icon" />
+    }
     <span>@vm.Text</span>
 
     <UnreadLogErrorsBadge

--- a/src/Aspire.Dashboard/Model/ComponentMetadata.cs
+++ b/src/Aspire.Dashboard/Model/ComponentMetadata.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public sealed class ComponentMetadata
+{
+    public required Type Type { get; init; }
+    public Dictionary<string, object> Parameters { get; } = [];
+}

--- a/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
+++ b/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
@@ -24,10 +24,10 @@ public sealed class KnownPropertyLookup : IKnownPropertyLookup
         [
             new(KnownProperties.Resource.DisplayName, loc => loc[nameof(ResourcesDetailsDisplayNameProperty)]),
             new(KnownProperties.Resource.State, loc => loc[nameof(ResourcesDetailsStateProperty)]),
+            new(KnownProperties.Resource.HealthState, loc => loc[nameof(ResourcesDetailsHealthStateProperty)]),
             new(KnownProperties.Resource.StartTime, loc => loc[nameof(ResourcesDetailsStartTimeProperty)]),
             new(KnownProperties.Resource.StopTime, loc => loc[nameof(ResourcesDetailsStopTimeProperty)]),
             new(KnownProperties.Resource.ExitCode, loc => loc[nameof(ResourcesDetailsExitCodeProperty)]),
-            new(KnownProperties.Resource.HealthState, loc => loc[nameof(ResourcesDetailsHealthStateProperty)]),
             new(KnownProperties.Resource.ConnectionString, loc => loc[nameof(ResourcesDetailsConnectionStringProperty)])
         ];
 

--- a/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
@@ -3,25 +3,27 @@
 
 namespace Aspire.Dashboard.Model;
 
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 internal static class ResourceIconHelpers
 {
     /// <summary>
     /// Maps a resource to a default icon.
     /// </summary>
-    public static Icon GetIconForResource(ResourceViewModel resource, IconSize desiredSize)
+    public static Icon GetIconForResource(ResourceViewModel resource, IconSize desiredSize, IconVariant desiredVariant = IconVariant.Filled)
     {
         var icon = resource.ResourceType switch
         {
-            KnownResourceTypes.Executable => IconResolver.ResolveIconName("SettingsCogMultiple", desiredSize, IconVariant.Filled),
-            KnownResourceTypes.Project => IconResolver.ResolveIconName("CodeCircle", desiredSize, IconVariant.Filled),
-            KnownResourceTypes.Container => IconResolver.ResolveIconName("Box", desiredSize, IconVariant.Filled),
-            KnownResourceTypes.Parameter => IconResolver.ResolveIconName("Settings", desiredSize, IconVariant.Filled),
-            KnownResourceTypes.ConnectionString => IconResolver.ResolveIconName("PlugConnectedSettings", desiredSize, IconVariant.Filled),
-            KnownResourceTypes.ExternalService => IconResolver.ResolveIconName("CloudArrowUp", desiredSize, IconVariant.Filled),
-            string t when t.Contains("database", StringComparison.OrdinalIgnoreCase) => IconResolver.ResolveIconName("Database", desiredSize, IconVariant.Filled),
-            _ => IconResolver.ResolveIconName("SettingsCogMultiple", desiredSize, IconVariant.Filled),
+            KnownResourceTypes.Executable => IconResolver.ResolveIconName("SettingsCogMultiple", desiredSize, desiredVariant),
+            KnownResourceTypes.Project => IconResolver.ResolveIconName("CodeCircle", desiredSize, desiredVariant),
+            KnownResourceTypes.Container => IconResolver.ResolveIconName("Box", desiredSize, desiredVariant),
+            KnownResourceTypes.Parameter => IconResolver.ResolveIconName("Settings", desiredSize, desiredVariant),
+            KnownResourceTypes.ConnectionString => IconResolver.ResolveIconName("PlugConnectedSettings", desiredSize, desiredVariant),
+            KnownResourceTypes.ExternalService => IconResolver.ResolveIconName("CloudArrowUp", desiredSize, desiredVariant),
+            string t when t.Contains("database", StringComparison.OrdinalIgnoreCase) => IconResolver.ResolveIconName("Database", desiredSize, desiredVariant),
+            _ => IconResolver.ResolveIconName("SettingsCogMultiple", desiredSize, desiredVariant),
         };
 
         if (icon == null)
@@ -30,5 +32,16 @@ internal static class ResourceIconHelpers
         }
 
         return icon;
+    }
+
+    public static (Icon? icon, Color color) GetHealthStatusIcon(HealthStatus? healthStatus)
+    {
+        return healthStatus switch
+        {
+            HealthStatus.Healthy => (new Icons.Filled.Size16.Heart(), Color.Success),
+            HealthStatus.Degraded => (new Icons.Filled.Size16.HeartBroken(), Color.Warning),
+            HealthStatus.Unhealthy => (new Icons.Filled.Size16.HeartBroken(), Color.Error),
+            _ => (new Icons.Regular.Size16.CircleHint(), Color.Info)
+        };
     }
 }

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -423,18 +423,18 @@ namespace Aspire.Dashboard.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Cancel.
         /// </summary>
-        public static string OpenTraceDialogCancelButtonText {
+        public static string OpenSpanDialogCancelButtonText {
             get {
-                return ResourceManager.GetString("OpenTraceDialogCancelButtonText", resourceCulture);
+                return ResourceManager.GetString("OpenSpanDialogCancelButtonText", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Waiting for trace {0} to load....
+        ///   Looks up a localized string similar to Waiting for span {0} to load....
         /// </summary>
-        public static string OpenTraceDialogMessage {
+        public static string OpenSpanDialogMessage {
             get {
-                return ResourceManager.GetString("OpenTraceDialogMessage", resourceCulture);
+                return ResourceManager.GetString("OpenSpanDialogMessage", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -235,11 +235,11 @@
   <data name="ExemplarsDialogTrace" xml:space="preserve">
     <value>Trace</value>
   </data>
-  <data name="OpenTraceDialogMessage" xml:space="preserve">
-    <value>Waiting for trace {0} to load...</value>
-    <comment>{0} is a trace ID</comment>
+  <data name="OpenSpanDialogMessage" xml:space="preserve">
+    <value>Waiting for span {0} to load...</value>
+    <comment>{0} is a span ID</comment>
   </data>
-  <data name="OpenTraceDialogCancelButtonText" xml:space="preserve">
+  <data name="OpenSpanDialogCancelButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
   <data name="TextVisualizerDialogPlaintextFormat" xml:space="preserve">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -202,15 +202,15 @@
         <target state="translated">Otevřít ve vizualizéru textu</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">Zrušit</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">Čeká se na načtení trasování {0}...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -202,15 +202,15 @@
         <target state="translated">In Textschnellansicht öffnen</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">Abbrechen</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">Es wird auf das Laden der Ablaufverfolgung {0} gewartet...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -202,15 +202,15 @@
         <target state="translated">Abrir en visualizador de texto</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">Cancelar</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">Esperando a que se cargue el {0} de seguimiento...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -202,15 +202,15 @@
         <target state="translated">Ouvrir dans le visualiseur de texte</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">Annuler</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">En attente du chargement du {0} de trace...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -202,15 +202,15 @@
         <target state="translated">Apri nel visualizzatore di testo</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">Annulla</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">In attesa del caricamento della traccia {0}...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -202,15 +202,15 @@
         <target state="translated">テキスト ビジュアライザーで開く</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">キャンセル</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">トレース {0} の読み込みを待機しています...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -202,15 +202,15 @@
         <target state="translated">텍스트 시각화 도우미에서 열기</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">취소</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">추적 {0}이(가) 로드되기를 기다리는 중...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -202,15 +202,15 @@
         <target state="translated">Otwórz w wizualizatorze tekstu</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">Anuluj</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">Oczekiwanie na załadowanie śladu {0}...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -202,15 +202,15 @@
         <target state="translated">Abrir no visualizador de texto</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">Cancelar</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">Aguardando o rastreamento {0} ser carregado...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -202,15 +202,15 @@
         <target state="translated">Открыть в визуализаторе текста</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">Отмена</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">Ожидание загрузки трассировки {0}...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -202,15 +202,15 @@
         <target state="translated">Metin görselleştiricide aç</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">İptal</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">{0} izinin yüklenmesi bekleniyor...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -202,15 +202,15 @@
         <target state="translated">在文本可视化工具中打开</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">取消</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">正在等待跟踪 {0} 加载...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -202,15 +202,15 @@
         <target state="translated">在文字視覺化工具中開啟</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogCancelButtonText">
+      <trans-unit id="OpenSpanDialogCancelButtonText">
         <source>Cancel</source>
-        <target state="translated">取消</target>
+        <target state="new">Cancel</target>
         <note />
       </trans-unit>
-      <trans-unit id="OpenTraceDialogMessage">
-        <source>Waiting for trace {0} to load...</source>
-        <target state="translated">正在等候追蹤 {0} 載入...</target>
-        <note>{0} is a trace ID</note>
+      <trans-unit id="OpenSpanDialogMessage">
+        <source>Waiting for span {0} to load...</source>
+        <target state="new">Waiting for span {0} to load...</target>
+        <note>{0} is a span ID</note>
       </trans-unit>
       <trans-unit id="SettingsDialogDarkTheme">
         <source>Dark</source>

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -550,6 +550,16 @@ internal sealed class DashboardClient : IDashboardClient
             ?? "Aspire";
     }
 
+    public ResourceViewModel? GetResource(string resourceName)
+    {
+        EnsureInitialized();
+        if (_resourceByName.TryGetValue(resourceName, out var resource))
+        {
+            return resource;
+        }
+        return null;
+    }
+
     public async Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken)
     {
         EnsureInitialized();

--- a/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
@@ -41,6 +41,11 @@ public interface IDashboardClient : IAsyncDisposable
     /// </remarks>
     Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Gets a resource matching the specified name. This resource won't be updated with changes after it is fetched.
+    /// </summary>
+    ResourceViewModel? GetResource(string resourceName);
+
     IAsyncEnumerable<WatchInteractionsResponseUpdate> SubscribeInteractionsAsync(CancellationToken cancellationToken);
 
     Task SendInteractionRequestAsync(WatchInteractionsRequestUpdate request, CancellationToken cancellationToken);

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -146,7 +146,9 @@ partial class Resource
                 isValueSensitive: property.IsSensitive,
                 knownProperty: knownProperty,
                 priority: priority)
-            { IsValueMasked = property.IsSensitive };
+            {
+                IsValueMasked = property.IsSensitive
+            };
 
             if (builder.ContainsKey(propertyViewModel.Name))
             {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -77,6 +77,7 @@ fluent-toolbar::part(end) {
     --layout-toolbar-padding: calc(var(--design-unit) * 1.5px);
     --layout-left-padding: calc(var(--design-unit) * 4.5px);
     --layout-right-padding: calc(var(--design-unit) * 2px);
+    --inline-icon-margin: 5px;
     /*
         --neutral-layer-2 is the background for the body of most of the site so
         we can default the datagrid hover color to that and just override it as
@@ -324,6 +325,14 @@ td .long-inner-content {
     flex-grow: 0;
 }
 
+.button-hyperlink::part(control) {
+    padding: 0;
+}
+
+.button-hyperlink::part(start) {
+    margin-inline-end: var(--inline-icon-margin);
+}
+
 .ellipsis-overflow {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -360,12 +369,12 @@ td .long-inner-content {
 
 .severity-icon {
     vertical-align: text-bottom;
-    margin-right: 3px;
+    margin-right: var(--inline-icon-margin);
 }
 
 .persistent-container-icon {
     vertical-align: text-bottom;
-    margin-left: 4px;
+    margin-left: var(--inline-icon-margin);
 }
 
 .align-text-bottom {
@@ -821,7 +830,7 @@ fluent-tooltip[anchor="dialog_close"] > div {
 
 .resource-icon {
     vertical-align: text-bottom;
-    margin-right: 3px;
+    margin-right: var(--inline-icon-margin);
 }
 
 .aspire-menu-container > fluent-menu > fluent-menu-item::part(content) {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
-using Aspire.DashboardService.Proto.V1;
 using Bunit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -62,27 +61,13 @@ public class ApplicationNameTests : DashboardTestContext
         // Arrange
         Services.AddSingleton<IConfiguration>(new ConfigurationManager());
         Services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
-        Services.AddSingleton<IDashboardClient, MockDashboardClient>();
+        Services.AddSingleton<IDashboardClient>(new TestDashboardClient(applicationName: "<marquee>An HTML title!</marquee>"));
 
         // Act
         var cut = RenderComponent<ApplicationName>();
 
         // Assert
         cut.MarkupMatches("&lt;marquee&gt;An HTML title!&lt;/marquee&gt;");
-    }
-
-    private sealed class MockDashboardClient : IDashboardClient
-    {
-        public bool IsEnabled => true;
-        public Task WhenConnected => Task.CompletedTask;
-        public string ApplicationName => "<marquee>An HTML title!</marquee>";
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-        public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public Task SendInteractionRequestAsync(WatchInteractionsRequestUpdate request, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public IAsyncEnumerable<WatchInteractionsResponseUpdate> SubscribeInteractionsAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
-        public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 
     private sealed class TestStringLocalizer<T> : IStringLocalizer<T>

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/StructuredLogsSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/StructuredLogsSetupHelpers.cs
@@ -26,6 +26,8 @@ internal static class StructuredLogsSetupHelpers
         context.Services.AddSingleton<DashboardTelemetryService>();
         context.Services.AddSingleton<IDashboardTelemetrySender, TestDashboardTelemetrySender>();
         context.Services.AddSingleton<ComponentTelemetryContextProvider>();
+        context.Services.AddSingleton<PauseManager>();
+        context.Services.AddSingleton<IDashboardClient>(new TestDashboardClient());
 
         var version = typeof(FluentMain).Assembly.GetName().Version!;
 

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashboardClient.cs
@@ -24,6 +24,7 @@ public class TestDashboardClient : IDashboardClient
 
     public TestDashboardClient(
         bool? isEnabled = false,
+        string? applicationName = null,
         Func<string, Channel<IReadOnlyList<ResourceLogLine>>>? consoleLogsChannelProvider = null,
         Func<Channel<IReadOnlyList<ResourceViewModelChange>>>? resourceChannelProvider = null,
         Func<Channel<WatchInteractionsResponseUpdate>>? interactionChannelProvider = null,
@@ -32,6 +33,7 @@ public class TestDashboardClient : IDashboardClient
         IList<ResourceViewModel>? initialResources = null)
     {
         IsEnabled = isEnabled ?? false;
+        ApplicationName = applicationName ?? "TestApp";
         _consoleLogsChannelProvider = consoleLogsChannelProvider;
         _resourceChannelProvider = resourceChannelProvider;
         _interactionChannelProvider = interactionChannelProvider;
@@ -123,5 +125,10 @@ public class TestDashboardClient : IDashboardClient
         }
 
         await _sendInteractionUpdateChannel.Writer.WriteAsync(request, cancellationToken);
+    }
+
+    public ResourceViewModel? GetResource(string resourceName)
+    {
+        return null;
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -60,4 +60,9 @@ public sealed class MockDashboardClient : IDashboardClient
     {
         throw new NotImplementedException();
     }
+
+    public ResourceViewModel? GetResource(string resourceName)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -412,6 +412,7 @@ public class ResourceOutgoingPeerResolverTests
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public ResourceViewModel? GetResource(string resourceName) => throw new NotImplementedException();
         public Task SendInteractionRequestAsync(WatchInteractionsRequestUpdate request, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<WatchInteractionsResponseUpdate> SubscribeInteractionsAsync(CancellationToken cancellationToken) => throw new NotImplementedException();


### PR DESCRIPTION
## Description

- Add support for registering custom components to display property grid values
- Add custom components for linking to traces, spans and resources
- Icons added to various status icons

<img width="866" height="1007" alt="image" src="https://github.com/user-attachments/assets/3f77f2c1-e79d-4fe0-82e9-61b6540b79e4" />

<img width="1082" height="846" alt="image" src="https://github.com/user-attachments/assets/538e36f0-20b4-4eee-9774-53c631b1514f" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
