### PR TITLE
Trace details header clean up

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -24,12 +24,10 @@
             IsSummaryDetailsViewOpen="@(SelectedData is not null)"
             @ref="@_layout">
             <PageTitleSection>
-                <div class="page-header">
-                    <h1>
-                        <span>@GetPageTitle()</span>
-                        <span class="trace-id">@OtlpHelpers.ToShortenedId(trace.TraceId)</span>
-                    </h1>
-                </div>
+                <h1 class="page-header">
+                    <span>@GetPageTitle()</span>
+                    <span class="trace-id">@OtlpHelpers.ToShortenedId(trace.TraceId)</span>
+                </h1>
             </PageTitleSection>
             <ToolbarSection>
                 @if (ViewportInformation.IsDesktop)
@@ -329,7 +327,7 @@
         return @<FluentOverflow Class="trace-header-details">
             <ChildContent>
                 <FluentOverflowItem>
-                    @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)] <strong title="@FormatHelpers.FormatDateTime(TimeProvider, _trace.FirstSpan.StartTime, MillisecondsDisplay.Full)">@FormatHelpers.FormatDateTime(TimeProvider, _trace.FirstSpan.StartTime, MillisecondsDisplay.Truncated)</strong>
+                    @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)] <strong title="@FormatHelpers.FormatDateTime(TimeProvider, _trace.FirstSpan.StartTime, MillisecondsDisplay.Full)">@FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, _trace.FirstSpan.StartTime, MillisecondsDisplay.Truncated)</strong>
                 </FluentOverflowItem>
                 <FluentOverflowItem>
                     @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailDurationHeader)] <strong>@DurationFormatter.FormatDuration(trace.Duration)</strong>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -18,6 +18,7 @@
     padding-left: 0.5rem;
     font-size: 12px;
     font-weight: normal;
+    line-height: 1;
 }
 
 ::deep .trace-view-grid {


### PR DESCRIPTION
## Description

- Trace details header was slightly higher than traces header. Make consistent
- Simplify date in header to just the time if recorded today

<img width="1117" height="371" alt="image" src="https://github.com/user-attachments/assets/e2dce9f5-1911-4d9c-a18e-74e82a276dfa" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
