### PR TITLE
Fix rendering of Markdown links in CLI

### DIFF
--- a/src/Aspire.Cli/Utils/MarkdownToSpectreConverter.cs
+++ b/src/Aspire.Cli/Utils/MarkdownToSpectreConverter.cs
@@ -65,19 +65,19 @@ internal static partial class MarkdownToSpectreConverter
     {
         // Convert ###### Header 6 (most specific first)
         text = HeaderLevel6Regex().Replace(text, "[bold]$1[/]");
-        
+
         // Convert ##### Header 5
         text = HeaderLevel5Regex().Replace(text, "[bold]$1[/]");
-        
+
         // Convert #### Header 4
         text = HeaderLevel4Regex().Replace(text, "[bold]$1[/]");
-        
+
         // Convert ### Header 3
         text = HeaderLevel3Regex().Replace(text, "[bold yellow]$1[/]");
-        
+
         // Convert ## Header 2
         text = HeaderLevel2Regex().Replace(text, "[bold blue]$1[/]");
-        
+
         // Convert # Header 1
         text = HeaderLevel1Regex().Replace(text, "[bold green]$1[/]");
 
@@ -89,7 +89,7 @@ internal static partial class MarkdownToSpectreConverter
         // Convert **bold** and __bold__
         text = BoldDoubleAsterisksRegex().Replace(text, "[bold]$1[/]");
         text = BoldDoubleUnderscoresRegex().Replace(text, "[bold]$1[/]");
-        
+
         return text;
     }
 
@@ -98,7 +98,7 @@ internal static partial class MarkdownToSpectreConverter
         // Convert *italic* and _italic_ (but not ** or __)
         text = ItalicSingleAsteriskRegex().Replace(text, "[italic]$1[/]");
         text = ItalicSingleUnderscoreRegex().Replace(text, "[italic]$1[/]");
-        
+
         return text;
     }
 
@@ -110,12 +110,12 @@ internal static partial class MarkdownToSpectreConverter
 
     private static string ConvertCodeBlocks(string text)
     {
-        // Convert multi-line code blocks ```code``` 
+        // Convert multi-line code blocks ```code```
         // Remove language name from the beginning if present
         return CodeBlockRegex().Replace(text, match =>
         {
             var content = match.Groups[1].Value.Trim();
-            
+
             // Check if the first line contains a language name (no spaces, common language names)
             var lines = content.Split('\n');
             if (lines.Length > 1)
@@ -129,7 +129,7 @@ internal static partial class MarkdownToSpectreConverter
                     return $"[grey]{codeContent}[/]";
                 }
             }
-            
+
             return $"[grey]{content}[/]";
         });
     }
@@ -147,7 +147,7 @@ internal static partial class MarkdownToSpectreConverter
             "scala", "clojure", "haskell", "perl", "lua", "r", "matlab",
             "dockerfile", "makefile", "ini", "toml", "properties"
         };
-        
+
         return commonLanguages.Contains(text);
     }
 
@@ -157,7 +157,7 @@ internal static partial class MarkdownToSpectreConverter
         // Process line by line to avoid regex matching across line boundaries
         var lines = text.Split('\n');
         var regex = new Regex(@"^>\s*(.*)$");
-        
+
         for (int i = 0; i < lines.Length; i++)
         {
             var match = regex.Match(lines[i]);
@@ -167,7 +167,7 @@ internal static partial class MarkdownToSpectreConverter
                 lines[i] = $"[italic grey]{content}[/]";
             }
         }
-        
+
         return string.Join('\n', lines);
     }
 
@@ -185,8 +185,8 @@ internal static partial class MarkdownToSpectreConverter
 
     private static string ConvertLinks(string text)
     {
-        // Convert [text](url) to just the URL with underline and blue color
-        return LinkRegex().Replace(text, "[blue underline]$2[/]");
+        // Convert [text](url) to Spectre.Console link format [link=url]text[/]
+        return LinkRegex().Replace(text, "[link=$2]$1[/]");
     }
 
     private static string EscapeRemainingSquareBrackets(string text)
@@ -194,32 +194,32 @@ internal static partial class MarkdownToSpectreConverter
         // Escape any remaining square brackets that are not part of Spectre markup
         // We need to preserve Spectre markup tags like [bold], [/], [blue underline], etc.
         // but escape markdown constructs like reference links [text][ref]
-        
+
         // Use a regex to find standalone square brackets that are not Spectre markup
-        // Spectre markup pattern: [word] or [word word] or [/] 
+        // Spectre markup pattern: [word] or [word word] or [/]
         // Reference/other markdown pattern: everything else with square brackets
-        
+
         // First, temporarily replace all Spectre markup with placeholders
         var spectreMarkups = new List<string>();
-        var spectrePattern = @"\[(?:/?(?:bold|italic|grey|blue|green|yellow|underline|strikethrough)\s?)+\]|\[/\]";
+        var spectrePattern = @"\[(?:/?(?:bold|italic|grey|blue|green|yellow|underline|strikethrough)\s?)+\]|\[/\]|\[link=[^\]]+\]";
         var spectreRegex = new Regex(spectrePattern);
-        
+
         var textWithPlaceholders = spectreRegex.Replace(text, match =>
         {
             var placeholder = $"__SPECTRE_MARKUP_{spectreMarkups.Count}__";
             spectreMarkups.Add(match.Value);
             return placeholder;
         });
-        
+
         // Now escape remaining square brackets
         textWithPlaceholders = textWithPlaceholders.Replace("[", "[[").Replace("]", "]]");
-        
+
         // Restore Spectre markup
         for (int i = 0; i < spectreMarkups.Count; i++)
         {
             textWithPlaceholders = textWithPlaceholders.Replace($"__SPECTRE_MARKUP_{i}__", spectreMarkups[i]);
         }
-        
+
         return textWithPlaceholders;
     }
 

--- a/src/Aspire.Cli/Utils/MarkdownToSpectreConverter.cs
+++ b/src/Aspire.Cli/Utils/MarkdownToSpectreConverter.cs
@@ -185,8 +185,8 @@ internal static partial class MarkdownToSpectreConverter
 
     private static string ConvertLinks(string text)
     {
-        // Convert [text](url) to Spectre.Console link format [link=url]text[/]
-        return LinkRegex().Replace(text, "[link=$2]$1[/]");
+        // Convert [text](url) to Spectre.Console link format with cyan color
+        return LinkRegex().Replace(text, "[cyan link=$2]$1[/]");
     }
 
     private static string EscapeRemainingSquareBrackets(string text)
@@ -201,7 +201,7 @@ internal static partial class MarkdownToSpectreConverter
 
         // First, temporarily replace all Spectre markup with placeholders
         var spectreMarkups = new List<string>();
-        var spectrePattern = @"\[(?:/?(?:bold|italic|grey|blue|green|yellow|underline|strikethrough)\s?)+\]|\[/\]|\[link=[^\]]+\]";
+        var spectrePattern = @"\[(?:/?(?:bold|italic|grey|blue|green|yellow|cyan|underline|strikethrough)\s?)+\]|\[/\]|\[link=[^\]]+\]|\[cyan\s+link=[^\]]+\]";
         var spectreRegex = new Regex(spectrePattern);
 
         var textWithPlaceholders = spectreRegex.Replace(text, match =>

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -563,8 +563,8 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var promptCall = promptCalls[0];
 
         // The markdown "**Enter** the `config` value for [Azure Portal](https://portal.azure.com):"
-        // should be converted to Spectre markup with URL instead of text
-        var expectedSpectreMarkup = "[bold][bold]Enter[/] the [grey][bold]config[/][/] value for [blue underline]https://portal.azure.com[/]:[/]";
+        // should be converted to Spectre markup preserving both link text and URL
+        var expectedSpectreMarkup = "[bold]Enter[/] the [grey][bold]config[/][/] value for [link=https://portal.azure.com]Azure Portal[/]:";
         Assert.Equal(expectedSpectreMarkup, promptCall.PromptText);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -564,7 +564,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
 
         // The markdown "**Enter** the `config` value for [Azure Portal](https://portal.azure.com):"
         // should be converted to Spectre markup preserving both link text and URL
-        var expectedSpectreMarkup = "[bold]Enter[/] the [grey][bold]config[/][/] value for [link=https://portal.azure.com]Azure Portal[/]:";
+        var expectedSpectreMarkup = "[bold][bold]Enter[/] the [grey][bold]config[/][/] value for [cyan link=https://portal.azure.com]Azure Portal[/]:[/]";
         Assert.Equal(expectedSpectreMarkup, promptCall.PromptText);
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
@@ -101,8 +101,8 @@ public class MarkdownToSpectreConverterTests
     }
 
     [Theory]
-    [InlineData("[link text](https://example.com)", "[blue underline]https://example.com[/]")]
-    [InlineData("Visit [GitHub](https://github.com) for more info.", "Visit [blue underline]https://github.com[/] for more info.")]
+    [InlineData("[link text](https://example.com)", "[link=https://example.com]link text[/]")]
+    [InlineData("Visit [GitHub](https://github.com) for more info.", "Visit [link=https://github.com]GitHub[/] for more info.")]
     public void ConvertToSpectre_WithLinks_ConvertsCorrectly(string markdown, string expected)
     {
         // Act
@@ -130,7 +130,7 @@ Some more text.";
         var expected = @"[bold green]Main Header[/]
 This is [bold]bold[/] and [italic]italic[/] text with [grey][bold]inline code[/][/].
 [bold blue]Sub Header[/]
-Visit [blue underline]https://github.com[/] for more information.
+Visit [link=https://github.com]GitHub[/] for more information.
 [bold yellow]Small Header[/]
 Some more text.";
         // Normalize line endings in expected string to match converter output
@@ -174,7 +174,7 @@ Some more text.";
         var result = MarkdownToSpectreConverter.ConvertToSpectre(markdown);
 
         // Assert
-        Assert.Equal("Inline [blue underline]https://github.com[/] and reference [[docs]][[ref1]].", result);
+        Assert.Equal("Inline [link=https://github.com]GitHub[/] and reference [[docs]][[ref1]].", result);
     }
 
     [Theory]
@@ -227,7 +227,7 @@ Some more text.";
         var result = MarkdownToSpectreConverter.ConvertToSpectre(markdown);
 
         // Assert
-        Assert.Equal("Visit [blue underline]https://github.com[/] and see this  for details.", result);
+        Assert.Equal("Visit [link=https://github.com]GitHub[/] and see this  for details.", result);
     }
 
     [Fact]
@@ -246,7 +246,7 @@ Visit [our site](https://example.com) for more details.";
         var expected = @"[bold green]Documentation[/]
 This is [bold]important[/] information with an image: 
 
-Visit [blue underline]https://example.com[/] for more details.";
+Visit [link=https://example.com]our site[/] for more details.";
         // Normalize line endings in expected string to match converter output
         expected = expected.Replace("\r\n", "\n").Replace("\r", "\n");
         Assert.Equal(expected, result);

--- a/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MarkdownToSpectreConverterTests.cs
@@ -101,8 +101,8 @@ public class MarkdownToSpectreConverterTests
     }
 
     [Theory]
-    [InlineData("[link text](https://example.com)", "[link=https://example.com]link text[/]")]
-    [InlineData("Visit [GitHub](https://github.com) for more info.", "Visit [link=https://github.com]GitHub[/] for more info.")]
+    [InlineData("[link text](https://example.com)", "[cyan link=https://example.com]link text[/]")]
+    [InlineData("Visit [GitHub](https://github.com) for more info.", "Visit [cyan link=https://github.com]GitHub[/] for more info.")]
     public void ConvertToSpectre_WithLinks_ConvertsCorrectly(string markdown, string expected)
     {
         // Act
@@ -130,7 +130,7 @@ Some more text.";
         var expected = @"[bold green]Main Header[/]
 This is [bold]bold[/] and [italic]italic[/] text with [grey][bold]inline code[/][/].
 [bold blue]Sub Header[/]
-Visit [link=https://github.com]GitHub[/] for more information.
+Visit [cyan link=https://github.com]GitHub[/] for more information.
 [bold yellow]Small Header[/]
 Some more text.";
         // Normalize line endings in expected string to match converter output
@@ -174,7 +174,7 @@ Some more text.";
         var result = MarkdownToSpectreConverter.ConvertToSpectre(markdown);
 
         // Assert
-        Assert.Equal("Inline [link=https://github.com]GitHub[/] and reference [[docs]][[ref1]].", result);
+        Assert.Equal("Inline [cyan link=https://github.com]GitHub[/] and reference [[docs]][[ref1]].", result);
     }
 
     [Theory]
@@ -227,7 +227,7 @@ Some more text.";
         var result = MarkdownToSpectreConverter.ConvertToSpectre(markdown);
 
         // Assert
-        Assert.Equal("Visit [link=https://github.com]GitHub[/] and see this  for details.", result);
+        Assert.Equal("Visit [cyan link=https://github.com]GitHub[/] and see this  for details.", result);
     }
 
     [Fact]
@@ -246,7 +246,7 @@ Visit [our site](https://example.com) for more details.";
         var expected = @"[bold green]Documentation[/]
 This is [bold]important[/] information with an image: 
 
-Visit [link=https://example.com]our site[/] for more details.";
+Visit [cyan link=https://example.com]our site[/] for more details.";
         // Normalize line endings in expected string to match converter output
         expected = expected.Replace("\r\n", "\n").Replace("\r", "\n");
         Assert.Equal(expected, result);


### PR DESCRIPTION
<img width="1912" height="1237" alt="image" src="https://github.com/user-attachments/assets/e540d7eb-a269-4f6d-8851-c95c955d780b" />
