### PR TITLE
only apply overflow-y to mobile nav menu

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MobileNavMenu.razor
@@ -1,4 +1,4 @@
-﻿<FluentMenu Class="aspire-menu-container" Open="@IsNavMenuOpen" Anchored="false" Style="grid-area: nav-menu; height: 100vh; margin-top: 2px;">
+﻿<FluentMenu Class="aspire-menu-container" Open="@IsNavMenuOpen" Anchored="false" Style="grid-area: nav-menu; height: 100vh; margin-top: 2px; overflow-y: auto;">
     @foreach (var item in GetMobileNavMenuEntries())
     {
         <FluentMenuItem OnClick="@(async () => { CloseNavMenu(); await item.OnClick(); })" Style="height: 40px; width: 100vw; margin-bottom: 6px;" title="@item.Text">

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -868,10 +868,6 @@ fluent-tooltip[anchor="dialog_close"] > div {
     margin-right: var(--inline-icon-margin);
 }
 
-.aspire-menu-container {
-    overflow-y: auto;
-}
-
 .aspire-menu-container > fluent-menu > fluent-menu-item::part(content) {
     width: 100%;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Description

Fixes submenus not showing up in menus. Regressed in #11317 (sorry). The property now only applies to the mobile nav menu.

With fix:
<img width="1327" height="1008" alt="image" src="https://github.com/user-attachments/assets/3adaf633-bc24-46ee-862a-ac94c2ce2036" />


## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
