### PR TITLE
Fix grammar in AddX method responsibilities docs

### DIFF
--- a/docs/specs/appmodel.md
+++ b/docs/specs/appmodel.md
@@ -931,7 +931,7 @@ This guide describes each pattern and shows a **verbatim Redis example** at the 
 
 ## Adding Resources with `AddX(...)`
 
-An `AddX(...)` method executes:
+An `AddX(...)` method will:
 
 1. **Validate inputs** (`builder`, `name`, required arguments).  
 2. **Instantiate** the data-only resource (`new TResource(...)`).  


### PR DESCRIPTION
## Description

The docs said, "executes" but then said "validate inputs", which didn't read smoothly to me. Saying the method "will" "validate inputs" seems like a better fit.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
