### PR TITLE
Adjust markdown heading level

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/css/markdown.css
+++ b/src/Aspire.Dashboard/wwwroot/css/markdown.css
@@ -145,3 +145,19 @@
     padding-right: calc(.25rem * 1);
     padding-block: calc(.25rem * 1.5);
 }
+
+/* Markdown headings are modified to never be larger than h4 */
+.markdown-container h4 {
+    font-size: var(--type-ramp-plus-2-font-size);
+    line-height: var(--type-ramp-plus-2-line-height);
+}
+
+.markdown-container h5 {
+    font-size: var(--type-ramp-plus-1-font-size);
+    line-height: var(--type-ramp-plus-1-line-height);
+}
+
+.markdown-container h6 {
+    font-size: var(--type-ramp-base-font-size);
+    line-height: var(--type-ramp-base-line-height);
+}

--- a/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
@@ -1,0 +1,338 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+using Aspire.Dashboard.Model.Markdown;
+using Aspire.Dashboard.Resources;
+using Aspire.Dashboard.Tests.Model;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Markdown;
+
+public class MarkdownProcessorTests
+{
+    [Fact]
+    public void ToHtml_FencedCodeBlockBreaksIndentation_TrailingTextIsntACodeBlock()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            """
+            To restart the unhealthy container resources effectively, follow these steps:
+
+            1. **Identify the Unhealthy Containers**:
+               - From the resource graph, note the names of the unhealthy containers (e.g., `postgres-euaaphdw`, `basketcache-urvebuku`, `messaging-ffc632b9`).
+
+            2. **Restart Containers Individually**:
+               - Use the appropriate container management tool (e.g., Docker CLI, Docker Compose, Kubernetes) to restart each container. For Docker, you can use:
+             ```bash
+
+             docker restart <container_name>
+
+             ```
+                 Replace `<container_name>` with the actual container name (e.g., `postgres-euaaphdw`).
+
+            3. **Verify Restart Success**
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        var count = Regex.Matches(html, Regex.Escape("code-block")).Count;
+        Assert.Equal(1, count); // There should be one code block. There shouldn't be an indented code block.
+    }
+
+    [Fact]
+    public void ToHtml_StartFencedCodeBlock_NoHtmlCode()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            """
+            Test:
+            ```csha
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            """
+            <p>Test:</p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void ToHtml_FencedCodeBlockEmpty_HasHtmlCode()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            """
+            Test:
+            ```csharp
+            ```
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Contains("</code>", html);
+    }
+
+    [Fact]
+    public void ToHtml_ContainsFencedCodeBlock_HtmlHasCode()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            """
+            Test:
+            ```csha
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            """
+            <p>Test:</p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void ToHtml_IncompleteFencedCodeBlock_HtmlHasCode()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            """
+            Test:
+            ```
+            In code bl...
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Contains("</code>", html);
+    }
+
+    [Fact]
+    public void ToHtml_ContainsFencedCodeBlockCsharp_HtmlHasCode()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            """
+            Test:
+            ```csharp
+            In code block.
+            ```
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Contains("language-csharp", html);
+        Assert.Contains("</code>", html);
+    }
+
+    [Fact]
+    public void ToHtml_ContainsHtml_HtmlIgnored()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            """
+            **Waiting Resources:** <b>test</b>
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            """
+            <p><strong>Waiting Resources:</strong> &lt;b&gt;test&lt;/b&gt;</p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void ToHtml_UrlWithJavaScript_UrlRemoved()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            """
+            [malicious](javascript:alert('hi'))
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            """
+            <p><a href="">malicious</a></p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Theory]
+    [InlineData("http://localhost:8080")]
+    [InlineData("https://localhost:8081")]
+    [InlineData("mailto:test@test.com")]
+    public void ToHtml_UrlWithValidSchemes_LinkAdded(string url)
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor(safeUrlSchemes: MarkdownHelpers.SafeUrlSchemes);
+
+        var markdown =
+            $"""
+            [test]({url})
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            $"""
+            <p><a href="{url}" target="_blank" rel="noopener noreferrer nofollow">test</a></p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Theory]
+    [InlineData("vscode://localhost:8080")]
+    [InlineData("spotify://localhost:8080")]
+    public void ToHtml_UrlWithInvalidSchemes_LinkNotAdded(string url)
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor(safeUrlSchemes: MarkdownHelpers.SafeUrlSchemes);
+
+        var markdown =
+            $"""
+            [test]({url})
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            $"""
+            <p><a href="">test</a></p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Theory]
+    [InlineData("http://contoso.com:8080", "http://contoso.com:8080")]
+    [InlineData("https://contoso.com:8081", "https://contoso.com:8081")]
+    [InlineData("mailto:test@test.com", "test@test.com")]
+    public void ToHtml_AutoLinkWithValidSchemes_LinkAdded(string url, string text)
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor(safeUrlSchemes: MarkdownHelpers.SafeUrlSchemes);
+
+        var markdown =
+            $"""
+            {url}
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            $"""
+            <p><a href="{url}" target="_blank" rel="noopener noreferrer nofollow">{text}</a></p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Theory]
+    [InlineData("http://localhost:8080", "http://localhost:8080")]
+    [InlineData("https://localhost", "https://localhost")]
+    public void ToHtml_Localhost_LinkAdded(string url, string text)
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            $"""
+            {url}
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            $"""
+            <p><a href="{url}" target="_blank" rel="noopener noreferrer nofollow">{text}</a></p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void ToHtml_UrlInsideCodeWithExtra_NoLink()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            $"""
+            `http://localhost:8080 extra`
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(
+            $"""
+            <p><code>http://localhost:8080 extra</code></p>
+            """, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Theory]
+    [InlineData("# Header", "<h4>Header</h4>")]
+    [InlineData("## Header", "<h4>Header</h4>")]
+    [InlineData("### Header", "<h5>Header</h5>")]
+    [InlineData("#### Header", "<h5>Header</h5>")]
+    [InlineData("##### Header", "<h6>Header</h6>")]
+    [InlineData("###### Header", "<h6>Header</h6>")]
+    public void ToHtml_Header_LevelAdjusted(string header, string expected)
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            $"""
+            {header}
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        Assert.Equal(expected, html.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    internal static MarkdownProcessor CreateMarkdownProcessor(HashSet<string>? safeUrlSchemes = null)
+    {
+        return new MarkdownProcessor(new TestStringLocalizer<ControlsStrings>(), safeUrlSchemes);
+    }
+}


### PR DESCRIPTION
## Description

Adjust markdown heading level so that it isn't larger than the FluentUI dialog title.

Fixes https://github.com/dotnet/aspire/issues/10450

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
