### PR TITLE
Split up prompting for Azure subscription and location

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultArmClientProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultArmClientProvider.cs
@@ -18,6 +18,12 @@ internal sealed class DefaultArmClientProvider : IArmClientProvider
         return new DefaultArmClient(armClient);
     }
 
+    public IArmClient GetArmClient(TokenCredential credential)
+    {
+        var armClient = new ArmClient(credential);
+        return new DefaultArmClient(armClient);
+    }
+
     private sealed class DefaultArmClient(ArmClient armClient) : IArmClient
     {
         public async Task<(ISubscriptionResource subscription, ITenantResource tenant)> GetSubscriptionAndTenantAsync(CancellationToken cancellationToken = default)
@@ -42,6 +48,31 @@ internal sealed class DefaultArmClientProvider : IArmClientProvider
             }
 
             return (subscriptionResource, tenantResource);
+        }
+
+        public async Task<IList<(string SubscriptionId, string DisplayName)>> GetAvailableSubscriptionsAsync(CancellationToken cancellationToken = default)
+        {
+            var subscriptions = new List<(string SubscriptionId, string DisplayName)>();
+
+            await foreach (var subscription in armClient.GetSubscriptions().GetAllAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                subscriptions.Add((subscription.Data.SubscriptionId ?? subscription.Id.SubscriptionId!, subscription.Data.DisplayName ?? subscription.Id.SubscriptionId!));
+            }
+
+            return [.. subscriptions.OrderBy(s => s.DisplayName)];
+        }
+
+        public async Task<IList<(string Name, string DisplayName)>> GetAvailableLocationsAsync(string subscriptionId, CancellationToken cancellationToken = default)
+        {
+            var subscription = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscriptionId));
+            var locations = new List<(string Name, string DisplayName)>();
+
+            await foreach (var location in subscription.GetLocationsAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                locations.Add((location.Name, location.DisplayName ?? location.Name));
+            }
+
+            return [.. locations.OrderBy(l => l.DisplayName)];
         }
 
         private sealed class DefaultTenantResource(TenantResource tenantResource) : ITenantResource

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
@@ -20,6 +20,11 @@ internal interface IArmClientProvider
     /// Gets the ARM client for Azure resource management.
     /// </summary>
     IArmClient GetArmClient(TokenCredential credential, string subscriptionId);
+
+    /// <summary>
+    /// Gets the ARM client for Azure resource management without a specific subscription.
+    /// </summary>
+    IArmClient GetArmClient(TokenCredential credential);
 }
 
 /// <summary>
@@ -80,6 +85,16 @@ internal interface IArmClient
     /// Gets the default subscription and its matching tenant.
     /// </summary>
     Task<(ISubscriptionResource subscription, ITenantResource tenant)> GetSubscriptionAndTenantAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all available subscriptions for the authenticated user.
+    /// </summary>
+    Task<IList<(string SubscriptionId, string DisplayName)>> GetAvailableSubscriptionsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all available locations for the specified subscription.
+    /// </summary>
+    Task<IList<(string Name, string DisplayName)>> GetAvailableLocationsAsync(string subscriptionId, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.Designer.cs
+++ b/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.Designer.cs
@@ -153,6 +153,62 @@ namespace Aspire.Hosting.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Subscription.
+        /// </summary>
+        internal static string SubscriptionLabel {
+            get {
+                return ResourceManager.GetString("SubscriptionLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select subscription.
+        /// </summary>
+        internal static string SubscriptionPlaceholder {
+            get {
+                return ResourceManager.GetString("SubscriptionPlaceholder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Azure subscription.
+        /// </summary>
+        internal static string SubscriptionInputsTitle {
+            get {
+                return ResourceManager.GetString("SubscriptionInputsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the Azure subscription to use for provisioning resources..
+        /// </summary>
+        internal static string SubscriptionInputsMessage {
+            get {
+                return ResourceManager.GetString("SubscriptionInputsMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Azure provisioning details.
+        /// </summary>
+        internal static string LocationAndResourceGroupInputsTitle {
+            get {
+                return ResourceManager.GetString("LocationAndResourceGroupInputsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Configure the location and resource group for your Azure resources.
+        ///
+        ///To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning)..
+        /// </summary>
+        internal static string LocationAndResourceGroupInputsMessage {
+            get {
+                return ResourceManager.GetString("LocationAndResourceGroupInputsMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Resource group name must be a valid Azure resource group name..
         /// </summary>
         internal static string ValidationResourceGroupNameInvalid {

--- a/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.resx
+++ b/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.resx
@@ -147,6 +147,27 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
   <data name="SubscriptionIdPlaceholder" xml:space="preserve">
     <value>Select subscription ID</value>
   </data>
+  <data name="SubscriptionLabel" xml:space="preserve">
+    <value>Subscription</value>
+  </data>
+  <data name="SubscriptionPlaceholder" xml:space="preserve">
+    <value>Select subscription</value>
+  </data>
+  <data name="SubscriptionInputsTitle" xml:space="preserve">
+    <value>Azure subscription</value>
+  </data>
+  <data name="SubscriptionInputsMessage" xml:space="preserve">
+    <value>Select the Azure subscription to use for provisioning resources.</value>
+  </data>
+  <data name="LocationAndResourceGroupInputsTitle" xml:space="preserve">
+    <value>Azure provisioning details</value>
+  </data>
+  <data name="LocationAndResourceGroupInputsMessage" xml:space="preserve">
+    <value>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</value>
+    <comment>Contains markdown</comment>
+  </data>
   <data name="ResourceGroupLabel" xml:space="preserve">
     <value>Resource group</value>
   </data>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.cs.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.cs.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.de.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.de.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.es.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.es.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.fr.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.fr.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.it.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.it.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ja.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ja.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ko.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ko.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pl.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pl.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pt-BR.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ru.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ru.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.tr.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.tr.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hans.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hant.xlf
@@ -16,6 +16,20 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="new">Azure provisioning</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsMessage">
+        <source>Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</source>
+        <target state="new">Configure the location and resource group for your Azure resources.
+
+To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/azure/provisioning).</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="LocationAndResourceGroupInputsTitle">
+        <source>Azure provisioning details</source>
+        <target state="new">Azure provisioning details</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="new">Location</target>
@@ -54,6 +68,26 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="new">Select subscription ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsMessage">
+        <source>Select the Azure subscription to use for provisioning resources.</source>
+        <target state="new">Select the Azure subscription to use for provisioning resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionInputsTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionLabel">
+        <source>Subscription</source>
+        <target state="new">Subscription</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionPlaceholder">
+        <source>Select subscription</source>
+        <target state="new">Select subscription</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
@@ -173,6 +173,30 @@ internal sealed class TestArmClient : IArmClient
         var tenant = new TestTenantResource();
         return Task.FromResult<(ISubscriptionResource, ITenantResource)>((subscription, tenant));
     }
+
+    public Task<IList<(string SubscriptionId, string DisplayName)>> GetAvailableSubscriptionsAsync(CancellationToken cancellationToken = default)
+    {
+        var subscriptions = new List<(string SubscriptionId, string DisplayName)>
+        {
+            ("12345678-1234-1234-1234-123456789012", "Test Subscription 1"),
+            ("87654321-4321-4321-4321-210987654321", "Test Subscription 2"),
+            ("11111111-2222-3333-4444-555555555555", "Test Subscription 3")
+        };
+        return Task.FromResult<IList<(string SubscriptionId, string DisplayName)>>(subscriptions);
+    }
+
+    public Task<IList<(string Name, string DisplayName)>> GetAvailableLocationsAsync(string subscriptionId, CancellationToken cancellationToken = default)
+    {
+        var locations = new List<(string Name, string DisplayName)>
+        {
+            ("eastus", "East US"),
+            ("westus", "West US"),
+            ("centralus", "Central US"),
+            ("northeurope", "North Europe"),
+            ("westeurope", "West Europe")
+        };
+        return Task.FromResult<IList<(string Name, string DisplayName)>>(locations);
+    }
 }
 
 /// <summary>
@@ -316,6 +340,11 @@ internal sealed class MockResponse(int status) : Response
 internal sealed class TestArmClientProvider : IArmClientProvider
 {
     public IArmClient GetArmClient(TokenCredential credential, string subscriptionId)
+    {
+        return new TestArmClient();
+    }
+
+    public IArmClient GetArmClient(TokenCredential credential)
     {
         return new TestArmClient();
     }


### PR DESCRIPTION
Updates the implementation for provisioning prompting so that we:

- Query for the available subs then prompt via a list
- Get the locations available to the selected sub and only prompt for those