### PR TITLE
Updated AzureKeyVaultResource to expose inner Secrets store and SecretResolver

### DIFF
--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -40,7 +40,7 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     /// <summary>
     /// In run mode, this is set to the secret client used to access the Azure Key Vault.
     /// </summary>
-    public Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
+    Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
 
     Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? IAzureKeyVaultResource.SecretResolver
     {

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -18,7 +18,7 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
     /// <summary>
     /// The secrets for this Key Vault.
     /// </summary>
-    internal List<AzureKeyVaultSecretResource> Secrets { get; } = [];
+    public List<AzureKeyVaultSecretResource> Secrets { get; } = [];
     /// <summary>
     /// Gets the "vaultUri" output reference for the Azure Key Vault resource.
     /// </summary>
@@ -37,8 +37,10 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
 
     BicepOutputReference IAzureKeyVaultResource.VaultUriOutputReference => VaultUri;
 
-    // In run mode, this is set to the secret client used to access the Azure Key Vault.
-    internal Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
+    /// <summary>
+    /// In run mode, this is set to the secret client used to access the Azure Key Vault.
+    /// </summary>
+    public Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
 
     Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? IAzureKeyVaultResource.SecretResolver
     {

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResource.cs
@@ -37,10 +37,8 @@ public class AzureKeyVaultResource(string name, Action<AzureResourceInfrastructu
 
     BicepOutputReference IAzureKeyVaultResource.VaultUriOutputReference => VaultUri;
 
-    /// <summary>
-    /// In run mode, this is set to the secret client used to access the Azure Key Vault.
-    /// </summary>
-    Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
+    // In run mode, this is set to the secret client used to access the Azure Key Vault.
+    internal Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? SecretResolver { get; set; }
 
     Func<IAzureKeyVaultSecretReference, CancellationToken, Task<string?>>? IAzureKeyVaultResource.SecretResolver
     {


### PR DESCRIPTION
## Description

Exposes `internal` elements of `AzureKeyVaultResource`, allowing emulated components to hook into the resource's `Secrets` store in `RunMode`.

Related #10758 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
