### PR TITLE
Truncate large messages displayed in log grid

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -144,7 +144,8 @@
                                         <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.TimeStamp, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
                                             @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.TimeStamp, MillisecondsDisplay.Truncated)
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn ColumnId="@MessageColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">
+                                        <AspireTemplateColumn ColumnId="@MessageColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]">
+                                            @* Tooltip is displayed by the message GridValue instance *@
                                             <LogMessageColumnDisplay FilterText="@(ViewModel.FilterText)" LogEntry="@context" />
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@TraceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
@@ -3,11 +3,13 @@
 @using Aspire.Dashboard.Extensions
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 
 @inject IStringLocalizer<StructuredLogs> Loc
 
-<GridValue Value="@LogEntry.Message"
+<GridValue Value="@FormatHelpers.TruncateText(LogEntry.Message, FormatHelpers.ColumnMaximumTextLength)"
            ValueDescription="@Loc[nameof(StructuredLogs.StructuredLogsMessageColumnHeader)]"
+           ToolTip="@FormatHelpers.TruncateText(LogEntry.Message, FormatHelpers.TooltipMaximumTextLength)"
            EnableHighlighting="true"
            HighlightText="@FilterText"
            StopClickPropagation="true">

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -18,6 +18,10 @@ public enum MillisecondsDisplay
 
 internal static partial class FormatHelpers
 {
+    // Limit size of very long data that is written in large grids.
+    public const int ColumnMaximumTextLength = 250;
+    public const int TooltipMaximumTextLength = 1500;
+
     // There are an unbound number of CultureInfo instances so we don't want to use it as the key.
     // Someone could have also customized their culture so we don't want to use the name as the key.
     // This struct contains required information from the culture that is used in cached format strings.
@@ -132,5 +136,22 @@ internal static partial class FormatHelpers
             _ => throw new ArgumentException("Unexpected value.", nameof(maxDecimalPlaces))
         };
         return value.ToString(formatString, provider ?? CultureInfo.CurrentCulture);
+    }
+
+    public static string TruncateText(string text, int maxLength)
+    {
+        if (string.IsNullOrEmpty(text) || maxLength <= 0)
+        {
+            return string.Empty;
+        }
+
+        if (text.Length <= maxLength)
+        {
+            return text;
+        }
+
+        const string ellipsis = "…";
+
+        return string.Concat(text.AsSpan(0, maxLength - ellipsis.Length), ellipsis);
     }
 }

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -21,6 +21,7 @@ internal static partial class FormatHelpers
     // Limit size of very long data that is written in large grids.
     public const int ColumnMaximumTextLength = 250;
     public const int TooltipMaximumTextLength = 1500;
+    public const string Ellipsis = "…";
 
     // There are an unbound number of CultureInfo instances so we don't want to use it as the key.
     // Someone could have also customized their culture so we don't want to use the name as the key.
@@ -140,7 +141,7 @@ internal static partial class FormatHelpers
 
     public static string TruncateText(string text, int maxLength)
     {
-        if (string.IsNullOrEmpty(text) || maxLength <= 0)
+        if (string.IsNullOrEmpty(text))
         {
             return string.Empty;
         }
@@ -150,8 +151,6 @@ internal static partial class FormatHelpers
             return text;
         }
 
-        const string ellipsis = "…";
-
-        return string.Concat(text.AsSpan(0, maxLength - ellipsis.Length), ellipsis);
+        return string.Concat(text.AsSpan(0, maxLength - Ellipsis.Length), Ellipsis);
     }
 }

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -139,7 +139,7 @@ internal static partial class FormatHelpers
         return value.ToString(formatString, provider ?? CultureInfo.CurrentCulture);
     }
 
-    public static string TruncateText(string text, int maxLength)
+    public static string TruncateText(string? text, int maxLength)
     {
         if (string.IsNullOrEmpty(text))
         {

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -82,6 +82,15 @@ public class FormatHelpersTests
         Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ")), ignoreWhiteSpaceDifferences: true, ignoreCase: true);
     }
 
+    [Theory]
+    [InlineData("", 5, "")]
+    [InlineData("abcdef", 5, "abcd" + FormatHelpers.Ellipsis)]
+    [InlineData("abcdef", 10, "abcdef")]
+    public void TruncateText(string initialText, int maxLength, string expected)
+    {
+        Assert.Equal(expected, FormatHelpers.TruncateText(initialText, maxLength: maxLength));
+    }
+
     private static DateTime GetLocalDateTime(string value)
     {
         Assert.True(DateTime.TryParseExact(value, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var date));

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -83,10 +83,11 @@ public class FormatHelpersTests
     }
 
     [Theory]
+    [InlineData(null, 5, "")]
     [InlineData("", 5, "")]
     [InlineData("abcdef", 5, "abcd" + FormatHelpers.Ellipsis)]
     [InlineData("abcdef", 10, "abcdef")]
-    public void TruncateText(string initialText, int maxLength, string expected)
+    public void TruncateText(string? initialText, int maxLength, string expected)
     {
         Assert.Equal(expected, FormatHelpers.TruncateText(initialText, maxLength: maxLength));
     }


### PR DESCRIPTION
## Description

Limit the size of message values written in structured logs grid.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
