### PR TITLE
Fail if PublishAsAzureContainerAppJob is called without AddAzureContainerAppEnvironment

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -62,7 +62,10 @@ internal sealed class AzureContainerAppsInfrastructure(
     {
         foreach (var r in appModel.GetComputeResources())
         {
-            if (r.HasAnnotationOfType<AzureContainerAppCustomizationAnnotation>())
+            if (r.HasAnnotationOfType<AzureContainerAppCustomizationAnnotation>() ||
+#pragma warning disable ASPIREAZURE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                r.HasAnnotationOfType<AzureContainerAppJobCustomizationAnnotation>())
+#pragma warning restore ASPIREAZURE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             {
                 throw new InvalidOperationException($"Resource '{r.Name}' is configured to publish as an Azure Container App, but there are no '{nameof(AzureContainerAppEnvironmentResource)}' resources. Ensure you have added one by calling '{nameof(AzureContainerAppExtensions.AddAzureContainerAppEnvironment)}'.");
             }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1585,13 +1585,26 @@ public class AzureContainerAppsTests
                 .PublishAsAzureContainerApp((_, _) => { }));
 
         await RunTest(builder =>
+            builder.AddProject<Projects.ServiceA>("ServiceA", launchProfileName: null)
+                .PublishAsAzureContainerAppJob());
+
+        await RunTest(builder =>
             builder.AddContainer("api", "myimage")
                 .PublishAsAzureContainerApp((_, _) => { }));
+
+        await RunTest(builder =>
+            builder.AddContainer("api", "myimage")
+                .PublishAsAzureContainerAppJob());
 
         await RunTest(builder =>
             builder.AddExecutable("exe", "path/to/executable", ".")
                 .PublishAsDockerFile()
                 .PublishAsAzureContainerApp((_, _) => { }));
+
+        await RunTest(builder =>
+            builder.AddExecutable("exe", "path/to/executable", ".")
+                .PublishAsDockerFile()
+                .PublishAsAzureContainerAppJob());
     }
 
     [Fact]


### PR DESCRIPTION
This was missed in the initial feature checkin. We need to throw an exception if someone calls PublishAsAzureContainerAppJob, but hasn't configured an ACA environment explicitly. If you don't add an ACA environment, the project won't be deployed as an ACA Container App Job.