### PR TITLE
Remove integration Markdown scheme allow list

### DIFF
--- a/src/Aspire.Dashboard/Utils/InteractionMarkdownHelper.cs
+++ b/src/Aspire.Dashboard/Utils/InteractionMarkdownHelper.cs
@@ -20,10 +20,11 @@ public static class InteractionMarkdownHelper
         // Avoid adding paragraphs to HTML output from Markdown content unless there are multiple lines (aka multiple paragraphs).
         var hasNewline = markdown.Contains('\n') || markdown.Contains('\r');
 
+        // Interactions are trusted, so allow all schemes.
         var options = new MarkdownOptions
         {
             Pipeline = s_markdownPipeline,
-            AllowedSchemes = null,
+            AllowedUrlSchemes = null,
             SuppressSurroundingParagraph = !hasNewline
         };
 

--- a/src/Aspire.Dashboard/Utils/InteractionMarkdownHelper.cs
+++ b/src/Aspire.Dashboard/Utils/InteractionMarkdownHelper.cs
@@ -20,6 +20,13 @@ public static class InteractionMarkdownHelper
         // Avoid adding paragraphs to HTML output from Markdown content unless there are multiple lines (aka multiple paragraphs).
         var hasNewline = markdown.Contains('\n') || markdown.Contains('\r');
 
-        return MarkdownHelpers.ToHtml(markdown, s_markdownPipeline, !hasNewline);
+        var options = new MarkdownOptions
+        {
+            Pipeline = s_markdownPipeline,
+            AllowedSchemes = null,
+            SuppressSurroundingParagraph = !hasNewline
+        };
+
+        return MarkdownHelpers.ToHtml(markdown, options);
     }
 }

--- a/src/Aspire.Dashboard/Utils/MarkdownHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/MarkdownHelpers.cs
@@ -14,7 +14,7 @@ public sealed class MarkdownOptions
 {
     public required MarkdownPipeline Pipeline { get; init; }
     public required bool SuppressSurroundingParagraph { get; init; }
-    public required HashSet<string>? AllowedSchemes { get; init; }
+    public required HashSet<string>? AllowedUrlSchemes { get; init; }
 }
 
 public static class MarkdownHelpers
@@ -50,7 +50,7 @@ public static class MarkdownHelpers
         // Open absolute links in the response in a new window.
         foreach (var link in document.Descendants<LinkInline>())
         {
-            switch (DetectLink(link.Url, options.AllowedSchemes))
+            switch (DetectLink(link.Url, options.AllowedUrlSchemes))
             {
                 case LinkType.Absolute:
                     AddLinkAttributes(link);
@@ -62,7 +62,7 @@ public static class MarkdownHelpers
         }
         foreach (var link in document.Descendants<AutolinkInline>())
         {
-            switch (DetectLink(link.Url, options.AllowedSchemes))
+            switch (DetectLink(link.Url, options.AllowedUrlSchemes))
             {
                 case LinkType.Absolute:
                     AddLinkAttributes(link);
@@ -90,7 +90,7 @@ public static class MarkdownHelpers
 
         return writer.ToString();
 
-        static LinkType DetectLink(string? url, HashSet<string>? allowedSchemes)
+        static LinkType DetectLink(string? url, HashSet<string>? allowedUrlSchemes)
         {
             if (url == null || !Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
             {
@@ -102,7 +102,7 @@ public static class MarkdownHelpers
                 return LinkType.Relative;
             }
 
-            if (allowedSchemes != null && !allowedSchemes.Contains(uri.Scheme))
+            if (allowedUrlSchemes != null && !allowedUrlSchemes.Contains(uri.Scheme))
             {
                 return LinkType.Prohibited;
             }

--- a/tests/Aspire.Dashboard.Components.Tests/Interactions/InteractionsProviderTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Interactions/InteractionsProviderTests.cs
@@ -425,6 +425,8 @@ public partial class InteractionsProviderTests : DashboardTestContext
     [InlineData(true, "**Hello** _World_! <b>Bold</b>", "<strong>Hello</strong> <em>World</em>! &lt;b&gt;Bold&lt;/b&gt;")]
     [InlineData(false, "**Hello** _World_! <b>Bold</b>", "**Hello** _World_! &lt;b&gt;Bold&lt;/b&gt;")]
     [InlineData(true, "Para1\r\n\r\nPara2", "<p>Para1</p>\r\n<p>Para2</p>")]
+    [InlineData(true, "This is a test://www.localhost.com", "This is a test://www.localhost.com")]
+    [InlineData(true, "This is a [test](test://www.localhost.com)", "This is a <a href=\"test://www.localhost.com\" target=\"_blank\" rel=\"noopener noreferrer nofollow\">test</a>")]
     public async Task ReceiveData_InputDialogWithMarkdownMessage_ExpectedResolvedMessage(bool markdownSupported, string message, string expectedMessage)
     {
         // Arrange


### PR DESCRIPTION
## Description

Interactions are considered a trusted source (it's code executing in the app host) so don't limit the URL schemes allowed when rendering interaction markdown to HTML.

Fixes https://github.com/dotnet/aspire/issues/10772

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
