### PR TITLE
Add unofficial pipeline

### DIFF
--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -1,0 +1,172 @@
+trigger: none
+
+pr: none
+
+variables:
+  - template: /eng/pipelines/common-variables.yml@self
+  - template: /eng/common/templates-official/variables/pool-providers.yml@self
+
+  - name: _BuildConfig
+    value: Release
+  - name: Build.Arcade.ArtifactsPath
+    value: $(Build.SourcesDirectory)/artifacts/
+  - name: Build.Arcade.LogsPath
+    value: $(Build.Arcade.ArtifactsPath)log/$(_BuildConfig)/
+  - name: Build.Arcade.TestResultsPath
+    value: $(Build.Arcade.ArtifactsPath)TestResults/$(_BuildConfig)/
+
+  # needed for darc (dependency flow) publishing
+  - name: _PublishArgs
+    value: >-
+          /p:DotNetPublishUsingPipelines=true
+  - name: _OfficialBuildIdArgs
+    value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+  # needed for signing
+  - name: _SignType
+    value: test
+  - name: _SignArgs
+    value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign) /p:DotNetPublishUsingPipelines=true
+  - name: _Sign
+    value: true
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    containers:
+      linux_x64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64
+        env:
+          SysRoot: /crossrootfs/x64
+          LinkerFlavor: lld
+      linux_arm64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm64
+        env:
+          SysRoot: /crossrootfs/arm64
+          LinkerFlavor: lld
+      linux_musl_x64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64-musl
+        env:
+          SysRoot: /crossrootfs/x64
+          LinkerFlavor: lld
+
+    stages:
+
+    - stage: build_sign_native
+      displayName: Build+Sign native packages
+
+      jobs:
+      - template: /eng/pipelines/templates/build_sign_native.yml@self
+        parameters:
+          agentOs: macos
+          targetRidsForSameOS:
+            - osx-arm64
+            - osx-x64
+          codeSign: true
+          teamName: $(_TeamName)
+          extraBuildArgs: >-
+            /p:Configuration=$(_BuildConfig)
+            $(_SignArgs)
+            $(_OfficialBuildIdArgs)
+
+      - template: /eng/pipelines/templates/build_sign_native.yml@self
+        parameters:
+          agentOs: linux
+          targetRidsForSameOS:
+            - linux-x64
+            - linux-arm64
+            - linux-musl-x64
+          # no need to sign ELF binaries on linux
+          codeSign: false
+          teamName: $(_TeamName)
+          extraBuildArgs: >-
+            /p:Configuration=$(_BuildConfig)
+            $(_SignArgs)
+            $(_OfficialBuildIdArgs)
+
+    # ----------------------------------------------------------------
+    # This stage performs build, test, packaging
+    # ----------------------------------------------------------------
+    - stage: build
+      displayName: Build
+      dependsOn:
+      - build_sign_native
+      jobs:
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          enableMicrobuild: true
+          # Publish NuGet packages using v3
+          # https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md#basic-onboarding-scenario-for-new-repositories-to-the-current-publishing-version-v3
+          enablePublishUsingPipelines: false
+          enablePublishBuildAssets: false
+          enableTelemetry: true
+          enableSourceIndex: false
+          publishAssetsImmediately: false
+          # Publish build logs
+          enablePublishBuildArtifacts: false
+          # Publish test logs
+          enablePublishTestResults: false
+          workspace:
+            clean: all
+
+          jobs:
+
+          - job: Windows
+            ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+              # If the build is getting signed, then the timeout should be increased.
+              timeoutInMinutes: 120
+            ${{ else }}:
+              # timeout accounts for wait times for helix agents up to 30mins
+              timeoutInMinutes: 90
+
+            pool:
+              name: NetCore1ESPool-Internal
+              image: windows.vs2022preview.amd64
+              os: windows
+
+            variables:
+              - name: _buildScript
+                value: $(Build.SourcesDirectory)/build.cmd -ci
+
+            preSteps:
+              - checkout: self
+                fetchDepth: 1
+                clean: true
+
+            steps:
+              - task: DownloadPipelineArtifact@2
+                displayName: 🟣Download All Native Archives
+                inputs:
+                  itemPattern: |
+                    **/aspire-cli-*.zip
+                    **/aspire-cli-*.tar.gz
+                  targetPath: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+
+              - task: PowerShell@2
+                displayName: 🟣List artifacts packages contents
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\packages" -File -Recurse | Select-Object FullName, @{Name="Size(MB)";Expression={[math]::Round($_.Length/1MB,2)}} | Format-Table -AutoSize
+
+              - template: /eng/pipelines/templates/BuildAndTest.yml
+                parameters:
+                  dotnetScript: $(Build.SourcesDirectory)/dotnet.cmd
+                  buildScript: $(_buildScript)
+                  buildConfig: $(_BuildConfig)
+                  repoArtifactsPath: $(Build.Arcade.ArtifactsPath)
+                  repoLogPath: $(Build.Arcade.LogsPath)
+                  repoTestResultsPath: $(Build.Arcade.TestResultsPath)
+                  isWindows: true
+                  targetRids:
+                    # aot
+                    - win-x64
+                    - win-arm64
+                    # non-aot - single file builds
+                    - win-x86


### PR DESCRIPTION
Adds .yml to map to https://dev.azure.com/dnceng/internal/_build?definitionId=1477, which will be used for internal dev builds going forward. This is an almost exact copy of `azure-pipelines.yml`, but removes publishing to BAR & sets SignType to test.