### PR TITLE
Details padding consistency

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
@@ -27,6 +27,10 @@
         "main";
 }
 
+::deep .details-container fluent-toolbar {
+    padding-left: calc(var(--design-unit) * 2px);
+}
+
 ::deep .details-container > header {
     height: auto;
     grid-row-start: 1;

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -455,7 +455,7 @@ fluent-switch.table-switch::part(label) {
 }
 
 .property-grid-container > fluent-accordion > fluent-accordion-item::part(heading) {
-    padding-left: calc(var(--design-unit) * 2 * 1px);
+    padding-left: calc(var(--design-unit) * 3.5px);
 }
 
 .property-grid-container fluent-accordion .fluent-data-grid {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -455,7 +455,7 @@ fluent-switch.table-switch::part(label) {
 }
 
 .property-grid-container > fluent-accordion > fluent-accordion-item::part(heading) {
-    padding-left: calc(var(--design-unit) * 3.5px);
+    padding-left: calc(var(--design-unit) * 2px);
 }
 
 .property-grid-container fluent-accordion .fluent-data-grid {
@@ -483,7 +483,9 @@ fluent-switch.table-switch::part(label) {
 }
 
 .property-grid-container fluent-accordion-item::part(region) {
-    padding-bottom: 0;
+    padding: 0;
+    /* overflow hidden masks content in the item's rounded borders */
+    overflow: hidden;
 }
 
 .property-grid-container fluent-accordion-item::part(heading-content) {
@@ -508,6 +510,11 @@ fluent-switch.table-switch::part(label) {
 /* Under the current dark theme, the fluent-badge background color was too dark on --neutral-layer-1 */
 [data-theme="dark"] .property-grid-container fluent-accordion-item fluent-badge::part(control) {
     background-color: var(--neutral-fill-active);
+}
+
+.property-grid-container tr:last-child td {
+    /* bottom of the table is at the bottom of an accordion item so hide the bottom row's bottom border */
+    border-bottom: none;
 }
 
 .items-footer {


### PR DESCRIPTION
## Description

Before:

<img width="780" height="432" alt="image" src="https://github.com/user-attachments/assets/2513ec67-e20a-429d-a588-4574743a955d" />

After:

<img width="658" height="444" alt="image" src="https://github.com/user-attachments/assets/95dee2cd-01d7-4e82-8299-0fd62452cb13" />

<img width="220" height="204" alt="image" src="https://github.com/user-attachments/assets/243c853c-574e-499b-b0ad-d060f4499037" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
