### PR TITLE
Workaround for dashboard scroll bug on .NET 9 and 10

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
@@ -20,6 +20,7 @@
 <div id="metric-table-container" style="height: 40vh; overflow-y: auto; width:1200px;">
     @* ItemKey is to preserve row focus by associating rows with their associated time *@
     <FluentDataGrid
+        @ref="_dataGrid"
         Items="@_metricsView"
         ItemSize="46"
         Virtualize="true"

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
@@ -4,15 +4,15 @@
 using System.Diagnostics;
 using System.Globalization;
 using Aspire.Dashboard.Components.Controls.Chart;
-using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Components.Dialogs;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
-using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 using Microsoft.JSInterop;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -22,6 +22,7 @@ public partial class MetricTable : ChartBase
     private List<ChartExemplar> _exemplars = [];
     private string _unitColumnHeader = string.Empty;
     private IJSObjectReference? _jsModule;
+    private FluentDataGrid<MetricViewBase> _dataGrid = null!;
 
     private OtlpInstrumentSummary? _instrument;
     private bool _showCount;
@@ -234,6 +235,11 @@ public partial class MetricTable : ChartBase
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (_dataGrid != null && FluentDataGridHelper<MetricViewBase>.TrySetMaxItemCount(_dataGrid, 10_000))
+        {
+            StateHasChanged();
+        }
+
         if (firstRender)
         {
             _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "/Components/Controls/Chart/MetricTable.razor.js");

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
@@ -235,6 +235,8 @@ public partial class MetricTable : ChartBase
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        // Check to see whether max item count should be set on every render.
+        // This is required because the data grid's virtualize component can be recreated on data change.
         if (_dataGrid != null && FluentDataGridHelper<MetricViewBase>.TrySetMaxItemCount(_dataGrid, 10_000))
         {
             StateHasChanged();

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -14,7 +14,7 @@
     <div class="@GetLogContainerClass()" id="logContainer">
         @if (LogEntries is { } logEntries)
         {
-            <Virtualize Items="@logEntries.GetEntries()" ItemSize="20" OverscanCount="200" TItem="LogEntry">
+            <Virtualize @ref="VirtualizeRef" Items="@logEntries.GetEntries()" ItemSize="20" OverscanCount="200" TItem="LogEntry">
                 @if (context.Pause is { } pause)
                 {
                     // If this is a previous pause but no logs were obtained during the pause, we don't need to show anything.

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -52,6 +52,8 @@ public sealed partial class LogViewer
         set
         {
             field = value;
+
+            // Set max item count when the Virtualize component is set.
             if (field != null)
             {
                 VirtualizeHelper<LogEntry>.TrySetMaxItemCount(field, 10_000);

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -44,6 +44,19 @@ public sealed partial class LogViewer
     [Parameter]
     public bool NoWrapLogs { get; set; }
 
+    private Virtualize<LogEntry>? VirtualizeRef
+    {
+        get => field;
+        set
+        {
+            field = value;
+            if (field != null)
+            {
+                VirtualizeHelper<LogEntry>.TrySetMaxItemCount(field, 10000);
+            }
+        }
+    }
+
     protected override void OnParametersSet()
     {
         if (_logEntries != LogEntries)

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -4,8 +4,10 @@
 using System.Globalization;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ConsoleLogs;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components;
@@ -52,7 +54,7 @@ public sealed partial class LogViewer
             field = value;
             if (field != null)
             {
-                VirtualizeHelper<LogEntry>.TrySetMaxItemCount(field, 10000);
+                VirtualizeHelper<LogEntry>.TrySetMaxItemCount(field, 10_000);
             }
         }
     }

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
@@ -5,7 +5,7 @@
 
 <div class="log-overflow">
     <div class="log-container" @ref="_containerElement">
-        <Virtualize Items="@(!DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)" ItemSize="20" OverscanCount="200">
+        <Virtualize @ref="_virtualizeRef" Items="@(!DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)" ItemSize="20" OverscanCount="200">
             <div class="log-line-row-container">
                 <div class="log-line-row">
                     <span class="log-line-area">

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
@@ -5,7 +5,7 @@
 
 <div class="log-overflow">
     <div class="log-container" @ref="_containerElement">
-        <Virtualize @ref="_virtualizeRef" Items="@(!DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)" ItemSize="20" OverscanCount="200">
+        <Virtualize @ref="VirtualizeRef" Items="@(!DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)" ItemSize="20" OverscanCount="200">
             <div class="log-line-row-container">
                 <div class="log-line-row">
                     <span class="log-line-area">

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
@@ -13,7 +13,6 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
 {
     private IJSObjectReference? _jsModule;
     private ElementReference _containerElement;
-    private Virtualize<StringLogLine> _virtualizeRef = default!;
     private bool _isObserving;
 
     [Inject]
@@ -31,10 +30,23 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
     [Parameter]
     public bool DisplayUnformatted { get; set; }
 
+    private Virtualize<StringLogLine>? VirtualizeRef
+    {
+        get => field;
+        set
+        {
+            field = value;
+
+            // Set max item count when the Virtualize component is set.
+            if (field != null)
+            {
+                VirtualizeHelper<StringLogLine>.TrySetMaxItemCount(field, 10_000);
+            }
+        }
+    }
+
     protected override async Task OnInitializedAsync()
     {
-        VirtualizeHelper<StringLogLine>.TrySetMaxItemCount(_virtualizeRef, 10_000);
-
         await ThemeManager.EnsureInitializedAsync();
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
@@ -33,7 +33,7 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        VirtualizeHelper<StringLogLine>.TrySetMaxItemCount(_virtualizeRef, 10000);
+        VirtualizeHelper<StringLogLine>.TrySetMaxItemCount(_virtualizeRef, 10_000);
 
         await ThemeManager.EnsureInitializedAsync();
     }

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Controls;
@@ -12,6 +13,7 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
 {
     private IJSObjectReference? _jsModule;
     private ElementReference _containerElement;
+    private Virtualize<StringLogLine> _virtualizeRef = default!;
     private bool _isObserving;
 
     [Inject]
@@ -31,6 +33,8 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
+        VirtualizeHelper<StringLogLine>.TrySetMaxItemCount(_virtualizeRef, 10000);
+
         await ThemeManager.EnsureInitializedAsync();
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -339,6 +339,11 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (_dataGrid != null && FluentDataGridHelper<ResourceGridViewModel>.TrySetMaxItemCount(_dataGrid, 10_000))
+        {
+            StateHasChanged();
+        }
+
         if (PageViewModel.SelectedViewKind == ResourceViewKind.Graph && !_graphInitialized)
         {
             // Before any awaits, set a flag to indicate the graph is initialized. This prevents the graph being initialized multiple times.

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -339,6 +339,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        // Check to see whether max item count should be set on every render.
+        // This is required because the data grid's virtualize component can be recreated on data change.
         if (_dataGrid != null && FluentDataGridHelper<ResourceGridViewModel>.TrySetMaxItemCount(_dataGrid, 10_000))
         {
             StateHasChanged();

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -43,7 +43,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     private string? _elementIdBeforeDetailsViewOpened;
     private AspirePageContentLayout? _contentLayout;
     private string _filter = string.Empty;
-    private FluentDataGrid<OtlpLogEntry> _dataGrid = null!;
+    private FluentDataGrid<OtlpLogEntry>? _dataGrid;
     private GridColumnManager _manager = null!;
     private IList<GridColumn> _gridColumns = null!;
 
@@ -380,6 +380,11 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (_dataGrid != null && FluentDataGridHelper<OtlpLogEntry>.TrySetMaxItemCount(_dataGrid, 10_000))
+        {
+            StateHasChanged();
+        }
+
         if (_resourceChanged)
         {
             await JS.InvokeVoidAsync("resetContinuousScrollPosition");

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -380,6 +380,8 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        // Check to see whether max item count should be set on every render.
+        // This is required because the data grid's virtualize component can be recreated on data change.
         if (_dataGrid != null && FluentDataGridHelper<OtlpLogEntry>.TrySetMaxItemCount(_dataGrid, 10_000))
         {
             StateHasChanged();

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -239,6 +239,14 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         }
     }
 
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (_dataGrid != null && FluentDataGridHelper<SpanWaterfallViewModel>.TrySetMaxItemCount(_dataGrid, 10_000))
+        {
+            StateHasChanged();
+        }
+    }
+
     private void UpdateDetailViewData()
     {
         _resources = TelemetryRepository.GetResources();

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -241,6 +241,8 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
     protected override void OnAfterRender(bool firstRender)
     {
+        // Check to see whether max item count should be set on every render.
+        // This is required because the data grid's virtualize component can be recreated on data change.
         if (_dataGrid != null && FluentDataGridHelper<SpanWaterfallViewModel>.TrySetMaxItemCount(_dataGrid, 10_000))
         {
             StateHasChanged();

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -248,6 +248,8 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        // Check to see whether max item count should be set on every render.
+        // This is required because the data grid's virtualize component can be recreated on data change.
         if (_dataGrid != null && FluentDataGridHelper<OtlpTrace>.TrySetMaxItemCount(_dataGrid, 10_000))
         {
             StateHasChanged();

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -248,6 +248,11 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (_dataGrid != null && FluentDataGridHelper<OtlpTrace>.TrySetMaxItemCount(_dataGrid, 10_000))
+        {
+            StateHasChanged();
+        }
+
         if (_resourceChanged)
         {
             await JS.InvokeVoidAsync("resetContinuousScrollPosition");

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -110,6 +110,10 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         Action<WebApplicationBuilder>? preConfigureBuilder = null,
         WebApplicationOptions? options = null)
     {
+        // Workaround MaxItemCount regression. In .NET 8 the value is set via AppContext.
+        // The issue doesn't appear to impact .NET 8, but setting this value ensures the dashbaord is always run with a consistent MaxItemCount value.
+        AppContext.SetData("Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize.MaxItemCount", 10_000);
+
         var builder = options is not null ? WebApplication.CreateBuilder(options) : WebApplication.CreateBuilder();
 
         preConfigureBuilder?.Invoke(builder);

--- a/src/Aspire.Dashboard/Utils/MaxItemCountHelper.cs
+++ b/src/Aspire.Dashboard/Utils/MaxItemCountHelper.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Utils;
+
+public static class VirtualizeHelper<TItem>
+{
+    private static readonly PropertyInfo? s_setMaxItemCountPropertyInfo = GetSetMaxItemCountMethodInfo();
+
+    private static PropertyInfo? GetSetMaxItemCountMethodInfo()
+    {
+        var type = typeof(Virtualize<TItem>);
+        return type.GetProperty("MaxItemCount", BindingFlags.Instance | BindingFlags.Public);
+    }
+
+    public static bool TrySetMaxItemCount(Virtualize<TItem> virtualize, int max)
+    {
+        if (s_setMaxItemCountPropertyInfo == null)
+        {
+            return false;
+        }
+
+        var currentMaxItemCount = (int)s_setMaxItemCountPropertyInfo.GetValue(virtualize)!;
+        if (currentMaxItemCount == max)
+        {
+            return false;
+        }
+
+        s_setMaxItemCountPropertyInfo.SetValue(virtualize, max);
+        return true;
+    }
+}
+
+public static class FluentDataGridHelper<TGridItem>
+{
+    private static readonly FieldInfo? s_virtualizeComponentFieldInfo = GetVirtualizeComponentFieldInfo();
+
+    private static FieldInfo? GetVirtualizeComponentFieldInfo()
+    {
+        var type = typeof(FluentDataGrid<TGridItem>);
+        var field = type.GetField("_virtualizeComponent", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        return field;
+    }
+
+    private static Virtualize<(int, TGridItem)>? GetVirtualize(FluentDataGrid<TGridItem> dataGrid)
+    {
+        return s_virtualizeComponentFieldInfo?.GetValue(dataGrid) as Virtualize<(int, TGridItem)>;
+    }
+
+    public static bool TrySetMaxItemCount(FluentDataGrid<TGridItem> dataGrid, int max)
+    {
+        var virtualize = GetVirtualize(dataGrid);
+        if (virtualize == null)
+        {
+            return false;
+        }
+        return VirtualizeHelper<(int, TGridItem)>.TrySetMaxItemCount(virtualize, max);
+    }
+}
+

--- a/src/Aspire.Dashboard/Utils/MaxItemCountHelper.cs
+++ b/src/Aspire.Dashboard/Utils/MaxItemCountHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -11,48 +12,85 @@ namespace Aspire.Dashboard.Utils;
 // Required because dashboard currently targets .NET 8 and MaxItemCount isn't available.
 public static class VirtualizeHelper<TItem>
 {
-    private static readonly PropertyInfo? s_setMaxItemCountPropertyInfo = GetSetMaxItemCountMethodInfo();
+    private static readonly Func<Virtualize<TItem>, int>? s_getMaxItemCount =
+        CreateGetter();
 
-    private static PropertyInfo? GetSetMaxItemCountMethodInfo()
+    private static readonly Action<Virtualize<TItem>, int>? s_setMaxItemCount =
+        CreateSetter();
+
+    private static Func<Virtualize<TItem>, int>? CreateGetter()
     {
         var type = typeof(Virtualize<TItem>);
-        return type.GetProperty("MaxItemCount", BindingFlags.Instance | BindingFlags.Public);
+        var prop = type.GetProperty("MaxItemCount", BindingFlags.Instance | BindingFlags.Public);
+
+        if (prop == null || !prop.CanRead)
+        {
+            return null;
+        }
+
+        var instance = Expression.Parameter(type, "virtualize");
+        var body = Expression.Property(instance, prop);
+
+        return Expression.Lambda<Func<Virtualize<TItem>, int>>(body, instance).Compile();
+    }
+
+    private static Action<Virtualize<TItem>, int>? CreateSetter()
+    {
+        var type = typeof(Virtualize<TItem>);
+        var prop = type.GetProperty("MaxItemCount", BindingFlags.Instance | BindingFlags.Public);
+
+        if (prop == null || !prop.CanWrite)
+        {
+            return null;
+        }
+
+        var instance = Expression.Parameter(type, "virtualize");
+        var valueParam = Expression.Parameter(typeof(int), "value");
+        var body = Expression.Assign(Expression.Property(instance, prop), valueParam);
+
+        return Expression.Lambda<Action<Virtualize<TItem>, int>>(body, instance, valueParam).Compile();
     }
 
     public static bool TrySetMaxItemCount(Virtualize<TItem> virtualize, int max)
     {
-        if (s_setMaxItemCountPropertyInfo == null)
+        if (s_getMaxItemCount == null || s_setMaxItemCount == null)
         {
             return false;
         }
 
-        var currentMaxItemCount = (int)s_setMaxItemCountPropertyInfo.GetValue(virtualize)!;
-        if (currentMaxItemCount == max)
+        if (s_getMaxItemCount(virtualize) == max)
         {
             return false;
         }
 
-        s_setMaxItemCountPropertyInfo.SetValue(virtualize, max);
+        s_setMaxItemCount(virtualize, max);
         return true;
     }
 }
 
 public static class FluentDataGridHelper<TGridItem>
 {
-    private static readonly FieldInfo? s_virtualizeComponentFieldInfo = GetVirtualizeComponentFieldInfo();
+    private static readonly Func<FluentDataGrid<TGridItem>, Virtualize<(int, TGridItem)>>? s_getVirtualize =
+        CreateGetter();
 
-    private static FieldInfo? GetVirtualizeComponentFieldInfo()
+    private static Func<FluentDataGrid<TGridItem>, Virtualize<(int, TGridItem)>>? CreateGetter()
     {
         var type = typeof(FluentDataGrid<TGridItem>);
         var field = type.GetField("_virtualizeComponent", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        return field;
+        if (field == null)
+        {
+            return null;
+        }
+
+        var instance = Expression.Parameter(type, "dataGrid");
+        var body = Expression.Convert(Expression.Field(instance, field), typeof(Virtualize<(int, TGridItem)>));
+
+        return Expression.Lambda<Func<FluentDataGrid<TGridItem>, Virtualize<(int, TGridItem)>>> (body, instance).Compile();
     }
 
     private static Virtualize<(int, TGridItem)>? GetVirtualize(FluentDataGrid<TGridItem> dataGrid)
-    {
-        return s_virtualizeComponentFieldInfo?.GetValue(dataGrid) as Virtualize<(int, TGridItem)>;
-    }
+        => s_getVirtualize?.Invoke(dataGrid);
 
     public static bool TrySetMaxItemCount(FluentDataGrid<TGridItem> dataGrid, int max)
     {
@@ -61,7 +99,7 @@ public static class FluentDataGridHelper<TGridItem>
         {
             return false;
         }
+
         return VirtualizeHelper<(int, TGridItem)>.TrySetMaxItemCount(virtualize, max);
     }
 }
-

--- a/src/Aspire.Dashboard/Utils/MaxItemCountHelper.cs
+++ b/src/Aspire.Dashboard/Utils/MaxItemCountHelper.cs
@@ -7,6 +7,8 @@ using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Utils;
 
+// Temporary work around to set MaxItemCount on Virtualize component via reflection.
+// Required because dashboard currently targets .NET 8 and MaxItemCount isn't available.
 public static class VirtualizeHelper<TItem>
 {
     private static readonly PropertyInfo? s_setMaxItemCountPropertyInfo = GetSetMaxItemCountMethodInfo();

--- a/src/Aspire.Dashboard/Utils/MaxItemCountHelper.cs
+++ b/src/Aspire.Dashboard/Utils/MaxItemCountHelper.cs
@@ -10,6 +10,10 @@ namespace Aspire.Dashboard.Utils;
 
 // Temporary work around to set MaxItemCount on Virtualize component via reflection.
 // Required because dashboard currently targets .NET 8 and MaxItemCount isn't available.
+//
+// ASP.NET Core issue: https://github.com/dotnet/aspnetcore/issues/63651
+// Note that this work around should be left in place for a while after the issue is fixed in ASP.NET Core.
+// .NET 9 needs to be patched, and users may have unpatched versions of .NET 9 on their machines for a while.
 public static class VirtualizeHelper<TItem>
 {
     private static readonly Func<Virtualize<TItem>, int>? s_getMaxItemCount =


### PR DESCRIPTION
## Description

A change in .NET 9 and 10 around `Virtualize` and `MaxItemCount` causes rendering issues when the dashboard is run on those runtime versions.

The workaround in this PR is to set `MaxItemCount` to a large value. Because the dashboard only targets .NET 8, we must use reflection to set the property. Data grids can also be virtualized so we need to set the property on data grid's internal control.

Fixes https://github.com/dotnet/aspire/issues/7969
Fixes https://github.com/dotnet/aspire/issues/11208

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
