### PR TITLE
Improve instance id matching

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -284,7 +284,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     private SelectViewModel<ResourceTypeDetails> GetSelectedOption()
     {
         Debug.Assert(_resources is not null);
-        return _resources.GetResource(Logger, ResourceName, canSelectGrouping: true, fallback: _allResource);
+        return _resources.GetResource(Logger, ResourceName, canSelectGrouping: true, fallbackViewModel: _allResource);
     }
 
     private void SetStatus(ConsoleLogsViewModel viewModel, string statusName)
@@ -996,7 +996,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             else if (TryGetSingleResource() is { } r)
             {
                 // If there is no resource selected and there is only one resource available, select it.
-                viewModel.SelectedResource = _resources.GetResource(Logger, r.Name, canSelectGrouping: false, fallback: _allResource);
+                viewModel.SelectedResource = _resources.GetResource(Logger, r.Name, canSelectGrouping: false, fallbackViewModel: _allResource);
                 return this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false);
             }
         }

--- a/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
+++ b/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
@@ -52,7 +52,7 @@ public class ResourceTypeDetails : IEquatable<ResourceTypeDetails>
 
     public override string ToString()
     {
-        return $"Type = {Type}, InstanceId = {InstanceId}, ReplicaSetName = {ReplicaSetName}";
+        return $"Type = {Type}, InstanceId = {InstanceId ?? "(null)"}, ReplicaSetName = {ReplicaSetName ?? "(null)"}";
     }
 
     public bool Equals(ResourceTypeDetails? other)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -61,7 +61,7 @@ public static class OtlpHelpers
         }
 
         // service.instance.id is recommended but not required.
-        return new ResourceKey(serviceName, serviceInstanceId ?? serviceName);
+        return new ResourceKey(serviceName, serviceInstanceId);
     }
 
     public static string ToShortenedId(string id) => TruncateString(id, maxLength: ShortenedIdLength);

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -20,7 +20,7 @@ public class OtlpResource
     public const string PROCESS_EXECUTABLE_NAME = "process.executable.name";
 
     public string ResourceName { get; }
-    public string InstanceId { get; }
+    public string? InstanceId { get; }
     public OtlpContext Context { get; }
     // This flag indicates whether the app was created for an uninstrumented peer.
     // It's used to hide the app on pages that don't use uninstrumented peers.
@@ -34,7 +34,7 @@ public class OtlpResource
     private readonly Dictionary<OtlpInstrumentKey, OtlpInstrument> _instruments = new();
     private readonly ConcurrentDictionary<KeyValuePair<string, string>[], OtlpResourceView> _resourceViews = new(ResourceViewKeyComparer.Instance);
 
-    public OtlpResource(string name, string instanceId, bool uninstrumentedPeer, OtlpContext context)
+    public OtlpResource(string name, string? instanceId, bool uninstrumentedPeer, OtlpContext context)
     {
         ResourceName = name;
         InstanceId = instanceId;
@@ -272,7 +272,7 @@ public class OtlpResource
                     // Convert long GUID into a shorter, more human friendly format.
                     // Before: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
                     // After:  aaaaaaaa
-                    if (Guid.TryParse(instanceId, out var guid))
+                    if (instanceId != null && Guid.TryParse(instanceId, out var guid))
                     {
                         Span<char> chars = stackalloc char[32];
                         var result = guid.TryFormat(chars, charsWritten: out _, format: "N");
@@ -281,7 +281,12 @@ public class OtlpResource
                         instanceId = chars.Slice(0, 8).ToString();
                     }
 
-                    return $"{item.ResourceName}-{instanceId}";
+                    if (!string.IsNullOrEmpty(instanceId))
+                    {
+                        return $"{item.ResourceName}-{instanceId}";
+                    }
+
+                    return item.ResourceName;
                 }
             }
         }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -281,12 +281,12 @@ public class OtlpResource
                         instanceId = chars.Slice(0, 8).ToString();
                     }
 
-                    if (!string.IsNullOrEmpty(instanceId))
+                    if (instanceId == null)
                     {
-                        return $"{item.ResourceName}-{instanceId}";
+                        return item.ResourceName;
                     }
 
-                    return item.ResourceName;
+                    return $"{item.ResourceName}-{instanceId}";
                 }
             }
         }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResourceView.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResourceView.cs
@@ -43,9 +43,13 @@ public class OtlpResourceView
     {
         var props = new List<OtlpDisplayField>
         {
-            new OtlpDisplayField { DisplayName = "service.name", Key = KnownResourceFields.ServiceNameField, Value = Resource.ResourceName },
-            new OtlpDisplayField { DisplayName = "service.instance.id", Key = KnownResourceFields.ServiceInstanceIdField, Value = Resource.InstanceId }
+            new OtlpDisplayField { DisplayName = "service.name", Key = KnownResourceFields.ServiceNameField, Value = Resource.ResourceName }
         };
+
+        if (Resource.InstanceId is { } instanceId)
+        {
+            props.Add(new OtlpDisplayField { DisplayName = "service.instance.id", Key = KnownResourceFields.ServiceInstanceIdField, Value = instanceId });
+        }
 
         foreach (var kv in Properties)
         {

--- a/src/Aspire.Dashboard/Otlp/Storage/ResourceKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ResourceKey.cs
@@ -45,7 +45,7 @@ public readonly record struct ResourceKey(string Name, string? InstanceId) : ICo
             return c;
         }
 
-        return string.Compare(InstanceId, other.InstanceId, StringComparisons.ResourceName);
+        return string.Compare(InstanceId ?? string.Empty, other.InstanceId ?? string.Empty, StringComparisons.ResourceName);
     }
 
     public bool EqualsCompositeName(string name)
@@ -55,7 +55,7 @@ public readonly record struct ResourceKey(string Name, string? InstanceId) : ICo
             return false;
         }
 
-        if (InstanceId != null)
+        if (!string.IsNullOrEmpty(InstanceId))
         {
             // Composite name has the format "{Name}-{InstanceId}".
             if (name.Length != Name.Length + InstanceId.Length + 1)
@@ -88,7 +88,7 @@ public readonly record struct ResourceKey(string Name, string? InstanceId) : ICo
 
     public override string ToString()
     {
-        if (InstanceId == null)
+        if (string.IsNullOrEmpty(InstanceId))
         {
             return Name;
         }

--- a/src/Aspire.Dashboard/Otlp/Storage/ResourceKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ResourceKey.cs
@@ -45,7 +45,7 @@ public readonly record struct ResourceKey(string Name, string? InstanceId) : ICo
             return c;
         }
 
-        return string.Compare(InstanceId ?? string.Empty, other.InstanceId ?? string.Empty, StringComparisons.ResourceName);
+        return string.Compare(InstanceId, other.InstanceId, StringComparisons.ResourceName);
     }
 
     public bool EqualsCompositeName(string name)
@@ -55,7 +55,7 @@ public readonly record struct ResourceKey(string Name, string? InstanceId) : ICo
             return false;
         }
 
-        if (!string.IsNullOrEmpty(InstanceId))
+        if (InstanceId != null)
         {
             // Composite name has the format "{Name}-{InstanceId}".
             if (name.Length != Name.Length + InstanceId.Length + 1)
@@ -88,7 +88,7 @@ public readonly record struct ResourceKey(string Name, string? InstanceId) : ICo
 
     public override string ToString()
     {
-        if (string.IsNullOrEmpty(InstanceId))
+        if (InstanceId == null)
         {
             return Name;
         }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -237,7 +237,7 @@ public sealed class TelemetryRepository : IDisposable
         resource = _resources.GetOrAdd(key, _ =>
         {
             newResource = true;
-            return new OtlpResource(key.Name, key.InstanceId!, uninstrumentedPeer, _otlpContext);
+            return new OtlpResource(key.Name, key.InstanceId, uninstrumentedPeer, _otlpContext);
         });
         if (!newResource)
         {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -147,7 +147,7 @@ public sealed class TelemetryRepository : IDisposable
 
     public List<OtlpResource> GetResources(ResourceKey key, bool includeUninstrumentedPeers = false)
     {
-        if (string.IsNullOrEmpty(key.InstanceId))
+        if (key.InstanceId == null)
         {
             return GetResourcesByName(key.Name, includeUninstrumentedPeers: includeUninstrumentedPeers);
         }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -147,7 +147,7 @@ public sealed class TelemetryRepository : IDisposable
 
     public List<OtlpResource> GetResources(ResourceKey key, bool includeUninstrumentedPeers = false)
     {
-        if (key.InstanceId == null)
+        if (string.IsNullOrEmpty(key.InstanceId))
         {
             return GetResourcesByName(key.Name, includeUninstrumentedPeers: includeUninstrumentedPeers);
         }

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -95,6 +95,26 @@ public sealed class ResourcesSelectHelpersTests
         Assert.Equal(OtlpResourceType.Singleton, app.Id!.Type);
     }
 
+    [Theory]
+    [InlineData("singleton-", "", true)]
+    [InlineData("singleton-", null, false)]
+    [InlineData("singleton", "", true)]
+    [InlineData("singleton", null, true)]
+    public void GetResource_EmptyOrNullInstanceId_GetInstance(string name, string? instanceId, bool found)
+    {
+        // Arrange
+        var appVMs = ResourcesSelectHelpers.CreateResources(new List<OtlpResource>
+        {
+            CreateOtlpResource(name: "singleton", instanceId: instanceId)
+        });
+
+        // Act
+        var app = appVMs.GetResource(NullLogger.Instance, name, canSelectGrouping: false, null!);
+
+        // Assert
+        Assert.Equal(found, app != null);
+    }
+
     [Fact]
     public void GetResource_NameDifferentByCase_Merge()
     {

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -276,6 +276,6 @@ public sealed class ResourcesSelectHelpersTests
 
         var key = OtlpHelpers.GetResourceKey(resource);
 
-        return new OtlpResource(key.Name, key.InstanceId!, uninstrumentedPeer: false, TelemetryTestHelpers.CreateContext());
+        return new OtlpResource(key.Name, key.InstanceId, uninstrumentedPeer: false, TelemetryTestHelpers.CreateContext());
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -88,18 +88,27 @@ public sealed class ResourcesSelectHelpersTests
             {
                 Assert.Equal("NAME-instanceabc", app.Name);
                 Assert.Equal(OtlpResourceType.Instance, app.Id!.Type);
-                Assert.Equal("name-instanceabc", app.Id!.InstanceId);
+                Assert.Equal("NAME-instanceabc", app.Id!.InstanceId);
             });
 
         var testSink = new TestSink();
         var factory = LoggerFactory.Create(b => b.AddProvider(new TestLoggerProvider(testSink)));
+        var logger = factory.CreateLogger("Test");
 
         // Act
-        var app = appVMs.GetResource(factory.CreateLogger("Test"), "name-instance", canSelectGrouping: false, null!);
+        var app1 = appVMs.GetResource(logger, "name-instance", canSelectGrouping: false, null!);
 
         // Assert
-        Assert.Equal("name-instance", app.Id!.InstanceId);
-        Assert.Equal(OtlpResourceType.Instance, app.Id!.Type);
+        Assert.Equal("name-instance", app1.Id!.InstanceId);
+        Assert.Equal(OtlpResourceType.Instance, app1.Id!.Type);
+        Assert.Empty(testSink.Writes);
+
+        // Act
+        var app2 = appVMs.GetResource(logger, "name-instanceabc", canSelectGrouping: false, null!);
+
+        // Assert
+        Assert.Equal("NAME-instanceabc", app2.Id!.InstanceId);
+        Assert.Equal(OtlpResourceType.Instance, app2.Id!.Type);
         Assert.Empty(testSink.Writes);
     }
 


### PR DESCRIPTION
## Description

While investigating https://github.com/dotnet/aspire/issues/11138 I noticed that an uninstrumented peer resource created from an Aspire resource wouldn't match telemetry because it didn't have an instance ID.

Improve support for telemetry resource that doesn't have an instance ID.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
