### PR TITLE
Fix creating projects with GB18030 chars

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,8 +13,8 @@
     <DotNetRuntimeCurrentVersionForTesting>9.0.6</DotNetRuntimeCurrentVersionForTesting>
     <!-- dotnet 8.0 versions for running tests - used for templates tests -->
     <DotNetSdkPreviousVersionForTesting>8.0.406</DotNetSdkPreviousVersionForTesting>
-    <!-- dotnet 10.0 versions for running tests - used for templates tests -->
-    <DotNetSdkCurrentVersionForTesting>9.0.200</DotNetSdkCurrentVersionForTesting>
+    <!-- dotnet 9.0 versions for running tests - used for templates tests -->
+    <DotNetSdkCurrentVersionForTesting>9.0.304</DotNetSdkCurrentVersionForTesting>
     <XunitV3Version>3.0.0</XunitV3Version>
     <XUnitAnalyzersVersion>1.21.0</XUnitAnalyzersVersion>
     <XunitRunnerVisualStudioVersion>3.1.0</XunitRunnerVisualStudioVersion>

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/9.3/AspireApplication.1.sln
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/9.3/AspireApplication.1.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.0.0
 MinimumVisualStudioVersion = 17.8.0.0

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/9.4/AspireApplication.1.sln
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/9.4/AspireApplication.1.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.0.0
 MinimumVisualStudioVersion = 17.8.0.0

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.3/Aspire-StarterApplication.1.sln
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.3/Aspire-StarterApplication.1.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.0.0
 MinimumVisualStudioVersion = 17.8.0.0

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.4/Aspire-StarterApplication.1.sln
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.4/Aspire-StarterApplication.1.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.0.0
 MinimumVisualStudioVersion = 17.8.0.0

--- a/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
@@ -270,12 +270,7 @@ public partial class TemplateTestsBase
         {
             // Avoid running these cases on PR validation
 
-            if (!OperatingSystem.IsWindows())
-            {
-                // ActiveIssue for windows: https://github.com/dotnet/aspire/issues/4555
-                yield return "aspire_龦唉丂荳_㐁ᠭ_ᠤསྲིདخەلꌠ_1ᥕ";
-            }
-
+            yield return "aspire_龦唉丂荳_㐁ᠭ_ᠤསྲིདخەلꌠ_1ᥕ项目1"; // sln should have UTF-8 byte order mark
             yield return "aspire_starter.1period then.34letters";
             yield return "aspire-starter & with.1";
 


### PR DESCRIPTION
## Description

Fix https://github.com/dotnet/aspire/issues/10528

Our template .sln files do not have a BOM. Until recently, MSBuild would read these with "Encoding.Default" ie., UTF-8 on .NET Core. They changed back to old code to reading with "Encoding.GetEncoding(0)" which on Windows gives "Western European (Windows)" - not the same. (Docs being fixed in https://github.com/dotnet/dotnet-api-docs/pull/11712)

Reading a file containing GB18030 characters in UTF-8 encoding using "Western European" corrupts them. The solution parser does not validate they exist; the first place that discovers they don't are the Nuget targets.

* Re-enable test for this case
* Update 9.0 SDK we use to move from 9.0.200 (which works) to 9.0.304 (which exposes the bug) and validate tests fail.
* Add BOM to our sln's.
* Verified the whole solution now builds, ie., BOM is not necessary in the csproj or source files, as they assume UTF-8.


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x ] No
