### PR TITLE
[release/9.4] Update dependencies from microsoft/usvc-apiserver

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.15.19">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.15.20">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>2d0193f243232dc37900e3f85ac0b5c4af47d88d</Sha>
+      <Sha>f3bbebcdc637a7af175106dc55591cb9e9c56ed2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.15.19">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.15.20">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>2d0193f243232dc37900e3f85ac0b5c4af47d88d</Sha>
+      <Sha>f3bbebcdc637a7af175106dc55591cb9e9c56ed2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.15.19">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.15.20">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>2d0193f243232dc37900e3f85ac0b5c4af47d88d</Sha>
+      <Sha>f3bbebcdc637a7af175106dc55591cb9e9c56ed2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.15.19">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.15.20">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>2d0193f243232dc37900e3f85ac0b5c4af47d88d</Sha>
+      <Sha>f3bbebcdc637a7af175106dc55591cb9e9c56ed2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.15.19">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.15.20">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>2d0193f243232dc37900e3f85ac0b5c4af47d88d</Sha>
+      <Sha>f3bbebcdc637a7af175106dc55591cb9e9c56ed2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.15.19">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.15.20">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>2d0193f243232dc37900e3f85ac0b5c4af47d88d</Sha>
+      <Sha>f3bbebcdc637a7af175106dc55591cb9e9c56ed2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.15.19">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.15.20">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>2d0193f243232dc37900e3f85ac0b5c4af47d88d</Sha>
+      <Sha>f3bbebcdc637a7af175106dc55591cb9e9c56ed2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.15.19">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.15.20">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>2d0193f243232dc37900e3f85ac0b5c4af47d88d</Sha>
+      <Sha>f3bbebcdc637a7af175106dc55591cb9e9c56ed2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="9.7.0">
       <Uri>https://github.com/dotnet/extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,14 +28,14 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.15.19</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.15.19</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.15.19</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.15.19</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.15.19</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindows386Version>0.15.19</MicrosoftDeveloperControlPlanewindows386Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.15.19</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.15.19</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.15.20</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.15.20</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.15.20</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.15.20</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.15.20</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindows386Version>0.15.20</MicrosoftDeveloperControlPlanewindows386Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.15.20</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.15.20</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>10.0.0-beta.25351.1</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>10.0.0-beta.25351.1</MicrosoftDotNetXUnitV3ExtensionsVersion>


### PR DESCRIPTION
## Description

Updates DCP to 0.15.20 which includes a fix for a shutdown performance regression in 9.4.
