### PR TITLE
Don't show (None) on console logs if there is only one resource

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -471,8 +471,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             }
         }
 
-        // We still need to add the no selection option if there are no resources, as otherwise
-        // the dropdown will not have any options to select.
+        // If there is one resource then it is automatically selected. Remove None button so there is no way to unselect.
+        // If there are multiple resources, or zero, then none is the default so add it.
         if (builder.Count != 1)
         {
             builder.Insert(0, noSelectionViewModel);

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -470,7 +470,13 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             }
         }
 
-        builder.Insert(0, noSelectionViewModel);
+        // We still need to add the no selection option if there are no resources, as otherwise
+        // the dropdown will not have any options to select.
+        if (builder.Count != 1)
+        {
+            builder.Insert(0, noSelectionViewModel);
+        }
+
         return builder.ToImmutableList();
 
         SelectViewModel<ResourceTypeDetails> ToOption(ResourceViewModel resource, bool isReplica, string applicationName)

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -519,12 +519,12 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     private void UpdateResourcesList()
     {
         _resources = GetConsoleLogResourceSelectViewModels(_resourceByName, _noSelection, Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsUnknownState)], _showHiddenResources, out var optionToSelect);
+
         if (optionToSelect is not null)
         {
             Debug.Assert(optionToSelect.Id?.InstanceId is not null);
             PageViewModel.SelectedOption = optionToSelect;
             PageViewModel.SelectedResource = _resourceByName[optionToSelect.Id.InstanceId];
-            NavigationManager.NavigateTo(GetUrlFromSerializableViewModel(ConvertViewModelToSerializable()));
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -182,7 +182,17 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
     {
         _applications = TelemetryRepository.GetApplications();
         _applicationViewModels = ApplicationsSelectHelpers.CreateApplications(_applications);
-        _applicationViewModels.Insert(0, _selectApplication);
+
+        if (_applicationViewModels.Count != 1)
+        {
+            _applicationViewModels.Insert(0, _selectApplication);
+        }
+        else
+        {
+            PageViewModel.SelectedApplication = _applicationViewModels.Single();
+            NavigationManager.NavigateTo(GetUrlFromSerializableViewModel(ConvertViewModelToSerializable()));
+        }
+
         UpdateSubscription();
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -190,7 +190,6 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
         else
         {
             PageViewModel.SelectedApplication = _applicationViewModels.Single();
-            NavigationManager.NavigateTo(GetUrlFromSerializableViewModel(ConvertViewModelToSerializable()));
         }
 
         UpdateSubscription();

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -221,7 +221,16 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     {
         _applications = TelemetryRepository.GetApplications();
         _applicationViewModels = ApplicationsSelectHelpers.CreateApplications(_applications);
-        _applicationViewModels.Insert(0, _allApplication);
+
+        if (_applicationViewModels.Count != 1)
+        {
+            _applicationViewModels.Insert(0, _allApplication);
+        }
+        else
+        {
+            PageViewModel.SelectedApplication = _applicationViewModels.Single();
+            NavigationManager.NavigateTo(GetUrlFromSerializableViewModel(ConvertViewModelToSerializable()));
+        }
     }
 
     private Task HandleSelectedApplicationChangedAsync()

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -221,16 +221,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     {
         _applications = TelemetryRepository.GetApplications();
         _applicationViewModels = ApplicationsSelectHelpers.CreateApplications(_applications);
-
-        if (_applicationViewModels.Count != 1)
-        {
-            _applicationViewModels.Insert(0, _allApplication);
-        }
-        else
-        {
-            PageViewModel.SelectedApplication = _applicationViewModels.Single();
-            NavigationManager.NavigateTo(GetUrlFromSerializableViewModel(ConvertViewModelToSerializable()));
-        }
+        _applicationViewModels.Insert(0, _allApplication);
     }
 
     private Task HandleSelectedApplicationChangedAsync()

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -187,7 +187,17 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     {
         _applications = TelemetryRepository.GetApplications(includeUninstrumentedPeers: true);
         _applicationViewModels = ApplicationsSelectHelpers.CreateApplications(_applications);
-        _applicationViewModels.Insert(0, _allApplication);
+
+        if (_applicationViewModels.Count != 1)
+        {
+            _applicationViewModels.Insert(0, _allApplication);
+        }
+        else
+        {
+            PageViewModel.SelectedApplication = _applicationViewModels.Single();
+            NavigationManager.NavigateTo(GetUrlFromSerializableViewModel(ConvertViewModelToSerializable()));
+        }
+
         UpdateSubscription();
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -187,16 +187,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     {
         _applications = TelemetryRepository.GetApplications(includeUninstrumentedPeers: true);
         _applicationViewModels = ApplicationsSelectHelpers.CreateApplications(_applications);
-
-        if (_applicationViewModels.Count != 1)
-        {
-            _applicationViewModels.Insert(0, _allApplication);
-        }
-        else
-        {
-            PageViewModel.SelectedApplication = _applicationViewModels.Single();
-            NavigationManager.NavigateTo(GetUrlFromSerializableViewModel(ConvertViewModelToSerializable()));
-        }
+        _applicationViewModels.Insert(0, _allApplication);
 
         UpdateSubscription();
     }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -209,8 +209,8 @@ public partial class ConsoleLogsTests : DashboardTestContext
             var selectElement = resourceSelect.Find("fluent-select");
             var selectOptions = selectElement.QuerySelectorAll("fluent-option");
             
-            // Should have at least 2 options (None + regular resource) when resources are loaded
-            Assert.True(selectOptions.Length >= 2);
+            // Should have at least 1 option (regular resource) when resources are loaded
+            Assert.True(selectOptions.Length >= 1);
         });
         
         // Initially, hidden resources should not be shown
@@ -218,8 +218,8 @@ public partial class ConsoleLogsTests : DashboardTestContext
         var selectElement = resourceSelect.Find("fluent-select");
         var selectOptions = selectElement.QuerySelectorAll("fluent-option");
         
-        // Should only have "None" option + regular resource (hidden resource filtered out)
-        Assert.Equal(2, selectOptions.Length); // "None" + regular-resource
+        // Should only have regular resource (hidden resource filtered out)
+        Assert.Equal(1, selectOptions.Length); // regular-resource
         var optionValues = selectOptions.Select(opt => opt.GetAttribute("value")).ToList();
         Assert.Contains("regular-resource", optionValues);
         Assert.DoesNotContain("hidden-resource", optionValues);
@@ -241,7 +241,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         cut.WaitForAssertion(() =>
         {
             var updatedOptions = selectElement.QuerySelectorAll("fluent-option");
-            // Should now have "None" + both resources
+            // Should now have both resources
             Assert.Equal(3, updatedOptions.Length); // "None" + regular-resource + hidden-resource
             var updatedOptionValues = updatedOptions.Select(opt => opt.GetAttribute("value")).ToList();
             Assert.Contains("regular-resource", updatedOptionValues);
@@ -269,15 +269,15 @@ public partial class ConsoleLogsTests : DashboardTestContext
         cut.WaitForAssertion(() =>
         {
             var finalOptions = selectElement.QuerySelectorAll("fluent-option");
-            // Should be back to "None" + regular resource only
-            Assert.Equal(2, finalOptions.Length); // "None" + regular-resource
+            // Should be back to regular resource only
+            Assert.Equal(1, finalOptions.Length); // regular-resource
             var finalOptionValues = finalOptions.Select(opt => opt.GetAttribute("value")).ToList();
             Assert.Contains("regular-resource", finalOptionValues);
             Assert.DoesNotContain("hidden-resource", finalOptionValues);
         });
         
         // Selection should be cleared since selected resource is now hidden
-        cut.WaitForState(() => instance.PageViewModel.SelectedResource is null);
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource == regularResource);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
@@ -12,6 +12,38 @@ namespace Aspire.Dashboard.Tests.ConsoleLogsTests;
 
 public class CreateResourceSelectModelsTests
 {
+    [Fact]
+    public void GetViewModels_OneResource_OptionToSelectNotNull()
+    {
+        // Arrange
+        var applications = new List<ResourceViewModel>
+        {
+            ModelTestHelpers.CreateResource(appName: "App1", state: KnownResourceState.Running, displayName: "App1")
+        };
+
+        var resourcesByName = new ConcurrentDictionary<string, ResourceViewModel>(applications.ToDictionary(app => app.Name));
+
+        var unknownStateText = "unknown-state";
+        var selectAResourceText = "select-a-resource";
+        var noSelectionViewModel = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = selectAResourceText };
+
+        // Act
+        var viewModels = Components.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(resourcesByName, noSelectionViewModel, unknownStateText, false, out var optionToSelect);
+
+        // Assert
+        Assert.NotNull(optionToSelect);
+
+        Assert.Collection(viewModels,
+            entry =>
+            {
+                Assert.NotNull(entry.Id);
+                Assert.Equal(OtlpApplicationType.Singleton, entry.Id.Type);
+                Assert.Equal("App1", entry.Id.InstanceId);
+
+                Assert.Equal("App1", entry.Name);
+            });
+    }
+
     [Fact]
     public void GetViewModels_ReturnsRightReplicas()
     {
@@ -39,9 +71,12 @@ public class CreateResourceSelectModelsTests
         var noSelectionViewModel = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = selectAResourceText };
 
         // Act
-        var viewModels = Components.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(resourcesByName, noSelectionViewModel, unknownStateText, false);
+        var viewModels = Components.Pages.ConsoleLogs.GetConsoleLogResourceSelectViewModels(resourcesByName, noSelectionViewModel, unknownStateText, false, out var optionToSelect);
 
         // Assert
+
+        Assert.Null(optionToSelect);
+
         Assert.Collection(viewModels,
             entry =>
             {


### PR DESCRIPTION
## Description

Doesn't add (None) when there is exactly one option.

Fixes #10379

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
