### PR TITLE
Revert deployment connection string changes

### DIFF
--- a/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.AppHost/aspire-manifest.json
@@ -8,7 +8,7 @@
     },
     "chat": {
       "type": "value.v0",
-      "connectionString": "{foundry.connectionString};DeploymentId=chat;Model=Phi-4-mini-reasoning"
+      "connectionString": "Endpoint={foundry.outputs.endpoint};EndpointAIInference={foundry.outputs.aiFoundryApiEndpoint}models;DeploymentId=chat;Model=chat"
     },
     "webstory": {
       "type": "project.v0",

--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryDeploymentResource.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryDeploymentResource.cs
@@ -85,5 +85,5 @@ public class AzureAIFoundryDeploymentResource : Resource, IResourceWithParent<Az
     /// <summary>
     /// Gets the connection string expression for the Azure AI Foundry resource with model/deployment information.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent};DeploymentId={DeploymentName};Model={ModelName}");
+    public ReferenceExpression ConnectionStringExpression => Parent.GetConnectionString(DeploymentName);
 }

--- a/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryResource.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AzureAIFoundryResource.cs
@@ -92,4 +92,7 @@ public class AzureAIFoundryResource(string name, Action<AzureResourceInfrastruct
 
         _deployments.Add(deployment);
     }
+
+    internal ReferenceExpression GetConnectionString(string deploymentName) =>
+        ReferenceExpression.Create($"{ConnectionStringExpression};DeploymentId={deploymentName};Model={deploymentName}");
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAIFoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAIFoundryExtensionsTests.cs
@@ -122,7 +122,7 @@ public class AzureAIFoundryExtensionsTests
         var resource = Assert.Single(builder.Resources.OfType<AzureAIFoundryResource>());
         Assert.Single(resource.Deployments);
         var connectionString = await deployment.Resource.ConnectionStringExpression.GetValueAsync(default);
-        Assert.Contains("Model=gpt-4", connectionString);
+        Assert.Contains("Model=deployment1", connectionString);
         Assert.Contains("DeploymentId=deployment1", connectionString);
         Assert.Contains("Endpoint=", connectionString);
         Assert.Contains("Key=", connectionString);


### PR DESCRIPTION
## Description

Fixes the connection string between Aspire.Hosting.Azure.AIFoundry and Aspire.Azure.AI.OpenAI. It needs to set the deployment name for both deployment (inference) and model properties (openai).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
