### PR TITLE
Set up Azure deployer and provisioning context prompting

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREPUBLISHERS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+using Aspire.Hosting.Azure.Provisioning.Internal;
+
+namespace Aspire.Hosting.Azure;
+
+internal sealed class AzureDeployingContext(
+    IProvisioningContextProvider provisioningContextProvider,
+    IUserSecretsManager userSecretsManager)
+{
+    public async Task DeployModelAsync(CancellationToken cancellationToken = default)
+    {
+        var userSecrets = await userSecretsManager.LoadUserSecretsAsync(cancellationToken).ConfigureAwait(false);
+        await provisioningContextProvider.CreateProvisioningContextAsync(userSecrets, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Aspire.Hosting/Publishing/PublishingActivityReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityReporter.cs
@@ -263,12 +263,6 @@ internal sealed class PublishingActivityReporter : IPublishingActivityReporter, 
 
     private async Task HandleInteractionUpdateAsync(Interaction interaction, CancellationToken cancellationToken)
     {
-        // Only handle input interaction types
-        if (interaction.InteractionInfo is not Interaction.InputsInteractionInfo inputsInfo || inputsInfo.Inputs.Count == 0)
-        {
-            return;
-        }
-
         if (interaction.State == Interaction.InteractionState.InProgress)
         {
             if (HasStepsInProgress())
@@ -286,29 +280,63 @@ internal sealed class PublishingActivityReporter : IPublishingActivityReporter, 
                 return;
             }
 
-            var promptInputs = inputsInfo.Inputs.Select(input => new PublishingPromptInput
+            // Handle input interaction types
+            if (interaction.InteractionInfo is Interaction.InputsInteractionInfo inputsInfo && inputsInfo.Inputs.Count > 0)
             {
-                Label = input.Label,
-                InputType = input.InputType.ToString(),
-                Required = input.Required,
-                Options = input.Options,
-                Value = input.Value,
-                ValidationErrors = input.ValidationErrors
-            }).ToList();
-
-            var activity = new PublishingActivity
-            {
-                Type = PublishingActivityTypes.Prompt,
-                Data = new PublishingActivityData
+                var promptInputs = inputsInfo.Inputs.Select(input => new PublishingPromptInput
                 {
-                    Id = interaction.InteractionId.ToString(CultureInfo.InvariantCulture),
-                    StatusText = interaction.Message ?? $"{interaction.Title}: ",
-                    CompletionState = ToBackchannelCompletionState(CompletionState.InProgress),
-                    Inputs = promptInputs
-                }
-            };
+                    Label = input.Label,
+                    InputType = input.InputType.ToString(),
+                    Required = input.Required,
+                    Options = input.Options,
+                    Value = input.Value,
+                    ValidationErrors = input.ValidationErrors
+                }).ToList();
 
-            await ActivityItemUpdated.Writer.WriteAsync(activity, cancellationToken).ConfigureAwait(false);
+                var activity = new PublishingActivity
+                {
+                    Type = PublishingActivityTypes.Prompt,
+                    Data = new PublishingActivityData
+                    {
+                        Id = interaction.InteractionId.ToString(CultureInfo.InvariantCulture),
+                        StatusText = interaction.Message ?? $"{interaction.Title}: ",
+                        CompletionState = ToBackchannelCompletionState(CompletionState.InProgress),
+                        Inputs = promptInputs
+                    }
+                };
+
+                await ActivityItemUpdated.Writer.WriteAsync(activity, cancellationToken).ConfigureAwait(false);
+            }
+            // Handle notification interaction types (PromptNotificationAsync)
+            else if (interaction.InteractionInfo is Interaction.NotificationInteractionInfo)
+            {
+                var promptInputs = new List<PublishingPromptInput>
+                {
+                    new PublishingPromptInput
+                    {
+                        Label = "Confirm",
+                        InputType = "Boolean",
+                        Required = true,
+                        Options = null,
+                        Value = null,
+                        ValidationErrors = null
+                    }
+                };
+
+                var activity = new PublishingActivity
+                {
+                    Type = PublishingActivityTypes.Prompt,
+                    Data = new PublishingActivityData
+                    {
+                        Id = interaction.InteractionId.ToString(CultureInfo.InvariantCulture),
+                        StatusText = interaction.Message ?? $"{interaction.Title}: ",
+                        CompletionState = ToBackchannelCompletionState(CompletionState.InProgress),
+                        Inputs = promptInputs
+                    }
+                };
+
+                await ActivityItemUpdated.Writer.WriteAsync(activity, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 
@@ -334,6 +362,22 @@ internal sealed class PublishingActivityReporter : IPublishingActivityReporter, 
                         {
                             Complete = true,
                             State = inputsInfo.Inputs
+                        };
+                    }
+                    else if (interaction.InteractionInfo is Interaction.NotificationInteractionInfo)
+                    {
+                        // Handle notification interactions with boolean result
+                        bool result = false;
+                        if (responses is not null && responses.Length > 0)
+                        {
+                            // Parse the boolean value from the first response
+                            result = bool.TryParse(responses[0].Value, out var parsedValue) && parsedValue;
+                        }
+
+                        return new InteractionCompletionState
+                        {
+                            Complete = true,
+                            State = result
                         };
                     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIRECOMPUTE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREPUBLISHERS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+using Aspire.Hosting.Utils;
+using Aspire.Hosting.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Aspire.Hosting.Azure.Provisioning.Internal;
+using Aspire.Hosting.Testing;
+using System.Text.Json.Nodes;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureDeployerTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void DeployAsync_EmitsPublishedResources()
+    {
+        // Arrange
+        var tempDir = Directory.CreateTempSubdirectory(".azure-deployer-test");
+        output.WriteLine($"Temp directory: {tempDir.FullName}");
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", outputPath: tempDir.FullName, isDeploy: true);
+
+        var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
+
+        // Add a container that will use the container app environment
+        builder.AddContainer("api", "my-api-image:latest")
+            .WithHttpEndpoint();
+
+        // Act
+        using var app = builder.Build();
+        app.Run();
+
+        // Assert files exist but don't verify contents
+        var mainBicepPath = Path.Combine(tempDir.FullName, "main.bicep");
+        Assert.True(File.Exists(mainBicepPath));
+        var envBicepPath = Path.Combine(tempDir.FullName, "env", "env.bicep");
+        Assert.True(File.Exists(envBicepPath));
+
+        tempDir.Delete(recursive: true);
+    }
+
+    [Fact]
+    public async Task DeployAsync_PromptsViaInteractionService()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
+        var testInteractionService = new TestInteractionService();
+        ConfigureTestServices(builder, testInteractionService);
+
+        // Add an Azure environment resource which will trigger the deployment prompting
+        builder.AddAzureEnvironment();
+
+        // Act
+        using var app = builder.Build();
+
+        var runTask = Task.Run(app.Run);
+
+        // Assert - Wait for the first interaction (message bar)
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        Assert.Equal("Azure provisioning", messageBarInteraction.Title);
+        Assert.Contains("Azure resources that require an Azure Subscription", messageBarInteraction.Message ?? "");
+
+        // Complete the message bar interaction to proceed to inputs dialog
+        messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true)); // Data = true (user clicked Enter Values)
+
+        // Wait for the inputs interaction
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        Assert.Equal("Azure provisioning", inputsInteraction.Title);
+        Assert.True(inputsInteraction.Options!.EnableMessageMarkdown);
+
+        // Verify the expected inputs for Azure provisioning
+        Assert.Collection(inputsInteraction.Inputs,
+            input =>
+            {
+                Assert.Equal("Location", input.Label);
+                Assert.Equal(InputType.Choice, input.InputType);
+                Assert.True(input.Required);
+            },
+            input =>
+            {
+                Assert.Equal("Subscription ID", input.Label);
+                Assert.Equal(InputType.SecretText, input.InputType);
+                Assert.True(input.Required);
+            },
+            input =>
+            {
+                Assert.Equal("Resource group", input.Label);
+                Assert.Equal(InputType.Text, input.InputType);
+                Assert.False(input.Required);
+            });
+
+        // Complete the inputs interaction with valid values
+        inputsInteraction.Inputs[0].Value = inputsInteraction.Inputs[0].Options!.First(kvp => kvp.Key == "westus").Value;
+        inputsInteraction.Inputs[1].Value = "12345678-1234-1234-1234-123456789012";
+        inputsInteraction.Inputs[2].Value = "test-rg";
+
+        inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
+
+        // Wait for the run task to complete (or timeout)
+        await runTask.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    private static void ConfigureTestServices(IDistributedApplicationTestingBuilder builder, IInteractionService interactionService)
+    {
+        var options = ProvisioningTestHelpers.CreateOptions(null, null, null);
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
+        var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
+        var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
+        var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
+        builder.Services.AddSingleton(armClientProvider);
+        builder.Services.AddSingleton(userPrincipalProvider);
+        builder.Services.AddSingleton(tokenCredentialProvider);
+        builder.Services.AddSingleton(environment);
+        builder.Services.AddSingleton(logger);
+        builder.Services.AddSingleton(options);
+        builder.Services.AddSingleton(interactionService);
+        builder.Services.AddSingleton<IProvisioningContextProvider, DefaultProvisioningContextProvider>();
+        builder.Services.AddSingleton<IUserSecretsManager, NoOpUserSecretsManager>();
+    }
+
+    private sealed class NoOpUserSecretsManager : IUserSecretsManager
+    {
+        public Task<JsonObject> LoadUserSecretsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new JsonObject());
+
+        public Task SaveUserSecretsAsync(JsonObject userSecrets, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -24,6 +24,10 @@ public class AzureDeployerTests(ITestOutputHelper output)
         var tempDir = Directory.CreateTempSubdirectory(".azure-deployer-test");
         output.WriteLine($"Temp directory: {tempDir.FullName}");
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", outputPath: tempDir.FullName, isDeploy: true);
+        // Configure Azure settings to avoid prompting during deployment for this test case
+        builder.Configuration["Azure:SubscriptionId"] = "12345678-1234-1234-1234-123456789012";
+        builder.Configuration["Azure:ResourceGroup"] = "test-rg";
+        builder.Configuration["Azure:Location"] = "westus2";
 
         var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
 

--- a/tests/Aspire.Hosting.Azure.Tests/DefaultProvisioningContextProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DefaultProvisioningContextProviderTests.cs
@@ -5,15 +5,9 @@
 
 using System.Reflection;
 using System.Text.Json.Nodes;
-using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Azure.Provisioning.Internal;
 using Aspire.Hosting.Tests;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -25,9 +19,9 @@ public class DefaultProvisioningContextProviderTests
     public async Task CreateProvisioningContextAsync_ReturnsValidContext()
     {
         // Arrange
-        var options = CreateOptions();
-        var environment = CreateEnvironment();
-        var logger = CreateLogger();
+        var options = ProvisioningTestHelpers.CreateOptions();
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
         var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
@@ -40,7 +34,8 @@ public class DefaultProvisioningContextProviderTests
             logger,
             armClientProvider,
             userPrincipalProvider,
-            tokenCredentialProvider);
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -62,9 +57,9 @@ public class DefaultProvisioningContextProviderTests
     public async Task CreateProvisioningContextAsync_ThrowsWhenSubscriptionIdMissing()
     {
         // Arrange
-        var options = CreateOptions(subscriptionId: null);
-        var environment = CreateEnvironment();
-        var logger = CreateLogger();
+        var options = ProvisioningTestHelpers.CreateOptions(subscriptionId: null);
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
         var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
@@ -77,7 +72,8 @@ public class DefaultProvisioningContextProviderTests
             logger,
             armClientProvider,
             userPrincipalProvider,
-            tokenCredentialProvider);
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<MissingConfigurationException>(
@@ -89,9 +85,9 @@ public class DefaultProvisioningContextProviderTests
     public async Task CreateProvisioningContextAsync_ThrowsWhenLocationMissing()
     {
         // Arrange
-        var options = CreateOptions(location: null);
-        var environment = CreateEnvironment();
-        var logger = CreateLogger();
+        var options = ProvisioningTestHelpers.CreateOptions(location: null);
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
         var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
@@ -104,7 +100,8 @@ public class DefaultProvisioningContextProviderTests
             logger,
             armClientProvider,
             userPrincipalProvider,
-            tokenCredentialProvider);
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<MissingConfigurationException>(
@@ -116,9 +113,9 @@ public class DefaultProvisioningContextProviderTests
     public async Task CreateProvisioningContextAsync_GeneratesResourceGroupNameWhenNotProvided()
     {
         // Arrange
-        var options = CreateOptions(resourceGroup: null);
-        var environment = CreateEnvironment();
-        var logger = CreateLogger();
+        var options = ProvisioningTestHelpers.CreateOptions(resourceGroup: null);
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
         var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
@@ -131,7 +128,8 @@ public class DefaultProvisioningContextProviderTests
             logger,
             armClientProvider,
             userPrincipalProvider,
-            tokenCredentialProvider);
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -151,9 +149,9 @@ public class DefaultProvisioningContextProviderTests
     {
         // Arrange
         var resourceGroupName = "my-custom-rg";
-        var options = CreateOptions(resourceGroup: resourceGroupName);
-        var environment = CreateEnvironment();
-        var logger = CreateLogger();
+        var options = ProvisioningTestHelpers.CreateOptions(resourceGroup: resourceGroupName);
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
         var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
@@ -166,7 +164,8 @@ public class DefaultProvisioningContextProviderTests
             logger,
             armClientProvider,
             userPrincipalProvider,
-            tokenCredentialProvider);
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -180,9 +179,9 @@ public class DefaultProvisioningContextProviderTests
     public async Task CreateProvisioningContextAsync_RetrievesUserPrincipal()
     {
         // Arrange
-        var options = CreateOptions();
-        var environment = CreateEnvironment();
-        var logger = CreateLogger();
+        var options = ProvisioningTestHelpers.CreateOptions();
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
         var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
@@ -195,7 +194,8 @@ public class DefaultProvisioningContextProviderTests
             logger,
             armClientProvider,
             userPrincipalProvider,
-            tokenCredentialProvider);
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -210,9 +210,9 @@ public class DefaultProvisioningContextProviderTests
     public async Task CreateProvisioningContextAsync_SetsCorrectTenant()
     {
         // Arrange
-        var options = CreateOptions();
-        var environment = CreateEnvironment();
-        var logger = CreateLogger();
+        var options = ProvisioningTestHelpers.CreateOptions();
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
         var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
@@ -225,7 +225,8 @@ public class DefaultProvisioningContextProviderTests
             logger,
             armClientProvider,
             userPrincipalProvider,
-            tokenCredentialProvider);
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -241,9 +242,9 @@ public class DefaultProvisioningContextProviderTests
     {
         // Arrange
         var testInteractionService = new TestInteractionService();
-        var options = CreateOptions(null, null, null);
-        var environment = CreateEnvironment();
-        var logger = CreateLogger();
+        var options = ProvisioningTestHelpers.CreateOptions(null, null, null);
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
         var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
@@ -256,8 +257,8 @@ public class DefaultProvisioningContextProviderTests
             logger,
             armClientProvider,
             userPrincipalProvider,
-            tokenCredentialProvider);
-
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
         // Act
         var createTask = provider.CreateProvisioningContextAsync(userSecrets);
 
@@ -315,9 +316,9 @@ public class DefaultProvisioningContextProviderTests
     public async Task CreateProvisioningContextAsync_Prompt_ValidatesSubAndResourceGroup()
     {
         var testInteractionService = new TestInteractionService();
-        var options = CreateOptions(null, null, null);
-        var environment = CreateEnvironment();
-        var logger = CreateLogger();
+        var options = ProvisioningTestHelpers.CreateOptions(null, null, null);
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
         var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
@@ -330,7 +331,8 @@ public class DefaultProvisioningContextProviderTests
             logger,
             armClientProvider,
             userPrincipalProvider,
-            tokenCredentialProvider);
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
 
         var createTask = provider.CreateProvisioningContextAsync(userSecrets);
 
@@ -359,39 +361,4 @@ public class DefaultProvisioningContextProviderTests
         Assert.True((bool)context.GetType().GetProperty("HasErrors", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(context, null)!);
     }
 
-    private static IOptions<AzureProvisionerOptions> CreateOptions(
-        string? subscriptionId = "12345678-1234-1234-1234-123456789012",
-        string? location = "westus2",
-        string? resourceGroup = "test-rg")
-    {
-        var options = new AzureProvisionerOptions
-        {
-            SubscriptionId = subscriptionId,
-            Location = location,
-            ResourceGroup = resourceGroup
-        };
-        return Options.Create(options);
-    }
-
-    private static IHostEnvironment CreateEnvironment()
-    {
-        var environment = new TestHostEnvironment
-        {
-            ApplicationName = "TestApp"
-        };
-        return environment;
-    }
-
-    private static ILogger<DefaultProvisioningContextProvider> CreateLogger()
-    {
-        return NullLogger<DefaultProvisioningContextProvider>.Instance;
-    }
-
-    private sealed class TestHostEnvironment : IHostEnvironment
-    {
-        public string EnvironmentName { get; set; } = "Test";
-        public string ApplicationName { get; set; } = "TestApp";
-        public string ContentRootPath { get; set; } = "/test";
-        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
-    }
 }

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -17,12 +17,12 @@ namespace Aspire.Hosting.Utils;
 /// </summary>
 public static class TestDistributedApplicationBuilder
 {
-    public static IDistributedApplicationTestingBuilder Create(DistributedApplicationOperation operation, string publisher = "manifest", string outputPath = "./")
+    public static IDistributedApplicationTestingBuilder Create(DistributedApplicationOperation operation, string publisher = "manifest", string outputPath = "./", bool isDeploy = false)
     {
         var args = operation switch
         {
             DistributedApplicationOperation.Run => (string[])[],
-            DistributedApplicationOperation.Publish => [$"Publishing:Publisher={publisher}", $"Publishing:OutputPath={outputPath}"],
+            DistributedApplicationOperation.Publish => [$"Publishing:Publisher={publisher}", $"Publishing:OutputPath={outputPath}", $"Publishing:Deploy={isDeploy}"],
             _ => throw new ArgumentOutOfRangeException(nameof(operation))
         };
 


### PR DESCRIPTION
## Description

First of many (😅 ) PRs for the Azure deployer. This one wires up the DeployingCallbackAnnotation and hooks into the parameter resolution in the DefaultProvisioningContext for prompting in the CLI. Changes include:

- Map `PromptNotificationAsync` to confirmation prompts in the CLI
- Set up some test infra for the Azure deployer
- Refactor some existing test infrastrucutre to share provisioning options

It would be great to share as much of the behavior in the `DefaultProvisioningContext` between publish and run modes. I experimented with a bunch of different approaches but I think the best option would be to create a new `IProvisioningStateManager` API that wraps the behavior for writing provisioning options and state to either user secrets or the file system (depending on which mode you are in). I've ommitted this change from the PR for now.

Doing this work revealed the gap from #10791 (see GIF below) and the awkwardness with mapping InteractionService concepts 1:1 rom the dashboard to the CLI. In the GIF below, you get two outputs about needing subscription ID twice (once from the PromptNotificationAsync and again from PromptInputsAsync). 

Contributes to #10448

![aspire-deploy-provisioning-prompt](https://github.com/user-attachments/assets/a74b01d4-0e9a-469c-aa58-0ea0df0b9da5)
