### PR TITLE
Mark Kusto db as FailedToStart if creation fails

### DIFF
--- a/playground/AzureKusto/AzureKusto.AppHost/Program.cs
+++ b/playground/AzureKusto/AzureKusto.AppHost/Program.cs
@@ -45,5 +45,8 @@ db.OnResourceReady(async (dbResource, evt, ct) =>
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
 #endif
 
+// Add an invalid database to demonstrate how a "failed to start" resource appears in the dashboard
+kusto.AddDatabase("InvalidDb", "__invalid");
+
 var app = builder.Build();
 app.Run();

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/Aspire.Hosting.Azure.Kusto.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/Aspire.Hosting.Azure.Kusto.Tests.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" LinkBase="shared" />
     <Compile Include="$(TestsSharedDir)TestModuleInitializer.cs" LinkBase="shared" />
   </ItemGroup>

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
@@ -184,8 +184,7 @@ public class KustoFunctionalTests
 
         // Assert no warnings or errors were logged about the database already existing
         var snapshot = app.Services.GetRequiredService<FakeLogCollector>().GetSnapshot();
-        var logs = snapshot.Where(record => (record.Category ?? string.Empty).StartsWith("Aspire.Hosting.Tests.Resources", StringComparison.OrdinalIgnoreCase))
-            .Where(record => record.Level >= LogLevel.Warning);
+        var logs = snapshot.Where(IsResourceLog).Where(record => record.Level >= LogLevel.Warning);
         Assert.Empty(logs);
     }
 
@@ -215,8 +214,7 @@ public class KustoFunctionalTests
 
         // Assert an error was logged about the invalid database
         var snapshot = app.Services.GetRequiredService<FakeLogCollector>().GetSnapshot();
-        var logs = snapshot.Where(record => (record.Category ?? string.Empty).StartsWith("Aspire.Hosting.Tests.Resources", StringComparison.OrdinalIgnoreCase))
-            .Where(record => record.Level >= LogLevel.Warning);
+        var logs = snapshot.Where(IsResourceLog).Where(record => record.Level >= LogLevel.Warning);
         Assert.Single(logs);
     }
 
@@ -267,6 +265,11 @@ public class KustoFunctionalTests
 
             return Directory.GetFileSystemEntries(temp.Path, searchPattern, enumerationOptions);
         }
+    }
+
+    private static bool IsResourceLog(FakeLogRecord record)
+    {
+        return (record.Category ?? string.Empty).StartsWith("Aspire.Hosting.Tests.Resources", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

This PR changes how we handle database creation failure in the AppHost and does affiliated test cleanup.

### Mark database as FailedToStart if creation fails

Previously, database creation was part of the parent Kusto resource. This matched the behavior in other host integrations like Postgres and MySql. However, it can be confusing because waiting on the database resource waits forever, as the resource is stuck in Unhealthy.

Now, if the database creation fails we transition the database resource to FailedToStart. As part of that change, I moved the logs from the parent (Kusto cluster) resource to the database resource, so that debugging database failures in the dashboard is easier. 

Also updated the playground app to include an invalid database to play around with the dashboard.

### Add functional tests

Added missing functional tests
- Creating a database that already exists does not log warnings or errors
- Creating an invalid database logs an error and marks the resource as failed, but does not block healthy databases or the cluster as a whole

### Simplified test setup

Updated existing tests to use direct health checks (`WaitForResourceHealthyAsync`) instead of a custom waiter resource, and removed the now-unnecessary `WaiterResource`.

Contributes to #8233 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No