### PR TITLE
Look for operation in GenAI filter

### DIFF
--- a/src/Aspire.Dashboard/Model/SpanType.cs
+++ b/src/Aspire.Dashboard/Model/SpanType.cs
@@ -53,7 +53,8 @@ public class SpanType
             "messaging.system",
             "rpc.system",
             "gen_ai.system",
-            "gen_ai.provider.name"
+            "gen_ai.provider.name",
+            "gen_ai.operation.name"
         ]));
 
     public static List<SelectViewModel<SpanType>> CreateKnownSpanTypes(IStringLocalizer<ControlsStrings> loc)

--- a/src/Aspire.Dashboard/Model/SpanType.cs
+++ b/src/Aspire.Dashboard/Model/SpanType.cs
@@ -42,7 +42,7 @@ public class SpanType
     // https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
     public static readonly SpanType GenAI = new SpanType(
         "genai",
-        new SpanHasAttributeTelemetryFilter(["gen_ai.system", "gen_ai.provider.name"]));
+        new SpanHasAttributeTelemetryFilter(["gen_ai.system", "gen_ai.provider.name", "gen_ai.operation.name"]));
 
     public static readonly SpanType Other = new SpanType(
         "other",

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -164,6 +164,7 @@ public sealed class SpanWaterfallViewModelTests
     [InlineData("rpc", new string[] { }, false)]
     [InlineData("genai", new string[] { "gen_ai.system" }, true)]
     [InlineData("genai", new string[] { "gen_ai.provider.name" }, true)]
+    [InlineData("genai", new string[] { "gen_ai.operation.name" }, true)]
     [InlineData("genai", new string[] { }, false)]
     public void MatchesFilter_SpanType_ReturnsExpected(string spanTypeName, string[] presentAttributeNames, bool expected)
     {


### PR DESCRIPTION
## Description

GenAI spans that execute on your machine, i.e. tool calls, don't have a system/provider attribute. Also check for operation name to include tool call spans.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
