### PR TITLE
[release/9.4] Add feature flag control for ExecCommand with default disabled (#10664)

### DIFF
--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -94,7 +94,10 @@ internal sealed class RootCommand : BaseRootCommand
         {
             Subcommands.Add(deployCommand);
         }
-
-        Subcommands.Add(execCommand);
+        
+        if (featureFlags.IsFeatureEnabled(KnownFeatures.ExecCommandEnabled, false))
+        {
+            Subcommands.Add(execCommand);
+        }
     }
 }

--- a/src/Aspire.Cli/KnownFeatures.cs
+++ b/src/Aspire.Cli/KnownFeatures.cs
@@ -10,4 +10,5 @@ internal static class KnownFeatures
     public static string UpdateNotificationsEnabled => "updateNotificationsEnabled";
     public static string MinimumSdkCheckEnabled => "minimumSdkCheckEnabled";
     public static string DeployCommandEnabled => "deployCommandEnabled";
+    public static string ExecCommandEnabled => "execCommandEnabled";
 }

--- a/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
@@ -42,6 +42,7 @@ public class ExecCommandTests
         using var workspace = TemporaryWorkspace.Create(_outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, _outputHelper, options =>
         {
+            options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
         });
         var provider = services.BuildServiceProvider();
@@ -59,6 +60,7 @@ public class ExecCommandTests
         using var workspace = TemporaryWorkspace.Create(_outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, _outputHelper, options =>
         {
+            options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
             options.ProjectLocatorFactory = _ => new MultipleProjectFilesProjectLocator();
         });
         var provider = services.BuildServiceProvider();
@@ -76,6 +78,7 @@ public class ExecCommandTests
         using var workspace = TemporaryWorkspace.Create(_outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, _outputHelper, options =>
         {
+            options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
             options.ProjectLocatorFactory = _ => new ProjectFileDoesNotExistLocator();
         });
         var provider = services.BuildServiceProvider();
@@ -85,6 +88,29 @@ public class ExecCommandTests
 
         var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
         Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode);
+    }
+
+    [Fact]
+    public async Task ExecCommand_WhenFeatureFlagEnabled_CommandAvailable()
+    {
+        using var workspace = TemporaryWorkspace.Create(_outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, _outputHelper, options =>
+        {
+            options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var commandLineConfiguration = new CommandLineConfiguration(command);
+        var testOutputWriter = new TestOutputTextWriter(_outputHelper);
+        commandLineConfiguration.Output = testOutputWriter;
+
+        var result = command.Parse("exec --help", commandLineConfiguration);
+
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        
+        // Should succeed because exec command is registered when feature flag is enabled
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
     [Fact]
@@ -117,6 +143,7 @@ public class ExecCommandTests
         using var workspace = TemporaryWorkspace.Create(_outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, _outputHelper, options =>
         {
+            options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
             options.ProjectLocatorFactory = _ => new TestProjectLocator();
 
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner

--- a/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
@@ -118,6 +118,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
+            options.EnabledFeatures = [KnownFeatures.ExecCommandEnabled];
             options.DotNetSdkInstallerFactory = _ => new TestDotNetSdkInstaller
             {
                 CheckAsyncCallback = _ => false // SDK not installed


### PR DESCRIPTION
Backport of #10664 to release/9.4

## Customer Impact

Hides the `aspire exec` command by default.

## Testing

Manually tested and has unit tests which need to turn it on (which proves that it works).

## Risk

Low.

## Regression?
