### PR TITLE
Don't add timestamp disambugation to deployment name

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -17,7 +17,8 @@ internal sealed class BicepProvisioner(
     ResourceNotificationService notificationService,
     ResourceLoggerService loggerService,
     IBicepCompiler bicepCompiler,
-     ISecretClientProvider secretClientProvider) : IBicepProvisioner
+    ISecretClientProvider secretClientProvider,
+    DistributedApplicationExecutionContext executionContext) : IBicepProvisioner
 {
     /// <inheritdoc />
     public async Task<bool> ConfigureResourceAsync(IConfiguration configuration, AzureBicepResource resource, CancellationToken cancellationToken)
@@ -168,7 +169,7 @@ internal sealed class BicepProvisioner(
         var deployments = resource.Scope?.Subscription != null
             ? context.Subscription.GetArmDeployments()
             : resourceGroup.GetArmDeployments();
-        var deploymentName = resource.Name;
+        var deploymentName = executionContext.IsPublishMode ? $"{resource.Name}-{DateTimeOffset.Now.ToUnixTimeSeconds()}" : resource.Name;
 
         var deploymentContent = new ArmDeploymentContent(new(ArmDeploymentMode.Incremental)
         {

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -176,8 +176,6 @@ internal sealed class BicepProvisioner(
             Parameters = BinaryData.FromObjectAsJson(parameters),
             DebugSettingDetailLevel = "ResponseContent"
         });
-        // Set the location and use timestamped deployment name for all resources
-        deploymentName = $"{resource.Name}-{DateTimeOffset.Now.ToUnixTimeSeconds()}";
         var operation = await deployments.CreateOrUpdateAsync(WaitUntil.Started, deploymentName, deploymentContent, cancellationToken).ConfigureAwait(false);
 
         // Resolve the deployment URL before waiting for the operation to complete

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -78,22 +78,23 @@ public class AzureBicepProvisionerTests
     public void BicepProvisioner_CanBeInstantiated()
     {
         // Test that BicepProvisioner can be instantiated with required dependencies
-        
+
         // Arrange
         using var builder = TestDistributedApplicationBuilder.Create();
         var services = builder.Services.BuildServiceProvider();
-        
+
         var bicepExecutor = new TestBicepCliExecutor();
         var secretClientProvider = new TestSecretClientProvider();
         var tokenCredentialProvider = new TestTokenCredentialProvider();
-        
+
         // Act
         var provisioner = new BicepProvisioner(
             services.GetRequiredService<ResourceNotificationService>(),
             services.GetRequiredService<ResourceLoggerService>(),
             bicepExecutor,
-            secretClientProvider);
-        
+            secretClientProvider,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+
         // Assert
         Assert.NotNull(provisioner);
     }
@@ -102,13 +103,13 @@ public class AzureBicepProvisionerTests
     public async Task BicepCliExecutor_CompilesBicepToArm()
     {
         // Test the mock bicep executor behavior
-        
+
         // Arrange
         var bicepExecutor = new TestBicepCliExecutor();
-        
+
         // Act
         var result = await bicepExecutor.CompileBicepToArmAsync("test.bicep", CancellationToken.None);
-        
+
         // Assert
         Assert.True(bicepExecutor.CompileBicepToArmAsyncCalled);
         Assert.Equal("test.bicep", bicepExecutor.LastCompiledPath);
@@ -120,14 +121,14 @@ public class AzureBicepProvisionerTests
     public void SecretClientProvider_CreatesSecretClient()
     {
         // Test the mock secret client provider behavior
-        
+
         // Arrange
         var secretClientProvider = new TestSecretClientProvider();
         var vaultUri = new Uri("https://test.vault.azure.net/");
-        
+
         // Act
         var client = secretClientProvider.GetSecretClient(vaultUri);
-        
+
         // Assert
         Assert.True(secretClientProvider.GetSecretClientCalled);
         // Client will be null in our mock, but the call was tracked
@@ -138,15 +139,15 @@ public class AzureBicepProvisionerTests
     public void TestTokenCredential_ProvidesAccessToken()
     {
         // Test the mock token credential behavior
-        
+
         // Arrange
         var tokenProvider = new TestTokenCredentialProvider();
         var credential = tokenProvider.TokenCredential;
         var requestContext = new TokenRequestContext(["https://management.azure.com/.default"]);
-        
+
         // Act
         var token = credential.GetToken(requestContext, CancellationToken.None);
-        
+
         // Assert
         Assert.Equal("mock-token", token.Token);
         Assert.True(token.ExpiresOn > DateTimeOffset.UtcNow);
@@ -156,15 +157,15 @@ public class AzureBicepProvisionerTests
     public async Task TestTokenCredential_ProvidesAccessTokenAsync()
     {
         // Test the mock token credential async behavior
-        
+
         // Arrange
         var provider = new TestTokenCredentialProvider();
         var credential = provider.TokenCredential;
         var requestContext = new TokenRequestContext(["https://management.azure.com/.default"]);
-        
+
         // Act
         var token = await credential.GetTokenAsync(requestContext, CancellationToken.None);
-        
+
         // Assert
         Assert.Equal("mock-token", token.Token);
         Assert.True(token.ExpiresOn > DateTimeOffset.UtcNow);
@@ -176,10 +177,10 @@ public class AzureBicepProvisionerTests
 
         private sealed class MockTokenCredential : TokenCredential
         {
-            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken) => 
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken) =>
                 new("mock-token", DateTimeOffset.UtcNow.AddHours(1));
 
-            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken) => 
+            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken) =>
                 ValueTask.FromResult(new AccessToken("mock-token", DateTimeOffset.UtcNow.AddHours(1)));
         }
     }


### PR DESCRIPTION
Instead of creating a new deployment for each resource, we'll reuse the same deployment. We do lose the ability to view deployment history with this but it reduces the number of deployments we create, especially since we deploy individual resources instead of just the main infrastructure.