### PR TITLE
Switch grid display mode to fix scrolling

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Grid/AspireTemplateColumn.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Grid/AspireTemplateColumn.cs
@@ -17,6 +17,11 @@ public class AspireTemplateColumn<TGridItem> : TemplateColumn<TGridItem>, IAspir
     protected override void OnInitialized()
     {
         Tooltip = true;
+
+        if (ColumnManager is not null && ColumnId is not null)
+        {
+            Width = ColumnManager.GetColumnWidth(ColumnId);
+        }
     }
 
     protected override bool ShouldRender()

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -3,7 +3,7 @@
 @inject IStringLocalizer<ControlsStrings> Loc
 @inject IStringLocalizer<Dialogs> DialogsLoc
 
-<div class="@GetContainerClass()" style="width: inherit;">
+<div class="@GetContainerClass()" style="width: 100%">
 
     @* Value area *@
 

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -3,7 +3,7 @@
 @inject IStringLocalizer<ControlsStrings> Loc
 @inject IStringLocalizer<Dialogs> DialogsLoc
 
-<div class="@GetContainerClass()" style="width: 100%">
+<div class="@GetContainerClass()">
 
     @* Value area *@
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -131,14 +131,14 @@
                                                     ItemsProvider="@GetData"
                                                     ResizableColumns="true"
                                                     ResizeColumnOnAllRows="false"
-                                                    GridTemplateColumns="@_manager.GetGridTemplateColumns()"
                                                     RowClass="@(r => GetRowClass(r.Resource))"
                                                     Loading="!_loadingTcs.Task.IsCompleted"
                                                     ShowHover="true"
                                                     TGridItem="ResourceGridViewModel"
                                                     ItemKey="@(r => r.Resource.Name)"
                                                     OnRowClick="@(r => r.ExecuteOnDefault(d => ShowResourceDetailsAsync(d.Resource, buttonId: null)))"
-                                                    Class="main-grid enable-row-click">
+                                                    Class="main-grid enable-row-click"
+                                                    DisplayMode="DataGridDisplayMode.Table">
                                         <ChildContent>
                                             <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => $"{c.Resource.ResourceType}: {GetResourceName(c.Resource)}")" Class="expand-col">
                                                 @{

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -127,7 +127,7 @@
                                                     Virtualize="true"
                                                     GenerateHeader="GenerateHeaderOption.Sticky"
                                                     ItemSize="46"
-                                                    OverscanCount="100"
+                                                    OverscanCount="@DashboardUIHelpers.DefaultDataGridOverscanCount"
                                                     ItemsProvider="@GetData"
                                                     ResizableColumns="true"
                                                     ResizeColumnOnAllRows="false"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -34,7 +34,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private const string ActionsColumn = nameof(ActionsColumn);
 
     private Subscription? _logsSubscription;
-    private IList<GridColumn>? _gridColumns;
+    private List<GridColumn>? _gridColumns;
     private EventCallback _onToggleCollapseAllCallback;
     private EventCallback _onToggleResourceTypeCallback;
     private bool _hideResourceGraph;
@@ -175,13 +175,13 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlsStringsLoc);
 
         _gridColumns = [
-            new GridColumn(Name: NameColumn, DesktopWidth: "1.5fr", MobileWidth: "1.5fr"),
-            new GridColumn(Name: StateColumn, DesktopWidth: "1.25fr", MobileWidth: "1.25fr"),
-            new GridColumn(Name: StartTimeColumn, DesktopWidth: "1fr"),
-            new GridColumn(Name: TypeColumn, DesktopWidth: "1fr", IsVisible: () => _showResourceTypeColumn),
-            new GridColumn(Name: SourceColumn, DesktopWidth: "2.25fr"),
-            new GridColumn(Name: UrlsColumn, DesktopWidth: "2.25fr", MobileWidth: "2fr"),
-            new GridColumn(Name: ActionsColumn, DesktopWidth: "minmax(150px, 1.5fr)", MobileWidth: "1fr")
+            new GridColumn(Name: NameColumn, DesktopWidth: Width.Fraction(1.5m), MobileWidth: Width.Fraction(1.5m)),
+            new GridColumn(Name: StateColumn, DesktopWidth: Width.Fraction(1.25m), MobileWidth: Width.Fraction(1.25m)),
+            new GridColumn(Name: StartTimeColumn, DesktopWidth: Width.Fraction(1)),
+            new GridColumn(Name: TypeColumn, DesktopWidth: Width.Fraction(1), IsVisible: () => _showResourceTypeColumn),
+            new GridColumn(Name: SourceColumn, DesktopWidth: Width.Fraction(2.25m)),
+            new GridColumn(Name: UrlsColumn, DesktopWidth: Width.Fraction(2.25m), MobileWidth: Width.Fraction(2)),
+            new GridColumn(Name: ActionsColumn, DesktopWidth: Width.Fraction(1.5m), MobileWidth: Width.Fraction(1))
         ];
 
         _onToggleCollapseAllCallback = EventCallback.Factory.Create(this, OnToggleCollapseAll);

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -122,7 +122,7 @@
                                                 RowClass="@GetRowClass"
                                                 GenerateHeader="GenerateHeaderOption.Sticky"
                                                 ItemSize="46"
-                                                OverscanCount="100"
+                                                OverscanCount="20"
                                                 ResizableColumns="true"
                                                 ResizeColumnOnAllRows="false"
                                                 ItemsProvider="@GetData"
@@ -133,21 +133,21 @@
                                                 Class="main-grid enable-row-click"
                                                 DisplayMode="DataGridDisplayMode.Table">
                                     <ChildContent>
-                                        <AspireTemplateColumn Width="20%" ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.ApplicationView))">
+                                        <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.ApplicationView))">
                                             <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.ApplicationView)));">
                                                 @GetResourceName(context.ApplicationView)
                                             </span>
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn Width="10%" ColumnId="@LogLevelColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
+                                        <AspireTemplateColumn ColumnId="@LogLevelColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
                                             <LogLevelColumnDisplay LogEntry="@context" />
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn Width="10%" ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.TimeStamp, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
+                                        <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.TimeStamp, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
                                             @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.TimeStamp, MillisecondsDisplay.Truncated)
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn Width="40%" ColumnId="@MessageColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">
+                                        <AspireTemplateColumn ColumnId="@MessageColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">
                                             <LogMessageColumnDisplay FilterText="@(ViewModel.FilterText)" LogEntry="@context" />
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn Width="10%" ColumnId="@TraceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
+                                        <AspireTemplateColumn ColumnId="@TraceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
                                             @if (!string.IsNullOrEmpty(context.TraceId))
                                             {
                                                 <a href="@DashboardUrls.TraceDetailUrl(context.TraceId, context.SpanId)" class="long-inner-content" @onclick:stopPropagation="true">
@@ -159,7 +159,7 @@
                                                 <span class="empty-data"></span>
                                             }
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn Width="10%" ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.ActionsColumnHeader)]" Class="no-ellipsis">
+                                        <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.ActionsColumnHeader)]" Class="no-ellipsis">
                                             @{
                                                 var id = $"details-button-{context.InternalId}";
                                             }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -127,27 +127,27 @@
                                                 ResizeColumnOnAllRows="false"
                                                 ItemsProvider="@GetData"
                                                 TGridItem="OtlpLogEntry"
-                                                GridTemplateColumns="@_manager.GetGridTemplateColumns()"
                                                 ShowHover="true"
                                                 ItemKey="@(r => r.InternalId)"
                                                 OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))"
-                                                Class="main-grid enable-row-click">
+                                                Class="main-grid enable-row-click"
+                                                DisplayMode="DataGridDisplayMode.Table">
                                     <ChildContent>
-                                        <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.ApplicationView))">
+                                        <AspireTemplateColumn Width="20%" ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.ApplicationView))">
                                             <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.ApplicationView)));">
                                                 @GetResourceName(context.ApplicationView)
                                             </span>
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn ColumnId="@LogLevelColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
+                                        <AspireTemplateColumn Width="10%" ColumnId="@LogLevelColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
                                             <LogLevelColumnDisplay LogEntry="@context" />
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.TimeStamp, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
+                                        <AspireTemplateColumn Width="10%" ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.TimeStamp, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
                                             @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.TimeStamp, MillisecondsDisplay.Truncated)
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn ColumnId="@MessageColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">
+                                        <AspireTemplateColumn Width="40%" ColumnId="@MessageColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">
                                             <LogMessageColumnDisplay FilterText="@(ViewModel.FilterText)" LogEntry="@context" />
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn ColumnId="@TraceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
+                                        <AspireTemplateColumn Width="10%" ColumnId="@TraceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
                                             @if (!string.IsNullOrEmpty(context.TraceId))
                                             {
                                                 <a href="@DashboardUrls.TraceDetailUrl(context.TraceId, context.SpanId)" class="long-inner-content" @onclick:stopPropagation="true">
@@ -159,7 +159,7 @@
                                                 <span class="empty-data"></span>
                                             }
                                         </AspireTemplateColumn>
-                                        <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.ActionsColumnHeader)]" Class="no-ellipsis">
+                                        <AspireTemplateColumn Width="10%" ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.ActionsColumnHeader)]" Class="no-ellipsis">
                                             @{
                                                 var id = $"details-button-{context.InternalId}";
                                             }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -122,7 +122,7 @@
                                                 RowClass="@GetRowClass"
                                                 GenerateHeader="GenerateHeaderOption.Sticky"
                                                 ItemSize="46"
-                                                OverscanCount="20"
+                                                OverscanCount="@DashboardUIHelpers.DefaultDataGridOverscanCount"
                                                 ResizableColumns="true"
                                                 ResizeColumnOnAllRows="false"
                                                 ItemsProvider="@GetData"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -44,7 +44,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     private string _filter = string.Empty;
     private FluentDataGrid<OtlpLogEntry> _dataGrid = null!;
     private GridColumnManager _manager = null!;
-    private IList<GridColumn> _gridColumns = null!;
+    private List<GridColumn> _gridColumns = null!;
 
     private ColumnResizeLabels _resizeLabels = ColumnResizeLabels.Default;
     private ColumnSortLabels _sortLabels = ColumnSortLabels.Default;
@@ -152,12 +152,12 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlsStringsLoc);
 
         _gridColumns = [
-            new GridColumn(Name: ResourceColumn, DesktopWidth: "20%", MobileWidth: "1fr"),
-            new GridColumn(Name: LogLevelColumn, DesktopWidth: "10%"),
-            new GridColumn(Name: TimestampColumn, DesktopWidth: "15%"),
-            new GridColumn(Name: MessageColumn, DesktopWidth: "50%", MobileWidth: "2.5fr"),
-            new GridColumn(Name: TraceColumn, DesktopWidth: "10%"),
-            new GridColumn(Name: ActionsColumn, DesktopWidth: "10%", MobileWidth: "0.8fr")
+            new GridColumn(Name: ResourceColumn, DesktopWidth: Width.Fraction(2), MobileWidth: Width.Fraction(1)),
+            new GridColumn(Name: LogLevelColumn, DesktopWidth: Width.Fraction(1)),
+            new GridColumn(Name: TimestampColumn, DesktopWidth: Width.Fraction(1.5m)),
+            new GridColumn(Name: MessageColumn, DesktopWidth: Width.Fraction(5), MobileWidth: Width.Fraction(2.5m)),
+            new GridColumn(Name: TraceColumn, DesktopWidth: Width.Fraction(1)),
+            new GridColumn(Name: ActionsColumn, DesktopWidth: Width.Fraction(1), MobileWidth: Width.Fraction(0.8m))
         ];
 
         if (!string.IsNullOrEmpty(TraceId))

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -152,12 +152,12 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlsStringsLoc);
 
         _gridColumns = [
-            new GridColumn(Name: ResourceColumn, DesktopWidth: "2fr", MobileWidth: "1fr"),
-            new GridColumn(Name: LogLevelColumn, DesktopWidth: "1fr"),
-            new GridColumn(Name: TimestampColumn, DesktopWidth: "1.5fr"),
-            new GridColumn(Name: MessageColumn, DesktopWidth: "5fr", "2.5fr"),
-            new GridColumn(Name: TraceColumn, DesktopWidth: "1fr"),
-            new GridColumn(Name: ActionsColumn, DesktopWidth: "1fr", MobileWidth: "0.8fr")
+            new GridColumn(Name: ResourceColumn, DesktopWidth: "20%", MobileWidth: "1fr"),
+            new GridColumn(Name: LogLevelColumn, DesktopWidth: "10%"),
+            new GridColumn(Name: TimestampColumn, DesktopWidth: "15%"),
+            new GridColumn(Name: MessageColumn, DesktopWidth: "50%", MobileWidth: "2.5fr"),
+            new GridColumn(Name: TraceColumn, DesktopWidth: "10%"),
+            new GridColumn(Name: ActionsColumn, DesktopWidth: "10%", MobileWidth: "0.8fr")
         ];
 
         if (!string.IsNullOrEmpty(TraceId))
@@ -379,25 +379,26 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        await Task.Yield();
         if (_applicationChanged)
         {
-            await JS.InvokeVoidAsync("resetContinuousScrollPosition");
+            //await JS.InvokeVoidAsync("resetContinuousScrollPosition");
             _applicationChanged = false;
         }
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("initializeContinuousScroll");
+            //await JS.InvokeVoidAsync("initializeContinuousScroll");
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }
 
     private void OnBrowserResize(object? o, EventArgs args)
     {
-        InvokeAsync(async () =>
-        {
-            await JS.InvokeVoidAsync("resetContinuousScrollPosition");
-            await JS.InvokeVoidAsync("initializeContinuousScroll");
-        });
+        //InvokeAsync(async () =>
+        //{
+        //    await JS.InvokeVoidAsync("resetContinuousScrollPosition");
+        //    await JS.InvokeVoidAsync("initializeContinuousScroll");
+        //});
     }
 
     private string? PauseText => PauseManager.AreStructuredLogsPaused(out var startTime)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -379,7 +379,6 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await Task.Yield();
         if (_applicationChanged)
         {
             await JS.InvokeVoidAsync("resetContinuousScrollPosition");

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -382,23 +382,23 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         await Task.Yield();
         if (_applicationChanged)
         {
-            //await JS.InvokeVoidAsync("resetContinuousScrollPosition");
+            await JS.InvokeVoidAsync("resetContinuousScrollPosition");
             _applicationChanged = false;
         }
         if (firstRender)
         {
-            //await JS.InvokeVoidAsync("initializeContinuousScroll");
+            await JS.InvokeVoidAsync("initializeContinuousScroll");
             DimensionManager.OnViewportInformationChanged += OnBrowserResize;
         }
     }
 
     private void OnBrowserResize(object? o, EventArgs args)
     {
-        //InvokeAsync(async () =>
-        //{
-        //    await JS.InvokeVoidAsync("resetContinuousScrollPosition");
-        //    await JS.InvokeVoidAsync("initializeContinuousScroll");
-        //});
+        InvokeAsync(async () =>
+        {
+            await JS.InvokeVoidAsync("resetContinuousScrollPosition");
+            await JS.InvokeVoidAsync("initializeContinuousScroll");
+        });
     }
 
     private string? PauseText => PauseManager.AreStructuredLogsPaused(out var startTime)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -108,7 +108,7 @@
                                             TGridItem="SpanWaterfallViewModel"
                                             RowClass="@GetRowClass"
                                             RowSize="DataGridRowSize.Small"
-                                            OverscanCount="100"
+                                            OverscanCount="@DashboardUIHelpers.DefaultDataGridOverscanCount"
                                             ShowHover="true"
                                             ItemKey="@(r => r.Span.SpanId)"
                                             OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))"

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -107,12 +107,12 @@
                                             ItemsProvider="@GetData"
                                             TGridItem="SpanWaterfallViewModel"
                                             RowClass="@GetRowClass"
-                                            GridTemplateColumns="@_manager.GetGridTemplateColumns()"
                                             RowSize="DataGridRowSize.Small"
                                             OverscanCount="100"
                                             ShowHover="true"
                                             ItemKey="@(r => r.Span.SpanId)"
-                                            OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))">
+                                            OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))"
+                                            DisplayMode="DataGridDisplayMode.Table">
                                 <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailNameHeader)]" Tooltip="true" TooltipText="@(c => c.GetTooltip(_applications))" Class="expand-col">
                                     @{
                                         var isServerOrConsumer = context.Span.Kind == OtlpSpanKind.Server || context.Span.Kind == OtlpSpanKind.Consumer;

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -35,7 +35,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     private string? _elementIdBeforeDetailsViewOpened;
     private FluentDataGrid<SpanWaterfallViewModel> _dataGrid = null!;
     private GridColumnManager _manager = null!;
-    private IList<GridColumn> _gridColumns = null!;
+    private List<GridColumn> _gridColumns = null!;
     private string _filter = string.Empty;
 
     [Parameter]
@@ -83,9 +83,9 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         TelemetryContextProvider.Initialize(TelemetryContext);
 
         _gridColumns = [
-            new GridColumn(Name: NameColumn, DesktopWidth: "6fr", MobileWidth: "6fr"),
-            new GridColumn(Name: TicksColumn, DesktopWidth: "12fr", MobileWidth: "12fr"),
-            new GridColumn(Name: ActionsColumn, DesktopWidth: "100px", MobileWidth: null)
+            new GridColumn(Name: NameColumn, DesktopWidth: Width.Fraction(6), MobileWidth: Width.Fraction(6)),
+            new GridColumn(Name: TicksColumn, DesktopWidth: Width.Fraction(12), MobileWidth: Width.Fraction(12)),
+            new GridColumn(Name: ActionsColumn, DesktopWidth: Width.Pixels(120), MobileWidth: null)
         ];
 
         foreach (var resolver in OutgoingPeerResolvers)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -85,7 +85,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         _gridColumns = [
             new GridColumn(Name: NameColumn, DesktopWidth: Width.Fraction(6), MobileWidth: Width.Fraction(6)),
             new GridColumn(Name: TicksColumn, DesktopWidth: Width.Fraction(12), MobileWidth: Width.Fraction(12)),
-            new GridColumn(Name: ActionsColumn, DesktopWidth: Width.Pixels(120), MobileWidth: null)
+            new GridColumn(Name: ActionsColumn, DesktopWidth: Width.Pixels(100), MobileWidth: null)
         ];
 
         foreach (var resolver in OutgoingPeerResolvers)

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -97,11 +97,11 @@
                                     ResizeColumnOnAllRows="false"
                                     ItemsProvider="@GetData"
                                     TGridItem="OtlpTrace"
-                                    GridTemplateColumns="@_manager.GetGridTemplateColumns()"
                                     ShowHover="true"
                                     ItemKey="@(r => r.TraceId)"
                                     OnRowClick="@(r => r.ExecuteOnDefault(d => NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(d.TraceId))))"
-                                    Class="main-grid enable-row-click">
+                                    Class="main-grid enable-row-click"
+                                    DisplayMode="DataGridDisplayMode.Table">
                         <ChildContent>
                             <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
                                 @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -92,7 +92,7 @@
                                     RowClass="@GetRowClass"
                                     GenerateHeader="GenerateHeaderOption.Sticky"
                                     ItemSize="46"
-                                    OverscanCount="100"
+                                    OverscanCount="@DashboardUIHelpers.DefaultDataGridOverscanCount"
                                     ResizableColumns="true"
                                     ResizeColumnOnAllRows="false"
                                     ItemsProvider="@GetData"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -27,7 +27,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     private const string SpansColumn = nameof(SpansColumn);
     private const string DurationColumn = nameof(DurationColumn);
     private const string ActionsColumn = nameof(ActionsColumn);
-    private IList<GridColumn> _gridColumns = null!;
+    private List<GridColumn> _gridColumns = null!;
     private SelectViewModel<ResourceTypeDetails> _allApplication = null!;
 
     private TotalItemsFooter _totalItemsFooter = default!;
@@ -154,11 +154,11 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
         (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlsStringsLoc);
 
         _gridColumns = [
-            new GridColumn(Name: TimestampColumn, DesktopWidth: "0.8fr", MobileWidth: "0.8fr"),
-            new GridColumn(Name: NameColumn, DesktopWidth: "2fr", MobileWidth: "2fr"),
-            new GridColumn(Name: SpansColumn, DesktopWidth: "3fr"),
-            new GridColumn(Name: DurationColumn, DesktopWidth: "0.8fr"),
-            new GridColumn(Name: ActionsColumn, DesktopWidth: "0.5fr", MobileWidth: "1fr")
+            new GridColumn(Name: TimestampColumn, DesktopWidth: Width.Fraction(0.8m), MobileWidth: Width.Fraction(0.8m)),
+            new GridColumn(Name: NameColumn, DesktopWidth: Width.Fraction(2), MobileWidth: Width.Fraction(2)),
+            new GridColumn(Name: SpansColumn, DesktopWidth: Width.Fraction(3)),
+            new GridColumn(Name: DurationColumn, DesktopWidth: Width.Fraction(0.8m)),
+            new GridColumn(Name: ActionsColumn, DesktopWidth: Width.Fraction(0.5m), MobileWidth: Width.Fraction(1))
         ];
 
         _allApplication = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = ControlsStringsLoc[name: nameof(ControlsStrings.LabelAll)] };

--- a/src/Aspire.Dashboard/Model/GridColumn.cs
+++ b/src/Aspire.Dashboard/Model/GridColumn.cs
@@ -3,10 +3,11 @@
 
 namespace Aspire.Dashboard.Model;
 
-public record GridColumn(string Name, Width? DesktopWidth, Width? MobileWidth = null, Func<bool>? IsVisible = null)
+public record GridColumn(string Name, Width? DesktopWidth, Width? MobileWidth = null, Func<bool>? IsVisible = null);
+
+public record GridColumnView(string Name, Width Width, Func<bool>? IsVisible = null)
 {
-    public string? ResolvedDesktopWidth { get; set; }
-    public string? ResolvedMobileWidth { get; set; }
+    public string? ResolvedBrowserWidth { get; set; }
 }
 
 public enum WidthUnit

--- a/src/Aspire.Dashboard/Model/GridColumn.cs
+++ b/src/Aspire.Dashboard/Model/GridColumn.cs
@@ -3,4 +3,20 @@
 
 namespace Aspire.Dashboard.Model;
 
-public record GridColumn(string Name, string? DesktopWidth, string? MobileWidth = null, Func<bool>? IsVisible = null);
+public record GridColumn(string Name, Width? DesktopWidth, Width? MobileWidth = null, Func<bool>? IsVisible = null)
+{
+    public string? ResolvedDesktopWidth { get; set; }
+    public string? ResolvedMobileWidth { get; set; }
+}
+
+public enum WidthUnit
+{
+    Pixels,
+    Fraction
+}
+
+public record struct Width(decimal Value, WidthUnit Unit)
+{
+    public static Width Pixels(decimal value) => new(value, WidthUnit.Pixels);
+    public static Width Fraction(decimal value) => new(value, WidthUnit.Fraction);
+}

--- a/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
@@ -14,6 +14,8 @@ internal static class DashboardUIHelpers
 {
     public const string MessageBarSection = "MessagesTop";
 
+    public const int DefaultDataGridOverscanCount = 20;
+
     // The initial data fetch for a FluentDataGrid doesn't include a count of items to return.
     // The data grid doesn't specify a count because it doesn't know how many items fit in the UI.
     // Once it knows the height of items and the height of the grid then it specifies the desired item count


### PR DESCRIPTION
## Description

This is a proper fix for the scrolling issues in grids:

- Enables table mode on virtualized grids
- Refactor widths to be set on columns instead of `GridTemplateColumns`
- Update widths to be set as percentages instead of fractions on columns
- Reduce overscan count to improve performance

There are some issues with this change that I believe are issues in FluentUI:

- Empty and loading templates column span is broken
- Pixel width columns aren't sized correctly on refresh
- Column resizing in general doesn't feel good. Some columns can't be decreased, some columns immediately increase in size on resize

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
