### PR TITLE
Make copying project templates incremental

### DIFF
--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -19,35 +19,38 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- see https://github.com/dotnet/aspire/pull/1225 -->
     <None Include="templates\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <TemplateProjectFiles Include="$(MSBuildThisFileDirectory)templates\**\*.csproj">
+      <PackagePath>content/templates/%(RecursiveDir)</PackagePath>
+      <DestinationFile>$(IntermediateOutputPath)content\templates\%(RecursiveDir)%(Filename)%(Extension)</DestinationFile>
+    </TemplateProjectFiles>
+    <TemplateProjectFilesObj Include="@(TemplateProjectFiles->'%(DestinationFile)')" />
+
+    <TemplateFiles Include="$(MSBuildThisFileDirectory)templates\**\*"
+                   Exclude="$(MSBuildThisFileDirectory)templates\**\bin\**;$(MSBuildThisFileDirectory)templates\**\obj\**;$(MSBuildThisFileDirectory)templates\**\*.csproj">
+      <PackagePath>content/templates/%(RecursiveDir)</PackagePath>
+    </TemplateFiles>
+    <TemplateFilesObj Include="@(TemplateFiles->'$(IntermediateOutputPath)content\templates\%(RecursiveDir)%(Filename)%(Extension)')" />
   </ItemGroup>
 
   <!-- When building a package, this target will run to copy all the templates into the intermediate directory,
        replaces the package versions, and adds them to the package.-->
   <Target Name="AddTemplatesToPackageAsContent"
           DependsOnTargets="ReplacePackageVersionOnTemplates">
-
-    <!-- Creating a temporary item instead of defining content items directly in order to avoid MSBuild MSB4120
-    message shown when an item within a target references itself which may cuase unintended expansion. -->
     <ItemGroup>
-      <_TemplatesForPackage Include="$(IntermediateOutputPath)\content\templates\**\*" />
-    </ItemGroup>
-    <ItemGroup>
-      <Content Include="%(_TemplatesForPackage.Identity)"
-              PackagePath="content/templates/%(_TemplatesForPackage.RecursiveDir)" />
+      <Content Include="@(TemplateFilesObj);@(TemplateProjectFilesObj)" />
     </ItemGroup>
   </Target>
 
   <!-- Replaces the versions referenced by the templates projects to use the version of the packages being live-built -->
   <Target Name="ReplacePackageVersionOnTemplates"
-          DependsOnTargets="CopyTemplatesToIntermediateOutputPath">
-
-    <ItemGroup>
-      <TemplateProjectFiles Include="templates\**\*.csproj" />
-      <TemplateProjectFiles>
-        <DestinationFile>$(IntermediateOutputPath)\content\templates\%(RecursiveDir)%(Filename)%(Extension)</DestinationFile>
-      </TemplateProjectFiles>
-    </ItemGroup>
+          DependsOnTargets="CopyTemplatesToIntermediateOutputPath"
+          Inputs="@(TemplateProjectFiles)"
+          Outputs="@(TemplateProjectFilesObj)">
 
     <WriteLinesToFile File="%(TemplateProjectFiles.DestinationFile)"
                       Lines="$([System.IO.File]::ReadAllText('%(TemplateProjectFiles.FullPath)')
@@ -61,19 +64,18 @@
                                                  .Replace('!!REPLACE_WITH_OTEL_ASPNETCORE_VERSION!!', '$(OpenTelemetryInstrumentationAspNetCoreVersion)')
                                                  .Replace('!!REPLACE_WITH_OTEL_HTTP_VERSION!!', '$(OpenTelemetryInstrumentationHttpVersion)')
                                                  .Replace('!!REPLACE_WITH_OTEL_RUNTIME_VERSION!!', '$(OpenTelemetryInstrumentationRuntimeVersion)') )"
+                      WriteOnlyWhenDifferent="True"
                       Overwrite="true" />
   </Target>
 
   <!-- Grabs the contents of the templates folder and copies them to IntermediateOutputPath directory -->
-  <Target Name="CopyTemplatesToIntermediateOutputPath">
+  <Target Name="CopyTemplatesToIntermediateOutputPath"
+          Inputs="@(TemplateFiles)"
+          Outputs="@(TemplateFilesObj)">
 
-    <ItemGroup>
-      <_ContentFilesToPackage Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**;templates\**\*.csproj" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(_ContentFilesToPackage)"
-          SkipUnchangedFiles="true"
-          DestinationFolder="$(IntermediateOutputPath)\content\templates\%(RecursiveDir)" />
+    <Copy SourceFiles="@(TemplateFiles)"
+          DestinationFiles="@(TemplateFilesObj)"
+          SkipUnchangedFiles="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Use item transforms to specify destination item paths
Declare Inputs and Outputs on targets that copy templates to obj
Set WriteLinesToFile.WriteOnlyWhenDifferent
