### PR TITLE
Do not match `pipe` as port separator

### DIFF
--- a/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
+++ b/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
@@ -53,7 +53,7 @@ internal static partial class ConnectionStringParser
     /// Matches host:port or host,port patterns with optional IPv6 bracket notation.
     /// Examples: "localhost:5432", "127.0.0.1,1433", "[::1]:6379"
     /// </summary>
-    [GeneratedRegex(@"(\[[^\]]+\]|[^,:;\s]+)[:|,](\d{1,5})", RegexOptions.Compiled)]
+    [GeneratedRegex(@"(\[[^\]]+\]|[^,:;\s]+)[:,](\d{1,5})", RegexOptions.Compiled)]
     private static partial Regex HostPortRegex();
 
     /// <summary>


### PR DESCRIPTION
## Description

Using [grep.app](https://grep.app/search?regexp=true&q=GeneratedRegex.*%5C%5B.%5C%7C) I noticed that a slightly incorrect regex was introduced in #10340 to match "host and port".

`[:|,]` matches any of the characters `:`, '|' or `,`, where the updated regex `[:,]` only matches `:` or `,`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
