### PR TITLE
Add cloud type filter to tracing pages

### DIFF
--- a/src/Aspire.Dashboard/Model/SpanType.cs
+++ b/src/Aspire.Dashboard/Model/SpanType.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Localization;
 
 namespace Aspire.Dashboard.Model;
 
-public class SpanType
+public sealed class SpanType
 {
     public string Name { get; }
     public TelemetryFilter Filter { get; }
@@ -44,17 +44,21 @@ public class SpanType
         "genai",
         new SpanHasAttributeTelemetryFilter(["gen_ai.system", "gen_ai.provider.name", "gen_ai.operation.name"]));
 
+    // AWSSDK: https://github.com/aws/aws-sdk-net/blob/3acb8af23e9df891b4e37cf4cda9c5131be0389c/sdk/src/Core/Amazon.Runtime/Telemetry/TelemetryConstants.cs#L26
+    // Azure: https://github.com/Azure/azure-sdk-for-net/blob/1af7c19fe8dcb7f7f843730117accbd6927ad2a4/sdk/ai/Azure.AI.Inference/src/Telemetry/OpenTelemetryConstants.cs#L46
+    public static readonly SpanType Cloud = new SpanType(
+        "cloud",
+        new SpanScopePrefixTelemetryFilter(["Azure", "AWSSDK"]));
+
     public static readonly SpanType Other = new SpanType(
         "other",
-        new SpanNoAttributeTelemetryFilter([
-            "http.request.method",
-            "db.system.name",
-            "db.system",
-            "messaging.system",
-            "rpc.system",
-            "gen_ai.system",
-            "gen_ai.provider.name",
-            "gen_ai.operation.name"
+        new SpanNoMatchTelemetryFilter([
+            Http.Filter,
+            Database.Filter,
+            Messaging.Filter,
+            Rpc.Filter,
+            GenAI.Filter,
+            Cloud.Filter
         ]));
 
     public static List<SelectViewModel<SpanType>> CreateKnownSpanTypes(IStringLocalizer<ControlsStrings> loc)
@@ -67,12 +71,13 @@ public class SpanType
             new() { Id = Messaging, Name = loc[nameof(ControlsStrings.SpanTypeMessaging)] },
             new() { Id = Rpc, Name = loc[nameof(ControlsStrings.SpanTypeRpc)] },
             new() { Id = GenAI, Name = loc[nameof(ControlsStrings.SpanTypeGenAI)] },
+            new() { Id = Cloud, Name = loc[nameof(ControlsStrings.SpanTypeCloud)] },
             new() { Id = Other, Name = loc[nameof(ControlsStrings.LabelOther)] },
         };
     }
 }
 
-public class SpanHasAttributeTelemetryFilter : TelemetryFilter
+public sealed class SpanHasAttributeTelemetryFilter : TelemetryFilter
 {
     private readonly string[] _attributeNames;
 
@@ -105,13 +110,13 @@ public class SpanHasAttributeTelemetryFilter : TelemetryFilter
     }
 }
 
-public class SpanNoAttributeTelemetryFilter : TelemetryFilter
+public sealed class SpanNoMatchTelemetryFilter : TelemetryFilter
 {
-    private readonly string[] _attributeNames;
+    private readonly TelemetryFilter[] _filters;
 
-    public SpanNoAttributeTelemetryFilter(string[] attributeNames)
+    public SpanNoMatchTelemetryFilter(TelemetryFilter[] filters)
     {
-        _attributeNames = attributeNames;
+        _filters = filters;
     }
 
     public override IEnumerable<OtlpLogEntry> Apply(IEnumerable<OtlpLogEntry> input)
@@ -121,15 +126,59 @@ public class SpanNoAttributeTelemetryFilter : TelemetryFilter
 
     public override bool Apply(OtlpSpan span)
     {
-        foreach (var attributeName in _attributeNames)
+        foreach (var filter in _filters)
         {
-            if (!string.IsNullOrEmpty(span.Attributes.GetValue(attributeName)))
+            if (filter.Apply(span))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    public override bool Equals(TelemetryFilter? other)
+    {
+        return false;
+    }
+}
+
+public sealed class SpanScopePrefixTelemetryFilter : TelemetryFilter
+{
+    private readonly string[] _scopePrefixes;
+
+    public SpanScopePrefixTelemetryFilter(string[] scopePrefixes)
+    {
+        _scopePrefixes = scopePrefixes;
+    }
+
+    public override IEnumerable<OtlpLogEntry> Apply(IEnumerable<OtlpLogEntry> input)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override bool Apply(OtlpSpan span)
+    {
+        foreach (var scopePrefix in _scopePrefixes)
+        {
+            if (span.Scope.Name.StartsWith(scopePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                // Exact match.
+                if (span.Scope.Name.Length == scopePrefix.Length)
+                {
+                    return true;
+                }
+                // Starts with prefix followed by delimiter.
+                if (span.Scope.Name[scopePrefix.Length] == '.')
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        return false;
     }
 
     public override bool Equals(TelemetryFilter? other)

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Aspire.Dashboard.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ControlsStrings {
@@ -993,6 +993,15 @@ namespace Aspire.Dashboard.Resources {
         public static string SpanDetailsStartTime {
             get {
                 return ResourceManager.GetString("SpanDetailsStartTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cloud.
+        /// </summary>
+        public static string SpanTypeCloud {
+            get {
+                return ResourceManager.GetString("SpanTypeCloud", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -511,4 +511,7 @@
   <data name="SpanTypeGenAI" xml:space="preserve">
     <value>Gen AI</value>
   </data>
+  <data name="SpanTypeCloud" xml:space="preserve">
+    <value>Cloud</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Čas spuštění: &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">Databáze</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Startzeit &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">Datenbank</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Hora de inicio &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">Base de datos</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -522,6 +522,11 @@
         <target state="translated">&lt;strong&gt;Heure de début : &lt;/strong&gt; {0}</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">Base de données</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Ora di inizio &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">Database</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -522,6 +522,11 @@
         <target state="translated">開始時刻 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">データベース</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -522,6 +522,11 @@
         <target state="translated">시작 시간 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">데이터베이스</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Czas rozpoczęcia: &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">Baza danych</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Horário de início &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">Banco de dados</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -522,6 +522,11 @@
         <target state="translated">&lt;strong&gt;Время начала: &lt;/strong&gt; {0}</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">База данных</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Başlangıç zamanı &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">Veritabanı</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -522,6 +522,11 @@
         <target state="translated">开始时间 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">数据库</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -522,6 +522,11 @@
         <target state="translated">開始時間 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanTypeCloud">
+        <source>Cloud</source>
+        <target state="new">Cloud</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeDatabase">
         <source>Database</source>
         <target state="translated">資料庫</target>

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -152,27 +152,33 @@ public sealed class SpanWaterfallViewModelTests
     }
 
     [Theory]
-    [InlineData("http", new string[] { }, false)]
-    [InlineData("http", new string[] { "http.request.method" }, true)]
-    [InlineData("database", new string[] { "http.request.method" }, false)]
-    [InlineData("database", new string[] { "db.system.name" }, true)]
-    [InlineData("database", new string[] { "db.system" }, true)]
-    [InlineData("database", new string[] { }, false)]
-    [InlineData("messaging", new string[] { "messaging.system" }, true)]
-    [InlineData("messaging", new string[] { }, false)]
-    [InlineData("rpc", new string[] { "rpc.system" }, true)]
-    [InlineData("rpc", new string[] { }, false)]
-    [InlineData("genai", new string[] { "gen_ai.system" }, true)]
-    [InlineData("genai", new string[] { "gen_ai.provider.name" }, true)]
-    [InlineData("genai", new string[] { "gen_ai.operation.name" }, true)]
-    [InlineData("genai", new string[] { }, false)]
-    public void MatchesFilter_SpanType_ReturnsExpected(string spanTypeName, string[] presentAttributeNames, bool expected)
+    [InlineData("http", null, new string[] { }, false)]
+    [InlineData("http", null, new string[] { "http.request.method" }, true)]
+    [InlineData("database", "Azure", new string[] { "http.request.method" }, false)]
+    [InlineData("database", null, new string[] { "db.system.name" }, true)]
+    [InlineData("database", null, new string[] { "db.system" }, true)]
+    [InlineData("database", null, new string[] { }, false)]
+    [InlineData("messaging", null, new string[] { "messaging.system" }, true)]
+    [InlineData("messaging", null, new string[] { }, false)]
+    [InlineData("rpc", "Azure", new string[] { "rpc.system" }, true)]
+    [InlineData("rpc", null, new string[] { }, false)]
+    [InlineData("genai", null, new string[] { "gen_ai.system" }, true)]
+    [InlineData("genai", null, new string[] { "gen_ai.provider.name" }, true)]
+    [InlineData("genai", null, new string[] { "gen_ai.operation.name" }, true)]
+    [InlineData("genai", null, new string[] { }, false)]
+    [InlineData("cloud", "Azure", new string[0], true)]
+    [InlineData("cloud", "AZURE", new string[0], true)]
+    [InlineData("cloud", "AZURE.", new string[0], true)]
+    [InlineData("cloud", "Azure.Whatever", new string[0], true)]
+    [InlineData("cloud", "AWSSDK", new string[0], true)]
+    [InlineData("cloud", "Other", new string[0], false)]
+    public void MatchesFilter_SpanType_ReturnsExpected(string spanTypeName, string? scopeName, string[] presentAttributeNames, bool expected)
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
         var app = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
-        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context, name: scopeName);
         var spanType = SpanType.CreateKnownSpanTypes(new TestStringLocalizer<ControlsStrings>()).Single(t => t.Id?.Name == spanTypeName);
         var otherSpanType = SpanType.CreateKnownSpanTypes(new TestStringLocalizer<ControlsStrings>()).Single(t => t.Id?.Name == "other");
 


### PR DESCRIPTION
## Description

Add a `Cloud` filter to traces page. Matches telemetry from cloud libraries.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
