### PR TITLE
updating templates to be "AppHost" and "Aspire" instead of app host and .NET Aspire

### DIFF
--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -10,7 +10,7 @@
     <PackageType>Template</PackageType>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <Description>.NET Aspire Template Pack for Microsoft Template Engine</Description>
+    <Description>Aspire Template Pack for Microsoft Template Engine</Description>
     <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
   </PropertyGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
@@ -3,12 +3,12 @@
   "author": "Microsoft",
   "classifications": [
     "Common",
-    ".NET Aspire",
+    "Aspire",
     "Cloud"
   ],
-  "name": ".NET Aspire App Host",
+  "name": "Aspire AppHost",
   "defaultName": "AppHost",
-  "description": "A project template for creating a .NET Aspire app host (orchestrator) project.",
+  "description": "A project template for creating an Aspire AppHost (orchestrator) project.",
   "shortName": "aspire-apphost",
   "sourceName": "Aspire.AppHost1",
   "preferNameDirectory": true,
@@ -59,73 +59,73 @@
     },
     "AspireVersionCli": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersion": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },{
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet9": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet10": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -3,16 +3,16 @@
   "author": "Microsoft",
   "classifications": [
     "Common",
-    ".NET Aspire",
+    "Aspire",
     "Cloud",
     "Web",
     "Web API",
     "API",
     "Service"
   ],
-  "name": ".NET Aspire Empty App",
+  "name": "Aspire Empty App",
   "defaultName": "AspireApp",
-  "description": "A project template for creating an empty .NET Aspire app.",
+  "description": "A project template for creating an empty Aspire app.",
   "shortName": "aspire",
   "sourceName": "AspireApplication.1",
   "preferNameDirectory": true,
@@ -87,35 +87,35 @@
     },
     "AspireVersion": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework != net10.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet10": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/9.3/AspireApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/9.3/AspireApplication.1.ServiceDefaults/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/9.4/AspireApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/9.4/AspireApplication.1.ServiceDefaults/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [
     "Common",
-    ".NET Aspire",
+    "Aspire",
     "Cloud",
     "Web",
     "Web API",
@@ -12,9 +12,9 @@
     "Test",
     "MSTest"
   ],
-  "name": ".NET Aspire Test Project (MSTest)",
+  "name": "Aspire Test Project (MSTest)",
   "defaultName": "Tests",
-  "description": "A project that contains MSTest integration tests of a .NET Aspire app host project.",
+  "description": "A project that contains MSTest integration tests of an Aspire AppHost project.",
   "shortName": "aspire-mstest",
   "sourceName": "Aspire.Tests.1",
   "preferNameDirectory": true,
@@ -62,74 +62,74 @@
     },
     "AspireVersionCli": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersion": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet9": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet10": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [
     "Common",
-    ".NET Aspire",
+    "Aspire",
     "Cloud",
     "Web",
     "Web API",
@@ -12,9 +12,9 @@
     "Test",
     "NUnit"
   ],
-  "name": ".NET Aspire Test Project (NUnit)",
+  "name": "Aspire Test Project (NUnit)",
   "defaultName": "Tests",
-  "description": "A project that contains NUnit integration tests of a .NET Aspire app host project.",
+  "description": "A project that contains NUnit integration tests of an Aspire AppHost project.",
   "shortName": "aspire-nunit",
   "sourceName": "Aspire.Tests.1",
   "preferNameDirectory": true,
@@ -62,74 +62,74 @@
     },
     "AspireVersionCli": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersion": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet9": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet10": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
@@ -3,16 +3,16 @@
   "author": "Microsoft",
   "classifications": [
     "Common",
-    ".NET Aspire",
+    "Aspire",
     "Cloud",
     "Web",
     "Web API",
     "API",
     "Service"
   ],
-  "name": ".NET Aspire Service Defaults",
+  "name": "Aspire Service Defaults",
   "defaultName": "ServiceDefaults",
-  "description": "A project template for creating a .NET Aspire service defaults project.",
+  "description": "A project template for creating an Aspire service defaults project.",
   "shortName": "aspire-servicedefaults",
   "sourceName": "Aspire.ServiceDefaults1",
   "preferNameDirectory": true,
@@ -60,74 +60,74 @@
     },
     "AspireVersionCli": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersion": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet9": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet10": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.3/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.3/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.4/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.4/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [
     "Common",
-    ".NET Aspire",
+    "Aspire",
     "Blazor",
     "Web",
     "Web API",
@@ -15,9 +15,9 @@
     "NUnit",
     "xUnit"
   ],
-  "name": ".NET Aspire Starter App",
+  "name": "Aspire Starter App",
   "defaultName": "AspireApp",
-  "description": "A project template for creating a .NET Aspire app with a Blazor web frontend and web API backend service, optionally using Redis for caching.",
+  "description": "A project template for creating an Aspire AppHost, a Blazor web frontend, and a web API backend service, optionally using Redis for caching.",
   "shortName": "aspire-starter",
   "sourceName": "Aspire-StarterApplication.1",
   "preferNameDirectory": false,
@@ -103,74 +103,74 @@
     },
     "AspireVersionCli": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersion": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet9": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet10": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         }
       ],
       "defaultValue": "9.4"

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.3/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.3/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.4/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.4/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [
     "Common",
-    ".NET Aspire",
+    "Aspire",
     "Cloud",
     "Web",
     "Web API",
@@ -12,9 +12,9 @@
     "Test",
     "xUnit"
   ],
-  "name": ".NET Aspire Test Project (xUnit)",
+  "name": "Aspire Test Project (xUnit)",
   "defaultName": "Tests",
-  "description": "A project that contains xUnit.net integration tests of a .NET Aspire AppHost project.",
+  "description": "A project that contains xUnit.net integration tests of an Aspire AppHost project.",
   "shortName": "aspire-xunit",
   "sourceName": "Aspire.Tests.1",
   "preferNameDirectory": true,
@@ -62,74 +62,74 @@
     },
     "AspireVersionCli": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersion": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net8.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet9": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net9.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         },
         {
           "choice": "9.3",
           "displayName": "9.3",
-          "description": "Chooses .NET Aspire 9.3"
+          "description": "Chooses Aspire 9.3"
         }
       ],
       "defaultValue": "9.4"
     },
     "AspireVersionNet10": {
       "type": "parameter",
-      "description": "The version of .NET Aspire to use.",
-      "displayName": ".NET Aspire version",
+      "description": "The version of Aspire to use.",
+      "displayName": "Aspire version",
       "datatype": "choice",
       "isEnabled": "Framework == net10.0",
       "choices": [
         {
           "choice": "9.4",
           "displayName": "9.4",
-          "description": "Chooses .NET Aspire 9.4"
+          "description": "Chooses Aspire 9.4"
         }
       ],
       "defaultValue": "9.4"


### PR DESCRIPTION
Fixes #10887

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
