### PR TITLE
fix for wrong OpenAIClientOptions used with keyed OpenAIClient(s)

### DIFF
--- a/src/Components/Aspire.OpenAI/AspireOpenAIExtensions.cs
+++ b/src/Components/Aspire.OpenAI/AspireOpenAIExtensions.cs
@@ -124,20 +124,9 @@ public static class AspireOpenAIExtensions
         {
             if (settings.Key is not null)
             {
-                OpenAIClientOptions options;
-
-                if (serviceKey is null)
-                {
-                    // non-keyed: default options
-                    options = serviceProvider.GetRequiredService<IOptions<OpenAIClientOptions>>().Value;
-                }
-                else
-                {
-                    // keyed: named options
-                    options = serviceProvider
-                        .GetRequiredService<IOptionsMonitor<OpenAIClientOptions>>()
-                        .Get(serviceKey);
-                }
+                var options = serviceKey is null ?
+                    serviceProvider.GetRequiredService<IOptions<OpenAIClientOptions>>().Value :
+                    serviceProvider.GetRequiredService<IOptionsMonitor<OpenAIClientOptions>>().Get(serviceKey);
 
                 return new OpenAIClient(new ApiKeyCredential(settings.Key), options);
             }

--- a/src/Components/Aspire.OpenAI/AspireOpenAIExtensions.cs
+++ b/src/Components/Aspire.OpenAI/AspireOpenAIExtensions.cs
@@ -124,7 +124,21 @@ public static class AspireOpenAIExtensions
         {
             if (settings.Key is not null)
             {
-                var options = serviceProvider.GetRequiredService<IOptions<OpenAIClientOptions>>().Value;
+                OpenAIClientOptions options;
+
+                if (serviceKey is null)
+                {
+                    // non-keyed: default options
+                    options = serviceProvider.GetRequiredService<IOptions<OpenAIClientOptions>>().Value;
+                }
+                else
+                {
+                    // keyed: named options
+                    options = serviceProvider
+                        .GetRequiredService<IOptionsMonitor<OpenAIClientOptions>>()
+                        .Get(serviceKey);
+                }
+
                 return new OpenAIClient(new ApiKeyCredential(settings.Key), options);
             }
             else


### PR DESCRIPTION
with keyed OpenAIClients

```
builder.AddKeyedOpenAIClient("openai");
builder.AddKeyedOpenAIClient("ionos");
```

assuming that at least one keyed OpenAIClient has a differnt endpoint,

```
{
  "ConnectionStrings": {
    "openai": "Key={account_key};"
    "ionos": "Endpoint=https://{openai_rest_api_url};Key={account_key};"
  }
}
```

 getting the client with

```
var client = serviceProvider.GetRequiredKeyedService<OpenAIClient>("ionos")
```

the client uses the key from the connectionstring but it still has the default enpoint https://api.openai.com/v1

The issue is that ConfigureOpenAI ignores the serviceKey and always get's the default OpenAIClientOptions instead of the one created with optionsName = servicekey.

This makes using keyed OpenAIClients virtually impossible because the main reason having multiple OpenAIClients is having different endpoints.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
