### PR TITLE
[CI] Bump timeout for Hosting tests on linux to 25m

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,8 @@ jobs:
     with:
       testShortName: ${{ matrix.shortname }}
       os: "ubuntu-latest"
+      # Docker tests are run on linux, and Hosting tests take longer to finish
+      testSessionTimeout: ${{ matrix.shortname == 'Hosting' && '25m' || '15m' }}
       extraTestArgs: "--filter-not-trait \"quarantined=true\""
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 


### PR DESCRIPTION
These tests have been taken longer and creeping close to the 15min timeout. And sometimes end up timing out causing CI to break.