### PR TITLE
Hide resource footer on graph view

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -234,10 +234,13 @@
             </SummaryDetailsView>
         </MainSection>
         <FooterSection>
-            <TotalItemsFooter @ref="_totalItemsFooter"
-                              SingularText="@Loc[nameof(Dashboard.Resources.Resources.TotalItemsFooterSingularText)]"
-                              PluralText="@Loc[nameof(Dashboard.Resources.Resources.TotalItemsFooterPluralText)]"
-                              TotalItemCount="@_totalItemsCount"/>
+            @* Don't display footer with the resource graph *@
+            <div hidden="@(PageViewModel.SelectedViewKind != ResourceViewKind.Table)">
+                <TotalItemsFooter @ref="_totalItemsFooter"
+                                  SingularText="@Loc[nameof(Dashboard.Resources.Resources.TotalItemsFooterSingularText)]"
+                                  PluralText="@Loc[nameof(Dashboard.Resources.Resources.TotalItemsFooterPluralText)]"
+                                  TotalItemCount="@_totalItemsCount"/>
+            </div>
         </FooterSection>
     </AspirePageContentLayout>
 </div>


### PR DESCRIPTION
I noticed the resource footer was displayed with the graph view. It should only be visible when viewing the table:

<img width="2455" height="1083" alt="image" src="https://github.com/user-attachments/assets/90ca014b-1d68-4033-93f7-1dba4ae1b887" />
