### PR TITLE
Always display .NET runtime version in dashboard settings

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -57,19 +57,12 @@
         }
 
         <div class="version">
-            @string.Format(Loc[nameof(Dialogs.SettingsDialogVersion)], VersionHelpers.DashboardDisplayVersion)
-            @RenderRuntimeVersion()
+            <div>
+                @string.Format(Loc[nameof(Dialogs.SettingsDialogDotNetRuntimeVersion)], System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)
+            </div>
+            <div>
+                @string.Format(Loc[nameof(Dialogs.SettingsDialogVersion)], VersionHelpers.DashboardDisplayVersion)
+            </div>
         </div>
     </FluentStack>
 </FluentDialogBody>
-
-@code {
-    private RenderFragment RenderRuntimeVersion()
-    {
-#if DEBUG
-        return @<text><br />.NET version: @System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription</text>;
-#else
-        return @<text></text>;
-#endif
-    }
-}

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -58,10 +58,10 @@
 
         <div class="version">
             <div>
-                @string.Format(Loc[nameof(Dialogs.SettingsDialogDotNetRuntimeVersion)], System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)
+                @string.Format(Loc[nameof(Dialogs.SettingsDialogVersion)], VersionHelpers.DashboardDisplayVersion)
             </div>
             <div>
-                @string.Format(Loc[nameof(Dialogs.SettingsDialogVersion)], VersionHelpers.DashboardDisplayVersion)
+                @string.Format(Loc[nameof(Dialogs.SettingsDialogDotNetRuntimeVersion)], System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)
             </div>
         </div>
     </FluentStack>

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -19,7 +19,7 @@ namespace Aspire.Dashboard.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Dialogs {
@@ -687,6 +687,15 @@ namespace Aspire.Dashboard.Resources {
         public static string SettingsDialogDashboardLogsAndTelemetry {
             get {
                 return ResourceManager.GetString("SettingsDialogDashboardLogsAndTelemetry", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Runtime: {0}.
+        /// </summary>
+        public static string SettingsDialogDotNetRuntimeVersion {
+            get {
+                return ResourceManager.GetString("SettingsDialogDotNetRuntimeVersion", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -386,4 +386,8 @@
   <data name="GenAINoMessages" xml:space="preserve">
     <value>No messages found.</value>
   </data>
+  <data name="SettingsDialogDotNetRuntimeVersion" xml:space="preserve">
+    <value>Runtime: {0}</value>
+    <comment>{0} is the .NET runtime version</comment>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -352,6 +352,11 @@
         <target state="translated">Protokoly prostředků a telemetrie</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">Jazyk</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -352,6 +352,11 @@
         <target state="translated">Ressourcenprotokolle und Telemetrie</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">Sprache</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -352,6 +352,11 @@
         <target state="translated">Registros de recursos y telemetría</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">Idioma</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -352,6 +352,11 @@
         <target state="translated">Journaux d’activité de ressources et télémétrie</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">Langue</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -352,6 +352,11 @@
         <target state="translated">Log delle risorse e telemetria</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">Lingua</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -352,6 +352,11 @@
         <target state="translated">リソース ログとテレメトリ</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">言語</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -352,6 +352,11 @@
         <target state="translated">리소스 로그 및 원격 분석</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">언어</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -352,6 +352,11 @@
         <target state="translated">Dzienniki zasobów i dane telemetryczne</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">Język</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -352,6 +352,11 @@
         <target state="translated">Logs e telemetria do recurso</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">Idioma</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -352,6 +352,11 @@
         <target state="translated">Журналы ресурсов и телеметрия</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">Язык</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -352,6 +352,11 @@
         <target state="translated">Kaynak günlükleri ve telemetri</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">Dil</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -352,6 +352,11 @@
         <target state="translated">资源日志和遥测</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">语言</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -352,6 +352,11 @@
         <target state="translated">資源記錄與遙測</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogDotNetRuntimeVersion">
+        <source>Runtime: {0}</source>
+        <target state="new">Runtime: {0}</target>
+        <note>{0} is the .NET runtime version</note>
+      </trans-unit>
       <trans-unit id="SettingsDialogLanguage">
         <source>Language</source>
         <target state="translated">語言</target>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -336,16 +336,15 @@ td .long-inner-content {
 }
 
 .version {
+    color: var(--foreground-subtext-rest);
     text-align: end;
     font-size: small;
     width: 100%;
-    flex-grow: 1;
-
-    /* right/bottom align the inner version text */
     display: flex;
-    flex-direction: column-reverse;
+    flex-direction: column;
     align-items: flex-end;
-    row-gap: 8px;
+    row-gap: 4px;
+    margin-top: auto;
 }
 
 .anchor-no-padding::part(control) {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -343,8 +343,9 @@ td .long-inner-content {
 
     /* right/bottom align the inner version text */
     display: flex;
-    flex-direction: row-reverse;
+    flex-direction: column-reverse;
     align-items: flex-end;
+    row-gap: 8px;
 }
 
 .anchor-no-padding::part(control) {


### PR DESCRIPTION
## Description

Always display .NET runtime version in dashboard settings dialog. Useful to identify what version of .NET the dashboard is running on when there are errors.

<img width="997" height="878" alt="image" src="https://github.com/user-attachments/assets/fa4aa8dc-415d-4090-bdc5-4ddebc9dab44" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
