### PR TITLE
[CI] Enable Native AOT for Cli on linux-arm64, and linux-musl-x64

### DIFF
--- a/eng/clipack/Aspire.Cli.linux-arm64.csproj
+++ b/eng/clipack/Aspire.Cli.linux-arm64.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <CliRuntime>linux-arm64</CliRuntime>
     <CliPlatformType>Unix</CliPlatformType>
-    <!-- linux builds on x64, but doesn't have arm64 native tools. So disable native AOT for now. -->
-    <PublishNativeAot>false</PublishNativeAot>
+
+    <!-- linux-arm64:    ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=8db97d6234306fc4d4da1c9a7275a2a9d9b3a21f, stripped -->
+    <FileSignatureRegex>ELF 64-bit LSB pie executable, ARM aarch64,.*/ld-linux-aarch64\.so</FileSignatureRegex>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />
-
 </Project>

--- a/eng/clipack/Aspire.Cli.linux-musl-x64.csproj
+++ b/eng/clipack/Aspire.Cli.linux-musl-x64.csproj
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <CliRuntime>linux-musl-x64</CliRuntime>
     <CliPlatformType>Unix</CliPlatformType>
-    <!-- need to be on a linux-musl machine to native AOT for linux-musl-->
-    <PublishNativeAot>false</PublishNativeAot>
+
+    <!-- linux-musl-x64: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, BuildID[sha1]=6cfdc2be10e553c81dbd3f98b808c32e9820b4e7, stripped -->
+    <FileSignatureRegex>ELF 64-bit LSB pie executable, x86-64,.*/ld-musl-x86_64\.so</FileSignatureRegex>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />

--- a/eng/clipack/Aspire.Cli.linux-x64.csproj
+++ b/eng/clipack/Aspire.Cli.linux-x64.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <CliRuntime>linux-x64</CliRuntime>
     <CliPlatformType>Unix</CliPlatformType>
+
+    <!-- linux-x64: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=6092ab9b5b1cd27f812a7f08b1845fc4a48589fe, stripped -->
+    <FileSignatureRegex>ELF 64-bit LSB pie executable, x86-64,.*/ld-linux-x86-64\.so</FileSignatureRegex>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />

--- a/eng/clipack/Aspire.Cli.osx-arm64.csproj
+++ b/eng/clipack/Aspire.Cli.osx-arm64.csproj
@@ -2,8 +2,10 @@
   <PropertyGroup>
     <CliRuntime>osx-arm64</CliRuntime>
     <CliPlatformType>Unix</CliPlatformType>
+
+    <!-- osx-arm64:      Mach-O 64-bit executable arm64 -->
+    <FileSignatureRegex>Mach-O 64-bit executable arm64</FileSignatureRegex>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />
-
 </Project>

--- a/eng/clipack/Aspire.Cli.osx-x64.csproj
+++ b/eng/clipack/Aspire.Cli.osx-x64.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <CliRuntime>osx-x64</CliRuntime>
     <CliPlatformType>Unix</CliPlatformType>
+
+    <!-- osx-x64:        Mach-O 64-bit executable x86_64 -->
+    <FileSignatureRegex>Mach-O 64-bit executable x86_64</FileSignatureRegex>
   </PropertyGroup>
 
   <Import Project="Common.projitems" />

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -73,7 +73,7 @@
   </Target>
 
   <Target Name="_ValidateNativeBinaryFileSignatureOnUnix" Condition="'$(_CheckFileSignature)' == 'true'">
-    <Error Condition="$(FileSignatureRegex) == ''" Text="Missing %24(FileSignatureRegex)" />
+    <Error Condition="$(FileSignatureRegex) == ''" Text="Property %24(FileSignatureRegex) is unset." />
 
     <Exec Command="file -b $(_NativeBinaryPath)" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="_FileCommandOutput" />

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -11,13 +11,33 @@
     <PublishNativeAot Condition="'$(PublishNativeAot)' == '' and $([System.OperatingSystem]::IsWindows()) and $(CliRuntime.StartsWith('win-'))">true</PublishNativeAot>
     <PublishNativeAot Condition="'$(PublishNativeAot)' == '' and $([System.OperatingSystem]::IsLinux()) and $(CliRuntime.StartsWith('linux-'))">true</PublishNativeAot>
     <PublishNativeAot Condition="'$(PublishNativeAot)' == '' and $([System.OperatingSystem]::IsMacOS()) and $(CliRuntime.StartsWith('osx-'))">true</PublishNativeAot>
+
+    <!-- Run `file` on the native binary and check the output but only on Linux/macOS -->
+    <_CheckFileSignature Condition="'$(PublishNativeAot)' == 'true' and !$([System.OperatingSystem]::IsWindows())">true</_CheckFileSignature>
+
+    <_NativeBinaryPath>$([MSBuild]::NormalizePath($(OutputPath), 'aspire'))</_NativeBinaryPath>
+    <_NativeBinaryPath Condition="$(CliRuntime.StartsWith('win-'))">$(_NativeBinaryPath).exe</_NativeBinaryPath>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Archives" />
   </ItemGroup>
 
-  <Target Name="PublishToDisk">
+  <Target Name="PublishToDisk"
+          DependsOnTargets="_PublishProject;_ValidateNativeBinaryFileSignatureOnUnix;PrepareOutputPathForPublishToDisk" />
+
+  <Target Name="PrepareOutputPathForPublishToDisk">
+    <!-- TODO: avoid generating the file instead of manually deleting it here -->
+    <Delete Files="$(OutputPath)\aspire.xml" Condition="Exists('$(OutputPath)\aspire.xml')" />
+
+    <!-- work around https://github.com/dotnet/runtime/issues/116758 by removing the Xliff folders. -->
+    <ItemGroup>
+      <DirectoriesToRemove Include="$(XlfLanguages)" />
+    </ItemGroup>
+    <RemoveDir Directories="$(OutputPath)\%(DirectoriesToRemove.Identity)" />
+  </Target>
+
+  <Target Name="_PublishProject">
     <ItemGroup>
       <AdditionalProperties Include="RuntimeIdentifier=$(CliRuntime)" />
       <AdditionalProperties Include="PublishDir=$(OutputPath)" />
@@ -49,17 +69,20 @@
         Properties="@(AdditionalProperties)"
         RemoveProperties="OutputPath;TargetFramework" />
 
-    <PropertyGroup>
-      <_OutputBinaryPath>$(OutputPath)/aspire</_OutputBinaryPath>
-    </PropertyGroup>
-
-    <!-- TODO: avoid generating the file instead of manually deleting it here -->
-    <Delete Files="$(OutputPath)\aspire.xml" Condition="Exists('$(OutputPath)\aspire.xml')" />
-
-    <!-- work around https://github.com/dotnet/runtime/issues/116758 by removing the Xliff folders. -->
-    <ItemGroup>
-      <DirectoriesToRemove Include="$(XlfLanguages)" />
-    </ItemGroup>
-    <RemoveDir Directories="$(OutputPath)\%(DirectoriesToRemove.Identity)" />
+    <Error Condition="!Exists('$(_NativeBinaryPath)')" Text="Could not find expected `aspire` binary at $(_NativeBinaryPath)" />
   </Target>
+
+  <Target Name="_ValidateNativeBinaryFileSignatureOnUnix" Condition="'$(_CheckFileSignature)' == 'true'">
+    <Error Condition="$(FileSignatureRegex) == ''" Text="Missing %27(FileSignatureRegex)" />
+
+    <Exec Command="file -b $(_NativeBinaryPath)" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_FileCommandOutput" />
+    </Exec>
+
+    <Error Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$(_FileCommandOutput)', '$(FileSignatureRegex)'))"
+           Text="`file` signature for `$(CliRuntime)` did not match the expected regex.
+           Got     : $(_FileCommandOutput)
+           vs regex: $(FileSignatureRegex)" />
+  </Target>
+
 </Project>

--- a/eng/clipack/Common.projitems
+++ b/eng/clipack/Common.projitems
@@ -73,7 +73,7 @@
   </Target>
 
   <Target Name="_ValidateNativeBinaryFileSignatureOnUnix" Condition="'$(_CheckFileSignature)' == 'true'">
-    <Error Condition="$(FileSignatureRegex) == ''" Text="Missing %27(FileSignatureRegex)" />
+    <Error Condition="$(FileSignatureRegex) == ''" Text="Missing %24(FileSignatureRegex)" />
 
     <Exec Command="file -b $(_NativeBinaryPath)" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="_FileCommandOutput" />

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -81,10 +81,6 @@ variables:
       value: true
 
 resources:
-  containers:
-  - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
-
   repositories:
   - repository: 1ESPipelineTemplates
     type: git
@@ -109,6 +105,22 @@ extends:
         enabled: true
     customBuildTags:
     - ES365AIMigrationTooling
+    containers:
+      linux_x64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64
+        env:
+          SysRoot: /crossrootfs/x64
+          LinkerFlavor: lld
+      linux_arm64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm64
+        env:
+          SysRoot: /crossrootfs/arm64
+          LinkerFlavor: lld
+      linux_musl_x64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64-musl
+        env:
+          SysRoot: /crossrootfs/x64
+          LinkerFlavor: lld
 
     stages:
 

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -17,6 +17,7 @@ jobs:
       enableTelemetry: true
       # Publish build logs
       enablePublishBuildArtifacts: true
+      container: ${{ replace(targetRid, '-', '_') }}
 
       jobs:
       - job: BuildNative_${{ replace(targetRid, '-', '_') }}

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -31,6 +31,10 @@
     <PublishAot>false</PublishAot>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(PublishAot)' == 'true'">
+    <LinkerArg Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64'" Include="--target=x86_64-alpine-linux-musl" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="System.CommandLine" />


### PR DESCRIPTION
- These are cross compiled on linux-x64 images.
Co-authored by Alexander Köplinger <alkpli@microsoft.com>

- Add a check for the output of 'file' command on unix, to confirm that the native binary is for the correct arch. This is meant as a simply sanity check.

Contributes to https://github.com/dotnet/aspire/issues/10288