### PR TITLE
Update dialog headers to h2 instead of h4

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -15,7 +15,7 @@
 
 <FluentDialogHeader ShowDismiss="@Dialog.Instance.Parameters.ShowDismiss">
     <FluentStack VerticalAlignment="VerticalAlignment.Center">
-        <FluentLabel Typo="Typography.PaneHeader">
+        <FluentLabel Typo="Typography.H2">
             @Dialog.Instance.Parameters.Title
         </FluentLabel>
     </FluentStack>

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -15,7 +15,7 @@
 
 <FluentDialogHeader ShowDismiss="@Dialog.Instance.Parameters.ShowDismiss">
     <FluentStack VerticalAlignment="VerticalAlignment.Center">
-        <FluentLabel Typo="Typography.H2">
+        <FluentLabel Typo="Typography.H2" Class="dialog-header">
             @Dialog.Instance.Parameters.Title
         </FluentLabel>
     </FluentStack>

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -9,7 +9,7 @@
 <FluentDialogHeader ShowDismiss="true">
     <div class="visualizer-title-grid">
         <FluentIcon Value="@(new Icons.Regular.Size24.SlideSearch())" Style="grid-area: dialog-icon; align-self: center;" />
-        <FluentLabel Typo="Typography.PaneHeader" Class="col-long-content" Style="grid-area: dialog-title;">
+        <FluentLabel Typo="Typography.H2" Class="col-long-content" Style="grid-area: dialog-title;">
             @Content.Description
         </FluentLabel>
 

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -9,7 +9,7 @@
 <FluentDialogHeader ShowDismiss="true">
     <div class="visualizer-title-grid">
         <FluentIcon Value="@(new Icons.Regular.Size24.SlideSearch())" Style="grid-area: dialog-icon; align-self: center;" />
-        <FluentLabel Typo="Typography.H2" Class="col-long-content" Style="grid-area: dialog-title;">
+        <FluentLabel Typo="Typography.H2" Class="col-long-content dialog-header" Style="grid-area: dialog-title;">
             @Content.Description
         </FluentLabel>
 

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -859,3 +859,8 @@ fluent-tooltip[anchor="dialog_close"] > div {
     font-size: var(--type-ramp-plus-2-font-size);
     font-weight: 500;
 }
+
+.dialog-header {
+    font-size: var(--type-ramp-plus-3-font-size);
+    line-height: var(--type-ramp-plus-3-line-height);
+}


### PR DESCRIPTION
## Description

PaneHeader seems like an appropriate typography for dialog headers, but it renders as an h4, which is too high of a heading number for the importance of the content. h2 is the appropriate level. No change in appearance

Before:
<img width="397" height="234" alt="image" src="https://github.com/user-attachments/assets/08478633-5229-4929-9c20-14b62d77b70c" />

After:
<img width="397" height="234" alt="image" src="https://github.com/user-attachments/assets/950bef1f-0259-4300-ace2-e11fca7095ce" />

Related: #10450 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
