### PR TITLE
Fix span link attributes not displayed

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -107,7 +107,8 @@
                                 Style="width:100%"
                                 RowSize="DataGridRowSize.Medium"
                                 GridTemplateColumns="4fr 1fr"
-                                ShowHover="true">
+                                ShowHover="true"
+                                Multiline="true">
                     <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsSpanColumnHeader)]">
                         @WriteSpanLink(context)
                     </TemplateColumn>
@@ -132,7 +133,8 @@
                                 Style="width:100%"
                                 RowSize="DataGridRowSize.Medium"
                                 GridTemplateColumns="4fr 1fr"
-                                ShowHover="true">
+                                ShowHover="true"
+                                Multiline="true">
                     <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsSpanColumnHeader)]">
                         @WriteSpanLink(context)
                     </TemplateColumn>


### PR DESCRIPTION
## Description

<img width="877" height="1028" alt="image" src="https://github.com/user-attachments/assets/35aee5ec-25eb-476a-8019-c868fd39574c" />

Fixes https://github.com/dotnet/aspire/issues/10601

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
