### PR TITLE
Fix CTRL-C stall issue.

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -31,7 +31,7 @@ internal abstract class BaseCommand : Command
                     // being available (it should already be in the cache for longer running
                     // commands and some commands will opt out entirely)
                     var cts = !Debugger.IsAttached
-                        ? new CancellationTokenSource(TimeSpan.FromSeconds(10))
+                        ? new CancellationTokenSource(TimeSpan.FromMilliseconds(100))
                         : new CancellationTokenSource();
                     await updateNotifier.NotifyIfUpdateAvailableAsync(currentDirectory, cancellationToken: cts.Token);
                 }

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Utils;
 
@@ -24,16 +23,7 @@ internal abstract class BaseCommand : Command
             {
                 try
                 {
-                    var currentDirectory = new DirectoryInfo(Environment.CurrentDirectory);
-
-                    // We use a separate CTS here because we want this check to run even if we've got a cancellation,
-                    // but we'll only wait so long before we get details back about updates
-                    // being available (it should already be in the cache for longer running
-                    // commands and some commands will opt out entirely)
-                    var cts = !Debugger.IsAttached
-                        ? new CancellationTokenSource(TimeSpan.FromMilliseconds(100))
-                        : new CancellationTokenSource();
-                    await updateNotifier.NotifyIfUpdateAvailableAsync(currentDirectory, cancellationToken: cts.Token);
+                    updateNotifier.NotifyIfUpdateAvailable();
                 }
                 catch
                 {

--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -3,12 +3,13 @@
 
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.NuGet;
 
-internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> logger, INuGetPackageCache nuGetPackageCache, CliExecutionContext executionContext, IFeatures features, IPackagingService packagingService) : BackgroundService
+internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> logger, CliExecutionContext executionContext, IFeatures features, IPackagingService packagingService, ICliUpdateNotifier cliUpdateNotifier) : BackgroundService
 {
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -41,10 +42,8 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
             {
                 try
                 {
-                    await nuGetPackageCache.GetCliPackagesAsync(
+                    await cliUpdateNotifier.CheckForCliUpdatesAsync(
                         workingDirectory: executionContext.WorkingDirectory,
-                        prerelease: true,
-                        nugetConfigFile: null,
                         cancellationToken: stoppingToken
                         );
                 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -107,7 +107,7 @@ public class Program
         builder.Services.AddSingleton(BuildCliExecutionContext);
         builder.Services.AddSingleton(BuildAnsiConsole);
         AddInteractionServices(builder);
-        builder.Services.AddSingleton(BuildProjectLocator);
+        builder.Services.AddSingleton<IProjectLocator, ProjectLocator>();
         builder.Services.AddSingleton<INewCommandPrompter, NewCommandPrompter>();
         builder.Services.AddSingleton<IAddCommandPrompter, AddCommandPrompter>();
         builder.Services.AddSingleton<IPublishCommandPrompter, PublishCommandPrompter>();
@@ -119,7 +119,7 @@ public class Program
         builder.Services.AddSingleton<IDotNetSdkInstaller, DotNetSdkInstaller>();
         builder.Services.AddTransient<IAppHostBackchannel, AppHostBackchannel>();
         builder.Services.AddSingleton<INuGetPackageCache, NuGetPackageCache>();
-    builder.Services.AddHostedService(BuildNuGetPackagePrefetcher);
+        builder.Services.AddHostedService<NuGetPackagePrefetcher>();
         builder.Services.AddSingleton<ICliUpdateNotifier, CliUpdateNotifier>();
         builder.Services.AddSingleton<IPackagingService, PackagingService>();
         builder.Services.AddMemoryCache();
@@ -190,16 +190,6 @@ public class Program
         return new ConfigurationService(configuration, executionContext, globalSettingsFile);
     }
 
-    private static NuGetPackagePrefetcher BuildNuGetPackagePrefetcher(IServiceProvider serviceProvider)
-    {
-        var logger = serviceProvider.GetRequiredService<ILogger<NuGetPackagePrefetcher>>();
-        var nuGetPackageCache = serviceProvider.GetRequiredService<INuGetPackageCache>();
-        var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        var features = serviceProvider.GetRequiredService<IFeatures>();
-        var packagingService = serviceProvider.GetRequiredService<IPackagingService>();
-        return new NuGetPackagePrefetcher(logger, nuGetPackageCache, executionContext, features, packagingService);
-    }
-
     private static IAnsiConsole BuildAnsiConsole(IServiceProvider serviceProvider)
     {
         AnsiConsoleSettings settings = new AnsiConsoleSettings()
@@ -210,17 +200,6 @@ public class Program
         };
         var ansiConsole = AnsiConsole.Create(settings);
         return ansiConsole;
-    }
-
-    private static IProjectLocator BuildProjectLocator(IServiceProvider serviceProvider)
-    {
-        var logger = serviceProvider.GetRequiredService<ILogger<ProjectLocator>>();
-        var runner = serviceProvider.GetRequiredService<IDotNetCliRunner>();
-        var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
-        var configurationService = serviceProvider.GetRequiredService<IConfigurationService>();
-        var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
-        return new ProjectLocator(logger, runner, executionContext, interactionService, configurationService, telemetry);
     }
 
     public static async Task<int> Main(string[] args)

--- a/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
@@ -65,7 +65,8 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         var provider = services.BuildServiceProvider();
         var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
 
-        await notifier.NotifyIfUpdateAvailableAsync(workspace.WorkspaceRoot).WaitAsync(CliTestConstants.DefaultTimeout);
+        await notifier.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).WaitAsync(CliTestConstants.DefaultTimeout);
+        notifier.NotifyIfUpdateAvailable();
         var suggestedVersion = await suggestedVersionTcs.Task.WaitAsync(CliTestConstants.DefaultTimeout);
 
         Assert.Equal("9.4.0-preview", suggestedVersion);
@@ -119,7 +120,8 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         var provider = services.BuildServiceProvider();
         var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
 
-        await notifier.NotifyIfUpdateAvailableAsync(workspace.WorkspaceRoot).WaitAsync(CliTestConstants.DefaultTimeout);
+        await notifier.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).WaitAsync(CliTestConstants.DefaultTimeout);
+        notifier.NotifyIfUpdateAvailable();
         var suggestedVersion = await suggestedVersionTcs.Task.WaitAsync(CliTestConstants.DefaultTimeout);
 
         Assert.Equal("9.4.0", suggestedVersion);
@@ -173,7 +175,8 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         var provider = services.BuildServiceProvider();
         var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
 
-        await notifier.NotifyIfUpdateAvailableAsync(workspace.WorkspaceRoot).WaitAsync(CliTestConstants.DefaultTimeout);
+        await notifier.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).WaitAsync(CliTestConstants.DefaultTimeout);
+        notifier.NotifyIfUpdateAvailable();
         var suggestedVersion = await suggestedVersionTcs.Task.WaitAsync(CliTestConstants.DefaultTimeout);
 
         Assert.Equal("9.5.0", suggestedVersion);
@@ -223,7 +226,8 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         var provider = services.BuildServiceProvider();
         var notifier = provider.GetRequiredService<ICliUpdateNotifier>();
 
-        await notifier.NotifyIfUpdateAvailableAsync(workspace.WorkspaceRoot).WaitAsync(CliTestConstants.DefaultTimeout);
+        await notifier.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None).WaitAsync(CliTestConstants.DefaultTimeout);
+        notifier.NotifyIfUpdateAvailable();
     }
 
     [Fact]
@@ -247,7 +251,8 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         ]);
 
         // Act & Assert (should not throw)
-        await service.NotifyIfUpdateAvailableAsync(workspace.WorkspaceRoot);
+        await service.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None);
+        service.NotifyIfUpdateAvailable();
     }
 
     [Fact]
@@ -265,7 +270,8 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
         var service = provider.GetRequiredService<ICliUpdateNotifier>();
 
         // Act & Assert (should not throw)
-        await service.NotifyIfUpdateAvailableAsync(workspace.WorkspaceRoot);
+        await service.CheckForCliUpdatesAsync(workspace.WorkspaceRoot, CancellationToken.None);
+        service.NotifyIfUpdateAvailable();
     }
 }
 


### PR DESCRIPTION
Fixes #10955

I need to do a bit more investigtation to figure out why task cancellation isn't unwinding the dotnet package search process faster but this fixes it on the calling side. 

Putting this up so I can validate PR bits in a few different scenarios.