### PR TITLE
Quarantine: BrowserToken_LoginPage_Success_RedirectToResources

### DIFF
--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -30,6 +30,7 @@ public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenA
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/7921")]
     public async Task BrowserToken_LoginPage_Success_RedirectToResources()
     {
         // Arrange


### PR DESCRIPTION
Quarantining this test as it has become flaky again.

See: https://github.com/dotnet/aspire/issues/7921