### PR TITLE
Fixed properties override when publishing an update in external service

### DIFF
--- a/src/Aspire.Hosting/ExternalServiceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExternalServiceBuilderExtensions.cs
@@ -145,9 +145,7 @@ public static class ExternalServiceBuilderExtensions
 
                 await e.Notifications.PublishUpdateAsync(resource, snapshot => snapshot with
                 {
-                    Properties = [
-                        new(CustomResourceKnownProperties.Source, uri.Host)
-                    ],
+                    Properties = snapshot.Properties.SetResourceProperty(CustomResourceKnownProperties.Source, uri.Host),
                     // Add the URL if it came from a parameter as non-static URLs must be published by the owning custom resource
                     Urls = AddUrlIfNotPresent(snapshot.Urls, uri),
                     // Required in order for health checks to work


### PR DESCRIPTION
## Description

This PR fixes an issue where properties of an external resource were being overridden upon publishing an update with state Running.

Fixes #10680

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
