### PR TITLE
Remove IResourceWithoutLifetime on everything

### DIFF
--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/AppHost.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/AppHost.cs
@@ -22,7 +22,7 @@ var db = builder.AddSqlServer("sql")
 var insertionrows = builder.AddParameter("insertionrows")
     .WithDescription("The number of rows to insert into the database.");
 
-var cs = builder.AddConnectionString("cs", ReferenceExpression.Create($"sql={db};rows={insertionrows}"));
+var cs = builder.AddConnectionString("cs", ReferenceExpression.Create($"sql={db.Resource.Parent.PrimaryEndpoint};rows={insertionrows}"));
 var parameterFromConnectionStringConfig = builder.AddConnectionString("parameterFromConnectionStringConfig");
 
 var throwing = builder.AddParameter("throwing", () => throw new InvalidOperationException("This is a test exception."));

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a parameter resource.
 /// </summary>
-public class ParameterResource : Resource, IResourceWithoutLifetime, IManifestExpressionProvider, IValueProvider
+public class ParameterResource : Resource, IManifestExpressionProvider, IValueProvider
 {
     private readonly Lazy<string> _lazyValue;
     private readonly Func<ParameterDefault?, string> _valueGetter;

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -22,4 +22,25 @@
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Aspire.Hosting.ApplicationModel.ParameterResource</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Aspire.Hosting.ConnectionStringResource</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:Aspire.Hosting.ExternalServiceResource</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
 </Suppressions>

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -61,7 +61,7 @@ public static class ConnectionStringBuilderExtensions
                 if (resourceNames.Add(resource.Name))
                 {
                     // Wait for the resource.
-                    rb.WithAnnotation(new WaitAnnotation(resource, WaitType.WaitUntilHealthy));
+                    rb.WaitForStart(builder.CreateResourceBuilder(resource));
                 }
             }
             else if (value is IValueWithReferences valueWithReferences)
@@ -71,7 +71,7 @@ public static class ConnectionStringBuilderExtensions
                     if (resourceNames.Add(innerRef.Name))
                     {
                         // Wait for the inner resource.
-                        rb.WithAnnotation(new WaitAnnotation(innerRef, WaitType.WaitUntilHealthy));
+                        rb.WaitForStart(builder.CreateResourceBuilder(innerRef));
                     }
                 }
             }

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -61,7 +61,7 @@ public static class ConnectionStringBuilderExtensions
                 if (resourceNames.Add(resource.Name))
                 {
                     // Wait for the resource.
-                    rb.WithAnnotation(new WaitAnnotation(resource, WaitType.WaitUntilStarted));
+                    rb.WithAnnotation(new WaitAnnotation(resource, WaitType.WaitUntilHealthy));
                 }
             }
             else if (value is IValueWithReferences valueWithReferences)
@@ -71,7 +71,7 @@ public static class ConnectionStringBuilderExtensions
                     if (resourceNames.Add(innerRef.Name))
                     {
                         // Wait for the inner resource.
-                        rb.WithAnnotation(new WaitAnnotation(innerRef, WaitType.WaitUntilStarted));
+                        rb.WithAnnotation(new WaitAnnotation(innerRef, WaitType.WaitUntilHealthy));
                     }
                 }
             }

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -88,6 +88,7 @@ public static class ConnectionStringBuilderExtensions
                  {
                      try
                      {
+                         // This is where waiting happens
                          await @evt.Eventing.PublishAsync(new BeforeResourceStartedEvent(r, @evt.Services), ct).ConfigureAwait(false);
 
                          // Publish the update with the connection string value and the state as running.

--- a/src/Aspire.Hosting/ConnectionStringResource.cs
+++ b/src/Aspire.Hosting/ConnectionStringResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="connectionStringExpression">The connection string expression.</param>
-public sealed class ConnectionStringResource(string name, ReferenceExpression connectionStringExpression) : Resource(name), IResourceWithConnectionString
+public sealed class ConnectionStringResource(string name, ReferenceExpression connectionStringExpression) : Resource(name), IResourceWithConnectionString, IResourceWithWaitSupport
 {
     /// <summary>
     /// Describes the connection string format string used for this resource.

--- a/src/Aspire.Hosting/ConnectionStringResource.cs
+++ b/src/Aspire.Hosting/ConnectionStringResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="connectionStringExpression">The connection string expression.</param>
-public sealed class ConnectionStringResource(string name, ReferenceExpression connectionStringExpression) : Resource(name), IResourceWithConnectionString, IResourceWithoutLifetime
+public sealed class ConnectionStringResource(string name, ReferenceExpression connectionStringExpression) : Resource(name), IResourceWithConnectionString
 {
     /// <summary>
     /// Describes the connection string format string used for this resource.

--- a/src/Aspire.Hosting/ExternalServiceResource.cs
+++ b/src/Aspire.Hosting/ExternalServiceResource.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting;
 /// <summary>
 /// Represents an external service resource with service discovery capabilities.
 /// </summary>
-public sealed class ExternalServiceResource : Resource, IResourceWithoutLifetime
+public sealed class ExternalServiceResource : Resource
 {
     private readonly Uri? _uri;
     private readonly ParameterResource? _urlParameter;

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -70,7 +70,7 @@ internal sealed class ParameterProcessor(
                 return s with
                 {
                     Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, value, parameterResource.Secret),
-                    State = new(KnownResourceStates.Active, KnownResourceStateStyles.Success)
+                    State = KnownResourceStates.Running
                 };
             })
             .ConfigureAwait(false);
@@ -190,7 +190,7 @@ internal sealed class ParameterProcessor(
                             return s with
                             {
                                 Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, inputValue, parameter.Secret),
-                                State = new(KnownResourceStates.Active, KnownResourceStateStyles.Success)
+                                State = KnownResourceStates.Running
                             };
                         })
                         .ConfigureAwait(false);

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -216,7 +216,6 @@ public static class ParameterResourceBuilderExtensions
         {
             ResourceType = KnownResourceTypes.Parameter,
             Properties = [
-                new("parameter.secret", resource.Secret.ToString()),
                 new(CustomResourceKnownProperties.Source, resource.ConfigurationKey)
             ],
             State = KnownResourceStates.Waiting

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1202,16 +1202,6 @@ public static class ResourceBuilderExtensions
             builder.WaitForCore(parentBuilder, waitBehavior, addRelationship: false);
         }
 
-        // Wait for any referenced resources in the connection string.
-        if (dependency.Resource is ConnectionStringResource cs)
-        {
-            // We only look at top level resources with the assumption that they are transitive themselves.
-            foreach (var referencedResource in cs.ConnectionStringExpression.ValueProviders.OfType<IResource>())
-            {
-                builder.WaitForCore(builder.ApplicationBuilder.CreateResourceBuilder(referencedResource), waitBehavior, addRelationship: false);
-            }
-        }
-
         if (addRelationship)
         {
             builder.WithRelationship(dependency.Resource, KnownRelationshipTypes.WaitFor);

--- a/tests/Aspire.Hosting.Tests/AddConnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddConnectionStringTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Tests;
+
+public class AddConnectionStringTests
+{
+
+    [Fact]
+    public async Task AddConnectionStringExpressionIsAValueInTheManifest()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var endpoint = appBuilder.AddParameter("endpoint", "http://localhost:3452");
+        var key = appBuilder.AddParameter("key", "secretKey", secret: true);
+
+        // Get the service provider.
+        appBuilder.AddConnectionString("mycs", ReferenceExpression.Create($"Endpoint={endpoint};Key={key}"));
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var connectionStringResource = Assert.Single(appModel.Resources.OfType<ConnectionStringResource>());
+
+        Assert.Equal("mycs", connectionStringResource.Name);
+        var connectionStringManifest = await ManifestUtils.GetManifest(connectionStringResource).DefaultTimeout();
+
+        var expectedManifest = $$"""
+            {
+              "type": "value.v0",
+              "connectionString": "Endpoint={endpoint.value};Key={key.value}"
+            }
+            """;
+
+        var s = connectionStringManifest.ToString();
+
+        Assert.Equal(expectedManifest, s);
+    }
+
+    [Fact]
+    public void ConnectionStringsAreVisibleByDefault()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var endpoint = appBuilder.AddParameter("endpoint", "http://localhost:3452");
+        var key = appBuilder.AddParameter("key", "secretKey", secret: true);
+
+        appBuilder.AddConnectionString("testcs", ReferenceExpression.Create($"Endpoint={endpoint};Key={key}"));
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var connectionStringResource = Assert.Single(appModel.Resources.OfType<ConnectionStringResource>());
+        var annotation = connectionStringResource.Annotations.OfType<ResourceSnapshotAnnotation>().SingleOrDefault();
+
+        Assert.NotNull(annotation);
+
+        var state = annotation.InitialSnapshot;
+
+        Assert.False(state.IsHidden);
+        Assert.Equal(KnownResourceTypes.ConnectionString, state.ResourceType);
+        Assert.Equal(KnownResourceStates.Waiting, state.State?.Text);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/AddConnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddConnectionStringTests.cs
@@ -10,7 +10,6 @@ namespace Aspire.Hosting.Tests;
 
 public class AddConnectionStringTests
 {
-
     [Fact]
     public async Task AddConnectionStringExpressionIsAValueInTheManifest()
     {

--- a/tests/Aspire.Hosting.Tests/AddConnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddConnectionStringTests.cs
@@ -87,12 +87,12 @@ public class AddConnectionStringTests
             wa =>
             {
                 Assert.Same(redis.Resource, wa.Resource);
-                Assert.Equal(WaitType.WaitUntilHealthy, wa.WaitType);
+                Assert.Equal(WaitType.WaitUntilStarted, wa.WaitType);
             },
             wa =>
             {
                 Assert.Same(key.Resource, wa.Resource);
-                Assert.Equal(WaitType.WaitUntilHealthy, wa.WaitType);
+                Assert.Equal(WaitType.WaitUntilStarted, wa.WaitType);
             });
     }
 

--- a/tests/Aspire.Hosting.Tests/AddConnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddConnectionStringTests.cs
@@ -63,7 +63,7 @@ public class AddConnectionStringTests
 
         Assert.False(state.IsHidden);
         Assert.Equal(KnownResourceTypes.ConnectionString, state.ResourceType);
-        Assert.Equal(KnownResourceStates.Waiting, state.State?.Text);
+        Assert.Equal(KnownResourceStates.NotStarted, state.State?.Text);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -36,11 +36,6 @@ public class AddParameterTests
         Assert.Collection(state.Properties,
             prop =>
             {
-                Assert.Equal("parameter.secret", prop.Name);
-                Assert.Equal("True", prop.Value);
-            },
-            prop =>
-            {
                 Assert.Equal(CustomResourceKnownProperties.Source, prop.Name);
                 Assert.Equal("Parameters:pass", prop.Value);
             });

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Model;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Resources;
 using Aspire.Hosting.Utils;
@@ -328,37 +327,6 @@ public class AddParameterTests
         Assert.Equal(expectedManifest, s);
     }
 
-    [Fact]
-    public async Task AddConnectionStringExpressionIsAValueInTheManifest()
-    {
-        var appBuilder = DistributedApplication.CreateBuilder();
-
-        var endpoint = appBuilder.AddParameter("endpoint", "http://localhost:3452");
-        var key = appBuilder.AddParameter("key", "secretKey", secret: true);
-
-        // Get the service provider.
-        appBuilder.AddConnectionString("mycs", ReferenceExpression.Create($"Endpoint={endpoint};Key={key}"));
-
-        using var app = appBuilder.Build();
-
-        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var connectionStringResource = Assert.Single(appModel.Resources.OfType<ConnectionStringResource>());
-
-        Assert.Equal("mycs", connectionStringResource.Name);
-        var connectionStringManifest = await ManifestUtils.GetManifest(connectionStringResource).DefaultTimeout();
-
-        var expectedManifest = $$"""
-            {
-              "type": "value.v0",
-              "connectionString": "Endpoint={endpoint.value};Key={key.value}"
-            }
-            """;
-
-        var s = connectionStringManifest.ToString();
-
-        Assert.Equal(expectedManifest, s);
-    }
-
     private sealed class TestParameterDefault(string defaultValue) : ParameterDefault
     {
         public override string GetDefaultValue() => defaultValue;
@@ -367,31 +335,6 @@ public class AddParameterTests
         {
             throw new NotImplementedException();
         }
-    }
-
-    [Fact]
-    public void ConnectionStringsAreVisibleByDefault()
-    {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var endpoint = appBuilder.AddParameter("endpoint", "http://localhost:3452");
-        var key = appBuilder.AddParameter("key", "secretKey", secret: true);
-
-        appBuilder.AddConnectionString("testcs", ReferenceExpression.Create($"Endpoint={endpoint};Key={key}"));
-
-        using var app = appBuilder.Build();
-
-        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-
-        var connectionStringResource = Assert.Single(appModel.Resources.OfType<ConnectionStringResource>());
-        var annotation = connectionStringResource.Annotations.OfType<ResourceSnapshotAnnotation>().SingleOrDefault();
-
-        Assert.NotNull(annotation);
-
-        var state = annotation.InitialSnapshot;
-
-        Assert.False(state.IsHidden);
-        Assert.Equal(KnownResourceTypes.ConnectionString, state.ResourceType);
-        Assert.Equal(KnownResourceStates.Waiting, state.State?.Text);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
@@ -247,17 +247,6 @@ public class ExternalServiceTests
     }
 
     [Fact]
-    public void ExternalServiceResourceImplementsExpectedInterfaces()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create();
-
-        var externalService = builder.AddExternalService("nuget", "https://nuget.org/");
-
-        // Verify the resource implements the expected interfaces
-        Assert.IsAssignableFrom<IResourceWithoutLifetime>(externalService.Resource);
-    }
-
-    [Fact]
     public void ExternalServiceResourceIsExcludedFromPublishingManifest()
     {
         //ManifestPublishingCallbackAnnotation

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -16,7 +16,7 @@ namespace Aspire.Hosting.Tests.Orchestrator;
 public class ParameterProcessorTests
 {
     [Fact]
-    public async Task InitializeParametersAsync_WithValidParameters_SetsActiveState()
+    public async Task InitializeParametersAsync_WithValidParameters_SetsRunningState()
     {
         // Arrange
         var parameterProcessor = CreateParameterProcessor();
@@ -41,7 +41,7 @@ public class ParameterProcessorTests
     }
 
     [Fact]
-    public async Task InitializeParametersAsync_WithValidParametersAndDashboardEnabled_SetsActiveState()
+    public async Task InitializeParametersAsync_WithValidParametersAndDashboardEnabled_SetsRunningState()
     {
         // Arrange
         var interactionService = CreateInteractionService(disableDashboard: false);
@@ -93,8 +93,7 @@ public class ParameterProcessorTests
         // Assert
         var (resource, snapshot) = Assert.Single(updates);
         Assert.Same(secretParam, resource);
-        Assert.Equal(KnownResourceStates.Active, snapshot.State?.Text);
-        Assert.Equal(KnownResourceStateStyles.Success, snapshot.State?.Style);
+        Assert.Equal(KnownResourceStates.Running, snapshot.State?.Text);
     }
 
     [Fact]
@@ -246,17 +245,17 @@ public class ParameterProcessorTests
         Assert.Equal("secretValue", await secretParam.WaitForValueTcs.Task);
 
         // Notification service should have received updates for each parameter
-        // Marking them as Active with the provided values
+        // Marking them as Running with the provided values
         await updates.MoveNextAsync();
-        Assert.Equal(KnownResourceStates.Active, updates.Current.Snapshot.State?.Text);
+        Assert.Equal(KnownResourceStates.Running, updates.Current.Snapshot.State?.Text);
         Assert.Equal("value1", updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.Value);
 
         await updates.MoveNextAsync();
-        Assert.Equal(KnownResourceStates.Active, updates.Current.Snapshot.State?.Text);
+        Assert.Equal(KnownResourceStates.Running, updates.Current.Snapshot.State?.Text);
         Assert.Equal("value2", updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.Value);
 
         await updates.MoveNextAsync();
-        Assert.Equal(KnownResourceStates.Active, updates.Current.Snapshot.State?.Text);
+        Assert.Equal(KnownResourceStates.Running, updates.Current.Snapshot.State?.Text);
         Assert.Equal("secretValue", updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.Value);
         Assert.True(updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.IsSensitive ?? false);
     }

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -304,6 +304,16 @@ public class WithReferenceTests
         Assert.Collection(csRelationships,
             r =>
             {
+                Assert.Equal("WaitFor", r.Type);
+                Assert.Same(endpoint.Resource, r.Resource);
+            },
+            r =>
+            {
+                Assert.Equal("WaitFor", r.Type);
+                Assert.Same(key.Resource, r.Resource);
+            },
+            r =>
+            {
                 Assert.Equal("Reference", r.Type);
                 Assert.Same(endpoint.Resource, r.Resource);
             },


### PR DESCRIPTION
## Description

This comes after a long discussion on discord https://discord.com/channels/1361488941836140614/1402388529975263294 about the ability to WaitFor a parameter resource without using the value directly. Originally parameters we considered resources without a lifetime and we made it impossible to WaitFor them since their values could not change at runtime. With the new support to allow setting parameter values at runtime this has changed.

- ParameterResources can now be waited on
- Move init logic to ConnectionStringResource class and simplify it. Delete special logic for WaitFor ConnectionStringResource.
- Changed state to Running for ParameterResource and ConnectionStringResource

Also Fixes https://github.com/dotnet/aspire/issues/10827

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
