### PR TITLE
Make grid value component more reusable

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/IconValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/IconValue.razor
@@ -2,6 +2,6 @@
 
 @* Do this to trim significant whitespace so there isn't a space added between icon and text *@
 @{
-    <FluentIcon Icon="Icons.Regular.Size16.GanttChart" Color="Color.Neutral" Class="severity-icon" />
+    <FluentIcon Value="@Icon" Color="Color.Neutral" Class="severity-icon" />
 }
 <FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/IconValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/IconValue.razor.cs
@@ -2,14 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components.Controls.PropertyValues;
 
-public partial class SpanIdValue
+public partial class IconValue
 {
     [Parameter, EditorRequired]
     public required string Value { get; set; }
 
     [Parameter, EditorRequired]
     public required string HighlightText { get; set; }
+
+    [Parameter, EditorRequired]
+    public required Icon Icon { get; set; }
 }

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -12,6 +12,7 @@ using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -147,7 +148,8 @@ public partial class SpanDetails : IDisposable
                 },
                 [KnownTraceFields.SpanIdField] = new ComponentMetadata
                 {
-                    Type = typeof(SpanIdValue)
+                    Type = typeof(IconValue),
+                    Parameters = { ["Icon"] = new Icons.Regular.Size16.GanttChart() }
                 },
             };
         }


### PR DESCRIPTION
Minor refactor to make it easier to show an icon with a text value. I was doing this for some other work that I didn't like. This by itself is a small improvement though.