### PR TITLE
Hook up Azure Deployer to BicepProvisioner

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -161,6 +161,9 @@
     <Project Path="playground/DatabaseMigration/DatabaseMigration.AppHost/DatabaseMigration.AppHost.csproj" />
     <Project Path="playground/DatabaseMigration/DatabaseMigration.MigrationService/DatabaseMigration.MigrationService.csproj" />
   </Folder>
+  <Folder Name="/playground/deployers/">
+    <Project Path="playground/deployers/Deployers.AppHost/Deployers.AppHost.csproj" />
+  </Folder>
   <Folder Name="/playground/dockerfile/">
     <Project Path="playground/withdockerfile/WithDockerfile.AppHost/WithDockerfile.AppHost.csproj" />
   </Folder>

--- a/playground/deployers/Deployers.AppHost/AppHost.cs
+++ b/playground/deployers/Deployers.AppHost/AppHost.cs
@@ -1,0 +1,22 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAzureContainerAppEnvironment("env");
+
+var storage = builder.AddAzureStorage("storage");
+
+storage.AddBlobs("blobs");
+storage.AddBlobContainer("mycontainer1", blobContainerName: "test-container-1");
+storage.AddBlobContainer("mycontainer2", blobContainerName: "test-container-2");
+storage.AddQueue("myqueue", queueName: "my-queue");
+
+#if !SKIP_DASHBOARD_REFERENCE
+// This project is only added in playground projects to support development/debugging
+// of the dashboard. It is not required in end developer code. Comment out this code
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
+builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
+
+builder.Build().Run();

--- a/playground/deployers/Deployers.AppHost/Deployers.AppHost.csproj
+++ b/playground/deployers/Deployers.AppHost/Deployers.AppHost.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.AppContainers" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Storage" />
+  </ItemGroup>
+
+</Project>

--- a/playground/deployers/Deployers.AppHost/Properties/launchSettings.json
+++ b/playground/deployers/Deployers.AppHost/Properties/launchSettings.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17222;http://localhost:15020",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21267",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22116"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15020",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19093",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20094"
+      }
+    },
+    "deploy": {
+      "commandName": "Project",
+      "commandLineArgs": "--publisher default --deploy true --output-path deploy",
+    }
+  }
+}

--- a/playground/deployers/Deployers.AppHost/appsettings.Development.json
+++ b/playground/deployers/Deployers.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/playground/deployers/Deployers.AppHost/appsettings.json
+++ b/playground/deployers/Deployers.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -120,7 +120,8 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
             }
         }
 
-        return new(path, isTempFile && deleteTemporaryFileOnDispose);
+        var targetPath = directory is not null ? Path.Combine(directory, path) : path;
+        return new(targetPath, isTempFile && deleteTemporaryFileOnDispose);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -4,17 +4,74 @@
 #pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPUBLISHERS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Azure.Provisioning.Internal;
+using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting.Azure;
 
 internal sealed class AzureDeployingContext(
     IProvisioningContextProvider provisioningContextProvider,
-    IUserSecretsManager userSecretsManager)
+    IUserSecretsManager userSecretsManager,
+    IBicepProvisioner bicepProvisioner,
+    IPublishingActivityReporter activityReporter)
 {
-    public async Task DeployModelAsync(CancellationToken cancellationToken = default)
+    public async Task DeployModelAsync(AzureEnvironmentResource resource, CancellationToken cancellationToken = default)
     {
         var userSecrets = await userSecretsManager.LoadUserSecretsAsync(cancellationToken).ConfigureAwait(false);
-        await provisioningContextProvider.CreateProvisioningContextAsync(userSecrets, cancellationToken).ConfigureAwait(false);
+        var provisioningContext = await provisioningContextProvider.CreateProvisioningContextAsync(userSecrets, cancellationToken).ConfigureAwait(false);
+
+        if (resource.PublishingContext is null)
+        {
+            throw new InvalidOperationException($"Publishing context is not initialized. Please ensure that the {nameof(AzurePublishingContext)} has been initialized before deploying.");
+        }
+
+        var deployingStep = await activityReporter.CreateStepAsync("Deploying to Azure", cancellationToken).ConfigureAwait(false);
+        await using (deployingStep.ConfigureAwait(false))
+        {
+            // Map parameters from the AzurePublishingContext
+            foreach (var (parameterResource, provisioningParameter) in resource.PublishingContext.ParameterLookup)
+            {
+                if (parameterResource == resource.Location)
+                {
+                    resource.Parameters[provisioningParameter.BicepIdentifier] = provisioningContext.Location.Name;
+                }
+                else if (parameterResource == resource.ResourceGroupName)
+                {
+                    resource.Parameters[provisioningParameter.BicepIdentifier] = provisioningContext.ResourceGroup.Name;
+                }
+                else if (parameterResource == resource.PrincipalId)
+                {
+                    resource.Parameters[provisioningParameter.BicepIdentifier] = provisioningContext.Principal.Id.ToString();
+                }
+                else
+                {
+                    // TODO: Prompt here.
+                    await deployingStep.FailAsync("Deployment contains unresolvable parameters.", cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            try
+            {
+                var azureTask = await deployingStep.CreateTaskAsync("Provisioning Azure environment", cancellationToken).ConfigureAwait(false);
+                await using (azureTask.ConfigureAwait(false))
+                {
+                    try
+                    {
+                        await bicepProvisioner.GetOrCreateResourceAsync(resource, provisioningContext, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        await azureTask.FailAsync($"Provisioning failed: {ex.Message}", cancellationToken).ConfigureAwait(false);
+                        throw;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                await deployingStep.FailAsync($"Deployment failed: {ex.Message}", cancellationToken).ConfigureAwait(false);
+                throw;
+            }
+        }
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -6,7 +6,9 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Azure.Provisioning.Internal;
+using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -17,7 +19,7 @@ namespace Aspire.Hosting.Azure;
 /// Emits a <c>main.bicep</c> that aggregates all provisionable resources.
 /// </summary>
 [Experimental("ASPIREAZURE001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
-public sealed class AzureEnvironmentResource : Resource
+public sealed class AzureEnvironmentResource : AzureBicepResource
 {
     /// <summary>
     /// Gets or sets the Azure location that the resources will be deployed to.
@@ -34,6 +36,8 @@ public sealed class AzureEnvironmentResource : Resource
     /// </summary>
     public ParameterResource PrincipalId { get; set; }
 
+    internal AzurePublishingContext? PublishingContext { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureEnvironmentResource"/> class.
     /// </summary>
@@ -43,10 +47,11 @@ public sealed class AzureEnvironmentResource : Resource
     /// <param name="principalId">The Azure principal ID that will be used to deploy the resources.</param>
     /// <exception cref="ArgumentNullException">Thrown when the name is null or empty.</exception>
     /// <exception cref="ArgumentException">Thrown when the name is invalid.</exception>
-    public AzureEnvironmentResource(string name, ParameterResource location, ParameterResource resourceGroupName, ParameterResource principalId) : base(name)
+    public AzureEnvironmentResource(string name, ParameterResource location, ParameterResource resourceGroupName, ParameterResource principalId) : base(name, templateFile: "main.bicep")
     {
         Annotations.Add(new PublishingCallbackAnnotation(PublishAsync));
         Annotations.Add(new DeployingCallbackAnnotation(DeployAsync));
+        Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
 
         Location = location;
         ResourceGroupName = resourceGroupName;
@@ -57,24 +62,28 @@ public sealed class AzureEnvironmentResource : Resource
     {
         var azureProvisioningOptions = context.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>();
 
-        var azureCtx = new AzurePublishingContext(
+        PublishingContext = new AzurePublishingContext(
             context.OutputPath,
             azureProvisioningOptions.Value,
             context.Logger,
             context.ActivityReporter);
 
-        return azureCtx.WriteModelAsync(context.Model, this);
+        return PublishingContext.WriteModelAsync(context.Model, this);
     }
 
     private Task DeployAsync(DeployingContext context)
     {
         var provisioningContextProvider = context.Services.GetRequiredService<IProvisioningContextProvider>();
         var userSecretsManager = context.Services.GetRequiredService<IUserSecretsManager>();
+        var bicepProvisioner = context.Services.GetRequiredService<IBicepProvisioner>();
+        var activityPublisher = context.Services.GetRequiredService<IPublishingActivityReporter>();
 
         var azureCtx = new AzureDeployingContext(
             provisioningContextProvider,
-            userSecretsManager);
+            userSecretsManager,
+            bicepProvisioner,
+            activityPublisher);
 
-        return azureCtx.DeployModelAsync(context.CancellationToken);
+        return azureCtx.DeployModelAsync(this, context.CancellationToken);
     }
 }

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -251,6 +251,11 @@ public sealed class AzurePublishingContext(
                     module.Parameters.Add(parameter.Key, principalId);
                     continue;
                 }
+                if (parameter.Key == AzureBicepResource.KnownParameters.PrincipalId && parameter.Value is null)
+                {
+                    module.Parameters.Add(parameter.Key, principalId);
+                    continue;
+                }
 
                 var value = ResolveValue(Eval(parameter.Value));
 

--- a/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerExtensions.cs
@@ -36,8 +36,8 @@ public static class AzureProvisionerExtensions
 
         builder.Services.AddSingleton<ITokenCredentialProvider, DefaultTokenCredentialProvider>();
 
-        // Register BicepProvisioner directly
-        builder.Services.AddSingleton<BicepProvisioner>();
+        // Register BicepProvisioner via interface
+        builder.Services.AddSingleton<IBicepProvisioner, BicepProvisioner>();
 
         // Register the new internal services for testability
         builder.Services.AddSingleton<IArmClientProvider, DefaultArmClientProvider>();

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultArmDeploymentCollection.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultArmDeploymentCollection.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.Resources.Models;
+
+namespace Aspire.Hosting.Azure.Provisioning.Internal;
+
+internal sealed class DefaultArmDeploymentCollection(ArmDeploymentCollection armDeploymentCollection) : IArmDeploymentCollection
+{
+    public Task<ArmOperation<ArmDeploymentResource>> CreateOrUpdateAsync(
+        WaitUntil waitUntil,
+        string deploymentName,
+        ArmDeploymentContent content,
+        CancellationToken cancellationToken = default)
+    {
+        return armDeploymentCollection.CreateOrUpdateAsync(waitUntil, deploymentName, content, cancellationToken);
+    }
+}

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultProvisioningContextProvider.cs
@@ -220,14 +220,14 @@ internal sealed partial class DefaultProvisioningContextProvider(
             // Create a unique resource group name and save it in user secrets
             resourceGroupName = GetDefaultResourceGroupName();
 
-            createIfAbsent = distributedApplicationExecutionContext.IsRunMode;
+            createIfAbsent = true;
 
             userSecrets.Prop("Azure")["ResourceGroup"] = resourceGroupName;
         }
         else
         {
             resourceGroupName = _options.ResourceGroup;
-            createIfAbsent = distributedApplicationExecutionContext.IsRunMode && (_options.AllowResourceGroupCreation ?? false);
+            createIfAbsent = _options.AllowResourceGroupCreation ?? false;
         }
 
         var resourceGroups = subscriptionResource.GetResourceGroups();

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultResourceGroupResource.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultResourceGroupResource.cs
@@ -1,11 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Azure;
 using Azure.Core;
-using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
-using Azure.ResourceManager.Resources.Models;
 
 namespace Aspire.Hosting.Azure.Provisioning.Internal;
 
@@ -20,17 +17,5 @@ internal sealed class DefaultResourceGroupResource(ResourceGroupResource resourc
     public IArmDeploymentCollection GetArmDeployments()
     {
         return new DefaultArmDeploymentCollection(resourceGroupResource.GetArmDeployments());
-    }
-
-    private sealed class DefaultArmDeploymentCollection(ArmDeploymentCollection armDeploymentCollection) : IArmDeploymentCollection
-    {
-        public Task<ArmOperation<ArmDeploymentResource>> CreateOrUpdateAsync(
-            WaitUntil waitUntil,
-            string deploymentName,
-            ArmDeploymentContent content,
-            CancellationToken cancellationToken = default)
-        {
-            return armDeploymentCollection.CreateOrUpdateAsync(waitUntil, deploymentName, content, cancellationToken);
-        }
     }
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultSubscriptionResource.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultSubscriptionResource.cs
@@ -17,6 +17,11 @@ internal sealed class DefaultSubscriptionResource(SubscriptionResource subscript
     public string? DisplayName => subscriptionResource.Data.DisplayName;
     public Guid? TenantId => subscriptionResource.Data.TenantId;
 
+    public IArmDeploymentCollection GetArmDeployments()
+    {
+        return new DefaultArmDeploymentCollection(subscriptionResource.GetArmDeployments());
+    }
+
     public IResourceGroupCollection GetResourceGroups()
     {
         return new DefaultResourceGroupCollection(subscriptionResource.GetResourceGroups());

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
@@ -106,6 +106,11 @@ internal interface ISubscriptionResource
     /// Gets resource groups collection.
     /// </summary>
     IResourceGroupCollection GetResourceGroups();
+
+    /// <summary>
+    /// Gets ARM deployments collection.
+    /// </summary>
+    IArmDeploymentCollection GetArmDeployments();
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -16,7 +16,7 @@ internal sealed class AzureProvisioner(
     DistributedApplicationExecutionContext executionContext,
     IConfiguration configuration,
     IServiceProvider serviceProvider,
-    BicepProvisioner bicepProvisioner,
+    IBicepProvisioner bicepProvisioner,
     ResourceNotificationService notificationService,
     ResourceLoggerService loggerService,
     IDistributedApplicationEventing eventing,

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -17,8 +17,9 @@ internal sealed class BicepProvisioner(
     ResourceNotificationService notificationService,
     ResourceLoggerService loggerService,
     IBicepCompiler bicepCompiler,
-    ISecretClientProvider secretClientProvider)
+     ISecretClientProvider secretClientProvider) : IBicepProvisioner
 {
+    /// <inheritdoc />
     public async Task<bool> ConfigureResourceAsync(IConfiguration configuration, AzureBicepResource resource, CancellationToken cancellationToken)
     {
         var section = configuration.GetSection($"Azure:Deployments:{resource.Name}");
@@ -98,6 +99,7 @@ internal sealed class BicepProvisioner(
         return true;
     }
 
+    /// <inheritdoc />
     public async Task GetOrCreateResourceAsync(AzureBicepResource resource, ProvisioningContext context, CancellationToken cancellationToken)
     {
         var resourceGroup = context.ResourceGroup;
@@ -124,7 +126,7 @@ internal sealed class BicepProvisioner(
             ])
         }).ConfigureAwait(false);
 
-        var template = resource.GetBicepTemplateFile();
+        var template = resource.GetBicepTemplateFile(context.OutputPath);
         var path = template.Path;
 
         // GetBicepTemplateFile may have added new well-known parameters, so we need
@@ -162,15 +164,20 @@ internal sealed class BicepProvisioner(
 
         resourceLogger.LogInformation("Deploying {Name} to {ResourceGroup}", resource.Name, resourceGroup.Name);
 
-        var deployments = resourceGroup.GetArmDeployments();
+        // Deploy-time provisioning should target the subscription scope while run-time
+        // provisioning should target the resource group scope.
+        var deployments = context.ExecutionContext.IsPublishMode
+            ? context.Subscription.GetArmDeployments()
+            : resourceGroup.GetArmDeployments();
 
         var operation = await deployments.CreateOrUpdateAsync(WaitUntil.Started, resource.Name, new ArmDeploymentContent(new(ArmDeploymentMode.Incremental)
         {
             Template = BinaryData.FromString(armTemplateContents),
             Parameters = BinaryData.FromObjectAsJson(parameters),
             DebugSettingDetailLevel = "ResponseContent"
-        }),
-        cancellationToken).ConfigureAwait(false);
+        })
+        { Location = context.Location },
+            cancellationToken).ConfigureAwait(false);
 
         // Resolve the deployment URL before waiting for the operation to complete
         var url = GetDeploymentUrl(context, resourceGroup, resource.Name);
@@ -198,7 +205,10 @@ internal sealed class BicepProvisioner(
 
         if (deployment.Data.Properties.ProvisioningState == ResourcesProvisioningState.Succeeded)
         {
-            template.Dispose();
+            if (context.ExecutionContext.IsRunMode)
+            {
+                template.Dispose();
+            }
         }
         else
         {
@@ -206,40 +216,43 @@ internal sealed class BicepProvisioner(
         }
 
         // e.g. {  "sqlServerName": { "type": "String", "value": "<value>" }}
-
         var outputObj = outputs?.ToObjectFromJson<JsonObject>();
 
-        var az = context.UserSecrets.Prop("Azure");
-        az["Tenant"] = context.Tenant.DefaultDomain;
-
-        var resourceConfig = context.UserSecrets
-            .Prop("Azure")
-            .Prop("Deployments")
-            .Prop(resource.Name);
-
-        // Clear the entire section
-        resourceConfig.AsObject().Clear();
-
-        // Save the deployment id to the configuration
-        resourceConfig["Id"] = deployment.Id.ToString();
-
-        // Stash all parameters as a single JSON string
-        resourceConfig["Parameters"] = parameters.ToJsonString();
-
-        if (outputObj is not null)
+        // Populate values into user-secrets during run mode
+        if (context.ExecutionContext.IsRunMode)
         {
-            // Same for outputs
-            resourceConfig["Outputs"] = outputObj.ToJsonString();
-        }
+            var az = context.UserSecrets.Prop("Azure");
+            az["Tenant"] = context.Tenant.DefaultDomain;
 
-        // Write resource scope to config for consistent checksums
-        if (scope is not null)
-        {
-            resourceConfig["Scope"] = scope.ToJsonString();
-        }
+            var resourceConfig = context.UserSecrets
+                .Prop("Azure")
+                .Prop("Deployments")
+                .Prop(resource.Name);
 
-        // Save the checksum to the configuration
-        resourceConfig["CheckSum"] = BicepUtilities.GetChecksum(resource, parameters, scope);
+            // Clear the entire section
+            resourceConfig.AsObject().Clear();
+
+            // Save the deployment id to the configuration
+            resourceConfig["Id"] = deployment.Id.ToString();
+
+            // Stash all parameters as a single JSON string
+            resourceConfig["Parameters"] = parameters.ToJsonString();
+
+            if (outputObj is not null)
+            {
+                // Same for outputs
+                resourceConfig["Outputs"] = outputObj.ToJsonString();
+            }
+
+            // Write resource scope to config for consistent checksums
+            if (scope is not null)
+            {
+                resourceConfig["Scope"] = scope.ToJsonString();
+            }
+
+            // Save the checksum to the configuration
+            resourceConfig["CheckSum"] = BicepUtilities.GetChecksum(resource, parameters, scope);
+        }
 
         if (outputObj is not null)
         {

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/IBicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/IBicepProvisioner.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Hosting.Azure.Provisioning;
+
+/// <summary>
+/// Provides functionality for provisioning Azure Bicep resources.
+/// </summary>
+internal interface IBicepProvisioner
+{
+    /// <summary>
+    /// Configures an Azure Bicep resource from configuration settings.
+    /// </summary>
+    /// <param name="configuration">The configuration containing Azure deployment settings.</param>
+    /// <param name="resource">The Azure Bicep resource to configure.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains a value indicating whether the resource was successfully configured.</returns>
+    Task<bool> ConfigureResourceAsync(IConfiguration configuration, AzureBicepResource resource, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets an existing resource or creates a new Azure Bicep resource.
+    /// </summary>
+    /// <param name="resource">The Azure Bicep resource to get or create.</param>
+    /// <param name="context">The provisioning context containing Azure subscription, resource group, and other deployment details.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task GetOrCreateResourceAsync(AzureBicepResource resource, ProvisioningContext context, CancellationToken cancellationToken);
+}

--- a/src/Aspire.Hosting.Azure/Provisioning/ProvisioningContext.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/ProvisioningContext.cs
@@ -17,7 +17,9 @@ internal sealed class ProvisioningContext(
     ITenantResource tenant,
     AzureLocation location,
     UserPrincipal principal,
-    JsonObject userSecrets)
+    JsonObject userSecrets,
+    DistributedApplicationExecutionContext executionContext,
+    string? outputPath)
 {
     public TokenCredential Credential => credential;
     public IArmClient ArmClient => armClient;
@@ -27,4 +29,11 @@ internal sealed class ProvisioningContext(
     public AzureLocation Location => location;
     public UserPrincipal Principal => principal;
     public JsonObject UserSecrets => userSecrets;
+    public DistributedApplicationExecutionContext ExecutionContext => executionContext;
+    /// <summary>
+    /// The directory containing the Bicep template files to
+    /// deploy. If not specified, a temporary directory will be used
+    /// for run-mode provisioning. Typically set for deploy-time provisioning.
+    /// </summary>
+    public string? OutputPath => outputPath;
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Aspire.Hosting.Azure.Provisioning.Internal;
 using Aspire.Hosting.Testing;
 using System.Text.Json.Nodes;
+using Aspire.Hosting.Azure.Provisioning;
+using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -126,6 +128,7 @@ public class AzureDeployerTests(ITestOutputHelper output)
         builder.Services.AddSingleton(interactionService);
         builder.Services.AddSingleton<IProvisioningContextProvider, DefaultProvisioningContextProvider>();
         builder.Services.AddSingleton<IUserSecretsManager, NoOpUserSecretsManager>();
+        builder.Services.AddSingleton<IBicepProvisioner, NoOpBicepProvisioner>();
     }
 
     private sealed class NoOpUserSecretsManager : IUserSecretsManager
@@ -133,5 +136,18 @@ public class AzureDeployerTests(ITestOutputHelper output)
         public Task<JsonObject> LoadUserSecretsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new JsonObject());
 
         public Task SaveUserSecretsAsync(JsonObject userSecrets, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class NoOpBicepProvisioner : IBicepProvisioner
+    {
+        public Task<bool> ConfigureResourceAsync(IConfiguration configuration, AzureBicepResource resource, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task GetOrCreateResourceAsync(AzureBicepResource resource, ProvisioningContext context, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/DefaultProvisioningContextProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DefaultProvisioningContextProviderTests.cs
@@ -20,6 +20,7 @@ public class DefaultProvisioningContextProviderTests
     {
         // Arrange
         var options = ProvisioningTestHelpers.CreateOptions();
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -35,7 +36,8 @@ public class DefaultProvisioningContextProviderTests
             armClientProvider,
             userPrincipalProvider,
             tokenCredentialProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            publishingOptions);
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -58,6 +60,7 @@ public class DefaultProvisioningContextProviderTests
     {
         // Arrange
         var options = ProvisioningTestHelpers.CreateOptions(subscriptionId: null);
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -73,7 +76,8 @@ public class DefaultProvisioningContextProviderTests
             armClientProvider,
             userPrincipalProvider,
             tokenCredentialProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            publishingOptions);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<MissingConfigurationException>(
@@ -86,6 +90,7 @@ public class DefaultProvisioningContextProviderTests
     {
         // Arrange
         var options = ProvisioningTestHelpers.CreateOptions(location: null);
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -101,7 +106,8 @@ public class DefaultProvisioningContextProviderTests
             armClientProvider,
             userPrincipalProvider,
             tokenCredentialProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            publishingOptions);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<MissingConfigurationException>(
@@ -114,6 +120,7 @@ public class DefaultProvisioningContextProviderTests
     {
         // Arrange
         var options = ProvisioningTestHelpers.CreateOptions(resourceGroup: null);
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -129,7 +136,8 @@ public class DefaultProvisioningContextProviderTests
             armClientProvider,
             userPrincipalProvider,
             tokenCredentialProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            publishingOptions);
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -150,6 +158,7 @@ public class DefaultProvisioningContextProviderTests
         // Arrange
         var resourceGroupName = "my-custom-rg";
         var options = ProvisioningTestHelpers.CreateOptions(resourceGroup: resourceGroupName);
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -165,7 +174,8 @@ public class DefaultProvisioningContextProviderTests
             armClientProvider,
             userPrincipalProvider,
             tokenCredentialProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            publishingOptions);
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -180,6 +190,7 @@ public class DefaultProvisioningContextProviderTests
     {
         // Arrange
         var options = ProvisioningTestHelpers.CreateOptions();
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -195,7 +206,8 @@ public class DefaultProvisioningContextProviderTests
             armClientProvider,
             userPrincipalProvider,
             tokenCredentialProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            publishingOptions);
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -211,6 +223,7 @@ public class DefaultProvisioningContextProviderTests
     {
         // Arrange
         var options = ProvisioningTestHelpers.CreateOptions();
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -226,7 +239,8 @@ public class DefaultProvisioningContextProviderTests
             armClientProvider,
             userPrincipalProvider,
             tokenCredentialProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            publishingOptions);
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -243,6 +257,7 @@ public class DefaultProvisioningContextProviderTests
         // Arrange
         var testInteractionService = new TestInteractionService();
         var options = ProvisioningTestHelpers.CreateOptions(null, null, null);
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -258,7 +273,8 @@ public class DefaultProvisioningContextProviderTests
             armClientProvider,
             userPrincipalProvider,
             tokenCredentialProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            publishingOptions);
         // Act
         var createTask = provider.CreateProvisioningContextAsync(userSecrets);
 
@@ -317,6 +333,7 @@ public class DefaultProvisioningContextProviderTests
     {
         var testInteractionService = new TestInteractionService();
         var options = ProvisioningTestHelpers.CreateOptions(null, null, null);
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -332,7 +349,8 @@ public class DefaultProvisioningContextProviderTests
             armClientProvider,
             userPrincipalProvider,
             tokenCredentialProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            publishingOptions);
 
         var createTask = provider.CreateProvisioningContextAsync(userSecrets);
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_IgnoresAzureBicepResourcesWithIgnoreAnnotation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.AzurePublishingContext_IgnoresAzureBicepResourcesWithIgnoreAnnotation.verified.bicep
@@ -26,6 +26,6 @@ module included_storage_roles 'included-storage-roles/included-storage-roles.bic
     location: location
     included_storage_outputs_name: included_storage.outputs.name
     principalType: ''
-    principalId: ''
+    principalId: principalId
   }
 }


### PR DESCRIPTION
Contributes towards #10448.

The next step here is to revise the APIs for IBicepProvisioner so that it is possible to query the ARM deployment to get the status on each subresource that is deployed from `main.bicep`. The current `BicepProvisioner` implementation assumes that only one resource is deployed and that status is set through the `ResourceNotificationService`.

![aspire-deploy-azure-2](https://github.com/user-attachments/assets/f5ea49d3-704a-4be5-b30a-88377be6bdde)
