### PR TITLE
Fix update dependencies workflow issue by generating a temporary sln file

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -16,41 +16,26 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup .NET 9 and 10
-        uses: actions/setup-dotnet@b2ace4b12f4cec1b96b6361ff2694ba9e931ceb4 # v3.3.1
-        with:
-          dotnet-version: |
-            9.0.x
-            10.0.x
-
       - name: Restore solution
         run: ./build.sh -restore
 
       - name: Rewrite nuget.config
-        run: dotnet new nugetconfig --force
+        run: ./dotnet.sh new nugetconfig --force
 
       - name: Install dotnet-outdated
-        run: dotnet tool install --global dotnet-outdated-tool
-
-      - name: Install slngen
-        run: dotnet tool install --global Microsoft.VisualStudio.SlnGen.Tool
-
-      - name: Generate temporary solution file
-        run: slngen ./Aspire.slnx -o ./update.sln
-
-      - name: Restore temporary solution
-        run: dotnet restore ./update.sln
+        run: ./dotnet.sh tool install --global dotnet-outdated-tool
 
       - name: Update packages
         continue-on-error: true
-        run: dotnet outdated --no-restore -u --exclude Microsoft.FluentUI.AspNetCore ./update.sln || echo "Some dependencies could not be updated, but continuing workflow."
+        env:
+          DOTNET_ROOT: ${{ github.workspace }}/.dotnet
+        run: ./dotnet.sh outdated --no-restore -u --exclude Microsoft.FluentUI.AspNetCore ./Aspire.slnx || echo "Some dependencies could not be updated, but continuing workflow."
 
       - name: Revert all changes except Directory.Packages.props files
         run: |
           git add "**Directory.Packages.props"
           git add "**/Directory.Packages.props"
           rm nuget.config
-          rm -f update.sln
           git checkout -- .
 
       - name: Create Pull Request

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Update packages
         continue-on-error: true
         env:
-          DOTNET_ROOT: ${{ github.workspace }}/.dotnet
+          DOTNET_ROOT: ${{ github.workspace }}/.dotnet  # Even when calling the tool via ./dotnet.sh, dotnet tools require DOTNET_ROOT set to use the restored framework
         run: ./dotnet.sh outdated --no-restore -u --exclude Microsoft.FluentUI.AspNetCore ./Aspire.slnx || echo "Some dependencies could not be updated, but continuing workflow."
 
       - name: Revert all changes except Directory.Packages.props files

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -32,15 +32,25 @@ jobs:
       - name: Install dotnet-outdated
         run: dotnet tool install --global dotnet-outdated-tool
 
+      - name: Install slngen
+        run: dotnet tool install --global Microsoft.VisualStudio.SlnGen.Tool
+
+      - name: Generate temporary solution file
+        run: slngen ./Aspire.slnx -o ./update.sln
+
+      - name: Restore temporary solution
+        run: dotnet restore ./update.sln
+
       - name: Update packages
         continue-on-error: true
-        run: dotnet outdated --no-restore -u --exclude Microsoft.FluentUI.AspNetCore ./Aspire.slnx || echo "Some dependencies could not be updated, but continuing workflow."
+        run: dotnet outdated --no-restore -u --exclude Microsoft.FluentUI.AspNetCore ./update.sln || echo "Some dependencies could not be updated, but continuing workflow."
 
       - name: Revert all changes except Directory.Packages.props files
         run: |
           git add "**Directory.Packages.props"
           git add "**/Directory.Packages.props"
           rm nuget.config
+          rm -f update.sln
           git checkout -- .
 
       - name: Create Pull Request


### PR DESCRIPTION
## Description

@eerhardt noticed that our Update Dependencies workflow has started silently failing as there seems to be an issue with the .slnx file. Here is the error message we are seeing: `Unable to process the project `/home/runner/work/aspire/aspire/Aspire.slnx. Are you sure this is a valid .NET Core or .NET Standard project type?`. Neither of us can repro this locally as apparently the tool does support slnx files, but seems like generating a temporary .sln file from the slnx does seem to work as expected, so that is what is included in this change.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
