### PR TITLE
Verify multi-compute environment deployment for Azure

### DIFF
--- a/playground/deployers/Deployers.AppHost/AppHost.cs
+++ b/playground/deployers/Deployers.AppHost/AppHost.cs
@@ -1,6 +1,9 @@
+#pragma warning disable ASPIRECOMPUTE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureContainerAppEnvironment("env");
+var aca = builder.AddAzureContainerAppEnvironment("aca-env");
+var aas = builder.AddAzureAppServiceEnvironment("aas-env");
 
 var storage = builder.AddAzureStorage("storage");
 
@@ -9,14 +12,17 @@ storage.AddBlobContainer("mycontainer1", blobContainerName: "test-container-1");
 storage.AddBlobContainer("mycontainer2", blobContainerName: "test-container-2");
 storage.AddQueue("myqueue", queueName: "my-queue");
 
-builder.AddRedis("cache");
+builder.AddRedis("cache")
+    .WithComputeEnvironment(aca);
 
 builder.AddProject<Projects.Deployers_ApiService>("api-service")
-    .WithExternalHttpEndpoints();
+    .WithExternalHttpEndpoints()
+    .WithComputeEnvironment(aas);
 
 builder.AddDockerfile("python-app", "../Deployers.Dockerfile")
     .WithHttpEndpoint(targetPort: 80)
-    .WithExternalHttpEndpoints();
+    .WithExternalHttpEndpoints()
+    .WithComputeEnvironment(aca);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/deployers/Deployers.AppHost/Deployers.AppHost.csproj
+++ b/playground/deployers/Deployers.AppHost/Deployers.AppHost.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.AppContainers" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.AppService" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Storage" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Redis" />

--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -116,7 +116,7 @@ internal sealed class AzureDeployingContext(
 
     private async Task<bool> TryDeployContainerImages(DistributedApplicationModel model, CancellationToken cancellationToken)
     {
-        var computeResources = model.GetComputeResources();
+        var computeResources = model.GetComputeResources().Where(r => r.RequiresImageBuildAndPush());
 
         if (!computeResources.Any())
         {
@@ -188,7 +188,7 @@ internal sealed class AzureDeployingContext(
         {
             try
             {
-                if (computeResource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var deploymentTarget))
+                if (computeResource.GetDeploymentTargetAnnotation() is { } deploymentTarget)
                 {
                     if (deploymentTarget.DeploymentTarget is AzureBicepResource bicepResource)
                     {
@@ -223,7 +223,7 @@ internal sealed class AzureDeployingContext(
 
     private static bool TryGetContainerRegistry(IResource computeResource, [NotNullWhen(true)] out IContainerRegistry? containerRegistry)
     {
-        if (computeResource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var deploymentTarget) &&
+        if (computeResource.GetDeploymentTargetAnnotation() is { } deploymentTarget &&
             deploymentTarget.ContainerRegistry is { } registry)
         {
             containerRegistry = registry;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -186,8 +186,8 @@ public class AzureDeployerTests(ITestOutputHelper output)
         Assert.Equal("test.westus.azurecontainerapps.io", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"]);
         Assert.Equal("/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"]);
 
-        // Assert - Verify ACR login command was called
-        Assert.Contains(mockProcessRunner.ExecutedCommands,
+        // Assert - Verify ACR login command was not called since no image was pushed
+        Assert.DoesNotContain(mockProcessRunner.ExecutedCommands,
             cmd => cmd.ExecutablePath.Contains("az") &&
                    cmd.Arguments == "acr login --name testregistry");
 
@@ -198,6 +198,57 @@ public class AzureDeployerTests(ITestOutputHelper output)
                    cmd.Arguments.StartsWith("tag api testregistry.azurecr.io/"));
 
         Assert.DoesNotContain(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath == "docker" &&
+                   cmd.Arguments != null &&
+                   cmd.Arguments.StartsWith("push testregistry.azurecr.io/"));
+    }
+
+    [Fact]
+    public async Task DeployAsync_WithDockerfile_Works()
+    {
+        // Arrange
+        var mockProcessRunner = new MockProcessRunner();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
+        var deploymentOutputs = new Dictionary<string, object>
+        {
+            ["env_AZURE_CONTAINER_REGISTRY_NAME"] = new { type = "String", value = "testregistry" },
+            ["env_AZURE_CONTAINER_REGISTRY_ENDPOINT"] = new { type = "String", value = "testregistry.azurecr.io" },
+            ["env_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity" },
+            ["env_AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "test.westus.azurecontainerapps.io" },
+            ["env_AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv" }
+        };
+        var armClientProvider = new TestArmClientProvider(deploymentOutputs);
+        ConfigureTestServices(builder, armClientProvider: armClientProvider, processRunner: mockProcessRunner);
+
+        var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
+        var azureEnv = builder.AddAzureEnvironment();
+        builder.AddDockerfile("api", "api.Dockerfile");
+
+        // Act
+        using var app = builder.Build();
+        await app.StartAsync();
+        await app.WaitForShutdownAsync();
+
+        // Assert that container environment outputs are propagated to outputs because they are
+        // hoisted up for the container resource
+        Assert.Equal("testregistry", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_NAME"]);
+        Assert.Equal("testregistry.azurecr.io", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_ENDPOINT"]);
+        Assert.Equal("/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"]);
+        Assert.Equal("test.westus.azurecontainerapps.io", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"]);
+        Assert.Equal("/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"]);
+
+        // Assert - Verify ACR login command was called since Dockerfile image needs to be pushed
+        Assert.Contains(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath.Contains("az") &&
+                   cmd.Arguments == "acr login --name testregistry");
+
+        // Assert - Verify Docker tag and push called for Dockerfile
+        Assert.Contains(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath == "docker" &&
+                   cmd.Arguments != null &&
+                   cmd.Arguments.StartsWith("tag api testregistry.azurecr.io/"));
+
+        Assert.Contains(mockProcessRunner.ExecutedCommands,
             cmd => cmd.ExecutablePath == "docker" &&
                    cmd.Arguments != null &&
                    cmd.Arguments.StartsWith("push testregistry.azurecr.io/"));
@@ -252,6 +303,95 @@ public class AzureDeployerTests(ITestOutputHelper output)
             cmd => cmd.ExecutablePath == "docker" &&
                    cmd.Arguments != null &&
                    cmd.Arguments.StartsWith("push testregistry.azurecr.io/"));
+    }
+
+    [Fact]
+    public async Task DeployAsync_WithMultipleComputeEnvironments_Works()
+    {
+        // Arrange
+        var mockProcessRunner = new MockProcessRunner();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
+        var deploymentOutputs = new Dictionary<string, object>
+        {
+            ["aca_env_AZURE_CONTAINER_REGISTRY_NAME"] = new { type = "String", value = "acaregistry" },
+            ["aca_env_AZURE_CONTAINER_REGISTRY_ENDPOINT"] = new { type = "String", value = "acaregistry.azurecr.io" },
+            ["aca_env_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aca-identity" },
+            ["aca_env_AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "aca.westus.azurecontainerapps.io" },
+            ["aca_env_AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/acaenv" },
+            ["aas_env_AZURE_CONTAINER_REGISTRY_NAME"] = new { type = "String", value = "aasregistry" },
+            ["aas_env_AZURE_CONTAINER_REGISTRY_ENDPOINT"] = new { type = "String", value = "aasregistry.azurecr.io" },
+            ["aas_env_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aas-identity" },
+            ["aas_env_planId"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.Web/serverfarms/aasplan" },
+            ["aas_env_AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID"] = new { type = "String", value = "aas-client-id" }
+        };
+        var armClientProvider = new TestArmClientProvider(deploymentOutputs);
+        ConfigureTestServices(builder, armClientProvider: armClientProvider, processRunner: mockProcessRunner);
+
+        var acaEnv = builder.AddAzureContainerAppEnvironment("aca-env");
+        var aasEnv = builder.AddAzureAppServiceEnvironment("aas-env");
+        var azureEnv = builder.AddAzureEnvironment();
+
+        var storage = builder.AddAzureStorage("storage");
+        storage.AddBlobContainer("mycontainer1", blobContainerName: "test-container-1");
+        storage.AddBlobContainer("mycontainer2", blobContainerName: "test-container-2");
+        storage.AddQueue("myqueue", queueName: "my-queue");
+
+        builder.AddRedis("cache").WithComputeEnvironment(acaEnv);
+        builder.AddProject<Project>("api-service", launchProfileName: null).WithComputeEnvironment(aasEnv);
+        builder.AddDockerfile("python-app", "python-app.Dockerfile").WithComputeEnvironment(acaEnv);
+
+        // Act
+        using var app = builder.Build();
+        await app.StartAsync();
+        await app.WaitForShutdownAsync();
+
+        // Assert ACA environment outputs are properly set
+        Assert.Equal("acaregistry", acaEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_NAME"]);
+        Assert.Equal("acaregistry.azurecr.io", acaEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_ENDPOINT"]);
+        Assert.Equal("/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aca-identity", acaEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"]);
+        Assert.Equal("aca.westus.azurecontainerapps.io", acaEnv.Resource.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"]);
+        Assert.Equal("/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/acaenv", acaEnv.Resource.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"]);
+
+        // Assert AAS environment outputs are properly set
+        Assert.Equal("aasregistry", aasEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_NAME"]);
+        Assert.Equal("aasregistry.azurecr.io", aasEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_ENDPOINT"]);
+        Assert.Equal("/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aas-identity", aasEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"]);
+        Assert.Equal("/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.Web/serverfarms/aasplan", aasEnv.Resource.Outputs["planId"]);
+        Assert.Equal("aas-client-id", aasEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID"]);
+
+        // Assert ACR login commands were called for both registries
+        Assert.Contains(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath.Contains("az") &&
+                   cmd.Arguments == "acr login --name acaregistry");
+        Assert.Contains(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath.Contains("az") &&
+                   cmd.Arguments == "acr login --name aasregistry");
+
+        // Assert Docker operations for project resource deployed to AAS environment
+        Assert.Contains(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath == "docker" &&
+                   cmd.Arguments != null &&
+                   cmd.Arguments.StartsWith("tag api-service aasregistry.azurecr.io/"));
+        Assert.Contains(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath == "docker" &&
+                   cmd.Arguments != null &&
+                   cmd.Arguments.StartsWith("push aasregistry.azurecr.io/"));
+
+        // Assert Docker operations NOT performed for existing container image deployed to ACA environment
+        Assert.DoesNotContain(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath == "docker" &&
+                   cmd.Arguments != null &&
+                   cmd.Arguments.StartsWith("tag cache acaregistry.azurecr.io/"));
+
+        // Assert Docker operations for project resource deployed to ACA environment
+        Assert.Contains(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath == "docker" &&
+                   cmd.Arguments != null &&
+                   cmd.Arguments.StartsWith("tag python-app acaregistry.azurecr.io/"));
+        Assert.Contains(mockProcessRunner.ExecutedCommands,
+            cmd => cmd.ExecutablePath == "docker" &&
+                   cmd.Arguments != null &&
+                   cmd.Arguments.StartsWith("push acaregistry.azurecr.io/"));
     }
 
     private static void ConfigureTestServices(IDistributedApplicationTestingBuilder builder,


### PR DESCRIPTION
Contributes to #10448.

Some tweaks to make sure that we are respecting `ComputeEnvironmentAnnotation`s when multiple compute environments are configured.

I haven't made any updates to support showing the endpoints App Service websites are deployed to. It seems like we can derive this based on the website name but we'll need to figure out how to flow that through. I'm starting to think that an interface for the compute domain isn't enough and we might want to model this as a "get endpoint"s step with references to either the ACA domain or the App Service website name.

![20250825_212258](https://github.com/user-attachments/assets/89e2266c-63ff-4bb8-91bc-6a70d8dc7188)
