### PR TITLE
GenAI visualizer improvements and bug fixes

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -372,6 +372,44 @@ app.MapGet("/nested-trace-spans", async () =>
     })
     .WithName("GetWeatherForecast");
 
+app.MapGet("/genai-trace", async () =>
+{
+    var source = new ActivitySource("Services.Api", "1.0.0");
+
+    var activity = source.StartActivity("chat gpt", ActivityKind.Client);
+    if (activity != null)
+    {
+        activity.SetTag("gen_ai.system", "gpt");
+        activity.SetTag("gen_ai.input.messages", """
+            [
+              {
+                "role": "user",
+                "parts": [
+                  {
+                    "type": "text",
+                    "content": "This is the input prompt."
+                  },
+                  {
+                    "type": "image",
+                    "content": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection/9.0.9/icon"
+                  },
+                  {
+                    "type": "image",
+                    "content": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFwAAABcCAMAAADUMSJqAAAAilBMVEX///+XgOV0Vd1RK9S5qu7c1fZHGdKto+hOJ9Oag+ZNJNOWfuVyU91LINPi3Pi4qO6WiuOEbt9EEtJtTdtaNtZnRtn39f1WMdX6+f6ReeTs6fr08fwhAM68sO1iQtjIvvA8ANHl4fhePNeEaeHQx/Kjj+iwoOyeiednUtnCuO+jlOfWzvR5Xd5+Yt+aCjLkAAAD3ElEQVRoge2ZW3eqMBCFC0gM4VIJKlIPQkXbqvj//94hk1a5TChI+uZefes6X2dl78wMOS8vTz31VFPb7R+BN+nXv0pf6UY/295xalWifGfrZmcSDfg808sO7mxR/LtWeMSACj+WxSKd7BMX6DgyzSgWeH7Sx17vBTE2QbH4O/u1NviZCGAk4ZH4Q+Ssi73NxUEvzW8tBT3XdZ0K4Sb1fuBQOgv1sC/g5t68CRzgFy1wGUPvDvf0xTGFwldmTSsoPZ3OXse1GP4I4kinx/FYj2HDU3Kcyn5vu1mL4+QWU/gtN2ue+sU09gEK37XZprmD0g+T4BBpq8s2TeiS+ylTadaNYTOOs8fZa9JoKi1Pxe/I4y1mgcWwEUffeZQdEBlDz+ukRQj8IMGDcA+6YZkkYYnRZYspH2Nnoo0z0zEMw7lidIjjY6vABv7t0gC56LHHD8dxTuASOgB3Qqx0iCP5GM9+kxGX7EqlMo78bTQ8EU2FJT9sAy1dxjEZy7ZzmJu3wg0HTQzEMR+7PJoQQ9e4K1HH0RzHhhWLXZ0a3CmUno5bwGC20b3RUE8c4zFxhBXLD50GHI/j6AWsHUOtcQxFDGnSZuOeyjgOXsBgtsmm0lRfixk48TYQw9jtsHvj6A2Dw2xjRbfw3jjmgybeRm4qGLuSMo4WGRLHT2gqIQ7vi+Pid/Y7zLaV6yYuJqP0upILmP/7xIMVyz8f7MvpFdHsAzUa4Nff2IccZnpg23aQvc4QHbHTKgfFUYSWLm2pFKO/YqUb0GJ2/ew5hz0qkPALWvoZoTtwmnzex94yKu7DN9u2TygdvQFibFDat4AZ0A0z+yaMjXsaQhwNNTvgMBKDO/yAlv6Jle7B2FDHsRRNhdh1pYNLd1nvAgYrFjkHdTju6RHzFEpTLWAbmG07uyk07HgcxT1VTbwP4SZJgxYd9RSPoyidowvYmy9iWLbZCk8djA43kGETD2YbObTZYzxNmGLiBdBU3E7hlafowajjmHfjGIEbly5b5SlmqQHfeJ2JBysWPyOFC08xOhrHK0OeHDbw8hbhbJWn2MFAHK1mHBcyhji7amCD4xiyzgK2piKGhaLwSsNbzIq2X0tgDcJi2OupeuI1HgXE5fRDdeGKe4qWLmLX+E4SLzZEERUp9Cbh45S1Dl2szHIqK+HYuaCVm7QFFym/jWVMaBjR3uha7U8NWMj9wg4Uwk4lnX06Xbny27TRvKBr+XGyQGWEiApsa4wsZFt/g8d3ynxcDBPFBM2l/bKWiYPRI8o7o+6Q+3rYfpddnUzCOZksThL822ubzScr+6v/pnrqqad06z+o/mHi4pLvAgAAAABJRU5ErkJggg=="
+                  }
+                ]
+              }
+            ]
+            """);
+    }
+
+    await Task.Delay(100);
+
+    activity?.Stop();
+
+    return "Created GenAI trace";
+});
+
 app.Run();
 
 public record WeatherForecast(DateOnly Date, int TemperatureC, string Summary);

--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -85,6 +85,7 @@ serviceBuilder.WithHttpCommand("/multiple-traces-linked", "Multiple traces linke
 serviceBuilder.WithHttpCommand("/overflow-counter", "Overflow counter", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 serviceBuilder.WithHttpCommand("/nested-trace-spans", "Out of order nested spans", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 serviceBuilder.WithHttpCommand("/exemplars-no-span", "Examplars with no span", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
+serviceBuilder.WithHttpCommand("/genai-trace", "Gen AI trace", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 
 builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice")
        .WithUrls(c => c.Urls.Add(new() { Url = "https://someplace.com", DisplayText = "Some place" }))

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
@@ -6,30 +6,33 @@
 <div class="log-overflow">
     <div class="log-container" @ref="_containerElement">
         <Virtualize @ref="VirtualizeRef" Items="@(!DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)" ItemSize="20" OverscanCount="200">
-            <div class="log-line-row-container">
-                <div class="log-line-row">
-                    <span class="log-line-area">
-                        @if (!HideLineNumbers)
-                        {
-                            <span class="log-line-number text-visualizer-line-number">@context.LineNumber</span>
-                        }
-                        @if (context.FormatKind != DashboardUIHelpers.PlaintextFormat)
-                        {
-                            // data-content and data-language used in javascript when re-highlighting a node when its
-                            // content changes (through scrolling)
-                            <span class="@GetLogContentClass()" data-content="@context.Content" data-language="@context.FormatKind">
-                                @context.Content
-                            </span>
-                        }
-                        else
-                        {
-                            <span class="log-content">
-                                @context.Content
-                            </span>
-                        }
-                    </span>
+            @if (_isInitialized)
+            {
+                <div class="log-line-row-container">
+                    <div class="log-line-row">
+                        <span class="log-line-area">
+                            @if (!HideLineNumbers)
+                            {
+                                <span class="log-line-number text-visualizer-line-number">@context.LineNumber</span>
+                            }
+                            @if (context.FormatKind != DashboardUIHelpers.PlaintextFormat)
+                            {
+                                // data-content and data-language used in javascript when re-highlighting a node when its
+                                // content changes (through scrolling)
+                                <span class="@GetLogContentClass()" data-content="@context.Content" data-language="@context.FormatKind">
+                                    @context.Content
+                                </span>
+                            }
+                            else
+                            {
+                                <span class="log-content">
+                                    @context.Content
+                                </span>
+                            }
+                        </span>
+                    </div>
                 </div>
-            </div>
+            }
         </Virtualize>
     </div>
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
@@ -3,11 +3,31 @@
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils
 
-<div class="log-overflow">
+@if (Virtualize)
+{
+    <div class="log-overflow">
+        <div class="log-container" @ref="_containerElement">
+            <Virtualize @ref="VirtualizeRef" Items="@(!DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)" ItemSize="20" OverscanCount="200" ItemContent="@RenderLogLine">
+            </Virtualize>
+        </div>
+    </div>
+}
+else
+{
     <div class="log-container" @ref="_containerElement">
-        <Virtualize @ref="VirtualizeRef" Items="@(!DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)" ItemSize="20" OverscanCount="200">
-            @if (_isInitialized)
-            {
+        @foreach (var item in !DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)
+        {
+            @RenderLogLine(item)
+        }
+    </div>
+}
+
+@{
+    RenderFragment RenderLogLine(StringLogLine context)
+    {
+        return@<div>
+        @if (_isInitialized)
+        {
                 <div class="log-line-row-container">
                     <div class="log-line-row">
                         <span class="log-line-area">
@@ -32,7 +52,7 @@
                         </span>
                     </div>
                 </div>
-            }
-        </Virtualize>
-    </div>
-</div>
+        }
+        </div>;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
@@ -14,6 +14,7 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
     private IJSObjectReference? _jsModule;
     private ElementReference _containerElement;
     private bool _isObserving;
+    private bool _isInitialized;
 
     [Inject]
     public required ThemeManager ThemeManager { get; init; }
@@ -48,6 +49,7 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
     protected override async Task OnInitializedAsync()
     {
         await ThemeManager.EnsureInitializedAsync();
+        _isInitialized = true;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
@@ -31,6 +31,9 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
     [Parameter]
     public bool DisplayUnformatted { get; set; }
 
+    [Parameter]
+    public bool Virtualize { get; set; } = true;
+
     private Virtualize<StringLogLine>? VirtualizeRef
     {
         get => field;

--- a/src/Aspire.Dashboard/Components/Controls/TreeGenAISelector.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TreeGenAISelector.razor
@@ -3,7 +3,7 @@
 
 <FluentTreeView Class="genai-message-tree" @bind-CurrentSelected="@PageViewModel.SelectedTreeItem" @bind-CurrentSelected:after="HandleSelectedTreeItemChangedAsync">
     <ChildContent>
-        <FluentTreeItem @key="@PageViewModel.Span" Data="@PageViewModel.Span" title="@PageViewModel.Span.Name" InitiallySelected="@(PageViewModel.SelectedItem is null)">
+        <FluentTreeItem @key="@PageViewModel.Span" Data="@PageViewModel.Span" title="@PageViewModel.Span.Name" InitiallySelected="@(SelectedItem is null)">
             <span class="llm-badge">LLM</span> @PageViewModel.Span.Name
         </FluentTreeItem>
 
@@ -12,7 +12,7 @@
             <FluentTreeItem @key="itemVM"
                             Data="@itemVM.Index"
                             title="@itemVM.GetTitleBadge(Loc).Text"
-                            InitiallySelected="@(itemVM.Index == PageViewModel.SelectedItem?.Index)">
+                            InitiallySelected="@(itemVM.Index == SelectedItem?.Index)">
                 <div class="message-tree-item-container">
                     <GenAIItemTitle Item="itemVM" ResourceName="@itemVM.ResourceName" />
                 </div>

--- a/src/Aspire.Dashboard/Components/Controls/TreeGenAISelector.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TreeGenAISelector.razor.cs
@@ -15,6 +15,9 @@ public partial class TreeGenAISelector
     [Parameter, EditorRequired]
     public required GenAIVisualizerDialogViewModel PageViewModel { get; set; }
 
+    [Parameter, EditorRequired]
+    public required GenAIItemViewModel? SelectedItem { get; set; }
+
     [Inject]
     public required IStringLocalizer<Resources.Dialogs> Loc { get; init; }
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -122,10 +122,10 @@
                         @if (selectedView == ItemViewKind.Raw)
                         {
                             <div class="tab-container">
-                                    @foreach (var itemPart in selectedItem.ItemParts)
-                                    {
-                                        <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" DisplayUnformatted="true" />
-                                    }
+                                @foreach (var itemPart in selectedItem.ItemParts)
+                                {
+                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" DisplayUnformatted="true" />
+                                }
                             </div>
                         }
                         <FluentButton Id="@_copyButtonId"

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -89,7 +89,7 @@
                             <div class="tab-container">
                                 @foreach (var itemPart in selectedItem.ItemParts)
                                 {
-                                    if (IsImagePart(itemPart, out var imageContent))
+                                    if (IsImagePart(itemPart, out var imageContent) && IsSupportedImageScheme(imageContent))
                                     {
                                         <img src="@imageContent" />
                                     }

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -41,16 +41,17 @@
             <Panel1>
                 <div class="span-messages-sidebar">
                     <TreeGenAISelector PageViewModel="@Content"
+                                       SelectedItem="@SelectedItem"
                                        HandleSelectedTreeItemChangedAsync="@HandleSelectedTreeItemChangedAsync" />
                 </div>
             </Panel1>
             <Panel2>
                 <div class="span-messages-container">
-                    @if (Content.SelectedItem is { } selectedItem)
+                    @if (SelectedItem is { } selectedItem)
                     {
                         var selectedView = selectedItem.Type == GenAIItemType.Error
                             ? ItemViewKind.Raw
-                            : Content.MessageActiveView;
+                            : MessageActiveView;
 
                         <div>
                             <div class="message-header">
@@ -88,17 +89,32 @@
                             <div class="tab-container">
                                 @foreach (var itemPart in selectedItem.ItemParts)
                                 {
-                                    if (itemPart.TextVisualizerViewModel.FormatKind is DashboardUIHelpers.PlaintextFormat)
+                                    if (itemPart.MessagePart?.Type == "image" && itemPart.AdditionalProperties?.SingleOrDefault(p => p.Name == "content") is { } imageContent)
                                     {
-                                        @itemPart.TextVisualizerViewModel.FormattedText
+                                        <img src="@imageContent.Value" />
                                     }
-                                    else if (itemPart.TextVisualizerViewModel.FormatKind is DashboardUIHelpers.MarkdownFormat)
+                                    else if (itemPart.AdditionalProperties is { } additionalProperties && additionalProperties.Count > 0)
                                     {
-                                        <MarkdownRenderer MarkdownProcessor="@_markdownProcess" Markdown="@itemPart.TextVisualizerViewModel.FormattedText" />
+                                        <PropertyGrid TItem="GenAIPartPropertyViewModel"
+                                                      Items="additionalProperties.AsQueryable()"
+                                                      IsNameSortable="false"
+                                                      IsValueSortable="false"
+                                                      GridTemplateColumns="1fr 1.5fr" />
                                     }
                                     else
                                     {
-                                        <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" />
+                                        if (itemPart.TextVisualizerViewModel.FormatKind is DashboardUIHelpers.PlaintextFormat)
+                                        {
+                                            @itemPart.TextVisualizerViewModel.FormattedText
+                                        }
+                                        else if (itemPart.TextVisualizerViewModel.FormatKind is DashboardUIHelpers.MarkdownFormat)
+                                        {
+                                            <MarkdownRenderer MarkdownProcessor="@_markdownProcess" Markdown="@itemPart.TextVisualizerViewModel.FormattedText" />
+                                        }
+                                        else
+                                        {
+                                            <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" />
+                                        }
                                     }
                                 }
                             </div>
@@ -106,16 +122,16 @@
                         @if (selectedView == ItemViewKind.Raw)
                         {
                             <div class="tab-container">
-                                @foreach (var itemPart in selectedItem.ItemParts)
-                                {
-                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" DisplayUnformatted="true" />
-                                }
+                                    @foreach (var itemPart in selectedItem.ItemParts)
+                                    {
+                                        <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" DisplayUnformatted="true" />
+                                    }
                             </div>
                         }
                         <FluentButton Id="@_copyButtonId"
                                       Class="message-copy-button"
                                       Appearance="Appearance.Stealth"
-                                      AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(string.Join(Environment.NewLine + Environment.NewLine, selectedItem.ItemParts.Select(p => p.TextVisualizerViewModel.FormattedText)), ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
+                                      AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(string.Join(Environment.NewLine + Environment.NewLine, selectedItem.ItemParts.Select(p => p.TextVisualizerViewModel?.FormattedText ?? string.Empty)), ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
                             <span slot="start">
                                 <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
                                 <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
@@ -156,7 +172,7 @@
                                 Tab content isn't nested inside FluentTab elements. The tab control is just used to display the tabs.
                                 Content is located in manually created divs so they can be placed in their own CSS grid row.
                             *@
-                            <FluentTabs ActiveTabId="@($"tab-overview-{Content.OverviewActiveView}")" OnTabChange="@OnOverviewTabChange" Size="null">
+                            <FluentTabs ActiveTabId="@($"tab-overview-{OverviewActiveView}")" OnTabChange="@OnOverviewTabChange" Size="null">
                                 <FluentTab LabelClass="tab-label"
                                            Id="@($"tab-overview-{OverviewViewKind.InputOutput}")"
                                            Label="@Loc[nameof(Dialogs.GenAIInputOutputTabText)]">
@@ -167,7 +183,7 @@
                                 </FluentTab>
                             </FluentTabs>
                         </div>
-                        @if (Content.OverviewActiveView == OverviewViewKind.InputOutput)
+                        @if (OverviewActiveView == OverviewViewKind.InputOutput)
                         {
                             <div class="tab-container">
                                 @if (Content.NoMessageContent)
@@ -184,7 +200,7 @@
                                 }
                             </div>
                         }
-                        @if (Content.OverviewActiveView == OverviewViewKind.Details)
+                        @if (OverviewActiveView == OverviewViewKind.Details)
                         {
                             <div class="tab-container">
                                 <SpanDetails ViewModel="@Content.SpanDetailsViewModel" CloseCallback="@(() => { })" HideToolbar="true" />
@@ -202,7 +218,7 @@
 @{
     RenderFragment RenderMessageSection(string title, List<GenAIItemViewModel> items, bool noMessageContent)
     {
-        return@<div>
+        return@<div class="section-container">
             <div class="section-title">@title</div>
             @if (items.Count > 0)
             {
@@ -222,11 +238,14 @@
                                 <FluentIcon Icon="Icons.Regular.Size16.SlideSearch" />
                             </FluentButton>
                         </span>
-                        @foreach (var itemPart in itemParts)
+                        @if (itemParts.Count > 0)
                         {
-                            <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" />
+                            foreach (var itemPart in itemParts)
+                            {
+                                <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" />
+                            }
                         }
-                        @if (itemParts.Count == 0)
+                        else
                         {
                             <div class="no-message-content">
                                 @Loc[nameof(Dialogs.GenAINoMessageContent)]

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -89,9 +89,9 @@
                             <div class="tab-container">
                                 @foreach (var itemPart in selectedItem.ItemParts)
                                 {
-                                    if (itemPart.MessagePart?.Type == "image" && itemPart.AdditionalProperties?.SingleOrDefault(p => p.Name == "content") is { } imageContent)
+                                    if (IsImagePart(itemPart, out var imageContent))
                                     {
-                                        <img src="@imageContent.Value" />
+                                        <img src="@imageContent" />
                                     }
                                     else if (itemPart.AdditionalProperties is { } additionalProperties && additionalProperties.Count > 0)
                                     {

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -113,7 +113,7 @@
                                         }
                                         else
                                         {
-                                            <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" />
+                                            <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
                                         }
                                     }
                                 }
@@ -124,7 +124,7 @@
                             <div class="tab-container">
                                 @foreach (var itemPart in selectedItem.ItemParts)
                                 {
-                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" DisplayUnformatted="true" />
+                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" DisplayUnformatted="true" Virtualize="false" />
                                 }
                             </div>
                         }
@@ -242,7 +242,7 @@
                         {
                             foreach (var itemPart in itemParts)
                             {
-                                <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" />
+                                <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
                             }
                         }
                         else

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -62,6 +62,11 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
             _contextSpans = Content.GetContextGenAISpans();
             _currentSpanContextIndex = _contextSpans.FindIndex(s => s.SpanId == Content.Span.SpanId);
             _content = Content;
+
+            if (Content.SelectedLogEntryId != null)
+            {
+                SelectedItem = Content.Items.SingleOrDefault(e => e.InternalId == Content.SelectedLogEntryId);
+            }
         }
     }
 
@@ -146,7 +151,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
         var selectedIndex = SelectedItem?.Index;
 
         var spanDetailsViewModel = SpanDetailsViewModel.Create(newSpan, TelemetryRepository, TelemetryRepository.GetResources());
-        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, TelemetryRepository, Content.GetContextGenAISpans);
+        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, selectedLogEntryId: null, TelemetryRepository, Content.GetContextGenAISpans);
 
         if (selectedIndex != null)
         {
@@ -197,7 +202,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
 
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, telemetryRepository, resources);
 
-        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, telemetryRepository, getContextGenAISpans);
+        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, selectedLogEntryId, telemetryRepository, getContextGenAISpans);
 
         //if (selectedLogEntryId != null)
         //{

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -177,6 +177,22 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
         };
     }
 
+    private static bool IsImagePart(GenAIItemPartViewModel itemPart, [NotNullWhen(true)] out string? imageContent)
+    {
+        // Image part is a generic part with type "image" and content in additional properties.
+        // An image part currently isn't in the GenAI semantic conventions. This follows what MEAI does.
+        // This code will likely need to change to support a future standard.
+        if (itemPart.MessagePart?.Type == "image")
+        {
+            var contentType = itemPart.AdditionalProperties?.SingleOrDefault(p => p.Name == "content");
+            imageContent = contentType?.Value;
+            return !string.IsNullOrEmpty(imageContent);
+        }
+
+        imageContent = null;
+        return false;
+    }
+
     public void Dispose()
     {
         _resourcesSubscription?.Dispose();
@@ -203,11 +219,6 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, telemetryRepository, resources);
 
         var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, selectedLogEntryId, telemetryRepository, getContextGenAISpans);
-
-        //if (selectedLogEntryId != null)
-        //{
-        //    dialogViewModel.SelectedItem = dialogViewModel.Items.SingleOrDefault(e => e.InternalId == selectedLogEntryId);
-        //}
 
         await dialogService.ShowDialogAsync<GenAIVisualizerDialog>(dialogViewModel, parameters);
     }

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -180,8 +180,8 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
     private static bool IsImagePart(GenAIItemPartViewModel itemPart, [NotNullWhen(true)] out string? imageContent)
     {
         // Image part is a generic part with type "image" and content in additional properties.
-        // An image part currently isn't in the GenAI semantic conventions. This follows what MEAI does.
-        // This code will likely need to change to support a future standard.
+        // An image part isn't in the GenAI semantic conventions. This code follows what MEAI does and will need to change to support a future standard.
+        // See https://github.com/dotnet/extensions/pull/6809.
         if (itemPart.MessagePart?.Type == "image")
         {
             var contentType = itemPart.AdditionalProperties?.SingleOrDefault(p => p.Name == "content");

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -193,6 +193,17 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
         return false;
     }
 
+    private static bool IsSupportedImageScheme(string imageContent)
+    {
+        if (Uri.TryCreate(imageContent, UriKind.Absolute, out var result))
+        {
+            // Only attempt to display image if it is an http/https address, or an inline data image.
+            return result.Scheme.ToLowerInvariant() is "http" or "https" or "data";
+        }
+
+        return false;
+    }
+
     public void Dispose()
     {
         _resourcesSubscription?.Dispose();

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -20,7 +20,6 @@
 
 ::deep .message-container {
     padding: 12px;
-    margin-bottom: 16px;
     border: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-hover);
     border-radius: calc(var(--layer-corner-radius) * 0.5px);
     display: flex;
@@ -35,7 +34,6 @@
 
 ::deep .section-title {
     font-size: var(--type-ramp-plus-1-font-size);
-    margin-bottom: 12px;
     font-weight: 600;
 }
 
@@ -138,6 +136,24 @@
     margin-top: 10px;
     padding-right: 8px;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    row-gap: 12px;
+    /* don't stretch images */
+    align-items: flex-start;
+}
+
+::deep .tab-container img {
+    /* don't exceed available space and keep aspect ratio */
+    max-width: 100%;
+    height: auto;
+}
+
+::deep .section-container {
+    display: flex;
+    flex-direction: column;
+    row-gap: 12px;
+    width: 100%;
 }
 
 ::deep .span-details-layout, ::deep .property-grid-container {

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -162,10 +162,6 @@
     display: block;
 }
 
-::deep .message-container .log-overflow {
-    max-height: 300px;
-}
-
 ::deep .message-container .log-content {
     /* don't break on every word */
     word-break: normal;

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
@@ -1,11 +1,83 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Dashboard.Components.Controls;
+using Aspire.Dashboard.Utils;
+
 namespace Aspire.Dashboard.Model.GenAI;
 
-public class GenAIItemPartViewModel
+[DebuggerDisplay("Name = {Name}, Value = {Value}")]
+public sealed class GenAIPartPropertyViewModel : IPropertyGridItem
 {
-    public required MessagePart? MessagePart { get; init; }
-    public required string? ErrorMessage { get; init; }
+    public required string Name { get; set; }
+    public required string Value { get; set; }
+}
+
+public sealed class GenAIItemPartViewModel
+{
+    public MessagePart? MessagePart { get; init; }
+    public string? ErrorMessage { get; init; }
     public required TextVisualizerViewModel TextVisualizerViewModel { get; init; }
+    public List<GenAIPartPropertyViewModel>? AdditionalProperties { get; init; }
+
+    private GenAIItemPartViewModel()
+    {
+    }
+
+    public static GenAIItemPartViewModel CreateErrorMessage(string errorMessage)
+    {
+        return new GenAIItemPartViewModel
+        {
+            ErrorMessage = errorMessage,
+            TextVisualizerViewModel = new TextVisualizerViewModel(errorMessage, indentText: false)
+        };
+    }
+
+    public static GenAIItemPartViewModel CreateMessagePart(MessagePart part)
+    {
+        return new GenAIItemPartViewModel
+        {
+            MessagePart = part,
+            TextVisualizerViewModel = CreateMessagePartVisualizer(part),
+            AdditionalProperties = part is GenericPart genericPart
+                ? genericPart.AdditionalProperties?.Select(p => new GenAIPartPropertyViewModel { Name = p.Key, Value = p.Value.ToString() ?? string.Empty }).ToList()
+                : null
+        };
+    }
+
+    private static TextVisualizerViewModel CreateMessagePartVisualizer(MessagePart p)
+    {
+        if (p is TextPart textPart)
+        {
+            return new TextVisualizerViewModel(textPart.Content ?? string.Empty, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
+        }
+        if (p is ToolCallRequestPart toolCallRequestPart)
+        {
+            return new TextVisualizerViewModel($"{toolCallRequestPart.Name}({toolCallRequestPart.Arguments?.ToJsonString()})", indentText: true, knownFormat: DashboardUIHelpers.JavascriptFormat);
+        }
+        if (p is ToolCallResponsePart toolCallResponsePart)
+        {
+            return new TextVisualizerViewModel(toolCallResponsePart.Response?.ToJsonString() ?? string.Empty, indentText: true);
+        }
+
+        var additionalProperties = p is GenericPart genericPart ? genericPart.AdditionalProperties ?? [] : [];
+        var content = additionalProperties.Count > 0 ? ToJsonObject(additionalProperties).ToJsonString() : string.Empty;
+
+        return new TextVisualizerViewModel(content, indentText: true);
+    }
+
+    private static JsonObject ToJsonObject(Dictionary<string, JsonElement> dict)
+    {
+        var jsonObject = new JsonObject();
+
+        foreach (var kvp in dict)
+        {
+            jsonObject[kvp.Key] = JsonNode.Parse(kvp.Value.GetRawText());
+        }
+
+        return jsonObject;
+    }
 }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -17,7 +17,7 @@ public abstract class MessagePart
     public const string ToolCallType = "tool_call";
     public const string ToolCallResponseType = "tool_call_response";
 
-    public string Type { get; protected set; } = default!;
+    public string Type { get; set; } = default!;
 }
 
 /// <summary>
@@ -104,6 +104,12 @@ public class MessagePartConverter : JsonConverter<MessagePart>
             MessagePart.ToolCallResponseType => JsonSerializer.Deserialize<ToolCallResponsePart>(doc.RootElement.GetRawText(), options),
             _ => JsonSerializer.Deserialize<GenericPart>(doc.RootElement.GetRawText(), options),
         };
+
+        //static GenericPart CreateGenericPart(JsonElement element, string type)
+        //{
+        //    var genericPart = JsonSerializer.Deserialize<GenericPart>(doc.RootElement.GetRawText(), options);
+        //    return genericPart.T
+        //}
     }
 
     public override void Write(Utf8JsonWriter writer, MessagePart value, JsonSerializerOptions options)

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -104,12 +104,6 @@ public class MessagePartConverter : JsonConverter<MessagePart>
             MessagePart.ToolCallResponseType => JsonSerializer.Deserialize<ToolCallResponsePart>(doc.RootElement.GetRawText(), options),
             _ => JsonSerializer.Deserialize<GenericPart>(doc.RootElement.GetRawText(), options),
         };
-
-        //static GenericPart CreateGenericPart(JsonElement element, string type)
-        //{
-        //    var genericPart = JsonSerializer.Deserialize<GenericPart>(doc.RootElement.GetRawText(), options);
-        //    return genericPart.T
-        //}
     }
 
     public override void Write(Utf8JsonWriter writer, MessagePart value, JsonSerializerOptions options)

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -19,6 +19,7 @@ public sealed class GenAIVisualizerDialogViewModel
     public required OtlpSpan Span { get; init; }
     public required string Title { get; init; }
     public required SpanDetailsViewModel SpanDetailsViewModel { get; init; }
+    public required long? SelectedLogEntryId { get; init; }
     public required Func<List<OtlpSpan>> GetContextGenAISpans { get; init; }
 
     public string? PeerName { get; set; }
@@ -37,6 +38,7 @@ public sealed class GenAIVisualizerDialogViewModel
 
     public static GenAIVisualizerDialogViewModel Create(
         SpanDetailsViewModel spanDetailsViewModel,
+        long? selectedLogEntryId,
         TelemetryRepository telemetryRepository,
         Func<List<OtlpSpan>> getContextGenAISpans)
     {
@@ -45,6 +47,7 @@ public sealed class GenAIVisualizerDialogViewModel
             Span = spanDetailsViewModel.Span,
             Title = SpanWaterfallViewModel.GetTitle(spanDetailsViewModel.Span, spanDetailsViewModel.Resources),
             SpanDetailsViewModel = spanDetailsViewModel,
+            SelectedLogEntryId = selectedLogEntryId,
             GetContextGenAISpans = getContextGenAISpans
         };
 

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -13,13 +13,12 @@ using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Model.GenAI;
 
-[DebuggerDisplay("Span = {Span.SpanId}, Title = {Title}, Messages = {Messages.Count}")]
+[DebuggerDisplay("Span = {Span.SpanId}, Title = {Title}, Items = {Items.Count}")]
 public sealed class GenAIVisualizerDialogViewModel
 {
     public required OtlpSpan Span { get; init; }
     public required string Title { get; init; }
     public required SpanDetailsViewModel SpanDetailsViewModel { get; init; }
-    public required long? SelectedLogEntryId { get; init; }
     public required Func<List<OtlpSpan>> GetContextGenAISpans { get; init; }
 
     public string? PeerName { get; set; }
@@ -31,11 +30,6 @@ public sealed class GenAIVisualizerDialogViewModel
     public List<GenAIItemViewModel> OutputMessages { get; private set; } = default!;
     public GenAIItemViewModel? ErrorItem { get; private set; }
 
-    public GenAIItemViewModel? SelectedItem { get; set; }
-
-    public OverviewViewKind OverviewActiveView { get; set; }
-    public ItemViewKind MessageActiveView { get; set; }
-
     public bool NoMessageContent { get; set; }
     public string? ModelName { get; set; }
     public int? InputTokens { get; set; }
@@ -43,7 +37,6 @@ public sealed class GenAIVisualizerDialogViewModel
 
     public static GenAIVisualizerDialogViewModel Create(
         SpanDetailsViewModel spanDetailsViewModel,
-        long? selectedLogEntryId,
         TelemetryRepository telemetryRepository,
         Func<List<OtlpSpan>> getContextGenAISpans)
     {
@@ -52,7 +45,6 @@ public sealed class GenAIVisualizerDialogViewModel
             Span = spanDetailsViewModel.Span,
             Title = SpanWaterfallViewModel.GetTitle(spanDetailsViewModel.Span, spanDetailsViewModel.Resources),
             SpanDetailsViewModel = spanDetailsViewModel,
-            SelectedLogEntryId = selectedLogEntryId,
             GetContextGenAISpans = getContextGenAISpans
         };
 
@@ -85,22 +77,12 @@ public sealed class GenAIVisualizerDialogViewModel
             {
                 Index = viewModel.Items.Count,
                 InternalId = null,
-                ItemParts = [new GenAIItemPartViewModel
-                {
-                    MessagePart = null,
-                    ErrorMessage = errorMessage,
-                    TextVisualizerViewModel = new TextVisualizerViewModel(errorMessage, indentText: false)
-                }],
+                ItemParts = [GenAIItemPartViewModel.CreateErrorMessage(errorMessage)],
                 Parent = viewModel.Span,
                 ResourceName = viewModel.PeerName,
                 Type = GenAIItemType.Error
             };
             viewModel.Items.Add(viewModel.ErrorItem);
-        }
-
-        if (viewModel.SelectedLogEntryId != null)
-        {
-            viewModel.SelectedItem = viewModel.Items.SingleOrDefault(e => e.InternalId == viewModel.SelectedLogEntryId);
         }
 
         viewModel.InputMessages = viewModel.Items.Where(e => e.Type is GenAIItemType.SystemMessage or GenAIItemType.UserMessage or GenAIItemType.AssistantMessage or GenAIItemType.ToolMessage).ToList();
@@ -170,12 +152,7 @@ public sealed class GenAIVisualizerDialogViewModel
             if (systemInstructions != null)
             {
                 var instructionParts = JsonSerializer.Deserialize(systemInstructions, GenAIMessagesContext.Default.ListMessagePart)!;
-                viewModel.Items.Add(CreateMessage(viewModel, currentIndex, GenAIItemType.SystemMessage, instructionParts.Select(p => new GenAIItemPartViewModel
-                {
-                    MessagePart = p,
-                    ErrorMessage = null,
-                    TextVisualizerViewModel = CreateMessagePartVisualizer(p)
-                }).ToList(), internalId: null));
+                viewModel.Items.Add(CreateMessage(viewModel, currentIndex, GenAIItemType.SystemMessage, instructionParts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList(), internalId: null));
                 currentIndex++;
             }
             if (inputMessages != null)
@@ -226,12 +203,7 @@ public sealed class GenAIVisualizerDialogViewModel
         var inputParts = JsonSerializer.Deserialize(messages, GenAIMessagesContext.Default.ListChatMessage)!;
         foreach (var msg in inputParts)
         {
-            var parts = msg.Parts.Select(p => new GenAIItemPartViewModel
-            {
-                MessagePart = p,
-                ErrorMessage = null,
-                TextVisualizerViewModel = CreateMessagePartVisualizer(p)
-            }).ToList();
+            var parts = msg.Parts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
             var type = msg.Role switch
             {
                 "system" => GenAIItemType.SystemMessage,
@@ -244,24 +216,6 @@ public sealed class GenAIVisualizerDialogViewModel
         }
 
         return currentIndex;
-    }
-
-    private static TextVisualizerViewModel CreateMessagePartVisualizer(MessagePart p)
-    {
-        if (p is TextPart textPart)
-        {
-            return new TextVisualizerViewModel(textPart.Content ?? string.Empty, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
-        }
-        if (p is ToolCallRequestPart toolCallRequestPart)
-        {
-            return new TextVisualizerViewModel($"{toolCallRequestPart.Name}({toolCallRequestPart.Arguments?.ToJsonString()})", indentText: true, knownFormat: DashboardUIHelpers.JavascriptFormat);
-        }
-        if (p is ToolCallResponsePart toolCallResponsePart)
-        {
-            return new TextVisualizerViewModel(toolCallResponsePart.Response?.ToJsonString() ?? string.Empty, indentText: true);
-        }
-
-        return new TextVisualizerViewModel(string.Empty, indentText: false, knownFormat: DashboardUIHelpers.PlaintextFormat);
     }
 
     private static GenAIItemViewModel CreateMessage(GenAIVisualizerDialogViewModel viewModel, int currentIndex, GenAIItemType type, List<GenAIItemPartViewModel> parts, long? internalId)
@@ -286,12 +240,7 @@ public sealed class GenAIVisualizerDialogViewModel
             case GenAIItemType.SystemMessage:
             case GenAIItemType.UserMessage:
                 var systemOrUserEvent = JsonSerializer.Deserialize(message, GenAIEventsContext.Default.SystemOrUserEvent)!;
-                messagePartViewModels.Add(new()
-                {
-                    MessagePart = new TextPart { Content = systemOrUserEvent.Content },
-                    ErrorMessage = null,
-                    TextVisualizerViewModel = new TextVisualizerViewModel(systemOrUserEvent.Content ?? string.Empty, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat)
-                });
+                messagePartViewModels.Add(GenAIItemPartViewModel.CreateMessagePart(new TextPart { Content = systemOrUserEvent.Content }));
                 break;
             case GenAIItemType.AssistantMessage:
                 var assistantEvent = JsonSerializer.Deserialize(message, GenAIEventsContext.Default.AssistantEvent)!;
@@ -300,12 +249,7 @@ public sealed class GenAIVisualizerDialogViewModel
             case GenAIItemType.ToolMessage:
                 var toolEvent = JsonSerializer.Deserialize(message, GenAIEventsContext.Default.ToolEvent)!;
                 var toolResponse = ProcessJsonPayload(toolEvent.Content);
-                messagePartViewModels.Add(new()
-                {
-                    MessagePart = new ToolCallResponsePart { Id = toolEvent.Id, Response = toolResponse },
-                    ErrorMessage = null,
-                    TextVisualizerViewModel = new TextVisualizerViewModel(toolResponse?.ToJsonString() ?? string.Empty, indentText: true)
-                });
+                messagePartViewModels.Add(GenAIItemPartViewModel.CreateMessagePart(new ToolCallResponsePart { Id = toolEvent.Id, Response = toolResponse }));
                 break;
             case GenAIItemType.OutputMessage:
                 var choiceEvent = JsonSerializer.Deserialize(message, GenAIEventsContext.Default.ChoiceEvent)!;
@@ -322,12 +266,7 @@ public sealed class GenAIVisualizerDialogViewModel
         {
             if (assistantEvent.Content != null)
             {
-                messagePartViewModels.Add(new()
-                {
-                    MessagePart = new TextPart { Content = assistantEvent.Content },
-                    ErrorMessage = null,
-                    TextVisualizerViewModel = new TextVisualizerViewModel(assistantEvent.Content, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat)
-                });
+                messagePartViewModels.Add(GenAIItemPartViewModel.CreateMessagePart(new TextPart { Content = assistantEvent.Content }));
             }
             if (assistantEvent?.ToolCalls?.Length > 0)
             {
@@ -340,14 +279,7 @@ public sealed class GenAIVisualizerDialogViewModel
                     }
 
                     var args = ProcessJsonPayload(function.Arguments);
-                    var content = $"{function.Name}({args?.ToJsonString()})";
-
-                    messagePartViewModels.Add(new()
-                    {
-                        MessagePart = new ToolCallRequestPart { Name = function.Name, Arguments = function.Arguments },
-                        ErrorMessage = null,
-                        TextVisualizerViewModel = new TextVisualizerViewModel(content, indentText: false, knownFormat: "javascript")
-                    });
+                    messagePartViewModels.Add(GenAIItemPartViewModel.CreateMessagePart(new ToolCallRequestPart { Name = function.Name, Arguments = args }));
                 }
             }
         }

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -54,7 +54,6 @@ public sealed class GenAIVisualizerDialogViewModelTests
 
         // Assert
         Assert.Empty(vm.Items);
-        Assert.Null(vm.SelectedItem);
         Assert.Null(vm.ModelName);
         Assert.Null(vm.InputTokens);
         Assert.Null(vm.OutputTokens);
@@ -210,7 +209,6 @@ public sealed class GenAIVisualizerDialogViewModelTests
                 Assert.Collection(m.ItemParts,
                     p => Assert.Equal("Assistant!", Assert.IsType<TextPart>(p.MessagePart).Content));
             });
-        Assert.Null(vm.SelectedItem);
         Assert.Null(vm.ModelName);
         Assert.Null(vm.InputTokens);
         Assert.Null(vm.OutputTokens);
@@ -297,7 +295,6 @@ public sealed class GenAIVisualizerDialogViewModelTests
                 Assert.Collection(m.ItemParts,
                     p => Assert.Equal("Assistant!", Assert.IsType<TextPart>(p.MessagePart).Content));
             });
-        Assert.Null(vm.SelectedItem);
         Assert.Null(vm.ModelName);
         Assert.Null(vm.InputTokens);
         Assert.Null(vm.OutputTokens);
@@ -420,7 +417,6 @@ public sealed class GenAIVisualizerDialogViewModelTests
                 Assert.Collection(m.ItemParts,
                     p => Assert.Equal("Output!", Assert.IsType<TextPart>(p.MessagePart).Content));
             });
-        Assert.Null(vm.SelectedItem);
         Assert.Null(vm.ModelName);
         Assert.Null(vm.InputTokens);
         Assert.Null(vm.OutputTokens);
@@ -552,6 +548,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     {
         return GenAIVisualizerDialogViewModel.Create(
             spanDetailsViewModel,
+            selectedLogEntryId: null,
             telemetryRepository: repository,
             () => [spanDetailsViewModel.Span]);
     }

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -552,7 +552,6 @@ public sealed class GenAIVisualizerDialogViewModelTests
     {
         return GenAIVisualizerDialogViewModel.Create(
             spanDetailsViewModel,
-            selectedLogEntryId: null,
             telemetryRepository: repository,
             () => [spanDetailsViewModel.Span]);
     }


### PR DESCRIPTION
## Description

- Add support for displaying properties for generic part. They're displayed as JSON in the overview and property grids in message preview.
- Special case image part and display image in preview
- Fix losing selected message in dialog when telemetry updates

<img width="1403" height="995" alt="image" src="https://github.com/user-attachments/assets/3e1193c6-083f-4ee8-adce-dc82e8ac1197" />

<img width="1406" height="999" alt="image" src="https://github.com/user-attachments/assets/19596b4e-e7a1-4495-86ed-88e1e3dd2f97" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
