### PR TITLE
Update gitignore to ignore Aspire CLI files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ playground/**/publish/
 
 # Verify
 *.received.*
+
+#Aspire CLI
+.aspire/


### PR DESCRIPTION
We don't want Aspire CLI files in this repo.