### PR TITLE
Workaround for fluent select keyboard enter bug

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -26,7 +26,8 @@
                 Position="SelectPosition.Below"
                 Label="@Loc[nameof(Dialogs.SettingsDialogLanguage)]"
                 Items="@_languageOptions"
-                OptionText="@(c => c.NativeName.Humanize())"
+                OptionText="@(c => c!.NativeName.Humanize())"
+                ValueChanged="@ValuedChanged"
                 @bind-SelectedOption="@_selectedUiCulture"
                 @bind-SelectedOption:after="@OnLanguageChanged"
                 Class="language-select"/>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -27,7 +27,7 @@
                 Label="@Loc[nameof(Dialogs.SettingsDialogLanguage)]"
                 Items="@_languageOptions"
                 OptionText="@(c => c!.NativeName.Humanize())"
-                ValueChanged="@ValuedChanged"
+                ValueChanged="@ValueChanged"
                 @bind-SelectedOption="@_selectedUiCulture"
                 @bind-SelectedOption:after="@OnLanguageChanged"
                 Class="language-select"/>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -90,7 +90,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
 
     private static void ValuedChanged(string? value)
     {
-        // Do nothing. Required for bunit change to trigger SelectedOptionChanged.
+        // Do nothing. Required for FluentUI Blazor to trigger SelectedOptionChanged.
     }
 
     private async Task ClearAllSignals()

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -88,6 +88,11 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
             forceLoad: true);
     }
 
+    private static void ValuedChanged(string? value)
+    {
+        // Do nothing. Required for bunit change to trigger SelectedOptionChanged.
+    }
+
     private async Task ClearAllSignals()
     {
         TelemetryRepository.ClearAllSignals();

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -88,7 +88,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
             forceLoad: true);
     }
 
-    private static void ValuedChanged(string? value)
+    private static void ValueChanged(string? value)
     {
         // Do nothing. Required for FluentUI Blazor to trigger SelectedOptionChanged.
     }


### PR DESCRIPTION
## Description

While investigating #10128, I noticed that selecting language using the keyboard and pressing enter did not reload the page. On further investigation, I found that `OnSelectedChanged` is not being called due to the absence of `ValueChanged`. This works around the problem by adding an empty `ValueChanged` similar to `ResourceSelect` (which also starts to fail if you remove `ValueChanged`.

I will file an issue in fluentui-blazor, but this is a nasty issue and we should put this workaround in until/if the bug is fixed there.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
