### PR TITLE
Install .NET 8 globally in copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -41,6 +41,13 @@ jobs:
             10.x
           dotnet-quality: preview
 
+      # for MCP servers
+      - name: Install .NET 8.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.x
+
       # Diagnostics in the log
       - name: dotnet --info
         run: dotnet --info


### PR DESCRIPTION
Per Nuget folks, this will enable the Nuget MCP server to work. I tried this in my fork and indeed it appears to make it work.

This adds negligible time to the setup process for copilot.