### PR TITLE
Fix parameter tests with localized values

### DIFF
--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Resources;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
@@ -466,7 +467,7 @@ public class AddParameterTests
         Assert.Equal(InputType.Text, input.InputType);
         Assert.Equal("test", input.Label);
         Assert.Equal("Test description", input.Description);
-        Assert.Equal("Enter value for test", input.Placeholder);
+        Assert.Equal(string.Format(InteractionStrings.ParametersInputsParameterPlaceholder, "test"), input.Placeholder);
         Assert.False(input.EnableDescriptionMarkdown);
     }
 
@@ -485,7 +486,7 @@ public class AddParameterTests
         Assert.Equal(InputType.SecretText, input.InputType);
         Assert.Equal("secret", input.Label);
         Assert.Equal("Secret description", input.Description);
-        Assert.Equal("Enter value for secret", input.Placeholder);
+        Assert.Equal(string.Format(InteractionStrings.ParametersInputsParameterPlaceholder, "secret"), input.Placeholder);
         Assert.False(input.EnableDescriptionMarkdown);
     }
 


### PR DESCRIPTION
Parameter service uses localized values which causes some hardcoded tests to fail.

Fixes failing localization update: https://github.com/dotnet/aspire/actions/runs/16953709172?pr=10944
