### PR TITLE
[CI] Build Cli native archives on GH runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
         with:
-          name: build-cli-logs-${{ matrix.targets.os }}
+          name: cli-native-logs-${{ matrix.targets.rids }}
           path: artifacts/log/**
 
       - name: Upload CLI archives

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,6 +144,7 @@ jobs:
         with:
           name: built-nugets
           path: artifacts/packages
+          retention-days: 15
 
       - name: Upload logs
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,13 @@ jobs:
     runs-on: ${{ matrix.targets.os }}
     strategy:
       matrix:
-        targets: [{os: ubuntu-latest, rids: linux-x64}, {os: windows-latest, rids: win-x64}, {os: macos-latest, rids: osx-arm64}]
+        targets:
+          - os: ubuntu-latest
+            rids: linux-x64
+          - os: windows-latest
+            rids: win-x64
+          - os: macos-latest
+            rids: osx-arm64
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,6 +123,8 @@ jobs:
         with:
           name: cli-native-archives-${{ matrix.targets.rids }}
           path: artifacts/packages/**/aspire-cli*
+          retention-days: 15
+          if-no-files-found: error
 
   build_packages:
     name: Build packages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,62 @@ jobs:
           includeIntegrations: true
           includeTemplates: true
 
+  # Build CLI native archives
+  build_cli_archives:
+    name: Build CLI (${{ matrix.targets.os }})
+    runs-on: ${{ matrix.targets.os }}
+    strategy:
+      matrix:
+        targets: [{os: ubuntu-latest, rids: linux-x64}, {os: windows-latest, rids: win-x64}, {os: macos-latest, rids: osx-arm64}]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Build CLI packages (Windows)
+        env:
+          CI: false
+        if: ${{ matrix.targets.os == 'windows-latest' }}
+        shell: pwsh
+        run: >
+          .\build.cmd
+          -ci
+          -build
+          -restore
+          /bl:${{ github.workspace }}/artifacts/log/Debug/BuildCli.binlog
+          /p:ContinuousIntegrationBuild=true
+          /p:SkipManagedBuild=true
+          /p:TargetRids=${{ matrix.targets.rids }}
+
+      - name: Build CLI packages (Unix)
+        env:
+          CI: false
+        if: ${{ matrix.targets.os != 'windows-latest' }}
+        shell: bash
+        run: >
+          ./build.sh
+          --ci
+          --build
+          --restore
+          /bl:${{ github.workspace }}/artifacts/log/Debug/BuildCli.binlog
+          /p:ContinuousIntegrationBuild=true
+          /p:SkipManagedBuild=true
+          /p:TargetRids=${{ matrix.targets.rids }}
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
+        with:
+          name: build-cli-logs-${{ matrix.targets.os }}
+          path: artifacts/log/**
+
+      - name: Upload CLI archives
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
+        with:
+          name: cli-native-archives-${{ matrix.targets.rids }}
+          path: artifacts/packages/**/aspire-cli*
+
   build_packages:
     name: Build packages
     if: ${{ github.repository_owner == 'dotnet' }}
@@ -225,6 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Final Results
     needs: [
+      build_cli_archives,
       endtoend_tests,
       extension_tests_win,
       integrations_test_lin,


### PR DESCRIPTION
Build archives with Native Aot'ed CLI. These are produced for:

- `linux-x64`
- `osx-arm64`
- `win-x64`

And uploaded to artifacts named `cli-native-archives-*` like `cli-native-archives-linux-x64`.