### PR TITLE
Refactor WithContainerFiles to simplify annotation handling and remove run mode checks

### DIFF
--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -863,26 +863,16 @@ public static class ContainerResourceBuilderExtensions
             throw new InvalidOperationException($"The source path '{sourceFullPath}' does not exist. Ensure the path is correct and accessible.");
         }
 
-        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        var annotation = new ContainerFileSystemCallbackAnnotation
         {
-            // In run mode, use copied files as they allow us to configure permissions and ownership and support
-            // remote execution scenarios where the source path may not be accessible from the container runtime.
-            var annotation = new ContainerFileSystemCallbackAnnotation
-            {
-                DestinationPath = destinationPath,
-                Callback = (_, _) => Task.FromResult(ContainerDirectory.GetFileSystemItemsFromPath(sourceFullPath, searchOptions: SearchOption.AllDirectories)),
-                DefaultOwner = defaultOwner,
-                DefaultGroup = defaultGroup,
-                Umask = umask,
-            };
+            DestinationPath = destinationPath,
+            Callback = (_, _) => Task.FromResult(ContainerDirectory.GetFileSystemItemsFromPath(sourceFullPath, searchOptions: SearchOption.AllDirectories)),
+            DefaultOwner = defaultOwner,
+            DefaultGroup = defaultGroup,
+            Umask = umask,
+        };
 
-            builder.Resource.Annotations.Add(annotation);
-        }
-        else
-        {
-            // In publish mode, use a bind mount as it is better supported by publish targets
-            builder.WithBindMount(sourceFullPath, destinationPath, isReadOnly: true);
-        }
+        builder.Resource.Annotations.Add(annotation);
 
         return builder;
     }


### PR DESCRIPTION
## Description

- This PR refactors the WithContainerFiles extension method:
- Removes the conditional branch between RunMode and PublishMode.
- Always uses ContainerFileSystemCallbackAnnotation to copy files into the container instead of falling back to WithBindMount during publish.
- Simplifies code and ensures consistency across run and publish scenarios.
- Prevents runtime errors when publishing to Kubernetes where bind mounts are not supported.

This change was motivated by issues reported when using WithRealmImport for Keycloak. In publish mode, the method was creating a bind mount which caused the Kubernetes publisher to fail with:

`Bind mounts are not supported by the Kubernetes publisher`


Fixes # (issue)

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
