### PR TITLE
Standardizes logging parameter names for resources - p2

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -615,12 +615,12 @@ public class ResourceNotificationService : IDisposable
                 if (!string.IsNullOrWhiteSpace(previousStateText) && !string.Equals(previousStateText, newStateText, StringComparison.OrdinalIgnoreCase))
                 {
                     // The state text has changed from the previous state
-                    _logger.LogDebug("Resource {Resource}/{ResourceId} changed state: {PreviousState} -> {NewState}", resource.Name, resourceId, previousStateText, newStateText);
+                    _logger.LogDebug("Resource {ResourceName}/{ResourceId} changed state: {PreviousState} -> {NewState}", resource.Name, resourceId, previousStateText, newStateText);
                 }
                 else if (string.IsNullOrWhiteSpace(previousStateText))
                 {
                     // There was no previous state text so just log the new state
-                    _logger.LogDebug("Resource {Resource}/{ResourceId} changed state: {NewState}", resource.Name, resourceId, newStateText);
+                    _logger.LogDebug("Resource {ResourceName}/{ResourceId} changed state: {NewState}", resource.Name, resourceId, newStateText);
                 }
             }
 
@@ -630,7 +630,7 @@ public class ResourceNotificationService : IDisposable
                 // makes them more easily analyzed in a text editor
                 _logger.LogTrace(
                     "Version: {Version} " +
-                    "Resource {Resource}/{ResourceId} update published: " +
+                    "Resource {ResourceName}/{ResourceId} update published: " +
                     "ResourceType = {ResourceType}, " +
                     "CreationTimeStamp = {CreationTimeStamp:s}, " +
                     "State = {{ Text = {StateText}, Style = {StateStyle} }}, " +

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -80,7 +80,7 @@ internal class AppHostRpcTarget(
 
             if (!resourceEvent.Resource.TryGetEndpoints(out var endpoints))
             {
-                logger.LogTrace("Resource {Resource} does not have endpoints.", resourceEvent.Resource.Name);
+                logger.LogTrace("Resource {ResourceName} does not have endpoints.", resourceEvent.Resource.Name);
                 endpoints = Enumerable.Empty<EndpointAnnotation>();
             }
 

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -65,7 +65,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                                     return;
                                 }
 
-                                logger.LogError(ex, "Unexpected error ended health monitoring for resource '{Resource}'.", resourceName);
+                                logger.LogError(ex, "Unexpected error ended health monitoring for resource '{ResourceName}'.", resourceName);
                             }
                         }, state.CancellationToken);
                     }
@@ -112,14 +112,14 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
             //       dynamically add health checks at runtime. If this changes then we
             //       would need to revisit this and scan for transitive health checks
             //       on a periodic basis (you wouldn't want to do it on every pass.
-            logger.LogDebug("Resource '{Resource}' has no health checks to monitor.", resource.Name);
+            logger.LogDebug("Resource '{ResourceName}' has no health checks to monitor.", resource.Name);
             FireResourceReadyEvent(resource, cancellationToken);
 
             return;
         }
 
         var registrationKeysToCheck = annotations.DistinctBy(a => a.Key).Select(a => a.Key).ToFrozenSet();
-        logger.LogDebug("Resource '{Resource}' health checks to monitor: {HeathCheckKeys}", resource.Name, string.Join(", ", registrationKeysToCheck));
+        logger.LogDebug("Resource '{ResourceName}' health checks to monitor: {HeathCheckKeys}", resource.Name, string.Join(", ", registrationKeysToCheck));
 
         var lastHealthCheckTimestamp = 0L;
         var lastDelayInterrupted = false;
@@ -156,7 +156,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                     report = new HealthReport(registrationKeysToCheck.ToDictionary(k => k, k => new HealthReportEntry(HealthStatus.Unhealthy, "Error calling HealthCheckService.", TimeSpan.Zero, ex, data: null)), TimeSpan.Zero);
                 }
 
-                logger.LogTrace("Health report status for '{Resource}' is {HealthReportStatus}.", resource.Name, report.Status);
+                logger.LogTrace("Health report status for '{ResourceName}' is {HealthReportStatus}.", resource.Name, report.Status);
 
                 if (report.Status == HealthStatus.Healthy)
                 {
@@ -176,7 +176,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
 
                 if (ContainsAnyHealthReportChange(report, currentEvent.Snapshot.HealthReports))
                 {
-                    logger.LogTrace("Health reports for '{Resource}' have changed. Publishing updated reports.", resource.Name);
+                    logger.LogTrace("Health reports for '{ResourceName}' have changed. Publishing updated reports.", resource.Name);
 
                     await resourceNotificationService.PublishUpdateAsync(resource, s =>
                     {
@@ -197,7 +197,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                 // cancellation token is signaled.
                 logger.LogTrace(
                     ex,
-                    "Health check monitoring loop for resource '{Resource}' observed exception but was ignored.",
+                    "Health check monitoring loop for resource '{ResourceName}' observed exception but was ignored.",
                     resource.Name
                     );
             }
@@ -210,7 +210,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                 ? HealthyHealthCheckInterval
                 : NonHealthyHealthCheckStepInterval * Math.Min(5, nonHealthyReportCount);
 
-            logger.LogTrace("Resource '{Resource}' health check monitoring loop starting delay of {DelayInterval}.", resource.Name, delayInterval);
+            logger.LogTrace("Resource '{ResourceName}' health check monitoring loop starting delay of {DelayInterval}.", resource.Name, delayInterval);
 
             lastDelayInterrupted = await state.DelayAsync(currentEvent, delayInterval, cancellationToken).ConfigureAwait(false);
         }
@@ -239,26 +239,26 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
 
     private void FireResourceReadyEvent(IResource resource, CancellationToken cancellationToken)
     {
-        logger.LogDebug("Resource '{Resource}' is ready.", resource.Name);
+        logger.LogDebug("Resource '{ResourceName}' is ready.", resource.Name);
 
         // We don't want to block the monitoring loop while we fire the event.
         _ = Task.Run(async () =>
         {
             var resourceReadyEvent = new ResourceReadyEvent(resource, services);
 
-            logger.LogDebug("Publishing ResourceReadyEvent for '{Resource}'.", resource.Name);
+            logger.LogDebug("Publishing ResourceReadyEvent for '{ResourceName}'.", resource.Name);
 
             // Execute the publish and store the task so that waiters can await it and observe the result.
             var task = eventing.PublishAsync(resourceReadyEvent, cancellationToken);
 
-            logger.LogDebug("Waiting for ResourceReadyEvent for '{Resource}'.", resource.Name);
+            logger.LogDebug("Waiting for ResourceReadyEvent for '{ResourceName}'.", resource.Name);
 
             // Suppress exceptions, we just want to make sure that the event is completed.
             await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 
-            logger.LogDebug("ResourceReadyEvent for '{Resource}' completed.", resource.Name);
+            logger.LogDebug("ResourceReadyEvent for '{ResourceName}' completed.", resource.Name);
 
-            logger.LogDebug("Publishing the result of ResourceReadyEvent for '{Resource}'.", resource.Name);
+            logger.LogDebug("Publishing the result of ResourceReadyEvent for '{ResourceName}'.", resource.Name);
 
             await resourceNotificationService.PublishUpdateAsync(resource, s => s with
             {
@@ -315,7 +315,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
             _resourceName = initialEvent.Resource.Name;
             LatestEvent = initialEvent;
 
-            _logger.LogDebug("Starting health monitoring for resource '{Resource}'.", _resourceName);
+            _logger.LogDebug("Starting health monitoring for resource '{ResourceName}'.", _resourceName);
         }
 
         // Used to cancel and exit the monitoring loop for a resource.
@@ -325,7 +325,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
 
         public void StopResourceMonitor()
         {
-            _logger.LogDebug("Stopping health monitoring for resource '{Resource}'.", _resourceName);
+            _logger.LogDebug("Stopping health monitoring for resource '{ResourceName}'.", _resourceName);
             _cts.Cancel();
         }
 
@@ -353,7 +353,7 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                 // The event might have changed before delay was called. Interrupt immediately if required.
                 if (currentEvent != null && ShouldInterrupt(currentEvent, LatestEvent))
                 {
-                    _logger.LogTrace("Health monitoring delay interrupted for resource '{Resource}'.", _resourceName);
+                    _logger.LogTrace("Health monitoring delay interrupted for resource '{ResourceName}'.", _resourceName);
                     return true;
                 }
                 _delayInterruptTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -180,7 +180,7 @@ internal sealed class ResourceContainerImageBuilder(
 
     private async Task BuildImageAsync(IPublishingStep? step, IResource resource, ContainerBuildOptions? options, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Building container image for resource {Resource}", resource.Name);
+        logger.LogInformation("Building container image for resource {ResourceName}", resource.Name);
 
         if (resource is ProjectResource)
         {


### PR DESCRIPTION
Replaces inconsistent use of {Resource} with {ResourceName} across logging statements to improve log message clarity and consistency.

The change affects multiple components including resource notification service, health check monitoring, and container image building where resource names are logged.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

follow up on #11233

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
