### PR TITLE
Refactor console logs page to use item provider, shared channel for writing logs

### DIFF
--- a/playground/TestShop/TestShop.AppHost/Properties/launchSettings.json
+++ b/playground/TestShop/TestShop.AppHost/Properties/launchSettings.json
@@ -10,8 +10,7 @@
         "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16037",
         //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:16038",
-        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
-        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
       }
     },
     "http": {
@@ -25,7 +24,6 @@
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
         //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16032",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17031",
-        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -14,7 +14,7 @@
     <div class="@GetLogContainerClass()" id="logContainer">
         @if (LogEntries is { } logEntries)
         {
-            <Virtualize @ref="VirtualizeRef" Items="@logEntries.GetEntries()" ItemSize="20" OverscanCount="200" TItem="LogEntry">
+            <Virtualize @ref="VirtualizeRef" ItemsProvider="@GetItems" ItemSize="20" OverscanCount="200" TItem="LogEntry">
                 @if (context.Pause is { } pause)
                 {
                     // If this is a previous pause but no logs were obtained during the pause, we don't need to show anything.
@@ -28,9 +28,20 @@
                             <div class="log-line-area" role="log">
                                 <span class="log-line-number"></span>
                                 <span class="log-content log-pause">
+                                    @{
+                                        var hasPrefix = false;
+                                    }
                                     @if (ShowResourcePrefix && context.ResourcePrefix is { } resourcePrefix)
                                     {
+                                        if (DisplayPrefix(ref hasPrefix))
+                                        {
+                                            @s_spaceMarkup
+                                        }
                                         <span class="resource-prefix" style="background: @ColorGenerator.Instance.GetColorHexByKey(resourcePrefix);">@resourcePrefix</span>
+                                    }
+                                    @if (DisplayPrefix(ref hasPrefix))
+                                    {
+                                        @s_spaceMarkup
                                     }
                                     @pause.GetDisplayText(Loc, TimeProvider)
                                 </span>

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -63,12 +63,12 @@ public sealed partial class LogViewer
 
     public async Task RefreshDataAsync()
     {
-        if (_virtualizeRef == null)
+        if (VirtualizeRef == null)
         {
             return;
         }
 
-        await _virtualizeRef.RefreshDataAsync();
+        await VirtualizeRef.RefreshDataAsync();
         StateHasChanged();
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -20,7 +20,6 @@ public sealed partial class LogViewer
     private static readonly MarkupString s_spaceMarkup = new MarkupString("&#32;");
 
     private LogEntries? _logEntries;
-    private Virtualize<LogEntry>? _virtualizeRef;
     private bool _logsChanged;
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -106,6 +106,7 @@
 
         <MainSection>
             <LogViewer
+                @ref="_logViewerRef"
                 LogEntries="@_logEntries"
                 ShowTimestamp="@_showTimestamp"
                 IsTimestampUtc="@_isTimestampUtc"

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading.Channels;
 using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.ConsoleLogs;
@@ -125,13 +126,20 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
     private readonly CancellationTokenSource _resourceSubscriptionCts = new();
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
+    private readonly Channel<LogEntry> _logEntryChannel = Channel.CreateUnbounded<LogEntry>(new UnboundedChannelOptions
+    {
+        SingleReader = true,
+        SingleWriter = false
+    });
     private ImmutableList<SelectViewModel<ResourceTypeDetails>>? _resources;
     private CancellationToken _resourceSubscriptionToken;
     private Task? _resourceSubscriptionTask;
+    private Task? _logEntryChannelReaderTask;
     private readonly ConcurrentDictionary<string, ConsoleLogsSubscription> _consoleLogsSubscriptions = new(StringComparers.ResourceName);
     private bool _isSubscribedToAll;
     internal LogEntries _logEntries = null!;
     private readonly object _updateLogsLock = new object();
+    private LogViewer? _logViewerRef;
 
     // UI
     private SelectViewModel<ResourceTypeDetails> _allResource = null!;
@@ -159,6 +167,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         _logEntries = new(Options.Value.Frontend.MaxConsoleLogCount);
         _allResource = new() { Id = null, Name = ControlsStringsLoc[nameof(ControlsStrings.LabelAll)] };
         PageViewModel = new ConsoleLogsViewModel { SelectedResource = _allResource, Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLoadingResources)] };
+        _logEntryChannelReaderTask = StartLogEntryChannelReaderTask();
 
         _consoleLogsFiltersChangedSubscription = ConsoleLogsManager.OnFiltersChanged(async () =>
         {
@@ -168,7 +177,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 _logEntries.Clear(keepActivePauseEntries: true);
             }
 
-            await InvokeAsync(StateHasChanged);
+            await InvokeAsync(_logViewerRef.SafeRefreshDataAsync);
         });
 
         var consoleSettingsResult = await LocalStorage.GetUnprotectedAsync<ConsoleLogConsoleSettings>(BrowserStorageKeys.ConsoleLogConsoleSettings);
@@ -281,6 +290,37 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         }
     }
 
+    private async Task StartLogEntryChannelReaderTask()
+    {
+        await foreach (var batch in _logEntryChannel.GetBatchesAsync(minReadInterval: TimeSpan.FromMilliseconds(100), cancellationToken: _resourceSubscriptionToken))
+        {
+            lock (_updateLogsLock)
+            {
+                // Console logs are filtered in the UI by the timestamp of the log entry.
+                var timestampFilterDate = GetFilteredDateFromRemove();
+
+                foreach (var logEntry in batch)
+                {
+                    // Check if log entry is not displayed because of remove.
+                    if (logEntry.Timestamp is not null && timestampFilterDate is not null && !(logEntry.Timestamp > timestampFilterDate))
+                    {
+                        continue;
+                    }
+
+                    // Check if log entry is not displayed because of pause.
+                    if (_logEntries.ProcessPauseFilters(logEntry))
+                    {
+                        continue;
+                    }
+
+                    _logEntries.InsertSorted(logEntry);
+                }
+            }
+
+            await InvokeAsync(_logViewerRef.SafeRefreshDataAsync);
+        }
+    }
+
     private SelectViewModel<ResourceTypeDetails> GetSelectedOption()
     {
         Debug.Assert(_resources is not null);
@@ -330,9 +370,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
             // Clear log entries for new subscription
             Logger.LogDebug("Creating new log entries collection.");
-            _logEntries = new(Options.Value.Frontend.MaxConsoleLogCount);
+            _logEntries.Clear(keepActivePauseEntries: false);
 
-            await InvokeAsync(StateHasChanged);
+            await InvokeAsync(_logViewerRef.SafeRefreshDataAsync);
 
             if (isAllSelected)
             {
@@ -707,12 +747,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
                     foreach (var priorPause in pauseIntervals)
                     {
-                        _logEntries.InsertSorted(LogEntry.CreatePause(GetResourceName(subscription.Resource), priorPause.Start, priorPause.End));
+                        _logEntryChannel.Writer.TryWrite(LogEntry.CreatePause(GetResourceName(subscription.Resource), priorPause.Start, priorPause.End));
                     }
                 }
-
-                // Console logs are filtered in the UI by the timestamp of the log entry.
-                var timestampFilterDate = GetFilteredDateFromRemove();
 
                 var resourcePrefix = ResourceViewModel.GetResourceName(subscription.Resource, _resourceByName, _showHiddenResources);
 
@@ -726,34 +763,15 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                         continue;
                     }
 
-                    lock (_updateLogsLock)
+                    foreach (var (lineNumber, content, isErrorOutput) in batch)
                     {
-                        foreach (var (lineNumber, content, isErrorOutput) in batch)
-                        {
-                            subscription.CancellationToken.ThrowIfCancellationRequested();
+                        // Set the base line number using the reported line number of the first log line.
+                        _logEntries.BaseLineNumber ??= lineNumber;
 
-                            // Set the base line number using the reported line number of the first log line.
-                            _logEntries.BaseLineNumber ??= lineNumber;
+                        var logEntry = logParser.CreateLogEntry(content, isErrorOutput, resourcePrefix);
 
-                            var logEntry = logParser.CreateLogEntry(content, isErrorOutput, resourcePrefix);
-
-                            // Check if log entry is not displayed because of remove.
-                            if (logEntry.Timestamp is not null && timestampFilterDate is not null && !(logEntry.Timestamp > timestampFilterDate))
-                            {
-                                continue;
-                            }
-
-                            // Check if log entry is not displayed because of pause.
-                            if (_logEntries.ProcessPauseFilters(logEntry))
-                            {
-                                continue;
-                            }
-
-                            _logEntries.InsertSorted(logEntry);
-                        }
+                        _logEntryChannel.Writer.TryWrite(logEntry);
                     }
-
-                    await InvokeAsync(StateHasChanged);
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -797,7 +815,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
         if (PageViewModel.SelectedResource.Id is not null &&
             _consoleLogFilters.FilterResourceLogsDates.TryGetValue(
-                PageViewModel.SelectedResource.Id.GetResourceKey().ToString(),
+                PageViewModel.SelectedResource.Id.GetResourceKey(),
                 out var filterResourceLogsDate))
         {
             // There is a filter for this individual resource.
@@ -915,7 +933,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         else
         {
             _consoleLogFilters.FilterResourceLogsDates ??= [];
-            _consoleLogFilters.FilterResourceLogsDates[key.Value.ToString()] = now;
+            _consoleLogFilters.FilterResourceLogsDates[key.Value] = now;
         }
 
         // Save filters to session storage so they're persisted when navigating to and from the console logs page.
@@ -939,7 +957,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                     foreach (var subscription in _consoleLogsSubscriptions.Values)
                     {
                         Logger.LogDebug("Inserting new pause log entry for {Resource} starting at {StartTimestamp}.", subscription.Resource.Name, timestamp);
-                        _logEntries.InsertSorted(LogEntry.CreatePause(GetResourceName(subscription.Resource), timestamp));
+                        _logEntryChannel.Writer.TryWrite(LogEntry.CreatePause(GetResourceName(subscription.Resource), timestamp));
                     }
                 }
                 else
@@ -958,6 +976,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                     }
                 }
             }
+
+            _ = InvokeAsync(_logViewerRef.SafeRefreshDataAsync);
         }
     }
 
@@ -968,6 +988,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         _resourceSubscriptionCts.Cancel();
         _resourceSubscriptionCts.Dispose();
         await TaskHelpers.WaitIgnoreCancelAsync(_resourceSubscriptionTask);
+        await TaskHelpers.WaitIgnoreCancelAsync(_logEntryChannelReaderTask);
 
         await CancelAllSubscriptionsAsync();
         TelemetryContext.Dispose();

--- a/src/Aspire.Dashboard/Extensions/ComponentExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ComponentExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Extensions;
@@ -12,6 +13,14 @@ internal static class ComponentExtensions
         if (dataGrid != null)
         {
             await dataGrid.RefreshDataAsync().ConfigureAwait(false);
+        }
+    }
+
+    public static async Task SafeRefreshDataAsync(this LogViewer? logViewer)
+    {
+        if (logViewer != null)
+        {
+            await logViewer.RefreshDataAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/Aspire.Dashboard/Model/ConsoleLogsFilters.cs
+++ b/src/Aspire.Dashboard/Model/ConsoleLogsFilters.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Otlp.Storage;
+
 namespace Aspire.Dashboard.Model;
 
 public sealed class ConsoleLogsFilters
 {
     public DateTime? FilterAllLogsDate { get; set; }
-    public Dictionary<string, DateTime> FilterResourceLogsDates { get; set; } = [];
+    public Dictionary<ResourceKey, DateTime> FilterResourceLogsDates { get; set; } = [];
 }

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -682,16 +682,9 @@ internal sealed class DashboardClient : IDashboardClient
             }
         }, combinedTokens.Token);
 
-        await foreach (var batch in channel.GetBatchesAsync(TimeSpan.FromMilliseconds(100), combinedTokens.Token).ConfigureAwait(false))
+        await foreach (var batch in channel.Reader.ReadAllAsync(combinedTokens.Token).ConfigureAwait(false))
         {
-            if (batch.Count == 1)
-            {
-                yield return batch[0];
-            }
-            else
-            {
-                yield return batch.SelectMany(batch => batch).ToList();
-            }
+            yield return batch;
         }
 
         await readTask.ConfigureAwait(false);

--- a/src/Shared/ConsoleLogs/LogEntry.cs
+++ b/src/Shared/ConsoleLogs/LogEntry.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 namespace Aspire.Hosting.ConsoleLogs;
 
-[DebuggerDisplay("LineNumber = {LineNumber}, Timestamp = {Timestamp}, Content = {Content}, Type = {Type}")]
+[DebuggerDisplay("LineNumber = {LineNumber}, Timestamp = {Timestamp}, ResourcePrefix = {ResourcePrefix}, Content = {Content}, Type = {Type}")]
 #if ASPIRE_DASHBOARD
 public sealed class LogEntry
 #else


### PR DESCRIPTION
- Change console logs page to use item provider. This gives more control over when the console logs are updated.
- Write subscription log entries to a channel and a reader is responsible for updating UI. Channel is rate limited to 100ms between reads. Avoids excessive UI updates and subscriptions fighting over write lock

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
