### PR TITLE
Improve display of replica instances in resource selector

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelectOptionTemplate.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelectOptionTemplate.razor
@@ -17,7 +17,10 @@
     }
     else if (ViewModel.Id?.Type is OtlpResourceType.Instance)
     {
-        <span style="padding-left: 20px;" aria-label="@string.Format(@Loc[nameof(ControlsStrings.ResourceDropdownReplicaAccessibleTitle)], ViewModel.Name, ViewModel.Id.ReplicaSetName)">@ViewModel.Name</span>
+        <FluentIcon Icon="Icons.Regular.Size20.ArrowTurnDownRight"
+                    Color="Color.Accent"
+                    Style="vertical-align: text-bottom;" />
+        <span aria-label="@string.Format(@Loc[nameof(ControlsStrings.ResourceDropdownReplicaAccessibleTitle)], ViewModel.Name, ViewModel.Id.ReplicaSetName)">@ViewModel.Name</span>
     }
     else
     {


### PR DESCRIPTION
## Description

Before:
<img width="389" height="197" alt="image" src="https://github.com/user-attachments/assets/1e3fe61c-7767-4789-98b4-2e77108c887e" />

After:
<img width="548" height="351" alt="image" src="https://github.com/user-attachments/assets/7b4590c2-3b4a-4776-bff0-6c5eac873b1e" />

Fixes https://github.com/dotnet/aspire/issues/11404

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
