### PR TITLE
Add filter grouping labels for resource filters

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceFilters.razor
@@ -3,30 +3,30 @@
 @inject IStringLocalizer<Dashboard.Resources.Resources> Loc
 
 <FluentStack Orientation="Orientation.Vertical" VerticalGap="15">
-    <div>
-        <h5>@Loc[nameof(Resources.Resources.ResourcesResourceTypesHeader)]</h5>
+    <fieldset class="filter-group">
+        <legend>@Loc[nameof(Resources.Resources.ResourcesResourceTypesHeader)]</legend>
         <SelectResourceOptions
             Id="resource-types"
             Values="ResourceTypes"
             OnAllValuesCheckedChangedAsync="OnAllFilterVisibilityCheckedChangedAsync"
             OnValueVisibilityChangedAsync="OnResourceFilterVisibilityChangedAsync" />
-    </div>
-    <div>
-        <h5>@Loc[nameof(Resources.Resources.ResourcesResourceStatesHeader)]</h5>
+    </fieldset>
+    <fieldset class="filter-group">
+        <legend>@Loc[nameof(Resources.Resources.ResourcesResourceStatesHeader)]</legend>
         <SelectResourceOptions
             Id="resource-states"
             Values="ResourceStates"
             OnAllValuesCheckedChangedAsync="OnAllFilterVisibilityCheckedChangedAsync"
             OnValueVisibilityChangedAsync="OnResourceFilterVisibilityChangedAsync"/>
-    </div>
-    <div>
-        <h5>@Loc[nameof(Resources.Resources.ResourcesDetailsHealthStateProperty)]</h5>
+    </fieldset>
+    <fieldset class="filter-group">
+        <legend>@Loc[nameof(Resources.Resources.ResourcesDetailsHealthStateProperty)]</legend>
         <SelectResourceOptions
             Id="resource-health-states"
             Values="ResourceHealthStates"
             OnAllValuesCheckedChangedAsync="OnAllFilterVisibilityCheckedChangedAsync"
             OnValueVisibilityChangedAsync="OnResourceFilterVisibilityChangedAsync"/>
-    </div>
+    </fieldset>
 </FluentStack>
 
 @code {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -835,3 +835,7 @@ fluent-tooltip[anchor="dialog_close"] > div {
 .fluent-messagebar-action {
     font-size: var(--type-ramp-minus-1-font-size);
 }
+
+.filter-group > legend {
+    font-size: var(--type-ramp-plus-2-font-size);
+}

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -838,4 +838,5 @@ fluent-tooltip[anchor="dialog_close"] > div {
 
 .filter-group > legend {
     font-size: var(--type-ramp-plus-2-font-size);
+    font-weight: 500;
 }


### PR DESCRIPTION
## Description

Switches to fieldset/legend so that the group label is mentioned when the first filter is selected. Also removes the header bolding as it doesn't really fit in this context.

Before:
<img width="347" height="561" alt="image" src="https://github.com/user-attachments/assets/5a370dd2-9c2d-4e7c-89d8-f3a6eb6c6792" />

After:
<img width="347"  alt="image" src="https://github.com/user-attachments/assets/58d92790-250c-42ac-b18b-21a4ea3dcada" />

Fixes #10122 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
