### PR TITLE
cli-scripts README.md: fix the Quality value from 'ga' to 'release'

### DIFF
--- a/eng/scripts/README.md
+++ b/eng/scripts/README.md
@@ -13,7 +13,7 @@ Supported Quality values:
 
 - `dev` - builds from the `main` branch
 - `staging` - builds from the current `release` branch like `release/9.4`
-- `ga` - build for the latest GA
+- `release` - build for the latest release
 
 ## Parameters
 


### PR DESCRIPTION
Thanks to David Pine (@ IEvangelist) for finding this.