### PR TITLE
Fix 6648

### DIFF
--- a/src/Aspire.Hosting/Devcontainers/DevcontainerSettingsWriter.cs
+++ b/src/Aspire.Hosting/Devcontainers/DevcontainerSettingsWriter.cs
@@ -38,7 +38,7 @@ internal class DevcontainerSettingsWriter(ILogger<DevcontainerSettingsWriter> lo
         _pendingPorts.Add((url, port.ToString(CultureInfo.InvariantCulture), protocol, label, openBrowser));
     }
 
-    public async Task FlushAsync(CancellationToken cancellationToken = default)
+    public virtual async Task FlushAsync(CancellationToken cancellationToken = default)
     {
         await WriteSettingsAsync(cancellationToken).ConfigureAwait(false);
 

--- a/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
@@ -51,7 +51,6 @@ public class CodespacesUrlRewriterTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/6648")]
     public async Task VerifyUrlsRewrittenWhenInCodespaces()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);


### PR DESCRIPTION
## Description

Fixes #6648

The test should be fine now since the code that was throwing is no longer on the path for this particular test. However as part of this PR and for future mitigations if this comes up I've marked the FlushAsync method in the DevcontainerSettingsWriter as virtual so test writers can sub-class and overwrite the code that writes to the settings file to make unit tests more self contained.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
