### PR TITLE
Fix version checking with mixed state

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -240,6 +240,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddHostedService<DistributedApplicationRunner>();
         _innerBuilder.Services.AddHostedService<VersionCheckService>();
         _innerBuilder.Services.AddSingleton<IPackageFetcher, PackageFetcher>();
+        _innerBuilder.Services.AddSingleton<IPackageVersionProvider, PackageVersionProvider>();
         _innerBuilder.Services.AddSingleton(options);
         _innerBuilder.Services.AddSingleton<ResourceNotificationService>();
         _innerBuilder.Services.AddSingleton<ResourceLoggerService>();

--- a/src/Aspire.Hosting/VersionChecking/IPackageVersionProvider.cs
+++ b/src/Aspire.Hosting/VersionChecking/IPackageVersionProvider.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Semver;
+
+namespace Aspire.Hosting.VersionChecking;
+
+internal interface IPackageVersionProvider
+{
+    SemVersion? GetPackageVersion();
+}

--- a/src/Aspire.Hosting/VersionChecking/PackageVersionProvider.cs
+++ b/src/Aspire.Hosting/VersionChecking/PackageVersionProvider.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Shared;
+using Semver;
+
+namespace Aspire.Hosting.VersionChecking;
+
+internal sealed class PackageVersionProvider : IPackageVersionProvider
+{
+    public SemVersion? GetPackageVersion()
+    {
+        return PackageUpdateHelpers.GetCurrentPackageVersion();
+    }
+}

--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -93,6 +93,7 @@ internal sealed class VersionCheckService : BackgroundService
         }
 
         List<NuGetPackage>? packages = null;
+        SemVersion? storedKnownLatestVersion = null;
         if (checkForLatestVersion)
         {
             var appHostDirectory = _configuration["AppHost:Directory"]!;
@@ -100,8 +101,10 @@ internal sealed class VersionCheckService : BackgroundService
             SecretsStore.TrySetUserSecret(_options.Assembly, LastCheckDateKey, now.ToString("o", CultureInfo.InvariantCulture));
             packages = await _packageFetcher.TryFetchPackagesAsync(appHostDirectory, cancellationToken).ConfigureAwait(false);
         }
-
-        TryGetConfigVersion(KnownLatestVersionKey, out var storedKnownLatestVersion);
+        else
+        {
+            TryGetConfigVersion(KnownLatestVersionKey, out storedKnownLatestVersion);
+        }
 
         var latestVersion = PackageUpdateHelpers.GetNewerVersion(_appHostVersion, packages ?? [], storedKnownLatestVersion);
 

--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -15,19 +15,6 @@ using Semver;
 
 namespace Aspire.Hosting.VersionChecking;
 
-internal interface IPackageVersionProvider
-{
-    SemVersion? GetPackageVersion();
-}
-
-internal sealed class PackageVersionProvider : IPackageVersionProvider
-{
-    public SemVersion? GetPackageVersion()
-    {
-        return PackageUpdateHelpers.GetCurrentPackageVersion();
-    }
-}
-
 internal sealed class VersionCheckService : BackgroundService
 {
     private static readonly TimeSpan s_checkInterval = TimeSpan.FromDays(2);

--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -106,6 +106,8 @@ internal sealed class VersionCheckService : BackgroundService
             TryGetConfigVersion(KnownLatestVersionKey, out storedKnownLatestVersion);
         }
 
+        // Use known package versions to figure out what the newest valid version is.
+        // Note: A pre-release version is only selected if the current app host version is pre-release.
         var latestVersion = PackageUpdateHelpers.GetNewerVersion(_appHostVersion, packages ?? [], storedKnownLatestVersion);
 
         if (latestVersion == null || IsVersionGreaterOrEqual(_appHostVersion, latestVersion))

--- a/src/Shared/PackageUpdateHelpers.cs
+++ b/src/Shared/PackageUpdateHelpers.cs
@@ -56,7 +56,7 @@ internal static class PackageUpdateHelpers
         return informationalVersion;
     }
 
-    public static SemVersion? GetNewerVersion(SemVersion currentVersion, IEnumerable<NuGetPackage> availablePackages)
+    public static SemVersion? GetNewerVersion(SemVersion currentVersion, IEnumerable<NuGetPackage> availablePackages, SemVersion? storedVersion = null)
     {
         SemVersion? newestStable = null;
         SemVersion? newestPrerelease = null;
@@ -65,15 +65,13 @@ internal static class PackageUpdateHelpers
         {
             if (SemVersion.TryParse(package.Version, SemVersionStyles.Strict, out var version))
             {
-                if (version.IsPrerelease)
-                {
-                    newestPrerelease = newestPrerelease is null || SemVersion.PrecedenceComparer.Compare(version, newestPrerelease) > 0 ? version : newestPrerelease;
-                }
-                else
-                {
-                    newestStable = newestStable is null || SemVersion.PrecedenceComparer.Compare(version, newestStable) > 0 ? version : newestStable;
-                }
+                ProcessNewVersion(version);
             }
+        }
+
+        if (storedVersion != null)
+        {
+            ProcessNewVersion(storedVersion);
         }
 
         // Apply notification rules
@@ -101,6 +99,18 @@ internal static class PackageUpdateHelpers
         }
 
         return null;
+
+        void ProcessNewVersion(SemVersion version)
+        {
+            if (version.IsPrerelease)
+            {
+                newestPrerelease = newestPrerelease is null || SemVersion.PrecedenceComparer.Compare(version, newestPrerelease) > 0 ? version : newestPrerelease;
+            }
+            else
+            {
+                newestStable = newestStable is null || SemVersion.PrecedenceComparer.Compare(version, newestStable) > 0 ? version : newestStable;
+            }
+        }
     }
 
     public static List<NuGetPackage> ParsePackageSearchResults(string stdout, string? packageId = null)

--- a/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
@@ -188,9 +188,15 @@ public class VersionCheckServiceTests
     {
         // Arrange
         var interactionService = new TestInteractionService();
-        var configurationManager = new ConfigurationManager();
         var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
         var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
+
+        var configurationManager = new ConfigurationManager();
+        configurationManager.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [VersionCheckService.KnownLatestVersionKey] = "100.0.0" // ignored
+        });
+
         var service = CreateVersionCheckService(interactionService: interactionService, packageFetcher: packageFetcher, configuration: configurationManager);
 
         // Act

--- a/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
@@ -7,6 +7,7 @@ using Aspire.Shared;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Semver;
 
 namespace Aspire.Hosting.Tests.VersionChecking;
 
@@ -133,6 +134,55 @@ public class VersionCheckServiceTests
         Assert.False(packageFetcher.FetchCalled);
     }
 
+    [Theory]
+    [InlineData("100.0.0", "100.0.0", false)]
+    [InlineData("1.0.0", "100.0.0", true)]
+    [InlineData("1.0.0", "100.0.0-pre1", false)]
+    [InlineData("1.0.0-pre1", "100.0.0-pre1", true)]
+    public async Task ExecuteAsync_InsideLastCheckIntervalHasLastKnownPrerelease_NoFetchAndMaybeDisplayMessage(string currentVersion, string lastKnownVersion, bool displayNotification)
+    {
+        // Arrange
+        var currentDate = new DateTimeOffset(2000, 12, 29, 20, 59, 59, TimeSpan.Zero);
+        var lastCheckDate = currentDate.AddMinutes(-1);
+
+        var timeProvider = new TestTimeProvider { UtcNow = currentDate };
+        var interactionService = new TestInteractionService();
+        var configurationManager = new ConfigurationManager();
+        configurationManager.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [VersionCheckService.LastCheckDateKey] = lastCheckDate.ToString("o", CultureInfo.InvariantCulture),
+            [VersionCheckService.KnownLatestVersionKey] = lastKnownVersion
+        });
+
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var packageFetcher = new TestPackageFetcher(packagesTcs.Task);
+        var service = CreateVersionCheckService(
+            interactionService: interactionService,
+            packageFetcher: packageFetcher,
+            configuration: configurationManager,
+            timeProvider: timeProvider,
+            packageVersionProvider: new TestPackageVersionProvider(SemVersion.Parse(currentVersion)));
+
+        // Act
+        _ = service.StartAsync(CancellationToken.None);
+
+        if (displayNotification)
+        {
+            var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+            interaction.CompletionTcs.TrySetResult(InteractionResult.Ok(true));
+            await service.ExecuteTask!.DefaultTimeout();
+        }
+        else
+        {
+            await service.ExecuteTask!.DefaultTimeout();
+            interactionService.Interactions.Writer.Complete();
+            Assert.False(interactionService.Interactions.Reader.TryRead(out var _));
+        }
+
+        // Assert
+        Assert.False(packageFetcher.FetchCalled);
+    }
+
     [Fact]
     public async Task ExecuteAsync_OlderVersion_NoMessage()
     {
@@ -192,7 +242,8 @@ public class VersionCheckServiceTests
         IPackageFetcher? packageFetcher = null,
         IConfiguration? configuration = null,
         TimeProvider? timeProvider = null,
-        DistributedApplicationOptions? options = null)
+        DistributedApplicationOptions? options = null,
+        IPackageVersionProvider? packageVersionProvider = null)
     {
         return new VersionCheckService(
             interactionService ?? new TestInteractionService(),
@@ -201,7 +252,8 @@ public class VersionCheckServiceTests
             options ?? new DistributedApplicationOptions(),
             packageFetcher ?? new TestPackageFetcher(),
             new DistributedApplicationExecutionContext(new DistributedApplicationOperation()),
-            timeProvider ?? new TestTimeProvider());
+            timeProvider ?? new TestTimeProvider(),
+            packageVersionProvider ?? new TestPackageVersionProvider());
     }
 
     private sealed class TestTimeProvider : TimeProvider
@@ -213,6 +265,21 @@ public class VersionCheckServiceTests
         public override DateTimeOffset GetUtcNow()
         {
             return UtcNow;
+        }
+    }
+
+    private sealed class TestPackageVersionProvider : IPackageVersionProvider
+    {
+        private readonly SemVersion _version;
+
+        public TestPackageVersionProvider(SemVersion? version = null)
+        {
+            _version = version ?? new SemVersion(1, 0, 0);
+        }
+
+        public SemVersion? GetPackageVersion()
+        {
+            return _version;
         }
     }
 


### PR DESCRIPTION
## Description

How the bug occurs:

1. You're running pre-release.
2. Version checker runs and sees a newer version. Saved to state.
3. Within the version check interval (2 days) you switch the app to release.
4. Version checker uses save state on startup. Release app prompts for newer pre-release version.

Fix is to unify logic for getting new version through `PackageUpdateHelpers.GetNewerVersion`.

(I don't think a backport is required. This is a niche and easily ignorable scenario)

Fixes https://github.com/dotnet/aspire/issues/10749

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
