### PR TITLE
Tweak displaying (All) console logs content

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -48,21 +48,35 @@
                                     @{
                                         var hasPrefix = false;
                                     }
-                                    @if (ShowResourcePrefix && context.ResourcePrefix is { } resourcePrefix)
-                                    {
-                                        <span class="resource-prefix" style="background: @ColorGenerator.Instance.GetColorHexByKey(resourcePrefix);">@resourcePrefix</span>
-                                    }
                                     @if (ShowTimestamp && context.Timestamp is { } timestamp)
                                     {
-                                        hasPrefix = true;
+                                        if (DisplayPrefix(ref hasPrefix))
+                                        {
+                                            @s_spaceMarkup
+                                        }
                                         <span class="timestamp" title="@FormatHelpers.FormatDateTime(TimeProvider, timestamp, MillisecondsDisplay.Full, CultureInfo.CurrentCulture)">@GetDisplayTimestamp(timestamp)</span>
+                                    }
+                                    @if (ShowResourcePrefix && context.ResourcePrefix is { } resourcePrefix)
+                                    {
+                                        if (DisplayPrefix(ref hasPrefix))
+                                        {
+                                            @s_spaceMarkup
+                                        }
+                                        <span class="resource-prefix" style="background: @ColorGenerator.Instance.GetColorHexByKey(resourcePrefix);">@resourcePrefix</span>
                                     }
                                     @if (context.Type == LogEntryType.Error)
                                     {
-                                        hasPrefix = true;
+                                        if (DisplayPrefix(ref hasPrefix))
+                                        {
+                                            @s_spaceMarkup
+                                        }
                                         <fluent-badge appearance="accent">stderr</fluent-badge>
                                     }
-                                    @((MarkupString)((hasPrefix ? "&#32;" : string.Empty) + (context.Content ?? string.Empty)))
+                                    @if (DisplayPrefix(ref hasPrefix))
+                                    {
+                                        @s_spaceMarkup
+                                    }
+                                    @((MarkupString)(context.Content ?? string.Empty))
                                 </span>
                             </span>
                         </div>
@@ -72,3 +86,16 @@
         }
     </div>
 </div>
+
+@code {
+    public bool DisplayPrefix(ref bool hasPrefix)
+    {
+        if (hasPrefix)
+        {
+            return true;
+        }
+
+        hasPrefix = true;
+        return false;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -15,6 +15,8 @@ namespace Aspire.Dashboard.Components;
 /// </summary>
 public sealed partial class LogViewer
 {
+    private static readonly MarkupString s_spaceMarkup = new MarkupString("&#32;");
+
     private LogEntries? _logEntries;
     private bool _logsChanged;
 

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -145,4 +145,5 @@
     line-height: var(--type-ramp-minus-1-line-height);
     font-weight: initial;
     font-variation-settings: var(--type-ramp-minus-1-font-variations);
+    user-select: none;
 }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -149,5 +149,4 @@
     line-height: var(--type-ramp-minus-1-line-height);
     font-weight: initial;
     font-variation-settings: var(--type-ramp-minus-1-font-variations);
-    margin-right: calc(var(--design-unit) * 1.5px);
 }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -27,10 +27,6 @@
     user-select: none;
 }
 
-::deep .log-content > .timestamp + fluent-badge {
-    margin-left: 1ch;
-}
-
 ::deep .ansi-fg-black {
     color: var(--console-theme-black);
 }


### PR DESCRIPTION
## Description

- By popular demand, move timestamp before resource name
- Use text spaces instead of margin for spacing

Before:

<img width="1691" height="1097" alt="image" src="https://github.com/user-attachments/assets/ed086547-3b31-487f-8506-abfe19a436dd" />

After:

<img width="1770" height="1083" alt="image" src="https://github.com/user-attachments/assets/edd78a4f-e16a-43aa-b4fc-c07de30a152b" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
