### PR TITLE
Split up provisioning context between run-mode and publish-mode

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerExtensions.cs
@@ -46,7 +46,14 @@ public static class AzureProvisionerExtensions
         builder.Services.TryAddSingleton<IBicepCompiler, BicepCliCompiler>();
         builder.Services.TryAddSingleton<IUserSecretsManager, DefaultUserSecretsManager>();
         builder.Services.TryAddSingleton<IUserPrincipalProvider, DefaultUserPrincipalProvider>();
-        builder.Services.TryAddSingleton<IProvisioningContextProvider, DefaultProvisioningContextProvider>();
+        if (builder.ExecutionContext.IsPublishMode)
+        {
+            builder.Services.AddSingleton<IProvisioningContextProvider, PublishModeProvisioningContextProvider>();
+        }
+        else
+        {
+            builder.Services.AddSingleton<IProvisioningContextProvider, RunModeProvisioningContextProvider>();
+        }
         builder.Services.TryAddSingleton<IProcessRunner, DefaultProcessRunner>();
 
         return builder;

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/BaseProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/BaseProvisioningContextProvider.cs
@@ -3,10 +3,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
-using Aspire.Hosting.Azure.Resources;
 using Aspire.Hosting.Publishing;
 using Azure;
 using Azure.Core;
@@ -47,7 +45,7 @@ internal abstract partial class BaseProvisioningContextProvider(
 
     protected readonly TaskCompletionSource _provisioningOptionsAvailable = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    protected virtual void EnsureProvisioningOptions(JsonObject userSecrets)
+    protected void EnsureProvisioningOptions(JsonObject userSecrets)
     {
         if (!_interactionService.IsAvailable ||
             (!string.IsNullOrEmpty(_options.Location) && !string.IsNullOrEmpty(_options.SubscriptionId)))
@@ -75,86 +73,7 @@ internal abstract partial class BaseProvisioningContextProvider(
         });
     }
 
-    protected virtual async Task RetrieveAzureProvisioningOptions(JsonObject userSecrets, CancellationToken cancellationToken = default)
-    {
-        var locations = typeof(AzureLocation).GetProperties(BindingFlags.Public | BindingFlags.Static)
-                            .Where(p => p.PropertyType == typeof(AzureLocation))
-                            .Select(p => (AzureLocation)p.GetValue(null)!)
-                            .Select(location => KeyValuePair.Create(location.Name, location.DisplayName ?? location.Name))
-                            .OrderBy(kvp => kvp.Value)
-                            .ToList();
-
-        while (_options.Location == null || _options.SubscriptionId == null)
-        {
-            var messageBarResult = await _interactionService.PromptNotificationAsync(
-                 AzureProvisioningStrings.NotificationTitle,
-                 AzureProvisioningStrings.NotificationMessage,
-                 new NotificationInteractionOptions
-                 {
-                     Intent = MessageIntent.Warning,
-                     PrimaryButtonText = AzureProvisioningStrings.NotificationPrimaryButtonText
-                 },
-                 cancellationToken)
-                 .ConfigureAwait(false);
-
-            if (messageBarResult.Canceled)
-            {
-                // User canceled the prompt, so we exit the loop
-                _provisioningOptionsAvailable.SetException(new MissingConfigurationException("Azure provisioning options were not provided."));
-                return;
-            }
-
-            if (messageBarResult.Data)
-            {
-                var result = await _interactionService.PromptInputsAsync(
-                    AzureProvisioningStrings.InputsTitle,
-                    AzureProvisioningStrings.InputsMessage,
-                    [
-                        new InteractionInput { Name = LocationName, InputType = InputType.Choice, Label = AzureProvisioningStrings.LocationLabel, Placeholder = AzureProvisioningStrings.LocationPlaceholder, Required = true, Options = [..locations] },
-                        new InteractionInput { Name = SubscriptionIdName, InputType = InputType.SecretText, Label = AzureProvisioningStrings.SubscriptionIdLabel, Placeholder = AzureProvisioningStrings.SubscriptionIdPlaceholder, Required = true },
-                        new InteractionInput { Name = ResourceGroupName, InputType = InputType.Text, Label = AzureProvisioningStrings.ResourceGroupLabel, Value = GetDefaultResourceGroupName() },
-                    ],
-                    new InputsDialogInteractionOptions
-                    {
-                        EnableMessageMarkdown = true,
-                        ValidationCallback = static (validationContext) =>
-                        {
-                            var subscriptionInput = validationContext.Inputs[SubscriptionIdName];
-                            if (!Guid.TryParse(subscriptionInput.Value, out var _))
-                            {
-                                validationContext.AddValidationError(subscriptionInput, AzureProvisioningStrings.ValidationSubscriptionIdInvalid);
-                            }
-
-                            var resourceGroupInput = validationContext.Inputs[ResourceGroupName];
-                            if (!IsValidResourceGroupName(resourceGroupInput.Value))
-                            {
-                                validationContext.AddValidationError(resourceGroupInput, AzureProvisioningStrings.ValidationResourceGroupNameInvalid);
-                            }
-
-                            return Task.CompletedTask;
-                        }
-                    },
-                    cancellationToken).ConfigureAwait(false);
-
-                if (!result.Canceled)
-                {
-                    _options.Location = result.Data[LocationName].Value;
-                    _options.SubscriptionId = result.Data[SubscriptionIdName].Value;
-                    _options.ResourceGroup = result.Data[ResourceGroupName].Value;
-                    _options.AllowResourceGroupCreation = true; // Allow the creation of the resource group if it does not exist.
-
-                    var azureSection = userSecrets.Prop("Azure");
-
-                    // Persist the parameter value to user secrets so they can be reused in the future
-                    azureSection["Location"] = _options.Location;
-                    azureSection["SubscriptionId"] = _options.SubscriptionId;
-                    azureSection["ResourceGroup"] = _options.ResourceGroup;
-
-                    _provisioningOptionsAvailable.SetResult();
-                }
-            }
-        }
-    }
+    protected abstract Task RetrieveAzureProvisioningOptions(JsonObject userSecrets, CancellationToken cancellationToken = default);
 
     [GeneratedRegex(@"^[a-zA-Z0-9_\-\.\(\)]+$")]
     private static partial Regex ResourceGroupValidCharacters();

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
@@ -20,6 +20,11 @@ internal interface IArmClientProvider
     /// Gets the ARM client for Azure resource management.
     /// </summary>
     IArmClient GetArmClient(TokenCredential credential, string subscriptionId);
+
+    /// <summary>
+    /// Gets the ARM client for Azure resource management without a specific subscription.
+    /// </summary>
+    IArmClient GetArmClient(TokenCredential credential);
 }
 
 /// <summary>
@@ -80,6 +85,16 @@ internal interface IArmClient
     /// Gets the default subscription and its matching tenant.
     /// </summary>
     Task<(ISubscriptionResource subscription, ITenantResource tenant)> GetSubscriptionAndTenantAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all subscriptions accessible to the current user.
+    /// </summary>
+    Task<IEnumerable<ISubscriptionResource>> GetAvailableSubscriptionsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all available locations for the specified subscription.
+    /// </summary>
+    Task<IEnumerable<(string Name, string DisplayName)>> GetAvailableLocationsAsync(string subscriptionId, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -60,7 +60,22 @@ internal sealed class PublishModeProvisioningContextProvider(
         return $"{prefix}-{normalizedApplicationName}";
     }
 
-    protected override async Task RetrieveAzureProvisioningOptions(JsonObject userSecrets, CancellationToken cancellationToken = default)
+    public override async Task<ProvisioningContext> CreateProvisioningContextAsync(JsonObject userSecrets, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await RetrieveAzureProvisioningOptions(cancellationToken).ConfigureAwait(false);
+            _logger.LogDebug("Azure provisioning options have been handled successfully.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve Azure provisioning options.");
+        }
+
+        return await base.CreateProvisioningContextAsync(userSecrets, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task RetrieveAzureProvisioningOptions(CancellationToken cancellationToken = default)
     {
         while (_options.Location == null || _options.SubscriptionId == null)
         {
@@ -81,8 +96,6 @@ internal sealed class PublishModeProvisioningContextProvider(
                     continue;
                 }
             }
-
-            _provisioningOptionsAvailable.SetResult();
         }
     }
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -1,0 +1,280 @@
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using Aspire.Hosting.Azure.Resources;
+using Aspire.Hosting.Azure.Utils;
+using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Azure.Provisioning.Internal;
+
+/// <summary>
+/// Publish mode implementation of <see cref="IProvisioningContextProvider"/>.
+/// Uses enhanced prompting logic with dynamic subscription and location fetching.
+/// </summary>
+internal sealed class PublishModeProvisioningContextProvider(
+    IInteractionService interactionService,
+    IOptions<AzureProvisionerOptions> options,
+    IHostEnvironment environment,
+    ILogger<PublishModeProvisioningContextProvider> logger,
+    IArmClientProvider armClientProvider,
+    IUserPrincipalProvider userPrincipalProvider,
+    ITokenCredentialProvider tokenCredentialProvider,
+    DistributedApplicationExecutionContext distributedApplicationExecutionContext,
+    IOptions<PublishingOptions> publishingOptions) : BaseProvisioningContextProvider(
+        interactionService,
+        options,
+        environment,
+        logger,
+        armClientProvider,
+        userPrincipalProvider,
+        tokenCredentialProvider,
+        distributedApplicationExecutionContext,
+        publishingOptions)
+{
+    protected override string GetDefaultResourceGroupName()
+    {
+        var prefix = "rg-aspire";
+
+        if (!string.IsNullOrWhiteSpace(_options.ResourceGroupPrefix))
+        {
+            prefix = _options.ResourceGroupPrefix;
+        }
+
+        var maxApplicationNameSize = ResourceGroupNameHelpers.MaxResourceGroupNameLength - prefix.Length - 1; // extra '-'
+
+        var normalizedApplicationName = ResourceGroupNameHelpers.NormalizeResourceGroupName(_environment.ApplicationName.ToLowerInvariant());
+        if (normalizedApplicationName.Length > maxApplicationNameSize)
+        {
+            normalizedApplicationName = normalizedApplicationName[..maxApplicationNameSize];
+        }
+
+        // Publish mode doesn't include random suffix for consistency
+        return $"{prefix}-{normalizedApplicationName}";
+    }
+
+    protected override async Task RetrieveAzureProvisioningOptions(JsonObject userSecrets, CancellationToken cancellationToken = default)
+    {
+        while (_options.Location == null || _options.SubscriptionId == null)
+        {
+            if (_options.SubscriptionId == null)
+            {
+                await PromptForSubscriptionAsync(cancellationToken).ConfigureAwait(false);
+                if (_options.SubscriptionId == null)
+                {
+                    continue;
+                }
+            }
+
+            if (_options.Location == null)
+            {
+                await PromptForLocationAndResourceGroupAsync(cancellationToken).ConfigureAwait(false);
+                if (_options.Location == null)
+                {
+                    continue;
+                }
+            }
+
+            _provisioningOptionsAvailable.SetResult();
+        }
+    }
+
+    private async Task PromptForSubscriptionAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Try to enumerate available subscriptions using Azure APIs
+            var credential = _tokenCredentialProvider.TokenCredential;
+            var armClient = _armClientProvider.GetArmClient(credential);
+            var availableSubscriptions = await armClient.GetAvailableSubscriptionsAsync(cancellationToken).ConfigureAwait(false);
+            var subscriptionList = availableSubscriptions.ToList();
+
+            if (subscriptionList.Count > 0)
+            {
+                // Present subscriptions as a choice list
+                var subscriptionOptions = subscriptionList
+                    .Select(sub => KeyValuePair.Create(sub.Id.SubscriptionId ?? "", $"{sub.DisplayName ?? sub.Id.SubscriptionId} ({sub.Id.SubscriptionId})"))
+                    .OrderBy(kvp => kvp.Value)
+                    .ToList();
+
+                var result = await _interactionService.PromptInputsAsync(
+                    "Azure subscription",
+                    "Select your Azure subscription:",
+                    [
+                        new InteractionInput
+                        {
+                            Name = SubscriptionIdName,
+                            InputType = InputType.Choice,
+                            Label = AzureProvisioningStrings.SubscriptionIdLabel,
+                            Required = true,
+                            Options = [..subscriptionOptions]
+                        }
+                    ],
+                    new InputsDialogInteractionOptions
+                    {
+                        EnableMessageMarkdown = true
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (!result.Canceled)
+                {
+                    _options.SubscriptionId = result.Data[SubscriptionIdName].Value;
+                }
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to enumerate available subscriptions. Falling back to manual input.");
+        }
+
+        // Fallback to manual subscription entry
+        var manualResult = await _interactionService.PromptInputsAsync(
+            "Azure subscription",
+            "Enter your Azure subscription ID:",
+            [
+                new InteractionInput
+                {
+                    Name = SubscriptionIdName,
+                    InputType = InputType.SecretText,
+                    Label = AzureProvisioningStrings.SubscriptionIdLabel,
+                    Placeholder = AzureProvisioningStrings.SubscriptionIdPlaceholder,
+                    Required = true
+                }
+            ],
+            new InputsDialogInteractionOptions
+            {
+                EnableMessageMarkdown = true,
+                ValidationCallback = static (validationContext) =>
+                {
+                    var subscriptionInput = validationContext.Inputs[SubscriptionIdName];
+                    if (!Guid.TryParse(subscriptionInput.Value, out var _))
+                    {
+                        validationContext.AddValidationError(subscriptionInput, AzureProvisioningStrings.ValidationSubscriptionIdInvalid);
+                    }
+                    return Task.CompletedTask;
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!manualResult.Canceled)
+        {
+            _options.SubscriptionId = manualResult.Data[SubscriptionIdName].Value;
+        }
+    }
+
+    private async Task PromptForLocationAndResourceGroupAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Try to enumerate available locations using Azure APIs
+            var credential = _tokenCredentialProvider.TokenCredential;
+            var armClient = _armClientProvider.GetArmClient(credential);
+            var availableLocations = await armClient.GetAvailableLocationsAsync(_options.SubscriptionId!, cancellationToken).ConfigureAwait(false);
+            var locationList = availableLocations.ToList();
+
+            if (locationList.Count > 0)
+            {
+                // Present locations as a choice list
+                var locationOptions = locationList
+                    .Select(loc => KeyValuePair.Create(loc.Name, loc.DisplayName))
+                    .ToList();
+
+                var result = await _interactionService.PromptInputsAsync(
+                    "Azure location and resource group",
+                    "Select your Azure location and specify resource group:",
+                    [
+                        new InteractionInput
+                        {
+                            Name = LocationName,
+                            InputType = InputType.Choice,
+                            Label = AzureProvisioningStrings.LocationLabel,
+                            Required = true,
+                            Options = [..locationOptions]
+                        },
+                        new InteractionInput
+                        {
+                            Name = ResourceGroupName,
+                            InputType = InputType.Text,
+                            Label = AzureProvisioningStrings.ResourceGroupLabel,
+                            Value = GetDefaultResourceGroupName()
+                        }
+                    ],
+                    new InputsDialogInteractionOptions
+                    {
+                        EnableMessageMarkdown = true,
+                        ValidationCallback = static (validationContext) =>
+                        {
+                            var resourceGroupInput = validationContext.Inputs[ResourceGroupName];
+                            if (!IsValidResourceGroupName(resourceGroupInput.Value))
+                            {
+                                validationContext.AddValidationError(resourceGroupInput, AzureProvisioningStrings.ValidationResourceGroupNameInvalid);
+                            }
+                            return Task.CompletedTask;
+                        }
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (!result.Canceled)
+                {
+                    _options.Location = result.Data[LocationName].Value;
+                    _options.ResourceGroup = result.Data[ResourceGroupName].Value;
+                    _options.AllowResourceGroupCreation = true;
+                }
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to enumerate available locations. Falling back to manual input.");
+        }
+
+        // Fallback to manual location entry
+        var manualResult = await _interactionService.PromptInputsAsync(
+            "Azure location and resource group",
+            "Enter your Azure location and specify resource group:",
+            [
+                new InteractionInput
+                {
+                    Name = LocationName,
+                    InputType = InputType.Text,
+                    Label = AzureProvisioningStrings.LocationLabel,
+                    Placeholder = AzureProvisioningStrings.LocationPlaceholder,
+                    Required = true
+                },
+                new InteractionInput
+                {
+                    Name = ResourceGroupName,
+                    InputType = InputType.Text,
+                    Label = AzureProvisioningStrings.ResourceGroupLabel,
+                    Value = GetDefaultResourceGroupName()
+                }
+            ],
+            new InputsDialogInteractionOptions
+            {
+                EnableMessageMarkdown = true,
+                ValidationCallback = static (validationContext) =>
+                {
+                    var resourceGroupInput = validationContext.Inputs[ResourceGroupName];
+                    if (!IsValidResourceGroupName(resourceGroupInput.Value))
+                    {
+                        validationContext.AddValidationError(resourceGroupInput, AzureProvisioningStrings.ValidationResourceGroupNameInvalid);
+                    }
+                    return Task.CompletedTask;
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!manualResult.Canceled)
+        {
+            _options.Location = manualResult.Data[LocationName].Value;
+            _options.ResourceGroup = manualResult.Data[ResourceGroupName].Value;
+            _options.AllowResourceGroupCreation = true;
+        }
+    }
+}

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -105,8 +105,8 @@ internal sealed class PublishModeProvisioningContextProvider(
                     .ToList();
 
                 var result = await _interactionService.PromptInputsAsync(
-                    "Azure subscription",
-                    "Select your Azure subscription:",
+                    AzureProvisioningStrings.SubscriptionDialogTitle,
+                    AzureProvisioningStrings.SubscriptionSelectionMessage,
                     [
                         new InteractionInput
                         {
@@ -137,8 +137,8 @@ internal sealed class PublishModeProvisioningContextProvider(
 
         // Fallback to manual subscription entry
         var manualResult = await _interactionService.PromptInputsAsync(
-            "Azure subscription",
-            "Enter your Azure subscription ID:",
+            AzureProvisioningStrings.SubscriptionDialogTitle,
+            AzureProvisioningStrings.SubscriptionManualEntryMessage,
             [
                 new InteractionInput
                 {
@@ -188,8 +188,8 @@ internal sealed class PublishModeProvisioningContextProvider(
                     .ToList();
 
                 var result = await _interactionService.PromptInputsAsync(
-                    "Azure location and resource group",
-                    "Select your Azure location and specify resource group:",
+                    AzureProvisioningStrings.LocationDialogTitle,
+                    AzureProvisioningStrings.LocationSelectionMessage,
                     [
                         new InteractionInput
                         {
@@ -245,8 +245,8 @@ internal sealed class PublishModeProvisioningContextProvider(
                             .ToList();
 
         var manualResult = await _interactionService.PromptInputsAsync(
-            "Azure location and resource group",
-            "Select your Azure location and specify resource group:",
+            AzureProvisioningStrings.LocationDialogTitle,
+            AzureProvisioningStrings.LocationSelectionMessage,
             [
                 new InteractionInput
                 {

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -1,0 +1,60 @@
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography;
+using Aspire.Hosting.Azure.Utils;
+using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Azure.Provisioning.Internal;
+
+/// <summary>
+/// Run mode implementation of <see cref="IProvisioningContextProvider"/>.
+/// </summary>
+internal sealed class RunModeProvisioningContextProvider(
+    IInteractionService interactionService,
+    IOptions<AzureProvisionerOptions> options,
+    IHostEnvironment environment,
+    ILogger<RunModeProvisioningContextProvider> logger,
+    IArmClientProvider armClientProvider,
+    IUserPrincipalProvider userPrincipalProvider,
+    ITokenCredentialProvider tokenCredentialProvider,
+    DistributedApplicationExecutionContext distributedApplicationExecutionContext,
+    IOptions<PublishingOptions> publishingOptions) : BaseProvisioningContextProvider(
+        interactionService,
+        options,
+        environment,
+        logger,
+        armClientProvider,
+        userPrincipalProvider,
+        tokenCredentialProvider,
+        distributedApplicationExecutionContext,
+        publishingOptions)
+{
+    protected override string GetDefaultResourceGroupName()
+    {
+        var prefix = "rg-aspire";
+
+        if (!string.IsNullOrWhiteSpace(_options.ResourceGroupPrefix))
+        {
+            prefix = _options.ResourceGroupPrefix;
+        }
+
+        var suffix = RandomNumberGenerator.GetHexString(8, lowercase: true);
+
+        var maxApplicationNameSize = ResourceGroupNameHelpers.MaxResourceGroupNameLength - prefix.Length - suffix.Length - 2; // extra '-'s
+
+        var normalizedApplicationName = ResourceGroupNameHelpers.NormalizeResourceGroupName(_environment.ApplicationName.ToLowerInvariant());
+        if (normalizedApplicationName.Length > maxApplicationNameSize)
+        {
+            normalizedApplicationName = normalizedApplicationName[..maxApplicationNameSize];
+        }
+
+        // Run mode always includes random suffix for uniqueness
+        return $"{prefix}-{normalizedApplicationName}-{suffix}";
+    }
+}

--- a/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.Designer.cs
+++ b/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.Designer.cs
@@ -169,5 +169,50 @@ namespace Aspire.Hosting.Azure.Resources {
                 return ResourceManager.GetString("ValidationSubscriptionIdInvalid", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Azure subscription.
+        /// </summary>
+        internal static string SubscriptionDialogTitle {
+            get {
+                return ResourceManager.GetString("SubscriptionDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select your Azure subscription:.
+        /// </summary>
+        internal static string SubscriptionSelectionMessage {
+            get {
+                return ResourceManager.GetString("SubscriptionSelectionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter your Azure subscription ID:.
+        /// </summary>
+        internal static string SubscriptionManualEntryMessage {
+            get {
+                return ResourceManager.GetString("SubscriptionManualEntryMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Azure location and resource group.
+        /// </summary>
+        internal static string LocationDialogTitle {
+            get {
+                return ResourceManager.GetString("LocationDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select your Azure location and specify resource group:.
+        /// </summary>
+        internal static string LocationSelectionMessage {
+            get {
+                return ResourceManager.GetString("LocationSelectionMessage", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.resx
+++ b/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.resx
@@ -156,4 +156,19 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
   <data name="ValidationResourceGroupNameInvalid" xml:space="preserve">
     <value>Resource group name must be a valid Azure resource group name.</value>
   </data>
+  <data name="SubscriptionDialogTitle" xml:space="preserve">
+    <value>Azure subscription</value>
+  </data>
+  <data name="SubscriptionSelectionMessage" xml:space="preserve">
+    <value>Select your Azure subscription:</value>
+  </data>
+  <data name="SubscriptionManualEntryMessage" xml:space="preserve">
+    <value>Enter your Azure subscription ID:</value>
+  </data>
+  <data name="LocationDialogTitle" xml:space="preserve">
+    <value>Azure location and resource group</value>
+  </data>
+  <data name="LocationSelectionMessage" xml:space="preserve">
+    <value>Select your Azure location and specify resource group:</value>
+  </data>
 </root>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.cs.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.cs.xlf
@@ -16,6 +16,11 @@ Zjistěte více v [dokumentaci k nasazení Azure](https://aka.ms/dotnet/aspire/a
         <target state="translated">Zřizování Azure</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">Umístění</target>
@@ -24,6 +29,11 @@ Zjistěte více v [dokumentaci k nasazení Azure](https://aka.ms/dotnet/aspire/a
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">Vybrat umístění</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ Zjistěte více v [dokumentaci k nasazení Azure](https://aka.ms/dotnet/aspire/a
         <target state="translated">Skupina prostředků</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">ID předplatného</target>
@@ -54,6 +69,16 @@ Zjistěte více v [dokumentaci k nasazení Azure](https://aka.ms/dotnet/aspire/a
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">Vybrat ID předplatného</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.de.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.de.xlf
@@ -16,6 +16,11 @@ Weitere Informationen finden Sie in der [Azure-Bereitstellungsdokumentation](htt
         <target state="translated">Azure-Bereitstellung</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">Standort</target>
@@ -24,6 +29,11 @@ Weitere Informationen finden Sie in der [Azure-Bereitstellungsdokumentation](htt
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">Standort auswählen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ Weitere Informationen finden Sie in der [Azure-Bereitstellungsdokumentation](htt
         <target state="translated">Ressourcengruppe</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">Abonnement-ID</target>
@@ -54,6 +69,16 @@ Weitere Informationen finden Sie in der [Azure-Bereitstellungsdokumentation](htt
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">Abonnement-ID auswählen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.es.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.es.xlf
@@ -16,6 +16,11 @@ Para más información, consulte la [documentación de aprovisionamiento de Azur
         <target state="translated">Aprovisionamiento de Azure</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">Ubicación</target>
@@ -24,6 +29,11 @@ Para más información, consulte la [documentación de aprovisionamiento de Azur
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">Seleccionar ubicación</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ Para más información, consulte la [documentación de aprovisionamiento de Azur
         <target state="translated">Grupo de recursos</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">Id. de suscripción</target>
@@ -54,6 +69,16 @@ Para más información, consulte la [documentación de aprovisionamiento de Azur
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">Seleccionar id. de suscripción</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.fr.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.fr.xlf
@@ -16,6 +16,11 @@ Pour en savoir plus, consultez la [documentation d’approvisionnement Azure](ht
         <target state="translated">Approvisionnement Azure</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">Emplacement</target>
@@ -24,6 +29,11 @@ Pour en savoir plus, consultez la [documentation d’approvisionnement Azure](ht
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">Sélectionner un emplacement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ Pour en savoir plus, consultez la [documentation d’approvisionnement Azure](ht
         <target state="translated">Groupe de ressources</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">ID de l'abonnement</target>
@@ -54,6 +69,16 @@ Pour en savoir plus, consultez la [documentation d’approvisionnement Azure](ht
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">Sélectionner l’ID d’abonnement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.it.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.it.xlf
@@ -16,6 +16,11 @@ Per altre informazioni, vedere la [documentazione sul provisioning di Azure](htt
         <target state="translated">Provisioning Azure</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">Posizione</target>
@@ -24,6 +29,11 @@ Per altre informazioni, vedere la [documentazione sul provisioning di Azure](htt
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">Seleziona posizione</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ Per altre informazioni, vedere la [documentazione sul provisioning di Azure](htt
         <target state="translated">Gruppo di risorse</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">ID sottoscrizione</target>
@@ -54,6 +69,16 @@ Per altre informazioni, vedere la [documentazione sul provisioning di Azure](htt
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">Selezionare l'ID sottoscrizione</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ja.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ja.xlf
@@ -16,6 +16,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">Azure のプロビジョニング</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">場所</target>
@@ -24,6 +29,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">場所を選択</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">リソース グループ</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">サブスクリプション ID</target>
@@ -54,6 +69,16 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">サブスクリプション ID を選択</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ko.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ko.xlf
@@ -16,6 +16,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">Azure 프로비전</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">위치</target>
@@ -24,6 +29,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">위치 선택</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">리소스 그룹</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">구독 ID</target>
@@ -54,6 +69,16 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">구독 ID 선택</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pl.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pl.xlf
@@ -16,6 +16,11 @@ Aby dowiedzieć się więcej, zobacz [dokumentację aprowizacji platformy Azure]
         <target state="translated">Aprowizowanie platformy Azure</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">Lokalizacja</target>
@@ -24,6 +29,11 @@ Aby dowiedzieć się więcej, zobacz [dokumentację aprowizacji platformy Azure]
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">Wybierz lokalizację</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ Aby dowiedzieć się więcej, zobacz [dokumentację aprowizacji platformy Azure]
         <target state="translated">Grupa zasobów</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">Identyfikator subskrypcji</target>
@@ -54,6 +69,16 @@ Aby dowiedzieć się więcej, zobacz [dokumentację aprowizacji platformy Azure]
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">Wybierz identyfikator subskrypcji</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pt-BR.xlf
@@ -16,6 +16,11 @@ Para saber mais, veja a [documentação de provisionamento do Azure](https://aka
         <target state="translated">Provisionamento do Azure</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">Localização</target>
@@ -24,6 +29,11 @@ Para saber mais, veja a [documentação de provisionamento do Azure](https://aka
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">Selecionar o local</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ Para saber mais, veja a [documentação de provisionamento do Azure](https://aka
         <target state="translated">Grupo de recursos</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">ID da Assinatura</target>
@@ -54,6 +69,16 @@ Para saber mais, veja a [documentação de provisionamento do Azure](https://aka
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">Selecionar a ID da assinatura</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ru.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ru.xlf
@@ -16,6 +16,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">Подготовка Azure</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">Расположение</target>
@@ -24,6 +29,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">Выберите расположение</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">Группа ресурсов</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">ИД подписки</target>
@@ -54,6 +69,16 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">Выберите ИД подписки</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.tr.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.tr.xlf
@@ -16,6 +16,11 @@ Daha fazla bilgi için [Azure sağlama belgelerine](https://aka.ms/dotnet/aspire
         <target state="translated">Azure sağlama</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">Konum</target>
@@ -24,6 +29,11 @@ Daha fazla bilgi için [Azure sağlama belgelerine](https://aka.ms/dotnet/aspire
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">Konum seçin</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ Daha fazla bilgi için [Azure sağlama belgelerine](https://aka.ms/dotnet/aspire
         <target state="translated">Kaynak grubu</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">Abonelik Kimliği</target>
@@ -54,6 +69,16 @@ Daha fazla bilgi için [Azure sağlama belgelerine](https://aka.ms/dotnet/aspire
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">Abonelik kimliği seçin</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hans.xlf
@@ -16,6 +16,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">Azure 预配</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">位置</target>
@@ -24,6 +29,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">选择位置</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">资源组</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">订阅 ID</target>
@@ -54,6 +69,16 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">选择订阅 ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hant.xlf
@@ -16,6 +16,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">Azure 佈建</target>
         <note />
       </trans-unit>
+      <trans-unit id="LocationDialogTitle">
+        <source>Azure location and resource group</source>
+        <target state="new">Azure location and resource group</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LocationLabel">
         <source>Location</source>
         <target state="translated">位置</target>
@@ -24,6 +29,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="LocationPlaceholder">
         <source>Select location</source>
         <target state="translated">選取位置</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocationSelectionMessage">
+        <source>Select your Azure location and specify resource group:</source>
+        <target state="new">Select your Azure location and specify resource group:</target>
         <note />
       </trans-unit>
       <trans-unit id="NotificationMessage">
@@ -46,6 +56,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">資源群組</target>
         <note />
       </trans-unit>
+      <trans-unit id="SubscriptionDialogTitle">
+        <source>Azure subscription</source>
+        <target state="new">Azure subscription</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SubscriptionIdLabel">
         <source>Subscription ID</source>
         <target state="translated">訂用帳戶識別碼</target>
@@ -54,6 +69,16 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="SubscriptionIdPlaceholder">
         <source>Select subscription ID</source>
         <target state="translated">選取訂用帳戶識別碼</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionManualEntryMessage">
+        <source>Enter your Azure subscription ID:</source>
+        <target state="new">Enter your Azure subscription ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubscriptionSelectionMessage">
+        <source>Select your Azure subscription:</source>
+        <target state="new">Select your Azure subscription:</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -33,10 +33,6 @@ public class AzureDeployerTests(ITestOutputHelper output)
 
         var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
 
-        // Add a container that will use the container app environment
-        builder.AddContainer("api", "my-api-image:latest")
-            .WithHttpEndpoint();
-
         // Act
         using var app = builder.Build();
         app.Run();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -65,7 +65,7 @@ public class AzureDeployerTests(ITestOutputHelper output)
         // Wait for the first interaction (subscription selection)
         var subscriptionInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
         Assert.Equal("Azure subscription", subscriptionInteraction.Title);
-        Assert.True(subscriptionInteraction.Options!.EnableMessageMarkdown);
+        Assert.False(subscriptionInteraction.Options!.EnableMessageMarkdown);
 
         // Verify the expected input for subscription selection (fallback to manual entry)
         Assert.Collection(subscriptionInteraction.Inputs,
@@ -83,7 +83,7 @@ public class AzureDeployerTests(ITestOutputHelper output)
         // Wait for the second interaction (location and resource group selection)
         var locationInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
         Assert.Equal("Azure location and resource group", locationInteraction.Title);
-        Assert.True(locationInteraction.Options!.EnableMessageMarkdown);
+        Assert.False(locationInteraction.Options!.EnableMessageMarkdown);
 
         // Verify the expected inputs for location and resource group (fallback to manual entry)
         Assert.Collection(locationInteraction.Inputs,

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Azure.Tests;
 
-public class DefaultProvisioningContextProviderTests
+public class ProvisioningContextProviderTests
 {
     private readonly TestInteractionService _defaultInteractionService = new() { IsAvailable = false };
 
@@ -28,7 +28,7 @@ public class DefaultProvisioningContextProviderTests
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
         var userSecrets = new JsonObject();
 
-        var provider = new DefaultProvisioningContextProvider(
+        var provider = new RunModeProvisioningContextProvider(
             _defaultInteractionService,
             options,
             environment,
@@ -68,7 +68,7 @@ public class DefaultProvisioningContextProviderTests
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
         var userSecrets = new JsonObject();
 
-        var provider = new DefaultProvisioningContextProvider(
+        var provider = new RunModeProvisioningContextProvider(
             _defaultInteractionService,
             options,
             environment,
@@ -98,7 +98,7 @@ public class DefaultProvisioningContextProviderTests
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
         var userSecrets = new JsonObject();
 
-        var provider = new DefaultProvisioningContextProvider(
+        var provider = new RunModeProvisioningContextProvider(
             new TestInteractionService() { IsAvailable = false },
             options,
             environment,
@@ -128,7 +128,7 @@ public class DefaultProvisioningContextProviderTests
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
         var userSecrets = new JsonObject();
 
-        var provider = new DefaultProvisioningContextProvider(
+        var provider = new RunModeProvisioningContextProvider(
             _defaultInteractionService,
             options,
             environment,
@@ -166,7 +166,7 @@ public class DefaultProvisioningContextProviderTests
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
         var userSecrets = new JsonObject();
 
-        var provider = new DefaultProvisioningContextProvider(
+        var provider = new RunModeProvisioningContextProvider(
             _defaultInteractionService,
             options,
             environment,
@@ -198,7 +198,7 @@ public class DefaultProvisioningContextProviderTests
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
         var userSecrets = new JsonObject();
 
-        var provider = new DefaultProvisioningContextProvider(
+        var provider = new RunModeProvisioningContextProvider(
             _defaultInteractionService,
             options,
             environment,
@@ -231,7 +231,7 @@ public class DefaultProvisioningContextProviderTests
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
         var userSecrets = new JsonObject();
 
-        var provider = new DefaultProvisioningContextProvider(
+        var provider = new RunModeProvisioningContextProvider(
             _defaultInteractionService,
             options,
             environment,
@@ -265,7 +265,7 @@ public class DefaultProvisioningContextProviderTests
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
         var userSecrets = new JsonObject();
 
-        var provider = new DefaultProvisioningContextProvider(
+        var provider = new RunModeProvisioningContextProvider(
             testInteractionService,
             options,
             environment,
@@ -293,29 +293,29 @@ public class DefaultProvisioningContextProviderTests
         Assert.Collection(inputsInteraction.Inputs,
             input =>
             {
-                Assert.Equal(DefaultProvisioningContextProvider.LocationName, input.Name);
+                Assert.Equal(BaseProvisioningContextProvider.LocationName, input.Name);
                 Assert.Equal("Location", input.Label);
                 Assert.Equal(InputType.Choice, input.InputType);
                 Assert.True(input.Required);
             },
             input =>
             {
-                Assert.Equal(DefaultProvisioningContextProvider.SubscriptionIdName, input.Name);
+                Assert.Equal(BaseProvisioningContextProvider.SubscriptionIdName, input.Name);
                 Assert.Equal("Subscription ID", input.Label);
                 Assert.Equal(InputType.SecretText, input.InputType);
                 Assert.True(input.Required);
             },
             input =>
             {
-                Assert.Equal(DefaultProvisioningContextProvider.ResourceGroupName, input.Name);
+                Assert.Equal(BaseProvisioningContextProvider.ResourceGroupName, input.Name);
                 Assert.Equal("Resource group", input.Label);
                 Assert.Equal(InputType.Text, input.InputType);
                 Assert.False(input.Required);
             });
 
-        inputsInteraction.Inputs[DefaultProvisioningContextProvider.LocationName].Value = inputsInteraction.Inputs[0].Options!.First(kvp => kvp.Key == "westus").Value;
-        inputsInteraction.Inputs[DefaultProvisioningContextProvider.SubscriptionIdName].Value = "12345678-1234-1234-1234-123456789012";
-        inputsInteraction.Inputs[DefaultProvisioningContextProvider.ResourceGroupName].Value = "rg-myrg";
+        inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].Value = inputsInteraction.Inputs[0].Options!.First(kvp => kvp.Key == "westus").Value;
+        inputsInteraction.Inputs[BaseProvisioningContextProvider.SubscriptionIdName].Value = "12345678-1234-1234-1234-123456789012";
+        inputsInteraction.Inputs[BaseProvisioningContextProvider.ResourceGroupName].Value = "rg-myrg";
 
         inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
 
@@ -344,7 +344,7 @@ public class DefaultProvisioningContextProviderTests
         var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
         var userSecrets = new JsonObject();
 
-        var provider = new DefaultProvisioningContextProvider(
+        var provider = new RunModeProvisioningContextProvider(
             testInteractionService,
             options,
             environment,
@@ -364,9 +364,9 @@ public class DefaultProvisioningContextProviderTests
 
         // Wait for the inputs interaction
         var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        inputsInteraction.Inputs[DefaultProvisioningContextProvider.LocationName].Value = inputsInteraction.Inputs[0].Options!.First(kvp => kvp.Key == "westus").Value;
-        inputsInteraction.Inputs[DefaultProvisioningContextProvider.SubscriptionIdName].Value = "not a guid";
-        inputsInteraction.Inputs[DefaultProvisioningContextProvider.ResourceGroupName].Value = "invalid group";
+        inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].Value = inputsInteraction.Inputs[0].Options!.First(kvp => kvp.Key == "westus").Value;
+        inputsInteraction.Inputs[BaseProvisioningContextProvider.SubscriptionIdName].Value = "not a guid";
+        inputsInteraction.Inputs[BaseProvisioningContextProvider.ResourceGroupName].Value = "invalid group";
 
         var context = new InputsDialogValidationContext
         {
@@ -382,4 +382,43 @@ public class DefaultProvisioningContextProviderTests
         Assert.True((bool)context.GetType().GetProperty("HasErrors", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(context, null)!);
     }
 
+    [Fact]
+    public async Task PublishMode_CreateProvisioningContextAsync_ReturnsValidContext()
+    {
+        // Arrange
+        var options = ProvisioningTestHelpers.CreateOptions();
+        var publishingOptions = ProvisioningTestHelpers.CreatePublishingOptions();
+        var environment = ProvisioningTestHelpers.CreateEnvironment();
+        var logger = ProvisioningTestHelpers.CreateLogger<PublishModeProvisioningContextProvider>();
+        var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
+        var userPrincipalProvider = ProvisioningTestHelpers.CreateUserPrincipalProvider();
+        var tokenCredentialProvider = ProvisioningTestHelpers.CreateTokenCredentialProvider();
+        var userSecrets = new JsonObject();
+
+        var provider = new PublishModeProvisioningContextProvider(
+            _defaultInteractionService,
+            options,
+            environment,
+            logger,
+            armClientProvider,
+            userPrincipalProvider,
+            tokenCredentialProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
+            publishingOptions);
+
+        // Act
+        var context = await provider.CreateProvisioningContextAsync(userSecrets);
+
+        // Assert
+        Assert.NotNull(context);
+        Assert.NotNull(context.Credential);
+        Assert.NotNull(context.ArmClient);
+        Assert.NotNull(context.Subscription);
+        Assert.NotNull(context.ResourceGroup);
+        Assert.NotNull(context.Tenant);
+        Assert.NotNull(context.Location.DisplayName);
+        Assert.NotNull(context.Principal);
+        Assert.NotNull(context.UserSecrets);
+        Assert.Equal("westus2", context.Location.Name);
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
@@ -107,11 +107,19 @@ internal static class ProvisioningTestHelpers
     }
 
     /// <summary>
-    /// Creates a test logger for DefaultProvisioningContextProvider.
+    /// Creates a test logger for RunModeProvisioningContextProvider.
     /// </summary>
-    public static ILogger<DefaultProvisioningContextProvider> CreateLogger()
+    public static ILogger<RunModeProvisioningContextProvider> CreateLogger()
     {
-        return NullLogger<DefaultProvisioningContextProvider>.Instance;
+        return NullLogger<RunModeProvisioningContextProvider>.Instance;
+    }
+
+    /// <summary>
+    /// Creates a test logger for the specified type.
+    /// </summary>
+    public static ILogger<T> CreateLogger<T>() where T : class
+    {
+        return NullLogger<T>.Instance;
     }
 }
 
@@ -181,6 +189,26 @@ internal sealed class TestArmClient(Dictionary<string, object> deploymentOutputs
         var subscription = new TestSubscriptionResource(_deploymentOutputs);
         var tenant = new TestTenantResource();
         return Task.FromResult<(ISubscriptionResource, ITenantResource)>((subscription, tenant));
+    }
+
+    public Task<IEnumerable<ISubscriptionResource>> GetAvailableSubscriptionsAsync(CancellationToken cancellationToken = default)
+    {
+        var subscriptions = new List<ISubscriptionResource>
+        {
+            new TestSubscriptionResource()
+        };
+        return Task.FromResult<IEnumerable<ISubscriptionResource>>(subscriptions);
+    }
+
+    public Task<IEnumerable<(string Name, string DisplayName)>> GetAvailableLocationsAsync(string subscriptionId, CancellationToken cancellationToken = default)
+    {
+        var locations = new List<(string Name, string DisplayName)>
+        {
+            ("eastus", "East US"),
+            ("westus", "West US"),
+            ("westus2", "West US 2")
+        };
+        return Task.FromResult<IEnumerable<(string, string)>>(locations);
     }
 }
 
@@ -352,6 +380,11 @@ internal sealed class TestArmClientProvider(Dictionary<string, object> deploymen
     public IArmClient GetArmClient(TokenCredential credential, string subscriptionId)
     {
         return new TestArmClient(_deploymentOutputs);
+    }
+
+    public IArmClient GetArmClient(TokenCredential credential)
+    {
+        return new TestArmClient();
     }
 }
 


### PR DESCRIPTION
Contributes to #10448.

This pull request refactors the Azure provisioning context provider to better support different execution modes and improves the flexibility and testability of the provisioning code. It introduces a new base class for context providers, splits the implementation for publish and run modes, and enhances the ARM client interfaces to allow querying available subscriptions and locations.