### PR TITLE
Prevent state propagation to child resources with their own lifetime in ApplicationOrchestrator for specific resource types.

### DIFF
--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -411,7 +411,7 @@ internal sealed class ApplicationOrchestrator
 
     private async Task SetChildResourceAsync(IResource resource, string? state, DateTime? startTimeStamp, DateTime? stopTimeStamp)
     {
-        foreach (var child in _parentChildLookup[resource])
+        foreach (var child in _parentChildLookup[resource].Where(c => c is IResourceWithParent))
         {
             // Don't propagate state to resources that have a life of their own.
             if (ResourceHasOwnLifetime(child))

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -547,4 +547,96 @@ public class ApplicationOrchestratorTests
             return ValueTask.FromResult<string?>(connectionString);
         }
     }
+
+    [Fact]
+    public async Task ContainerChildResourcesWithOwnLifetimeDoNotReceiveParentStateChanges()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var parentContainer = builder.AddContainer("parent-container", "parent-image");
+        var childContainer = builder.AddContainer("child-container", "child-image")
+            .WithParentRelationship(parentContainer);
+        var customChild = builder.AddResource(new CustomChildResource("custom-child", parentContainer.Resource));
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events);
+        await appOrchestrator.RunApplicationAsync();
+
+        // Initialize resources
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        // Simulate parent container state change
+        await events.PublishAsync(new OnResourceChangedContext(
+            CancellationToken.None,
+            KnownResourceTypes.Container,
+            parentContainer.Resource,
+            "parent-container-dcp",
+            new ResourceStatus(KnownResourceStates.FailedToStart, null, null),
+            snapshot => snapshot with { State = KnownResourceStates.FailedToStart }));
+
+        // Check final states
+        var parentState = resourceNotificationService.TryGetCurrentState("parent-container-dcp", out var parentEvent) ? parentEvent.Snapshot.State?.Text : null;
+        var childContainerState = resourceNotificationService.TryGetCurrentState(childContainer.Resource.Name, out var childContainerEvent) ? childContainerEvent.Snapshot.State?.Text : null;
+        var customChildState = resourceNotificationService.TryGetCurrentState(customChild.Resource.Name, out var customChildEvent) ? customChildEvent.Snapshot.State?.Text : null;
+
+        // Parent should have the new state
+        Assert.Equal(KnownResourceStates.FailedToStart, parentState);
+        
+        // Child container (has own lifetime) should NOT receive parent state
+        Assert.NotEqual(KnownResourceStates.Running, childContainerState);
+        
+        // Custom child (does not have own lifetime) SHOULD receive parent state
+        Assert.Equal(KnownResourceStates.FailedToStart, customChildState);
+    }
+
+    [Fact]
+    public async Task ProjectChildResourcesWithOwnLifetimeDoNotReceiveParentStateChanges()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var parentContainer = builder.AddContainer("parent-container", "parent-image");
+        var childProject = builder.AddProject<ProjectA>("child-project")
+            .WithParentRelationship(parentContainer);
+        var customChild = builder.AddResource(new CustomChildResource("custom-child", parentContainer.Resource));
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events);
+        await appOrchestrator.RunApplicationAsync();
+
+        // Initialize resources
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        // Simulate parent container state change
+        await events.PublishAsync(new OnResourceChangedContext(
+            CancellationToken.None,
+            KnownResourceTypes.Container,
+            parentContainer.Resource,
+            "parent-container-dcp",
+            new ResourceStatus(KnownResourceStates.FailedToStart, null, null),
+            snapshot => snapshot with { State = KnownResourceStates.FailedToStart }));
+
+        // Check final states
+        var parentState = resourceNotificationService.TryGetCurrentState("parent-container-dcp", out var parentEvent) ? parentEvent.Snapshot.State?.Text : null;
+        var childProjectState = resourceNotificationService.TryGetCurrentState(childProject.Resource.Name, out var childProjectEvent) ? childProjectEvent.Snapshot.State?.Text : null;
+        var customChildState = resourceNotificationService.TryGetCurrentState(customChild.Resource.Name, out var customChildEvent) ? customChildEvent.Snapshot.State?.Text : null;
+
+        // Parent should have the new state
+        Assert.Equal(KnownResourceStates.FailedToStart, parentState);
+        
+        // Child project (has own lifetime) should NOT receive parent state
+        Assert.NotEqual(KnownResourceStates.Running, childProjectState);
+        
+        // Custom child (does not have own lifetime) SHOULD receive parent state
+        Assert.Equal(KnownResourceStates.FailedToStart, customChildState);
+    }
 }


### PR DESCRIPTION
## Description

Nesting resources with a lifetime underneath containers messes with the state and event publishing. This skips event and state propagation if the child resource has an independent lifetime.

Fixes #9165
Fixes #8823
Fixes #9163

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
