### PR TITLE
Disable guardian analyzer auto injection.

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -166,6 +166,8 @@ extends:
       jobs:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
+          featureFlags:
+            autoEnableRoslynWithNewRuleset: false
           enableMicrobuild: true
           # Publish NuGet packages using v3
           # https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md#basic-onboarding-scenario-for-new-repositories-to-the-current-publishing-version-v3


### PR DESCRIPTION
## Description

Disables the guardian analyzers roslyn rule auto injection which is breaking our CI builds right now.