### PR TITLE
Add more tests infra for Azure deployer

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -22,7 +22,8 @@ internal sealed class AzureDeployingContext(
     IUserSecretsManager userSecretsManager,
     IBicepProvisioner bicepProvisioner,
     IPublishingActivityReporter activityReporter,
-    IResourceContainerImageBuilder containerImageBuilder)
+    IResourceContainerImageBuilder containerImageBuilder,
+    IProcessRunner processRunner)
 {
     public async Task DeployModelAsync(AzureEnvironmentResource resource, DistributedApplicationModel model, CancellationToken cancellationToken = default)
     {
@@ -272,7 +273,7 @@ internal sealed class AzureDeployingContext(
         }
     }
 
-    private static async Task AuthenticateToAcr(IPublishingStep parentStep, string registryName, CancellationToken cancellationToken)
+    private async Task AuthenticateToAcr(IPublishingStep parentStep, string registryName, CancellationToken cancellationToken)
     {
         var loginTask = await parentStep.CreateTaskAsync($"Logging in to container registry", cancellationToken).ConfigureAwait(false);
         var command = BicepCliCompiler.FindFullPathFromPath("az") ?? throw new InvalidOperationException("Failed to find 'az' command");
@@ -284,7 +285,7 @@ internal sealed class AzureDeployingContext(
                 ThrowOnNonZeroReturnCode = false
             };
 
-            var (pendingResult, processDisposable) = ProcessUtil.Run(loginSpec);
+            var (pendingResult, processDisposable) = processRunner.Run(loginSpec);
             await using (processDisposable.ConfigureAwait(false))
             {
                 var result = await pendingResult.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -297,7 +298,7 @@ internal sealed class AzureDeployingContext(
         }
     }
 
-    private static async Task PushImageToAcr(IPublishingStep parentStep, IEnumerable<IResource> resources, CancellationToken cancellationToken)
+    private async Task PushImageToAcr(IPublishingStep parentStep, IEnumerable<IResource> resources, CancellationToken cancellationToken)
     {
         foreach (var resource in resources)
         {
@@ -330,20 +331,20 @@ internal sealed class AzureDeployingContext(
         }
     }
 
-    private static async Task TagAndPushImage(string localTag, string targetTag, CancellationToken cancellationToken)
+    private async Task TagAndPushImage(string localTag, string targetTag, CancellationToken cancellationToken)
     {
         await RunDockerCommand($"tag {localTag} {targetTag}", cancellationToken).ConfigureAwait(false);
         await RunDockerCommand($"push {targetTag}", cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task RunDockerCommand(string arguments, CancellationToken cancellationToken)
+    private async Task RunDockerCommand(string arguments, CancellationToken cancellationToken)
     {
         var dockerSpec = new ProcessSpec("docker")
         {
             Arguments = arguments
         };
 
-        var (pendingResult, processDisposable) = ProcessUtil.Run(dockerSpec);
+        var (pendingResult, processDisposable) = processRunner.Run(dockerSpec);
         await using (processDisposable.ConfigureAwait(false))
         {
             await pendingResult.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -78,13 +78,15 @@ public sealed class AzureEnvironmentResource : AzureBicepResource
         var bicepProvisioner = context.Services.GetRequiredService<IBicepProvisioner>();
         var activityPublisher = context.Services.GetRequiredService<IPublishingActivityReporter>();
         var containerImageBuilder = context.Services.GetRequiredService<IResourceContainerImageBuilder>();
+        var processRunner = context.Services.GetRequiredService<IProcessRunner>();
 
         var azureCtx = new AzureDeployingContext(
             provisioningContextProvider,
             userSecretsManager,
             bicepProvisioner,
             activityPublisher,
-            containerImageBuilder);
+            containerImageBuilder,
+            processRunner);
 
         return azureCtx.DeployModelAsync(this, context.Model, context.CancellationToken);
     }

--- a/src/Aspire.Hosting.Azure/IProcessRunner.cs
+++ b/src/Aspire.Hosting.Azure/IProcessRunner.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dcp.Process;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Interface for running external processes, abstracting ProcessUtil.Run to support testing.
+/// </summary>
+internal interface IProcessRunner
+{
+    /// <summary>
+    /// Runs a process with the specified configuration.
+    /// </summary>
+    /// <param name="processSpec">The process specification.</param>
+    /// <returns>A tuple containing the task representing the process result and an async disposable for cleanup.</returns>
+    (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec);
+}
+
+/// <summary>
+/// Default implementation of IProcessRunner that delegates to ProcessUtil.Run.
+/// </summary>
+internal sealed class DefaultProcessRunner : IProcessRunner
+{
+    public (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec)
+        => ProcessUtil.Run(processSpec);
+}

--- a/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerExtensions.cs
@@ -6,6 +6,7 @@ using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Azure.Provisioning.Internal;
 using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Aspire.Hosting;
 
@@ -34,18 +35,19 @@ public static class AzureProvisionerExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        builder.Services.AddSingleton<ITokenCredentialProvider, DefaultTokenCredentialProvider>();
+        builder.Services.TryAddSingleton<ITokenCredentialProvider, DefaultTokenCredentialProvider>();
 
         // Register BicepProvisioner via interface
-        builder.Services.AddSingleton<IBicepProvisioner, BicepProvisioner>();
+        builder.Services.TryAddSingleton<IBicepProvisioner, BicepProvisioner>();
 
         // Register the new internal services for testability
-        builder.Services.AddSingleton<IArmClientProvider, DefaultArmClientProvider>();
-        builder.Services.AddSingleton<ISecretClientProvider, DefaultSecretClientProvider>();
-        builder.Services.AddSingleton<IBicepCompiler, BicepCliCompiler>();
-        builder.Services.AddSingleton<IUserSecretsManager, DefaultUserSecretsManager>();
-        builder.Services.AddSingleton<IUserPrincipalProvider, DefaultUserPrincipalProvider>();
-        builder.Services.AddSingleton<IProvisioningContextProvider, DefaultProvisioningContextProvider>();
+        builder.Services.TryAddSingleton<IArmClientProvider, DefaultArmClientProvider>();
+        builder.Services.TryAddSingleton<ISecretClientProvider, DefaultSecretClientProvider>();
+        builder.Services.TryAddSingleton<IBicepCompiler, BicepCliCompiler>();
+        builder.Services.TryAddSingleton<IUserSecretsManager, DefaultUserSecretsManager>();
+        builder.Services.TryAddSingleton<IUserPrincipalProvider, DefaultUserPrincipalProvider>();
+        builder.Services.TryAddSingleton<IProvisioningContextProvider, DefaultProvisioningContextProvider>();
+        builder.Services.TryAddSingleton<IProcessRunner, DefaultProcessRunner>();
 
         return builder;
     }

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPUBLISHERS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
@@ -8,6 +10,7 @@ using System.Text.Json.Nodes;
 using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Azure.Provisioning.Internal;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Dcp.Process;
 using Azure;
 using Azure.Core;
 using Azure.ResourceManager;
@@ -50,7 +53,7 @@ internal static class ProvisioningTestHelpers
             tenant ?? new TestTenantResource(),
             location ?? AzureLocation.WestUS2,
             principal ?? new UserPrincipal(Guid.NewGuid(), "test@example.com"),
-            userSecrets ?? new JsonObject(),
+            userSecrets ?? [],
             executionContext ?? new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
             outputPath);
     }
@@ -165,11 +168,17 @@ internal sealed class TestTokenCredential : TokenCredential
 /// <summary>
 /// Test implementation of <see cref="IArmClient"/>.
 /// </summary>
-internal sealed class TestArmClient : IArmClient
+internal sealed class TestArmClient(Dictionary<string, object> deploymentOutputs) : IArmClient
 {
+    private readonly Dictionary<string, object> _deploymentOutputs = deploymentOutputs;
+
+    public TestArmClient() : this([])
+    {
+    }
+
     public Task<(ISubscriptionResource subscription, ITenantResource tenant)> GetSubscriptionAndTenantAsync(CancellationToken cancellationToken = default)
     {
-        var subscription = new TestSubscriptionResource();
+        var subscription = new TestSubscriptionResource(_deploymentOutputs);
         var tenant = new TestTenantResource();
         return Task.FromResult<(ISubscriptionResource, ITenantResource)>((subscription, tenant));
     }
@@ -178,37 +187,49 @@ internal sealed class TestArmClient : IArmClient
 /// <summary>
 /// Test implementation of <see cref="ISubscriptionResource"/>.
 /// </summary>
-internal sealed class TestSubscriptionResource : ISubscriptionResource
+internal sealed class TestSubscriptionResource(Dictionary<string, object> deploymentOutputs) : ISubscriptionResource
 {
+    private readonly Dictionary<string, object> _deploymentOutputs = deploymentOutputs;
+
+    public TestSubscriptionResource() : this([])
+    {
+    }
+
     public ResourceIdentifier Id { get; } = new ResourceIdentifier("/subscriptions/12345678-1234-1234-1234-123456789012");
     public string? DisplayName { get; } = "Test Subscription";
     public Guid? TenantId { get; } = Guid.Parse("87654321-4321-4321-4321-210987654321");
 
     public IArmDeploymentCollection GetArmDeployments()
     {
-        return new TestArmDeploymentCollection();
+        return new TestArmDeploymentCollection(_deploymentOutputs);
     }
 
     public IResourceGroupCollection GetResourceGroups()
     {
-        return new TestResourceGroupCollection();
+        return new TestResourceGroupCollection(_deploymentOutputs);
     }
 }
 
 /// <summary>
 /// Test implementation of <see cref="IResourceGroupCollection"/>.
 /// </summary>
-internal sealed class TestResourceGroupCollection : IResourceGroupCollection
+internal sealed class TestResourceGroupCollection(Dictionary<string, object> deploymentOutputs) : IResourceGroupCollection
 {
+    private readonly Dictionary<string, object> _deploymentOutputs = deploymentOutputs;
+
+    public TestResourceGroupCollection() : this([])
+    {
+    }
+
     public Task<Response<IResourceGroupResource>> GetAsync(string resourceGroupName, CancellationToken cancellationToken = default)
     {
-        var resourceGroup = new TestResourceGroupResource(resourceGroupName);
+        var resourceGroup = new TestResourceGroupResource(resourceGroupName, _deploymentOutputs);
         return Task.FromResult(Response.FromValue<IResourceGroupResource>(resourceGroup, new MockResponse(200)));
     }
 
     public Task<ArmOperation<IResourceGroupResource>> CreateOrUpdateAsync(WaitUntil waitUntil, string resourceGroupName, ResourceGroupData data, CancellationToken cancellationToken = default)
     {
-        var resourceGroup = new TestResourceGroupResource(resourceGroupName);
+        var resourceGroup = new TestResourceGroupResource(resourceGroupName, _deploymentOutputs);
         var operation = new TestArmOperation<IResourceGroupResource>(resourceGroup);
         return Task.FromResult<ArmOperation<IResourceGroupResource>>(operation);
     }
@@ -217,34 +238,41 @@ internal sealed class TestResourceGroupCollection : IResourceGroupCollection
 /// <summary>
 /// Test implementation of <see cref="IResourceGroupResource"/>.
 /// </summary>
-internal sealed class TestResourceGroupResource : IResourceGroupResource
+internal sealed class TestResourceGroupResource(string name, Dictionary<string, object> deploymentOutputs) : IResourceGroupResource
 {
-    public TestResourceGroupResource(string name = "test-rg")
+    private readonly Dictionary<string, object> _deploymentOutputs = deploymentOutputs;
+
+    public TestResourceGroupResource(string name = "test-rg") : this(name, [])
     {
-        Name = name;
     }
 
     public ResourceIdentifier Id { get; } = new ResourceIdentifier("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg");
-    public string Name { get; }
+    public string Name { get; } = name;
 
     public IArmDeploymentCollection GetArmDeployments()
     {
-        return new TestArmDeploymentCollection();
+        return new TestArmDeploymentCollection(_deploymentOutputs);
     }
 }
 
 /// <summary>
 /// Test implementation of <see cref="IArmDeploymentCollection"/>.
 /// </summary>
-internal sealed class TestArmDeploymentCollection : IArmDeploymentCollection
+internal sealed class TestArmDeploymentCollection(Dictionary<string, object> deploymentOutputs) : IArmDeploymentCollection
 {
+    private readonly Dictionary<string, object> _deploymentOutputs = deploymentOutputs;
+
+    public TestArmDeploymentCollection() : this([])
+    {
+    }
+
     public Task<ArmOperation<ArmDeploymentResource>> CreateOrUpdateAsync(
         WaitUntil waitUntil,
         string deploymentName,
         ArmDeploymentContent content,
         CancellationToken cancellationToken = default)
     {
-        var deployment = new TestArmDeploymentResource(deploymentName);
+        var deployment = new TestArmDeploymentResource(deploymentName, _deploymentOutputs);
         var operation = new TestArmOperation<ArmDeploymentResource>(deployment);
         return Task.FromResult<ArmOperation<ArmDeploymentResource>>(operation);
     }
@@ -281,11 +309,11 @@ internal sealed class TestArmOperation<T>(T value) : ArmOperation<T>
 /// <summary>
 /// Test implementation of ArmDeploymentResource for testing.
 /// </summary>
-internal sealed class TestArmDeploymentResource(string name) : ArmDeploymentResource
+internal sealed class TestArmDeploymentResource(string name, Dictionary<string, object> deploymentData) : ArmDeploymentResource
 {
     public override ResourceIdentifier Id { get; } = new ResourceIdentifier($"/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/{name}");
-    public override ArmDeploymentData Data => throw new NotImplementedException("Test implementation doesn't provide data");
-    public override bool HasData => false;
+    public override ArmDeploymentData Data => ArmResourcesModelFactory.ArmDeploymentData(Id, name, properties: ArmResourcesModelFactory.ArmDeploymentPropertiesExtended(provisioningState: ResourcesProvisioningState.Succeeded, outputs: BinaryData.FromObjectAsJson(deploymentData)));
+    public override bool HasData => true;
 }
 
 /// <summary>
@@ -313,11 +341,17 @@ internal sealed class MockResponse(int status) : Response
     public override void Dispose() { }
 }
 
-internal sealed class TestArmClientProvider : IArmClientProvider
+internal sealed class TestArmClientProvider(Dictionary<string, object> deploymentOutputs) : IArmClientProvider
 {
+    private readonly Dictionary<string, object> _deploymentOutputs = deploymentOutputs;
+
+    public TestArmClientProvider() : this([])
+    {
+    }
+
     public IArmClient GetArmClient(TokenCredential credential, string subscriptionId)
     {
-        return new TestArmClient();
+        return new TestArmClient(_deploymentOutputs);
     }
 }
 
@@ -356,7 +390,7 @@ internal sealed class TestBicepCompiler : IBicepCompiler
 
 internal sealed class TestUserSecretsManager : IUserSecretsManager
 {
-    private JsonObject _userSecrets = new JsonObject();
+    private JsonObject _userSecrets = [];
 
     public Task<JsonObject> LoadUserSecretsAsync(CancellationToken cancellationToken = default)
     {
@@ -382,4 +416,82 @@ internal sealed class TestUserPrincipalProvider : IUserPrincipalProvider
 internal sealed class TestTokenCredentialProvider : ITokenCredentialProvider
 {
     public TokenCredential TokenCredential => new TestTokenCredential();
+}
+
+/// <summary>
+/// Mock implementation of IProcessRunner for testing that captures executed commands.
+/// </summary>
+internal sealed class MockProcessRunner : IProcessRunner
+{
+    /// <summary>
+    /// Gets the list of commands that were executed.
+    /// </summary>
+    public List<ExecutedCommand> ExecutedCommands { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the configured results for specific commands.
+    /// Key format: "{executablePath} {arguments}"
+    /// </summary>
+    public Dictionary<string, ProcessResult> CommandResults { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the default process result to return when no specific result is configured.
+    /// </summary>
+    public ProcessResult DefaultResult { get; set; } = new(0);
+
+    /// <summary>
+    /// Represents a command that was executed.
+    /// </summary>
+    public sealed record ExecutedCommand(string ExecutablePath, string? Arguments, string? WorkingDirectory);
+
+    public (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec)
+    {
+        // Capture the executed command
+        var executedCommand = new ExecutedCommand(processSpec.ExecutablePath, processSpec.Arguments, processSpec.WorkingDirectory);
+        ExecutedCommands.Add(executedCommand);
+
+        // Determine the result to return
+        var commandKey = $"{processSpec.ExecutablePath} {processSpec.Arguments ?? ""}".Trim();
+        var result = CommandResults.TryGetValue(commandKey, out var configuredResult) ? configuredResult : DefaultResult;
+
+        // Create a task that completes immediately with the configured result
+        var resultTask = Task.FromResult(result);
+
+        // Create a no-op disposable
+        var disposable = new NoOpAsyncDisposable();
+
+        return (resultTask, disposable);
+    }
+
+    private sealed class NoOpAsyncDisposable : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Mock implementation of IResourceContainerImageBuilder for testing.
+/// </summary>
+internal sealed class MockImageBuilder : IResourceContainerImageBuilder
+{
+    public bool BuildImageCalled { get; private set; }
+    public bool BuildImagesCalled { get; private set; }
+    public List<ApplicationModel.IResource> BuildImageResources { get; } = [];
+    public List<ContainerBuildOptions?> BuildImageOptions { get; } = [];
+
+    public Task BuildImageAsync(ApplicationModel.IResource resource, ContainerBuildOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        BuildImageCalled = true;
+        BuildImageResources.Add(resource);
+        BuildImageOptions.Add(options);
+        return Task.CompletedTask;
+    }
+
+    public Task BuildImagesAsync(IEnumerable<ApplicationModel.IResource> resources, ContainerBuildOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        BuildImagesCalled = true;
+        BuildImageResources.AddRange(resources);
+        BuildImageOptions.Add(options);
+        return Task.CompletedTask;
+    }
 }


### PR DESCRIPTION
Contributes towards #10448.

This pull request introduces a new abstraction for running external processes in the Azure deployment workflow, improving testability and flexibility. The main change is the introduction of the `IProcessRunner` interface, which allows process execution logic to be easily mocked or replaced in tests. Several deployment methods are refactored to use this new abstraction, and the dependency injection setup is updated accordingly. Comprehensive tests are added to verify deployment scenarios involving containers and Azure resources.

**Process runner abstraction and dependency injection:**

* Added the `IProcessRunner` interface and its default implementation `DefaultProcessRunner` to abstract external process execution, replacing direct calls to `ProcessUtil.Run` in deployment logic. (`src/Aspire.Hosting.Azure/IProcessRunner.cs`)
* Refactored methods in `AzureDeployingContext` (`AuthenticateToAcr`, `PushImageToAcr`, `TagAndPushImage`, `RunDockerCommand`) to use the injected `IProcessRunner` instead of static `ProcessUtil.Run`, and updated the constructor to accept this new dependency. (`src/Aspire.Hosting.Azure/AzureDeployingContext.cs`) [[1]](diffhunk://#diff-e9212cb2aa4e32ec45592c1a281973b3c3529b644b7961d35ac65b67a2e3b3e0L25-R26) [[2]](diffhunk://#diff-e9212cb2aa4e32ec45592c1a281973b3c3529b644b7961d35ac65b67a2e3b3e0L287-R288) [[3]](diffhunk://#diff-e9212cb2aa4e32ec45592c1a281973b3c3529b644b7961d35ac65b67a2e3b3e0L300-R301) [[4]](diffhunk://#diff-e9212cb2aa4e32ec45592c1a281973b3c3529b644b7961d35ac65b67a2e3b3e0L333-R347)
* Updated dependency injection registration to use `TryAddSingleton` for all internal services, including the new `IProcessRunner`, improving testability and preventing duplicate registrations. (`src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerExtensions.cs`)

**Test improvements and scenarios:**

* Enhanced test setup to allow injection of mock implementations for `IProcessRunner`, `IBicepProvisioner`, and other dependencies, enabling verification of process execution during deployment. (`tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs`)
* Added new test cases to verify deployments with Azure Storage resources, container images, and project resources, asserting correct propagation of outputs and process execution behavior. (`tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs`)