### PR TITLE
Remove ingestion endpoint from Kusto emulator

### DIFF
--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -149,7 +149,6 @@ public static class AzureKustoBuilderExtensions
         surrogateBuilder
             .WithAnnotation(new EmulatorResourceAnnotation())
             .WithHttpEndpoint(targetPort: AzureKustoEmulatorContainerDefaults.DefaultTargetPort, name: "http")
-            .WithHttpEndpoint(targetPort: AzureKustoEmulatorContainerDefaults.DefaultIngestionTargetPort, name: "ingestionHttp")
             .WithAnnotation(new ContainerImageAnnotation
             {
                 Registry = AzureKustoEmulatorContainerImageTags.Registry,
@@ -196,22 +195,6 @@ public static class AzureKustoBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
 
         return builder.WithEndpoint("http", endpoint =>
-        {
-            endpoint.Port = port;
-        });
-    }
-
-    /// <summary>
-    /// Modifies the host port that the Kusto emulator listens on for HTTP ingestion requests.
-    /// </summary>
-    /// <param name="builder">Kusto emulator resource builder.</param>
-    /// <param name="port">Host port to use.</param>
-    /// <returns>An <see cref="IResourceBuilder{T}"/> for the <see cref="AzureKustoClusterResource"/>.</returns>
-    public static IResourceBuilder<AzureKustoEmulatorResource> WithIngestionHttpPort(this IResourceBuilder<AzureKustoEmulatorResource> builder, int port)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-
-        return builder.WithEndpoint("ingestionHttp", endpoint =>
         {
             endpoint.Port = port;
         });

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerDefaults.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerDefaults.cs
@@ -13,10 +13,4 @@ internal static class AzureKustoEmulatorContainerDefaults
     /// Based on Azure Data Explorer emulator documentation, it typically uses port 8080.
     /// </summary>
     public const int DefaultTargetPort = 8080;
-
-    /// <summary>
-    /// The default target port for the Kusto emulator container ingestion endpoint.
-    /// Based on Azure Data Explorer emulator documentation, it typically uses port 8081.
-    /// </summary>
-    public const int DefaultIngestionTargetPort = 8081;
 }

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/AddAzureKustoTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/AddAzureKustoTests.cs
@@ -333,29 +333,6 @@ public class AddAzureKustoTests
         Assert.Single(database.Resource.Annotations, annotation => annotation is HealthCheckAnnotation hca && hca.Key == $"{name}_check");
     }
 
-    [Fact]
-    public void RunAsEmulator_ShouldConfigureBothHttpAndIngestionEndpoints()
-    {
-        // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create();
-
-        // Act
-        var resourceBuilder = builder.AddAzureKustoCluster("kusto").RunAsEmulator();
-
-        // Assert
-        var endpointAnnotations = resourceBuilder.Resource.Annotations.OfType<EndpointAnnotation>().ToList();
-
-        var httpEndpoint = endpointAnnotations.SingleOrDefault(e => e.Name == "http");
-        Assert.NotNull(httpEndpoint);
-        Assert.Equal(AzureKustoEmulatorContainerDefaults.DefaultTargetPort, httpEndpoint.TargetPort);
-        Assert.Equal("http", httpEndpoint.UriScheme);
-
-        var ingestionEndpoint = endpointAnnotations.SingleOrDefault(e => e.Name == "ingestionHttp");
-        Assert.NotNull(ingestionEndpoint);
-        Assert.Equal(AzureKustoEmulatorContainerDefaults.DefaultIngestionTargetPort, ingestionEndpoint.TargetPort);
-        Assert.Equal("http", ingestionEndpoint.UriScheme);
-    }
-
     [Theory]
     [InlineData(9090)]
     [InlineData(8080)]
@@ -379,29 +356,6 @@ public class AddAzureKustoTests
         Assert.Equal("http", httpEndpoint.UriScheme);
     }
 
-    [Theory]
-    [InlineData(9091)]
-    [InlineData(8081)]
-    [InlineData(5678)]
-    public void WithIngestionHttpPort_ShouldSetIngestionHttpEndpointPort(int port)
-    {
-        // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create();
-
-        // Act
-        var resourceBuilder = builder.AddAzureKustoCluster("kusto")
-            .RunAsEmulator(c => c.WithIngestionHttpPort(port));
-
-        // Assert
-        var endpointAnnotations = resourceBuilder.Resource.Annotations.OfType<EndpointAnnotation>().ToList();
-        var ingestionEndpoint = endpointAnnotations.SingleOrDefault(e => e.Name == "ingestionHttp");
-
-        Assert.NotNull(ingestionEndpoint);
-        Assert.Equal(port, ingestionEndpoint.Port);
-        Assert.Equal(AzureKustoEmulatorContainerDefaults.DefaultIngestionTargetPort, ingestionEndpoint.TargetPort);
-        Assert.Equal("http", ingestionEndpoint.UriScheme);
-    }
-
     [Fact]
     public void WithHttpPort_ShouldThrowArgumentNullException_WhenBuilderIsNull()
     {
@@ -411,81 +365,5 @@ public class AddAzureKustoTests
         // Act & Assert
         var exception = Assert.Throws<ArgumentNullException>(() => builder.RunAsEmulator(c => c.WithHttpPort(8080)));
         Assert.Equal("builder", exception.ParamName);
-    }
-
-    [Fact]
-    public void WithIngestionHttpPort_ShouldThrowArgumentNullException_WhenBuilderIsNull()
-    {
-        // Arrange
-        IResourceBuilder<AzureKustoClusterResource> builder = null!;
-
-        // Act & Assert
-        var exception = Assert.Throws<ArgumentNullException>(() => builder.RunAsEmulator(c => c.WithIngestionHttpPort(8081)));
-        Assert.Equal("builder", exception.ParamName);
-    }
-
-    [Theory]
-    [InlineData(9090, 9091)]
-    [InlineData(8080, 8081)]
-    [InlineData(1234, 5678)]
-    public void WithHttpPortAndIngestionHttpPort_ShouldSetBothEndpointPorts(int httpPort, int ingestionPort)
-    {
-        // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create();
-
-        // Act
-        var resourceBuilder = builder.AddAzureKustoCluster("kusto")
-            .RunAsEmulator(c => c.WithHttpPort(httpPort).WithIngestionHttpPort(ingestionPort));
-
-        // Assert
-        var endpointAnnotations = resourceBuilder.Resource.Annotations.OfType<EndpointAnnotation>().ToList();
-
-        var httpEndpoint = endpointAnnotations.SingleOrDefault(e => e.Name == "http");
-        Assert.NotNull(httpEndpoint);
-        Assert.Equal(httpPort, httpEndpoint.Port);
-        Assert.Equal(AzureKustoEmulatorContainerDefaults.DefaultTargetPort, httpEndpoint.TargetPort);
-
-        var ingestionEndpoint = endpointAnnotations.SingleOrDefault(e => e.Name == "ingestionHttp");
-        Assert.NotNull(ingestionEndpoint);
-        Assert.Equal(ingestionPort, ingestionEndpoint.Port);
-        Assert.Equal(AzureKustoEmulatorContainerDefaults.DefaultIngestionTargetPort, ingestionEndpoint.TargetPort);
-    }
-
-    [Fact]
-    public void WithHttpPort_ShouldNotAffectIngestionEndpoint()
-    {
-        // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create();
-
-        // Act
-        var resourceBuilder = builder.AddAzureKustoCluster("kusto")
-            .RunAsEmulator(c => c.WithHttpPort(9090));
-
-        // Assert
-        var endpointAnnotations = resourceBuilder.Resource.Annotations.OfType<EndpointAnnotation>().ToList();
-
-        var ingestionEndpoint = endpointAnnotations.SingleOrDefault(e => e.Name == "ingestionHttp");
-        Assert.NotNull(ingestionEndpoint);
-        Assert.Null(ingestionEndpoint.Port); // Should remain null (default)
-        Assert.Equal(AzureKustoEmulatorContainerDefaults.DefaultIngestionTargetPort, ingestionEndpoint.TargetPort);
-    }
-
-    [Fact]
-    public void WithIngestionHttpPort_ShouldNotAffectHttpEndpoint()
-    {
-        // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create();
-
-        // Act
-        var resourceBuilder = builder.AddAzureKustoCluster("kusto")
-            .RunAsEmulator(c => c.WithIngestionHttpPort(9091));
-
-        // Assert
-        var endpointAnnotations = resourceBuilder.Resource.Annotations.OfType<EndpointAnnotation>().ToList();
-
-        var httpEndpoint = endpointAnnotations.SingleOrDefault(e => e.Name == "http");
-        Assert.NotNull(httpEndpoint);
-        Assert.Null(httpEndpoint.Port); // Should remain null (default)
-        Assert.Equal(AzureKustoEmulatorContainerDefaults.DefaultTargetPort, httpEndpoint.TargetPort);
     }
 }


### PR DESCRIPTION
## Description

This is a partial revert of #11226. That change added a `.WithHttpPort` and `.WithIngestionHttpPort` on the `AzureKustoEmulatorResource`. However, according to https://learn.microsoft.com/en-us/azure/data-explorer/kusto-emulator-overview#limitations, ingestion endpoints aren't supported on the emulator, so remove it before shipping to prevent confusion.

Contributes to #8233 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
