### PR TITLE
Unsubscribe once with multiple dispose calls

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
@@ -9,6 +9,7 @@ namespace Aspire.Dashboard.Otlp.Storage;
 [DebuggerDisplay("Name = {Name}, ResourceKey = {ResourceKey}, SubscriptionId = {SubscriptionId}")]
 public sealed class Subscription : IDisposable
 {
+    private const int StateNone = 0;
     private const int StateDisposed = 1;
 
     private static int s_subscriptionId;
@@ -39,10 +40,12 @@ public sealed class Subscription : IDisposable
 
     public void Dispose()
     {
-        if (Interlocked.Exchange(ref _disposed, StateDisposed) is not StateDisposed)
+        if (Interlocked.CompareExchange(ref _disposed, StateDisposed, StateNone) == StateDisposed)
         {
-            _unsubscribe();
-            _callbackThrottler.Dispose();
+            return;
         }
+
+        _unsubscribe();
+        _callbackThrottler.Dispose();
     }
 }

--- a/src/Aspire.Dashboard/Utils/CallbackThrottler.cs
+++ b/src/Aspire.Dashboard/Utils/CallbackThrottler.cs
@@ -104,7 +104,6 @@ public sealed class CallbackThrottler
     public void Dispose()
     {
         _cts.Cancel();
-        _cts.Dispose();
         _lock.Dispose();
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
@@ -132,4 +132,27 @@ public class TelemetryRepositoryTests
         }
     }
 
+    [Fact]
+    public void Subscription_MultipleDisposes_UnsubscribeOnce()
+    {
+        // Arrange
+        var telemetryRepository = CreateRepository();
+        var unsubscribeCallCount = 0;
+
+        var subscription = new Subscription(
+            name: "Test",
+            resourceKey: null,
+            subscriptionType: SubscriptionType.Read,
+            callback: () => Task.CompletedTask,
+            unsubscribe: () => unsubscribeCallCount++,
+            executionContext: null,
+            telemetryRepository: telemetryRepository);
+
+        // Act
+        subscription.Dispose();
+        subscription.Dispose();
+
+        // Assert
+        Assert.Equal(1, unsubscribeCallCount);
+    }
 }


### PR DESCRIPTION
## Description

Fix an error I saw in telemetry. I believe it was called by a subscription disposed more than once.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
