### PR TITLE
[CI] Fix outerloop and quarantine workflows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -216,7 +216,7 @@ jobs:
           -ci
           -build
           -projects ${{ env.TEST_PROJECT_PATH }}
-          ${{ inputs.enablePlaywrightInstall == true && '' || '/p:InstallBrowsersForPlaywright=false' }}
+          ${{ !inputs.enablePlaywrightInstall && '/p:InstallBrowsersForPlaywright=false' || '' }}
           ${{ inputs.versionOverrideArg }}
 
       - name: Build and archive test project
@@ -227,7 +227,7 @@ jobs:
           ${{ env.BUILD_SCRIPT }} -restore -ci -build -projects ${{ env.TEST_PROJECT_PATH }}
           /p:PrepareForHelix=true
           /bl:${{ github.workspace }}/artifacts/log/Debug/PrepareForHelix.binlog
-          ${{ inputs.enablePlaywrightInstall == true && '' || '/p:InstallBrowsersForPlaywright=false' }}
+          ${{ !inputs.enablePlaywrightInstall && '/p:InstallBrowsersForPlaywright=false' || '' }}
           ${{ inputs.versionOverrideArg }}
 
       # Workaround for bug in Azure Functions Worker SDK. See https://github.com/Azure/azure-functions-dotnet-worker/issues/2969.
@@ -284,7 +284,7 @@ jobs:
           DCP_DIAGNOSTICS_LOG_FOLDER: ${{ github.workspace }}/testresults/dcp
           BUILT_NUGETS_PATH: ${{ github.workspace }}/artifacts/packages/Debug/Shipping
           NUGET_PACKAGES: ${{ github.workspace }}/nuget-cache
-          PLAYWRIGHT_INSTALLED: ${{ inputs.enablePlaywrightInstall == true && 'true' || 'false' }}
+          PLAYWRIGHT_INSTALLED: ${{ !inputs.enablePlaywrightInstall && 'false' || 'true' }}
           TEST_LOG_PATH: ${{ github.workspace }}/artifacts/log/test-logs
           TestsRunningOutsideOfRepo: true
         run: >
@@ -309,7 +309,7 @@ jobs:
           # In this step, we are not using Arcade, but want to make sure that MSBuild is able to evaluate correctly.
           # So, we manually set NUGET_PACKAGES
           NUGET_PACKAGES: ${{ github.workspace }}/.packages
-          PLAYWRIGHT_INSTALLED: ${{ inputs.enablePlaywrightInstall == true && 'true' || 'false' }}
+          PLAYWRIGHT_INSTALLED: ${{ !inputs.enablePlaywrightInstall && 'false' || 'true' }}
         run: >
           ${{ env.DOTNET_SCRIPT }} test ${{ env.TEST_PROJECT_PATH }}
           /p:ContinuousIntegrationBuild=true

--- a/.github/workflows/specialized-test-runner.yml
+++ b/.github/workflows/specialized-test-runner.yml
@@ -42,7 +42,7 @@ jobs:
           --ci
           /p:CI=false
           /p:GeneratePackageOnBuild=false
-          /p:InstallBrowsersForPlaywright=false
+          ${{ !inputs.enablePlaywrightInstall && '/p:InstallBrowsersForPlaywright=false' || '' }}
 
       - name: Generate test runsheet
         id: generate_tests_matrix

--- a/.github/workflows/specialized-test-runner.yml
+++ b/.github/workflows/specialized-test-runner.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Generate test runsheet
         id: generate_tests_matrix
-        run: |
+        run: >
           ./build.sh
           --test
           /p:TestRunnerName=${{ inputs.testRunnerName }}

--- a/.github/workflows/tests-outerloop.yml
+++ b/.github/workflows/tests-outerloop.yml
@@ -4,7 +4,7 @@ name: Outerloop Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */6 * * *' # Every 6 hours
+    - cron: '0 2 * * *' # Daily at 02:00 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests-quarantine.yml
+++ b/.github/workflows/tests-quarantine.yml
@@ -4,7 +4,7 @@ name: Quarantined Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */6 * * *' # Every 6 hours
+    - cron: '0 2,14 * * *' # Twice daily at 02:00 and 14:00 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This was broken after #11250:

## Issue 1 - out of space errors

- The runner was failing with out of space errors. That was because the first build run with `./build.sh -ci` which use `$repo/.packages` as the package root, which takes about 12G.
  - and the second run for generating the run sheet had a build which caused the build to run with just `./build.sh` and causing `$HOME/.nuget/packages` to be used as the package root, and that trying to use up additional space.
  
- The fix for this was to correct have the multi-line string in yml be concatenated

## Issue 2 - playwright was never installed

Previously the workflows always passed /p:InstallBrowsersForPlaywright=false even when enablePlaywrightInstall was set to true. The ternary-style expression:

```yml
${{ inputs.enablePlaywrightInstall && '' || '/p:InstallBrowsersForPlaywright=false' }}
```

was flawed because the "true" branch produced an empty string (falsy), causing the `||` to select the false branch every time.

Changes made:

Replace the expression with one that only emits /p:InstallBrowsersForPlaywright=false when the flag is disabled and emits nothing (default install behavior) when enabled.
Align `PLAYWRIGHT_INSTALLED` env var so it now reflects the actual intent (true when enabled, false when disabled).

This ensures:

Passing `enablePlaywrightInstall: true` allows the default Playwright browser installation.
Passing `enablePlaywrightInstall: false` explicitly disables it.
Environment variable and MSBuild property are now consistent and truthful.