### PR TITLE
Improve displaying durations

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -18,7 +18,12 @@
         </div>
         <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <div>
-            @((MarkupString)string.Format(ControlsStrings.SpanDetailsStartTime, DurationFormatter.FormatDuration(ViewModel.Span.StartTime - ViewModel.Span.Trace.FirstSpan.StartTime)))
+            @{
+                // Start time for root span is zero. We don't want to display the smallest unit (0μs) because that looks odd. Use the unit from duration.
+                var startTime = ViewModel.Span.StartTime - ViewModel.Span.Trace.FirstSpan.StartTime;
+                var formattedStartTime = startTime > TimeSpan.Zero ? DurationFormatter.FormatDuration(startTime) : $"0{DurationFormatter.GetUnit(ViewModel.Span.Duration)}";
+            }
+            @((MarkupString)string.Format(ControlsStrings.SpanDetailsStartTime, formattedStartTime))
         </div>
         <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@DashboardUrls.StructuredLogsUrl(spanId: ViewModel.Span.SpanId)">@Loc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />

--- a/src/Aspire.Dashboard/Otlp/Model/DurationFormatter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/DurationFormatter.cs
@@ -12,17 +12,18 @@ public static class DurationFormatter
     {
         public required string Unit { get; init; }
         public required long Ticks { get; init; }
+        public required long Threshold { get; init; }
         public bool IsDecimal { get; init; }
     }
 
     private static readonly List<UnitStep> s_unitSteps = new List<UnitStep>
     {
-        new UnitStep { Unit = "d", Ticks = TimeSpan.TicksPerDay },
-        new UnitStep { Unit = "h", Ticks = TimeSpan.TicksPerHour },
-        new UnitStep { Unit = "m", Ticks = TimeSpan.TicksPerMinute },
-        new UnitStep { Unit = "s", Ticks = TimeSpan.TicksPerSecond, IsDecimal = true },
-        new UnitStep { Unit = "ms", Ticks = TimeSpan.TicksPerMillisecond, IsDecimal = true },
-        new UnitStep { Unit = "μs", Ticks = TimeSpan.TicksPerMicrosecond, IsDecimal = true },
+        new UnitStep { Unit = "d", Ticks = TimeSpan.TicksPerDay, Threshold = TimeSpan.TicksPerDay },
+        new UnitStep { Unit = "h", Ticks = TimeSpan.TicksPerHour, Threshold = TimeSpan.TicksPerHour },
+        new UnitStep { Unit = "m", Ticks = TimeSpan.TicksPerMinute, Threshold = TimeSpan.TicksPerMinute },
+        new UnitStep { Unit = "s", Ticks = TimeSpan.TicksPerSecond, Threshold = TimeSpan.TicksPerSecond / 10, IsDecimal = true },
+        new UnitStep { Unit = "ms", Ticks = TimeSpan.TicksPerMillisecond, Threshold = TimeSpan.TicksPerMillisecond / 100, IsDecimal = true },
+        new UnitStep { Unit = "μs", Ticks = TimeSpan.TicksPerMicrosecond, Threshold = TimeSpan.TicksPerMicrosecond, IsDecimal = true },
     };
 
     public static string FormatDuration(TimeSpan duration)
@@ -60,7 +61,7 @@ public static class DurationFormatter
         for (var i = 0; i < s_unitSteps.Count; i++)
         {
             var step = s_unitSteps[i];
-            var result = i < s_unitSteps.Count - 1 && step.Ticks > ticks;
+            var result = i < s_unitSteps.Count - 1 && step.Threshold > ticks;
 
             if (!result)
             {

--- a/tests/Aspire.Dashboard.Tests/DurationFormatterTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DurationFormatterTests.cs
@@ -12,8 +12,11 @@ public class DurationFormatterTests
     [Theory]
     [InlineData(0, "μs")]
     [InlineData(1, "μs")]
-    [InlineData(1_000, "μs")]
-    [InlineData(1_000_000, "ms")]
+    [InlineData(10, "μs")]
+    [InlineData(100, "ms")]
+    [InlineData(1_000, "ms")]
+    [InlineData(100_000, "ms")]
+    [InlineData(1_000_000, "s")]
     [InlineData(1_000_000_000, "s")]
     [InlineData(1_000_000_000_000, "h")]
     [InlineData(1_000_000_000_000_000, "h")]
@@ -69,6 +72,20 @@ public class DurationFormatterTests
     {
         var input = 2 * TimeSpan.TicksPerHour + 30 * TimeSpan.TicksPerMinute + 30 * TimeSpan.TicksPerSecond;
         Assert.Equal("2h 31m", DurationFormatter.FormatDuration(TimeSpan.FromTicks(input)));
+    }
+
+    [Fact]
+    public void DisplaysLargeFractionalMillisecondAsMilliseconds()
+    {
+        var input = 9155;
+        Assert.Equal(0.92m.ToString("0.##ms", CultureInfo.CurrentCulture), DurationFormatter.FormatDuration(TimeSpan.FromTicks(input)));
+    }
+
+    [Fact]
+    public void DisplaysLargeFractionalSecondsAsSeconds()
+    {
+        var input = 915 * TimeSpan.TicksPerMillisecond;
+        Assert.Equal(0.92m.ToString("0.##s", CultureInfo.CurrentCulture), DurationFormatter.FormatDuration(TimeSpan.FromTicks(input)));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Aspire has logic to display durations in either hours, minutes, seconds, milliseconds or picoseconds. For example, if a time is under a millisecond then it is displayed as picoseconds. If it is under a second it is displayed as milliseconds, etc.

Picoseconds are a bit unusual. This PR tweaks logic to only display picoseconds if the duration is so small that formatting it as milliseconds will display `0.00ms`. You should almost never see picoseconds.

Also, only display milliseconds for times less than 100 milliseconds. That means 712.59 milliseconds will now display as `0.71s` instead of `712.59ms`. Interested in what people think about this. IMO it is better to offer a cleaner UI that high percision with spans.

<img width="591" height="220" alt="image" src="https://github.com/user-attachments/assets/b442243e-ff06-4682-8999-ee73f48da48c" />

PR also makes the start time of the root span use the unit of its duration rather than `0μs`.

<img width="681" height="162" alt="image" src="https://github.com/user-attachments/assets/78bca740-22fb-4e59-9947-00a1b35cedcd" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
