### PR TITLE
Exe, ext service, + param icon updates for dashboard resource view + graph

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
@@ -16,12 +16,12 @@ internal static class ResourceIconHelpers
     {
         var icon = resource.ResourceType switch
         {
-            KnownResourceTypes.Executable => IconResolver.ResolveIconName("SettingsCogMultiple", desiredSize, desiredVariant),
+            KnownResourceTypes.Executable => IconResolver.ResolveIconName("Apps", desiredSize, desiredVariant),
             KnownResourceTypes.Project => IconResolver.ResolveIconName("CodeCircle", desiredSize, desiredVariant),
             KnownResourceTypes.Container => IconResolver.ResolveIconName("Box", desiredSize, desiredVariant),
-            KnownResourceTypes.Parameter => IconResolver.ResolveIconName("Settings", desiredSize, desiredVariant),
+            KnownResourceTypes.Parameter => IconResolver.ResolveIconName("Key", desiredSize, desiredVariant),
             KnownResourceTypes.ConnectionString => IconResolver.ResolveIconName("PlugConnectedSettings", desiredSize, desiredVariant),
-            KnownResourceTypes.ExternalService => IconResolver.ResolveIconName("CloudArrowUp", desiredSize, desiredVariant),
+            KnownResourceTypes.ExternalService => IconResolver.ResolveIconName("GlobeArrowForward", desiredSize, desiredVariant),
             string t when t.Contains("database", StringComparison.OrdinalIgnoreCase) => IconResolver.ResolveIconName("Database", desiredSize, desiredVariant),
             _ => IconResolver.ResolveIconName("SettingsCogMultiple", desiredSize, desiredVariant),
         };


### PR DESCRIPTION
## Description

Updated KnownResourceTypes.Parameter to Key (from single setting gear), Executable to Code (as opposed to multiple settings gears), External service to GlobeArrowForward (from cloud arrow up which is like upload).

Feels weird that exes were settings but I didn't want to change project (Code Circle) so i picked an alternative similar type. Would be cool if we could eventually use lang - like `ic_fluent_code_cs_rectangle_16_regular` - but theyre all only in 16px right now.

<img width="1886" height="1204" alt="image" src="https://github.com/user-attachments/assets/80d8abc7-5c56-4745-ab33-de5e69c61680" />

<img width="346" height="769" alt="image" src="https://github.com/user-attachments/assets/5a14c026-ff37-4074-947e-321c57db96b1" />

<img width="742" height="715" alt="image" src="https://github.com/user-attachments/assets/0ca6fc04-7318-471e-b57c-f4118c310085" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
