### PR TITLE
Change resource details view header to heading element

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/DetailView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/DetailView.razor
@@ -6,11 +6,11 @@
     <header style="height: auto;">
         @if (DetailsTitle is not null)
         {
-            <div class="details-header-title" title="@DetailsTitle">@DetailsTitle</div>
+            <h2 class="details-header-title" title="@DetailsTitle">@DetailsTitle</h2>
         }
         else if (DetailsTitleTemplate is not null)
         {
-            <div class="details-header-title">@DetailsTitleTemplate</div>
+            <h2 class="details-header-title">@DetailsTitleTemplate</h2>
         }
         <div class="header-actions">
             @if (ViewportInformation.IsDesktop)

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
@@ -62,6 +62,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    margin-bottom: 0;
 }
 
 ::deep .details-container > header > .header-actions {


### PR DESCRIPTION
## Description

Before
<img width="567" height="161" alt="image" src="https://github.com/user-attachments/assets/ee303729-d4cf-4456-b230-0ce690645704" />


After (no change)
<img width="601" height="161" alt="image" src="https://github.com/user-attachments/assets/76da0f1e-3b36-48cc-b046-e362e244ec25" />

Fixes #10130

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
