### PR TITLE
Allow menus to overflow vertically to avoid blocking off content

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -868,6 +868,10 @@ fluent-tooltip[anchor="dialog_close"] > div {
     margin-right: var(--inline-icon-margin);
 }
 
+.aspire-menu-container {
+    overflow-y: auto;
+}
+
 .aspire-menu-container > fluent-menu > fluent-menu-item::part(content) {
     width: 100%;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Description

Menus can get cut off vertically. They should always support scrolling.

Before:

https://github.com/user-attachments/assets/2a057a9c-dc81-475a-b392-bc8b4ada7a9e

After:

https://github.com/user-attachments/assets/f52c2de2-b7a1-440b-8548-95a1be042f80

Fixes #10141

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
