### PR TITLE
Explicit CTRL-C handling in Aspire CLI.

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -212,8 +212,6 @@ public class Program
     {
         Console.OutputEncoding = Encoding.UTF8;
 
-        using var cts = new CancellationTokenSource();
-
         using var app = await BuildApplicationAsync(args);
 
         await app.StartAsync().ConfigureAwait(false);


### PR DESCRIPTION
Quick fix to CTRL-C issues. Looks like System.CommandLine beta.7 introduced an issue where its not automatically handling CTRL-C for us.

Fixes https://github.com/dotnet/aspire/issues/11292