### PR TITLE
Fix competing resource generation on shared file

### DIFF
--- a/src/Aspire.Hosting.Azure.Functions/Aspire.Hosting.Azure.Functions.csproj
+++ b/src/Aspire.Hosting.Azure.Functions/Aspire.Hosting.Azure.Functions.csproj
@@ -24,16 +24,10 @@
   <ItemGroup>
     <Compile Include="..\Aspire.Hosting\Resources\LaunchProfileStrings.Designer.cs">
       <Link>Resources\LaunchProfileStrings.Designer.cs</Link>
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
       <DependentUpon>LaunchProfileStrings.resx</DependentUpon>
     </Compile>
     <EmbeddedResource Include="..\Aspire.Hosting\Resources\LaunchProfileStrings.resx">
       <Link>Resources\LaunchProfileStrings.resx</Link>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>LaunchProfileStrings.Designer.cs</LastGenOutput>
-      <CustomToolNamespace>Aspire.Hosting.Resources</CustomToolNamespace>
-      <LogicalName>Aspire.Hosting.Resources.LaunchProfileStrings.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 


### PR DESCRIPTION
`Aspire.Hosting.Azure.Functions` shares a resource file with `Aspire.Hosting`. Only have one project update it with a generator.

I noticed the generated file had a new namespace depending on what project was compiled.
