### PR TITLE
Add WithForwardedHeaders method to configure forwarded headers for Aspire dashboard

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResourceBuilderExtensions.cs
@@ -58,4 +58,24 @@ public static class DockerComposeAspireDashboardResourceBuilderExtensions
             e.IsExternal = port is not null;
         });
     }
+
+    /// <summary>
+    /// Configures whether forwarded headers processing is enabled for the Aspire dashboard container.
+    /// </summary>
+    /// <param name="builder">The <see cref="IResourceBuilder{DockerComposeAspireDashboardResource}"/> instance.</param>
+    /// <param name="enabled">True to enable forwarded headers (<c>ASPIRE_DASHBOARD_FORWARDEDHEADERS_ENABLED=true</c>), false to disable it (sets the value to <c>false</c>).</param>
+    /// <returns>The same <see cref="IResourceBuilder{DockerComposeAspireDashboardResource}"/> to allow chaining.</returns>
+    /// <remarks>
+    /// This sets the <c>ASPIRE_DASHBOARD_FORWARDEDHEADERS_ENABLED</c> environment variable inside the dashboard
+    /// container. When enabled, the dashboard will process <c>X-Forwarded-Host</c> and <c>X-Forwarded-Proto</c>
+    /// headers which is required when the dashboard is accessed through a reverse proxy or load balancer.
+    /// </remarks>
+    public static IResourceBuilder<DockerComposeAspireDashboardResource> WithForwardedHeaders(
+        this IResourceBuilder<DockerComposeAspireDashboardResource> builder,
+        bool enabled = true)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment("ASPIRE_DASHBOARD_FORWARDEDHEADERS_ENABLED", enabled ? "true" : "false");
+    }
 }

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DashboardWithForwardedHeadersWritesEnvVar.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DashboardWithForwardedHeadersWritesEnvVar.verified.yaml
@@ -1,0 +1,18 @@
+﻿services:
+  env-dashboard:
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    environment:
+      ASPIRE_DASHBOARD_FORWARDEDHEADERS_ENABLED: "true"
+    expose:
+      - "18888"
+      - "18889"
+    networks:
+      - "aspire"
+    restart: "always"
+  api:
+    image: "myimage:latest"
+    networks:
+      - "aspire"
+networks:
+  aspire:
+    driver: "bridge"


### PR DESCRIPTION
## Description

Add WithForwardedHeaders method to configure forwarded headers for Aspire dashboard in docker compose scenarios.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)

