### PR TITLE
Keyed redis distributed cache

### DIFF
--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
@@ -5,6 +5,7 @@ using Aspire.StackExchange.Redis;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
 namespace Microsoft.Extensions.Hosting;
@@ -78,8 +79,24 @@ public static class AspireRedisDistributedCacheExtensions
     /// Configures the Redis client to also provide distributed caching services through <see cref="IDistributedCache"/>.
     /// </summary>
     /// <param name="builder">The <see cref="AspireRedisClientBuilder"/> to configure.</param>
+    /// <param name="configureOptions">An optional method that can be used for customizing the <see cref="RedisCacheOptions"/>.</param>
     /// <returns>The <see cref="AspireRedisClientBuilder"/> for method chaining.</returns>
-    public static AspireRedisClientBuilder WithDistributedCache(this AspireRedisClientBuilder builder)
+    /// <example>
+    /// The following example creates keyed IDistributedCache service using the "myCache" key for a Redis client connection named "redis".
+    /// <code lang="csharp">
+    /// var builder = WebApplication.CreateBuilder(args);
+    ///
+    /// builder.AddRedisClientBuilder("redis")
+    ///        .WithDistributedCache();
+    /// </code>
+    /// The created IDistributedCache service can then be resolved from an IServiceProvider:
+    /// <code lang="csharp">
+    /// IServiceProvider serviceProvider = builder.Services.BuildServiceProvider();
+    ///
+    /// var cache = serviceProvider.GetRequiredService&lt;IDistributedCache&gt;();
+    /// </code>
+    /// </example>
+    public static AspireRedisClientBuilder WithDistributedCache(this AspireRedisClientBuilder builder, Action<RedisCacheOptions>? configureOptions = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -94,6 +111,8 @@ public static class AspireRedisDistributedCacheExtensions
             {
                 options.ConnectionMultiplexerFactory = () => Task.FromResult(sp.GetRequiredKeyedService<IConnectionMultiplexer>(key));
             }
+
+            configureOptions?.Invoke(options);
         });
 
         return builder;
@@ -105,5 +124,55 @@ public static class AspireRedisDistributedCacheExtensions
 
         builder.Services.AddOptions<RedisCacheOptions>() // note that RedisCacheOptions doesn't support named options
             .Configure(configureRedisOptions);
+    }
+
+    /// <summary>
+    /// Configures the Redis client to provide a keyed distributed caching service through <see cref="IDistributedCache"/> using <paramref name="name"/> as the key.
+    /// </summary>
+    /// <param name="builder">The <see cref="AspireRedisClientBuilder"/> to configure.</param>
+    /// <param name="name">The name which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service.</param>
+    /// <param name="configureOptions">An optional method that can be used for customizing the <see cref="RedisCacheOptions"/>.</param>
+    /// <returns>The <see cref="AspireRedisClientBuilder"/> for method chaining.</returns>
+    /// <example>
+    /// The following example creates keyed IDistributedCache service using the "myCache" key for a Redis client connection named "redis".
+    /// <code lang="csharp">
+    /// var builder = WebApplication.CreateBuilder(args);
+    ///
+    /// builder.AddRedisClientBuilder("redis")
+    ///        .WithKeyedDistributedCache("myCache", options => options.InstanceName = "myCache");
+    /// </code>
+    /// The created IDistributedCache service can then be resolved using the "myCache" key:
+    /// <code lang="csharp">
+    /// IServiceProvider serviceProvider = builder.Services.BuildServiceProvider();
+    ///
+    /// var cache = serviceProvider.GetRequiredKeyedService&lt;IDistributedCache&gt;("myCache");
+    /// </code>
+    /// </example>
+    public static AspireRedisClientBuilder WithKeyedDistributedCache(this AspireRedisClientBuilder builder, string name, Action<RedisCacheOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (configureOptions is not null)
+        {
+            // note that AddStackExchangeRedisCache doesn't support named RedisCacheOptions options, so we need to register the named options ourselves
+            builder.HostBuilder.Services
+                .AddOptions<RedisCacheOptions>(name)
+                .Configure(configureOptions);
+        }
+
+        builder.HostBuilder.Services.AddKeyedSingleton<IDistributedCache>(name, (sp, key) =>
+        {
+            var options = sp.GetRequiredService<IOptionsMonitor<RedisCacheOptions>>().Get((string?)key);
+
+            options.ConnectionMultiplexerFactory = () => Task.FromResult(sp.GetRequiredKeyedService<IConnectionMultiplexer>(builder.ServiceKey));
+
+            // AddStackExchangeRedisCache only supports unkeyed IDistributedCache, so we need to create the RedisCache instance ourselves.
+            // As of .NET 10, the drawback to this approach is that it doesn't use the internal RedisCacheImpl class. Which means:
+            // - The RedisCache won't log appropriately (but it only logs in one place - where it is unable to add library name suffix.
+            // - If HybridCache is being used, it won't add the 'HC' library name suffix to the connection.
+            return new RedisCache(options);
+        });
+
+        return builder;
     }
 }

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
@@ -82,7 +82,7 @@ public static class AspireRedisDistributedCacheExtensions
     /// <param name="configureOptions">An optional method that can be used for customizing the <see cref="RedisCacheOptions"/>.</param>
     /// <returns>The <see cref="AspireRedisClientBuilder"/> for method chaining.</returns>
     /// <example>
-    /// The following example creates keyed IDistributedCache service using the "myCache" key for a Redis client connection named "redis".
+    /// The following example creates an IDistributedCache service using the Redis client connection named "redis".
     /// <code lang="csharp">
     /// var builder = WebApplication.CreateBuilder(args);
     ///

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
@@ -151,6 +151,7 @@ public static class AspireRedisDistributedCacheExtensions
     public static AspireRedisClientBuilder WithKeyedDistributedCache(this AspireRedisClientBuilder builder, string name, Action<RedisCacheOptions>? configureOptions = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
 
         if (configureOptions is not null)
         {

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
@@ -39,7 +39,6 @@ public ProductsController(IDistributedCache cache)
 
 You can register multiple keyed `IDistributedCache` instances by building off the `AddRedisClientBuilder` extension method. The keyed services pattern allows you to register multiple instances of a service with different configurations and retrieve them using a key. The key used for the `IConnectionMultiplexer` service is separate from the key used to register the `IDistributedCache` service.
 
-
 ```csharp
 builder.AddRedisClientBuilder("redis") // register an unkeyed IConnectionMultiplexer with the connection name "redis"
        .WithKeyedDistributedCache("distributedCache"); // register a keyed IDistributedCache with key "distributedCache"

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
@@ -35,6 +35,27 @@ public ProductsController(IDistributedCache cache)
 }
 ```
 
+### Keyed IDistributedCache instances
+
+You can register multiple keyed `IDistributedCache` instances by building off the `AddRedisClientBuilder` extension method. The keyed services pattern allows you to register multiple instances of a service with different configurations and retrieve them using a key. The key used for the `IConnectionMultiplexer` service is separate from the key used to register the `IDistributedCache` service.
+
+
+```csharp
+builder.AddRedisClientBuilder("redis") // register an unkeyed IConnectionMultiplexer with the connection name "redis"
+       .WithKeyedDistributedCache("distributedCache"); // register a keyed IDistributedCache with key "distributedCache"
+```
+
+Then retrieve the keyed service using dependency injection. For example, to retrieve the cache from a Web API controller:
+
+```csharp
+private readonly IDistributedCache _cache;
+
+public ProductsController([FromKeyedServices("distributedCache")] IDistributedCache cache)
+{
+    _cache = cache;
+}
+```
+
 ## Configuration
 
 The .NET Aspire StackExchange Redis Distributed Cache component provides multiple options to configure the Redis connection based on the requirements and conventions of your project. Note that at least one host name is required to connect.

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/AspireRedisDistributedCacheExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/AspireRedisDistributedCacheExtensionsTests.cs
@@ -1,10 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.StackExchange.Redis.Tests;
+using Aspire.TestUtilities;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Aspire.StackExchange.Redis.DistributedCaching.Tests;
@@ -35,5 +39,102 @@ public class AspireRedisDistributedCacheExtensionsTests
         var cache = host.Services.GetRequiredService<IDistributedCache>();
 
         Assert.IsAssignableFrom<RedisCache>(cache);
+    }
+
+    [Fact]
+    [RequiresDocker]
+    public async Task AddsRedisBuilderDistributedCacheCanConfigure()
+    {
+        await using var container = await RedisContainerFixture.CreateContainerAsync();
+
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:redis", container.GetConnectionString()),
+        ]);
+
+        builder.AddRedisClientBuilder("redis")
+            .WithDistributedCache(options => options.InstanceName = "myCache");
+
+        using var host = builder.Build();
+        var distributedCache = host.Services.GetRequiredService<IDistributedCache>();
+
+        distributedCache.SetString("key", "value");
+
+        var connection = host.Services.GetRequiredService<IConnectionMultiplexer>();
+        var key = Assert.Single(connection.GetServers().Single().Keys());
+        Assert.StartsWith("myCache", key);
+    }
+
+    /// <summary>
+    /// Tests that you can use keyed services for distributed caches.
+    /// </summary>
+    [Fact]
+    [RequiresDocker]
+    public async Task CanAddMultipleKeyedCachingServicesBuilder()
+    {
+        await using var container1 = await RedisContainerFixture.CreateContainerAsync();
+        await using var container2 = await RedisContainerFixture.CreateContainerAsync();
+        await using var container3 = await RedisContainerFixture.CreateContainerAsync();
+
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:redis1", container1.GetConnectionString()),
+            new KeyValuePair<string, string?>("ConnectionStrings:redis2", container2.GetConnectionString()),
+            new KeyValuePair<string, string?>("ConnectionStrings:redis3", container3.GetConnectionString()),
+        ]);
+
+        builder.AddRedisClientBuilder("redis1")
+            .WithKeyedDistributedCache("dcache1", options => options.InstanceName = "dcache1");
+        builder.AddKeyedRedisClientBuilder("redis2")
+            .WithKeyedDistributedCache("dcache2"); // don't configure the options to ensure configuring separately works
+        builder.AddKeyedRedisClientBuilder("redis3")
+            .WithKeyedDistributedCache("dcache3", options => options.InstanceName = "dcache3");
+
+        using var host = builder.Build();
+
+        var connection1 = host.Services.GetRequiredService<IConnectionMultiplexer>();
+        var connection2 = host.Services.GetRequiredKeyedService<IConnectionMultiplexer>("redis2");
+        var connection3 = host.Services.GetRequiredKeyedService<IConnectionMultiplexer>("redis3");
+        var dcache1 = host.Services.GetRequiredKeyedService<IDistributedCache>("dcache1");
+        var dcache2 = host.Services.GetRequiredKeyedService<IDistributedCache>("dcache2");
+        var dcache3 = host.Services.GetRequiredKeyedService<IDistributedCache>("dcache3");
+
+        Assert.NotSame(connection1, connection2);
+        Assert.NotSame(connection1, connection3);
+        Assert.NotSame(connection2, connection3);
+        Assert.NotSame(dcache1, dcache2);
+        Assert.NotSame(dcache1, dcache3);
+        Assert.NotSame(dcache2, dcache3);
+
+        Assert.Equal(container1.GetConnectionString(), connection1.Configuration);
+        Assert.Equal(container2.GetConnectionString(), connection2.Configuration);
+        Assert.Equal(container3.GetConnectionString(), connection3.Configuration);
+
+        // set a value in the first distributed cache and ensure it is only in the redis1 server
+        dcache1.SetString("key1", "value1");
+
+        var key = Assert.Single(connection1.GetServers().Single().Keys());
+        Assert.Equal("dcache1key1", key);
+        Assert.Empty(connection2.GetServers().Single().Keys());
+        Assert.Empty(connection3.GetServers().Single().Keys());
+
+        // set a value in the second distributed cache and ensure it is only in the redis2 server
+        dcache2.SetString("key2", "value2");
+
+        key = Assert.Single(connection1.GetServers().Single().Keys());
+        Assert.Equal("dcache1key1", key);
+        key = Assert.Single(connection2.GetServers().Single().Keys());
+        Assert.Equal("key2", key);
+        Assert.Empty(connection3.GetServers().Single().Keys());
+
+        // set a value in the third distributed cache and ensure it is only in the redis3 server
+        dcache3.SetString("key3", "value3");
+
+        key = Assert.Single(connection1.GetServers().Single().Keys());
+        Assert.Equal("dcache1key1", key);
+        key = Assert.Single(connection2.GetServers().Single().Keys());
+        Assert.Equal("key2", key);
+        key = Assert.Single(connection3.GetServers().Single().Keys());
+        Assert.Equal("dcache3key3", key);
     }
 }


### PR DESCRIPTION
## Description

Add support for keyed Redis IDistributedCache

Building on top of https://github.com/dotnet/aspire/pull/11141, this adds a new WithKeyedDistributedCache API that allows callers to create a keyed IDistributedCache around a Redis connection.

Fix https://github.com/dotnet/aspire/issues/8528

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
