### PR TITLE
Add tooltip to selects with long content

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelectOptionTemplate.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelectOptionTemplate.razor
@@ -5,7 +5,9 @@
 
 @inject IStringLocalizer<ControlsStrings> Loc
 
-<FluentStack Orientation="Orientation.Horizontal" HorizontalGap="3">
+@* Allows long values to be viewed in option popup by adding a tooltip to options. *@
+@* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
+<FluentStack Orientation="Orientation.Horizontal" HorizontalGap="3" title="@(ViewModel.Name?.Length > 30 ? ViewModel.Name : null)">
     @if (ViewModel.Id?.Type is OtlpResourceType.ResourceGrouping)
     {
         <FluentIcon Icon="Icons.Regular.Size20.AppsList"

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -20,7 +20,15 @@
                           Width="100%"
                           Height="400px"
                           OptionText="@(c => c.Name)"
-                          OptionDisabled="@(c => c.Id is null)" />
+                          OptionDisabled="@(c => c.Id is null)">
+                <OptionTemplate Context="optionContext">
+                    @* Allows long values to be viewed in option popup by adding a tooltip to options. *@
+                    @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
+                    <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
+                        @optionContext.Name
+                    </span>                    
+                </OptionTemplate>
+            </FluentSelect>
         </div>
 
         <div class="filter-input-container">
@@ -51,7 +59,9 @@
                         @* Workaround this issue by inserting extra text using CSS. *@
                         <span data-filtercount="@optionContext.Id!.Count"></span>
                     </FluentBadge>
-                    <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" />
+                    <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
+                        <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" title="@optionContext.Name" />
+                    </span>                    
                 </OptionTemplate>
             </FluentCombobox>
             <ValidationMessage For="() => _formModel.Value" />

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -59,6 +59,8 @@
                         @* Workaround this issue by inserting extra text using CSS. *@
                         <span data-filtercount="@optionContext.Id!.Count"></span>
                     </FluentBadge>
+                    @* Allows long values to be viewed in option popup by adding a tooltip to options. *@
+                    @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
                     <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
                         <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" title="@optionContext.Name" />
                     </span>                    

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -26,7 +26,7 @@
                     @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
                     <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
                         @optionContext.Name
-                    </span>                    
+                    </span>
                 </OptionTemplate>
             </FluentSelect>
         </div>
@@ -62,7 +62,7 @@
                     @* Allows long values to be viewed in option popup by adding a tooltip to options. *@
                     @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
                     <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
-                        <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" title="@optionContext.Name" />
+                        <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" />
                     </span>                    
                 </OptionTemplate>
             </FluentCombobox>

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -63,7 +63,7 @@
                     @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
                     <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
                         <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" />
-                    </span>                    
+                    </span>
                 </OptionTemplate>
             </FluentCombobox>
             <ValidationMessage For="() => _formModel.Value" />

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -85,7 +85,15 @@
                                           OptionText="@(vm => vm.Name)"
                                           Height="250px"
                                           Position="SelectPosition.Below"
-                                          aria-describedby="@descriptionId" />
+                                          aria-describedby="@descriptionId">
+                                <OptionTemplate Context="optionContext">
+                                    @* Allows long values to be viewed in option popup by adding a tooltip to options. *@
+                                    @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
+                                    <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
+                                        @optionContext.Name
+                                    </span>
+                                </OptionTemplate>
+                            </FluentSelect>
                             @GetDescriptionContent(localItem.Input, descriptionId)
                             <ValidationMessage For="@(() => localItem.Value)" />
                             break;


### PR DESCRIPTION
## Description

Add tooltips to long selects. I suggested [some improvements to FluentUI](https://github.com/microsoft/fluentui-blazor/issues/4136) that we might be able to use in the future, but in the meantime we can add tooltips ourselves.

<img width="1423" height="624" alt="image" src="https://github.com/user-attachments/assets/482fe975-9fd3-4673-8227-cc86636400f4" />

Fixes https://github.com/dotnet/aspire/issues/11009

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
