### PR TITLE
Replace hyphens with underscores in Helm environment variable keys

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/Extensions/HelmExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/Extensions/HelmExtensions.cs
@@ -74,4 +74,14 @@ internal static class HelmExtensions
 
     public static bool ContainsHelmSecretExpression(this string value)
         => value.Contains($"{{{{ {ValuesSegment}.{SecretsKey}.", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Converts the specified environment variable key into a valid Helm key.
+    /// </summary>
+    /// <remarks>
+    /// The environment variable names in Helm values files can not contain hyphens ('-').
+    /// <see href="link">https://helm.sh/docs/chart_best_practices/values/</see>
+    /// </remarks>
+    public static string ToHelmEnvironmentVariable(this string key)
+        => $"{key.Replace("-", "_")}";
 }

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -260,7 +260,7 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
 
             foreach (var environmentVariable in context.EnvironmentVariables)
             {
-                var key = environmentVariable.Key;
+                var key = environmentVariable.Key.ToHelmEnvironmentVariable();
                 var value = await this.ProcessValueAsync(environmentContext, executionContext, environmentVariable.Value).ConfigureAwait(false);
 
                 switch (value)

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#01.verified.yaml
@@ -1,11 +1,15 @@
-parameters:
+﻿parameters:
   SpeciaL_ApP:
     SpeciaL_ApP_image: "SpeciaL-ApP:latest"
 secrets:
   SpeciaL_ApP:
     param3: ""
 config:
+  Special_resource_with_hyphens:
+    ORIGINAL_ENV: "value"
   SpeciaL_ApP:
     OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "true"
     OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
     OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "in_memory"
+    services__Special_resource_with_hyphens__http__0: "http://special-resource-with-hyphens-service:80"
+    services__Special_resource_with_hyphens__https__0: "https://special-resource-with-hyphens-service:443"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#03.verified.yaml
@@ -1,4 +1,4 @@
----
+﻿---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
@@ -11,3 +11,5 @@ data:
   OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "{{ .Values.config.SpeciaL_ApP.OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES }}"
   OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "{{ .Values.config.SpeciaL_ApP.OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES }}"
   OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "{{ .Values.config.SpeciaL_ApP.OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY }}"
+  services__Special_resource_with_hyphens__http__0: "{{ .Values.config.SpeciaL_ApP.services__Special_resource_with_hyphens__http__0 }}"
+  services__Special_resource_with_hyphens__https__0: "{{ .Values.config.SpeciaL_ApP.services__Special_resource_with_hyphens__https__0 }}"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#04.verified.yaml
@@ -1,4 +1,4 @@
----
+﻿---
 apiVersion: "v1"
 kind: "Secret"
 metadata:
@@ -9,5 +9,5 @@ metadata:
     app.kubernetes.io/instance: "{{.Release.Name}}"
 stringData:
   param3: "{{ .Values.secrets.SpeciaL_ApP.param3 }}"
-  ConnectionStrings__api-cs: "Url={{ .Values.config.SpeciaL_ApP.param0 }}, Secret={{ .Values.secrets.SpeciaL_ApP.param1 }}"
+  ConnectionStrings__api_cs: "Url={{ .Values.config.SpeciaL_ApP.param0 }}, Secret={{ .Values.secrets.SpeciaL_ApP.param1 }}"
 type: "Opaque"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#05.verified.yaml
@@ -1,0 +1,43 @@
+﻿---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "special-resource-with-hyphens-deployment"
+  labels:
+    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/component: "Special-resource-with-hyphens"
+    app.kubernetes.io/instance: "{{.Release.Name}}"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "my-chart"
+        app.kubernetes.io/component: "Special-resource-with-hyphens"
+        app.kubernetes.io/instance: "{{.Release.Name}}"
+    spec:
+      containers:
+        - image: "my-image:latest"
+          name: "Special-resource-with-hyphens"
+          envFrom:
+            - configMapRef:
+                name: "special-resource-with-hyphens-config"
+          ports:
+            - name: "http"
+              protocol: "TCP"
+              containerPort: 80
+            - name: "https"
+              protocol: "TCP"
+              containerPort: 443
+          imagePullPolicy: "Always"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "my-chart"
+      app.kubernetes.io/component: "Special-resource-with-hyphens"
+      app.kubernetes.io/instance: "{{.Release.Name}}"
+  replicas: 1
+  revisionHistoryLimit: 5
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: "RollingUpdate"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#06.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#06.verified.yaml
@@ -1,0 +1,24 @@
+﻿---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "special-resource-with-hyphens-service"
+  labels:
+    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/component: "Special-resource-with-hyphens"
+    app.kubernetes.io/instance: "{{.Release.Name}}"
+spec:
+  type: "ClusterIP"
+  selector:
+    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/component: "Special-resource-with-hyphens"
+    app.kubernetes.io/instance: "{{.Release.Name}}"
+  ports:
+    - name: "http"
+      protocol: "TCP"
+      port: 80
+      targetPort: 80
+    - name: "https"
+      protocol: "TCP"
+      port: 443
+      targetPort: 443

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#07.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#07.verified.yaml
@@ -1,0 +1,11 @@
+﻿---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "special-resource-with-hyphens-config"
+  labels:
+    app.kubernetes.io/name: "my-chart"
+    app.kubernetes.io/component: "Special-resource-with-hyphens"
+    app.kubernetes.io/instance: "{{.Release.Name}}"
+data:
+  ORIGINAL_ENV: "{{ .Values.config.Special_resource_with_hyphens.ORIGINAL_ENV }}"


### PR DESCRIPTION
Replace hyphens with underscores in Helm environment variable keys, adjust relevant test to properly validate this scenario.

## Description

Take this configMap example, taken from issue #10820
```
---
apiVersion: "v1"
kind: "ConfigMap"
metadata:
  name: "xx-yy-xx-webspa-config"
  labels:
    app: "aspire"
    component: "xx-yy-xx-webspa"
data:
  ASPNETCORE_URLS: "{{ .Values.config.xx_yy_xx_webspa.ASPNETCORE_URLS }}"
  ConnectionStrings__HangfireDb: "{{ .Values.config.xx_yy_xx_webspa.ConnectionStrings__HangfireDb }}"
  ConnectionStrings__rabbitmq: "{{ .Values.config.xx_yy_xx_webspa.ConnectionStrings__rabbitmq }}"
  services__xx-yy-xx-bookings__https__0: "{{ .Values.config.xx_yy_xx_webspa.services__xx-yy-xx-bookings__https__0 }}"
  services__xx-yy-xx-filestorage__https__0: "{{ .Values.config.xx_yy_xx_webspa.services__xx-yy-xx-filestorage__https__0 }}"
  services__xx-yy-xx-institutions__https__0: "{{ .Values.config.xx_yy_xx_webspa.services__xx-yy-xx-institutions__https__0 }}"
  services__xx-yy-xx-mapobjects__https__0: "{{ .Values.config.xx_yy_xx_webspa.services__xx-yy-xx-mapobjects__https__0 }}"
  services__xx-yy-xx-messenger__https__0: "{{ .Values.config.xx_yy_xx_webspa.services__xx-yy-xx-messenger__https__0 }}"
  services__xx-yy-xx-permissions__https__0: "{{ .Values.config.xx_yy_xx_webspa.services__xx-yy-xx-permissions__https__0 }}"
  services__xx-yy-xx-projects__https__0: "{{ .Values.config.xx_yy_xx_webspa.services__xx-yy-xx-projects__https__0 }}"

```

While hyphens are allowed in the `data` keys, and in `values` environment variable names, they are NOT allowed in the Helm expressions. This for example: `{{ .Values.config.xx_yy_xx_webspa.services__xx-yy-xx-bookings__https__0 }}` fails when ran through the `helm template` command.

Replacing the hyphens with underscores only in the Helm expression is not an option, because that makes the 'link' invalid, as there are no `services__xx_yy_xx_bookings__https__0` environment variable keys with that name, if they don't also get changed there.

Therefore, it has to be changed this way, so they are reflected both places.

Unit test `PublishAsync_HandlesSpecialResourceName()` was also changed, to properly test this scenario by adding a container resources, and adding a reference to it in the project resource, so it adds the `services__xx-yy-xx-bookings__https__0` reference, allowing us to properly test it.

Fixes #10820 

**NOTE!!**
This also makes any connectionstrings for example `ConnectionStrings__some-service` -> `ConnectionStrings__some_service` but I think that's fine, usually environment variables don't contain hyphens in most systems anyway.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
