### PR TITLE
Add method to create YarpCluster with a list of string as addresses

### DIFF
--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
@@ -46,7 +46,18 @@ public interface IYarpConfigurationBuilder
     /// <param name="clusterName">The name of the cluster.</param>
     /// <param name="destinations">The destinations used by this cluster.</param>
     /// <returns></returns>
-    public YarpCluster AddCluster(string clusterName, params string[] destinations);
+    public YarpCluster AddCluster(string clusterName, string[] destinations);
+
+    /// <summary>
+    /// Add a new cluster to YARP based on a collection of urls.
+    /// </summary>
+    /// <param name="clusterName">The name of the cluster.</param>
+    /// <param name="destination">The destinations used by this cluster.</param>
+    /// <returns></returns>
+    public YarpCluster AddCluster(string clusterName, string destination)
+    {
+        return AddCluster(clusterName, new[] { destination });
+    }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
@@ -39,6 +39,15 @@ public interface IYarpConfigurationBuilder
     /// <param name="externalService">The external service used by this cluster.</param>
     /// <returns></returns>
     public YarpCluster AddCluster(IResourceBuilder<ExternalServiceResource> externalService);
+
+
+    /// <summary>
+    /// Add a new cluster to YARP based on a collection of urls.
+    /// </summary>
+    /// <param name="clusterName">The name of the cluster.</param>
+    /// <param name="destinations">The destinations used by this cluster.</param>
+    /// <returns></returns>
+    public YarpCluster AddCluster(string clusterName, params string[] destinations);
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
@@ -40,7 +40,6 @@ public interface IYarpConfigurationBuilder
     /// <returns></returns>
     public YarpCluster AddCluster(IResourceBuilder<ExternalServiceResource> externalService);
 
-
     /// <summary>
     /// Add a new cluster to YARP based on a collection of urls.
     /// </summary>

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -13,10 +13,10 @@ namespace Aspire.Hosting.Yarp;
 public class YarpCluster
 {
     // Testing only
-    internal YarpCluster(ClusterConfig config, object target)
+    internal YarpCluster(ClusterConfig config, params object[] targets)
     {
         ClusterConfig = config;
-        Target = target;
+        Targets = targets;
     }
 
     /// <summary>
@@ -46,19 +46,29 @@ public class YarpCluster
     {
     }
 
-    private YarpCluster(string resourceName, object target)
+    /// <summary>
+    /// Creates a new instance of <see cref="YarpCluster"/> with a specified list of addresses.
+    /// </summary>
+    /// <param name="clusterName">The name of the cluster.</param>
+    /// <param name="addresses">The external addresses.</param>
+    internal YarpCluster(string clusterName, params string[] addresses)
+        : this(clusterName, (object[]) addresses)
+    {
+    }
+
+    private YarpCluster(string resourceName, params object[] targets)
     {
         ClusterConfig = new()
         {
             ClusterId = $"cluster_{resourceName}",
             Destinations = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase)
         };
-        Target = target;
+        Targets = targets;
     }
 
     internal ClusterConfig ClusterConfig { get; private set; }
 
-    internal object Target { get; private set; }
+    internal object[] Targets { get; private set; }
 
     internal void Configure(Func<ClusterConfig, ClusterConfig> configure)
     {

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
@@ -49,4 +49,12 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
         _parent.WithReference(externalService);
         return destination;
     }
+
+    /// <inheritdoc/>
+    public YarpCluster AddCluster(string clusterName, params string[] destinations)
+    {
+        var destination = new YarpCluster(clusterName, destinations);
+        _parent.Resource.Clusters.Add(destination);
+        return destination;
+    }
 }

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
@@ -51,7 +51,7 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
     }
 
     /// <inheritdoc/>
-    public YarpCluster AddCluster(string clusterName, params string[] destinations)
+    public YarpCluster AddCluster(string clusterName, string[] destinations)
     {
         var destination = new YarpCluster(clusterName, destinations);
         _parent.Resource.Clusters.Add(destination);

--- a/src/Aspire.Hosting.Yarp/YarpEnvConfigGenerator.cs
+++ b/src/Aspire.Hosting.Yarp/YarpEnvConfigGenerator.cs
@@ -25,7 +25,10 @@ internal class YarpEnvConfigGenerator
         foreach (var cluster in clusters)
         {
             FlattenToEnvVars(environmentVariables, cluster.ClusterConfig, $"{Prefix}CLUSTERS__{cluster.ClusterConfig.ClusterId}");
-            environmentVariables[$"{Prefix}CLUSTERS__{cluster.ClusterConfig.ClusterId}__DESTINATIONS__destination1__ADDRESS"] = cluster.Target;
+            for (var i =0; i < cluster.Targets.Length; i++)
+            {
+                environmentVariables[$"{Prefix}CLUSTERS__{cluster.ClusterConfig.ClusterId}__DESTINATIONS__destination{i + 1}__ADDRESS"] = cluster.Targets[i];
+            }
             // Hack: YARP throws if ClusterConfig.ClusterId is populated in the config.
             // YARP will get the ClusterId from the config key and populate the value in the ClusterConfig itself.
             environmentVariables.Remove($"{Prefix}CLUSTERS__{cluster.ClusterConfig.ClusterId}__CLUSTERID");

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpClusterTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpClusterTests.cs
@@ -9,6 +9,14 @@ namespace Aspire.Hosting.Yarp.Tests;
 public class YarpClusterTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
+    public void Create_YarpCluster_From_Raw_Strings()
+    {
+        var cluster = new YarpCluster("raw_cluster", "http://localhost:5000", "https://localhost:5001");
+        Assert.Equal("http://localhost:5000", cluster.Targets[0]);
+        Assert.Equal("https://localhost:5001", cluster.Targets[1]);
+    }
+
+    [Fact]
     public void Create_YarpCluster_From_Endpoints_With_Names()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
@@ -20,10 +28,10 @@ public class YarpClusterTests(ITestOutputHelper testOutputHelper)
         var httpsEndpoint = resource.GetEndpoint("anotherendpoint");
 
         var httpCluster = new YarpCluster(httpEndpoint);
-        Assert.Equal("http://_testendpoint.ServiceA", httpCluster.Target);
+        Assert.Equal("http://_testendpoint.ServiceA", httpCluster.Targets[0]);
 
         var httpsCluster = new YarpCluster(httpsEndpoint);
-        Assert.Equal("https://_anotherendpoint.ServiceA", httpsCluster.Target);
+        Assert.Equal("https://_anotherendpoint.ServiceA", httpsCluster.Targets[0]);
     }
 
     [Fact]
@@ -38,10 +46,10 @@ public class YarpClusterTests(ITestOutputHelper testOutputHelper)
         var httpsEndpoint = resource.GetEndpoint("https");
 
         var httpCluster = new YarpCluster(httpEndpoint);
-        Assert.Equal("http://_http.ServiceC", httpCluster.Target);
+        Assert.Equal("http://_http.ServiceC", httpCluster.Targets[0]);
 
         var httpsCluster = new YarpCluster(httpsEndpoint);
-        Assert.Equal("https://_https.ServiceC", httpsCluster.Target);
+        Assert.Equal("https://_https.ServiceC", httpsCluster.Targets[0]);
     }
 
     [Fact]
@@ -54,14 +62,14 @@ public class YarpClusterTests(ITestOutputHelper testOutputHelper)
                                  .WithHttpEndpoint(name: "grpc");
 
         var httpCluster = new YarpCluster(httpService.Resource);
-        Assert.Equal($"http://ServiceC", httpCluster.Target);
+        Assert.Equal($"http://ServiceC", httpCluster.Targets[0]);
 
         var httpsService = builder.AddResource(new TestResource("ServiceD"))
                                   .WithHttpsEndpoint()
                                   .WithHttpsEndpoint(name: "grpc");
 
         var httpsCluster = new YarpCluster(httpsService.Resource);
-        Assert.Equal($"https://ServiceD", httpsCluster.Target);
+        Assert.Equal($"https://ServiceD", httpsCluster.Targets[0]);
     }
 
     [Fact]
@@ -73,7 +81,7 @@ public class YarpClusterTests(ITestOutputHelper testOutputHelper)
                               .WithHttpsEndpoint();
 
         var clusterA = new YarpCluster(serviceA.Resource);
-        Assert.Equal($"https+http://ServiceA", clusterA.Target);
+        Assert.Equal($"https+http://ServiceA", clusterA.Targets[0]);
     }
 
     private sealed class TestResource(string name) : IResourceWithServiceDiscovery


### PR DESCRIPTION
## Description

Add a method to build a `YarpCluster` with a collection of string to use as addresses. 

Fixes #10751

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [X] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [X] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
