### PR TITLE
Adding Resource to `CommandLineArgsCallbackContext`

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppContext.cs
@@ -422,7 +422,7 @@ internal sealed class ContainerAppContext(IResource resource, ContainerAppEnviro
     {
         if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var commandLineArgsCallbackAnnotations))
         {
-            var context = new CommandLineArgsCallbackContext(Args, cancellationToken: cancellationToken)
+            var context = new CommandLineArgsCallbackContext(Args, resource, cancellationToken: cancellationToken)
             {
                 ExecutionContext = _containerAppEnvironmentContext.ExecutionContext,
             };

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -62,7 +62,7 @@ internal sealed class AzureAppServiceWebsiteContext(
     {
         if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var commandLineArgsCallbackAnnotations))
         {
-            var context = new CommandLineArgsCallbackContext(Args, cancellationToken)
+            var context = new CommandLineArgsCallbackContext(Args, resource, cancellationToken)
             {
                 ExecutionContext = environmentContext.ExecutionContext
             };

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -380,7 +380,7 @@ internal sealed class AzureResourcePreparer(
 
         if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var commandLineArgsCallbackAnnotations))
         {
-            var context = new CommandLineArgsCallbackContext([], cancellationToken: cancellationToken);
+            var context = new CommandLineArgsCallbackContext([], resource, cancellationToken: cancellationToken);
 
             foreach (var c in commandLineArgsCallbackAnnotations)
             {

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
@@ -144,7 +144,7 @@ internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentRe
     {
         if (serviceResource.TargetResource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var commandLineArgsCallbacks))
         {
-            var context = new CommandLineArgsCallbackContext(serviceResource.Args, cancellationToken: cancellationToken)
+            var context = new CommandLineArgsCallbackContext(serviceResource.Args, serviceResource.TargetResource, cancellationToken: cancellationToken)
             {
                 ExecutionContext = executionContext
             };

--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -226,7 +226,7 @@ public class KubernetesResource(string name, IResource resource, KubernetesEnvir
     {
         if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var commandLineArgsCallbackAnnotations))
         {
-            var context = new CommandLineArgsCallbackContext([], cancellationToken: cancellationToken);
+            var context = new CommandLineArgsCallbackContext([], resource, cancellationToken: cancellationToken);
 
             foreach (var c in commandLineArgsCallbackAnnotations)
             {

--- a/src/Aspire.Hosting/ApplicationModel/CommandLineArgsCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandLineArgsCallbackAnnotation.cs
@@ -48,9 +48,19 @@ public class CommandLineArgsCallbackAnnotation : IResourceAnnotation
 /// </summary>
 /// <param name="args"> The list of command-line arguments.</param>
 /// <param name="cancellationToken"> The cancellation token associated with this execution.</param>
-/// <param name="resource"> The resource associated with this callback context.</param>
-public sealed class CommandLineArgsCallbackContext(IList<object> args, IResource resource, CancellationToken cancellationToken = default)
+public sealed class CommandLineArgsCallbackContext(IList<object> args, CancellationToken cancellationToken = default)
 {
+    private readonly IResource? _resource;
+
+    /// <summary>
+    /// Represents a callback context for the list of command-line arguments associated with an executable resource.
+    /// </summary>
+    /// <param name="args"> The list of command-line arguments.</param>
+    /// <param name="resource"> The resource associated with this callback context.</param>
+    /// <param name="cancellationToken"> The cancellation token associated with this execution.</param>
+    public CommandLineArgsCallbackContext(IList<object> args, IResource? resource = null, CancellationToken cancellationToken = default)
+        : this(args, cancellationToken) => _resource = resource;
+
     /// <summary>
     /// Gets the list of command-line arguments.
     /// </summary>
@@ -72,7 +82,11 @@ public sealed class CommandLineArgsCallbackContext(IList<object> args, IResource
     public ILogger Logger { get; init; } = NullLogger.Instance;
 
     /// <summary>
-    /// Gets the resource associated with this callback context.
+    /// The resource associated with this callback context.
     /// </summary>
-    public IResource Resource { get; } = resource ?? throw new ArgumentNullException(nameof(resource));
+    /// <remarks>
+    /// This will be set to the resource in all cases where .NET Aspire invokes the callback.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">Thrown when the EnvironmentCallbackContext was created without a specified resource.</exception>
+    public IResource Resource => _resource ?? throw new InvalidOperationException($"{nameof(Resource)} is not set. This callback context is not associated with a resource.");
 }

--- a/src/Aspire.Hosting/ApplicationModel/CommandLineArgsCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandLineArgsCallbackAnnotation.cs
@@ -48,7 +48,8 @@ public class CommandLineArgsCallbackAnnotation : IResourceAnnotation
 /// </summary>
 /// <param name="args"> The list of command-line arguments.</param>
 /// <param name="cancellationToken"> The cancellation token associated with this execution.</param>
-public sealed class CommandLineArgsCallbackContext(IList<object> args, CancellationToken cancellationToken = default)
+/// <param name="resource"> The resource associated with this callback context.</param>
+public sealed class CommandLineArgsCallbackContext(IList<object> args, IResource resource, CancellationToken cancellationToken = default)
 {
     /// <summary>
     /// Gets the list of command-line arguments.
@@ -69,4 +70,9 @@ public sealed class CommandLineArgsCallbackContext(IList<object> args, Cancellat
     /// Gets or sets the logger for the distributed application.
     /// </summary>
     public ILogger Logger { get; init; } = NullLogger.Instance;
+
+    /// <summary>
+    /// Gets the resource associated with this callback context.
+    /// </summary>
+    public IResource Resource { get; } = resource ?? throw new ArgumentNullException(nameof(resource));
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -282,7 +282,7 @@ public static class ResourceExtensions
         if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var callbacks))
         {
             var args = new List<object>();
-            var context = new CommandLineArgsCallbackContext(args, cancellationToken)
+            var context = new CommandLineArgsCallbackContext(args, resource, cancellationToken)
             {
                 Logger = logger,
                 ExecutionContext = executionContext

--- a/tests/Aspire.Hosting.Containers.Tests/ContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ContainerResourceTests.cs
@@ -103,11 +103,17 @@ public class ContainerResourceTests
             });
 
         var c2 = appBuilder.AddContainer("container", "none")
+             .WithEndpoint("ep", e =>
+             {
+                 e.UriScheme = "http";
+                 e.AllocatedEndpoint = new(e, "localhost", 5678, targetPortExpression: "5678");
+             })
              .WithArgs(context =>
              {
                  context.Args.Add("arg1");
                  context.Args.Add(c1.GetEndpoint("ep"));
                  context.Args.Add(testResource);
+                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep"));
              });
 
         using var app = appBuilder.Build();
@@ -117,7 +123,8 @@ public class ContainerResourceTests
         Assert.Collection(args,
             arg => Assert.Equal("arg1", arg),
             arg => Assert.Equal("http://c1:1234", arg), // this is the container hostname
-            arg => Assert.Equal("connectionString", arg));
+            arg => Assert.Equal("connectionString", arg),
+            arg => Assert.Equal("http://container:5678", arg));
 
         // We don't yet process relationships set via the callbacks
         // so we don't see the testResource2 nor exe1
@@ -133,8 +140,17 @@ public class ContainerResourceTests
           "args": [
             "arg1",
             "{c1.bindings.ep.url}",
-            "{test.connectionString}"
-          ]
+            "{test.connectionString}",
+            "{container.bindings.ep.url}"
+          ],
+          "bindings": {
+            "ep": {
+              "scheme": "http",
+              "protocol": "tcp",
+              "transport": "http",
+              "targetPort": 8000
+            }
+          }
         }
         """;
 

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -25,12 +25,18 @@ public class ExecutableResourceTests
             });
 
         var exe2 = appBuilder.AddExecutable("e2", "python", ".", "app.py", exe1.GetEndpoint("ep"))
+             .WithEndpoint("ep", e =>
+             {
+                 e.UriScheme = "http";
+                 e.AllocatedEndpoint = new(e, "localhost", 5678);
+             })
              .WithArgs("arg1", testResource)
              .WithArgs(context =>
              {
                  context.Args.Add("arg2");
                  context.Args.Add(exe1.GetEndpoint("ep"));
                  context.Args.Add(testResource2);
+                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep"));
              });
 
         using var app = appBuilder.Build();
@@ -44,7 +50,8 @@ public class ExecutableResourceTests
             arg => Assert.Equal("connectionString", arg),
             arg => Assert.Equal("arg2", arg),
             arg => Assert.Equal("http://localhost:1234", arg),
-            arg => Assert.Equal("anotherConnectionString", arg)
+            arg => Assert.Equal("anotherConnectionString", arg),
+            arg => Assert.Equal("http://localhost:5678", arg)
             );
 
         Assert.True(exe2.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
@@ -58,6 +65,7 @@ public class ExecutableResourceTests
             });
 
         var manifest = await ManifestUtils.GetManifest(exe2.Resource).DefaultTimeout();
+
         // Note: resource working directory is <repo-root>\tests\Aspire.Hosting.Tests
         // Manifest directory is <repo-root>\artifacts\bin\Aspire.Hosting.Tests\Debug\net8.0
         var expectedManifest =
@@ -73,8 +81,17 @@ public class ExecutableResourceTests
             "{test.connectionString}",
             "arg2",
             "{e1.bindings.ep.url}",
-            "{test2.connectionString}"
-          ]
+            "{test2.connectionString}",
+            "{e2.bindings.ep.url}"
+          ],
+          "bindings": {
+            "ep": {
+              "scheme": "http",
+              "protocol": "tcp",
+              "transport": "http",
+              "targetPort": 8000
+            }
+          }
         }
         """;
 

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -580,10 +580,16 @@ public class ProjectResourceTests
             });
 
         var project = appBuilder.AddProject<TestProjectWithLaunchSettings>("projectName")
+             .WithEndpoint("ep", e =>
+             {
+                 e.UriScheme = "http";
+                 e.AllocatedEndpoint = new(e, "localhost", 8000);
+             })
              .WithArgs(context =>
              {
                  context.Args.Add("arg1");
                  context.Args.Add(c1.GetEndpoint("ep"));
+                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep"));
              });
 
         using var app = appBuilder.Build();
@@ -592,7 +598,8 @@ public class ProjectResourceTests
 
         Assert.Collection(args,
             arg => Assert.Equal("arg1", arg),
-            arg => Assert.Equal("http://localhost:1234", arg));
+            arg => Assert.Equal("http://localhost:1234", arg),
+            arg => Assert.Equal("http://localhost:8000", arg));
 
         // We don't yet process relationships set via the callbacks
         Assert.False(project.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));


### PR DESCRIPTION
## Description

Adds a new property to `CommandLineArgsCallbackContext` which exposes the resource that the callback is associated with, avoiding the need to capture it before the closure.

I think this would be classed as a breaking change, as the constructor signature of the type has changed.

Fixes #10863

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
