### PR TITLE
Delete and recreate devtunnels if they already exist & add configurable retries

### DIFF
--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
@@ -186,6 +186,15 @@ internal sealed class DevTunnelCli
         , outputWriter, errorWriter, logger, cancellationToken);
     }
 
+    public Task<int> DeletePortAsync(
+        string tunnelId,
+        int portNumber,
+        TextWriter? outputWriter = null,
+        TextWriter? errorWriter = null,
+        ILogger? logger = default,
+        CancellationToken cancellationToken = default)
+        => RunAsync(["port", "delete", tunnelId, "--port-number", portNumber.ToString(CultureInfo.InvariantCulture), "--force", "--json", "--nologo"], outputWriter, errorWriter, logger, cancellationToken);
+
     private Task<int> RunAsync(string[] args, TextWriter? outputWriter = null, TextWriter? errorWriter = null, ILogger? logger = default, CancellationToken cancellationToken = default)
         => RunAsync(args, outputWriter, errorWriter, useShellExecute: false, logger, cancellationToken);
 

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
@@ -138,7 +138,7 @@ internal sealed class DevTunnelCli
         TextWriter? errorWriter = null,
         ILogger? logger = default,
         CancellationToken cancellationToken = default)
-        => RunAsync(["delete", tunnelId, "--json", "--nologo"], outputWriter, errorWriter, logger, cancellationToken);
+        => RunAsync(["delete", tunnelId, "--force", "--json", "--nologo"], outputWriter, errorWriter, logger, cancellationToken);
 
     public Task<int> ShowTunnelAsync(
         string tunnelId,

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.DevTunnels;
 
@@ -28,24 +29,25 @@ internal sealed class DevTunnelCli
         _cliPath = filePath;
     }
 
-    public Task<int> UserLoginMicrosoftAsync(CancellationToken cancellationToken = default)
-        => RunAsync(["user", "login", "--entra", "--json", "--nologo"], null, null, useShellExecute: true, cancellationToken);
+    public Task<int> UserLoginMicrosoftAsync(ILogger? logger = default, CancellationToken cancellationToken = default)
+        => RunAsync(["user", "login", "--entra", "--json", "--nologo"], null, null, useShellExecute: true, logger, cancellationToken);
 
-    public Task<int> UserLoginGitHubAsync(CancellationToken cancellationToken = default)
-        => RunAsync(["user", "login", "--github", "--json", "--nologo"], null, null, useShellExecute: true, cancellationToken);
+    public Task<int> UserLoginGitHubAsync(ILogger? logger = default, CancellationToken cancellationToken = default)
+        => RunAsync(["user", "login", "--github", "--json", "--nologo"], null, null, useShellExecute: true, logger, cancellationToken);
 
-    public Task<int> UserLogoutAsync(TextWriter? outputWriter = null, TextWriter? errorWriter = null, CancellationToken cancellationToken = default)
+    public Task<int> UserLogoutAsync(TextWriter? outputWriter = null, TextWriter? errorWriter = null, ILogger? logger = default, CancellationToken cancellationToken = default)
         => RunAsync(new ArgsBuilder(["user", "logout", "--json", "--nologo"])
-        , outputWriter, errorWriter, cancellationToken);
+        , outputWriter, errorWriter, logger, cancellationToken);
 
-    public Task<int> UserStatusAsync(TextWriter? outputWriter = null, TextWriter? errorWriter = null, CancellationToken cancellationToken = default)
-        => RunAsync(["user", "show", "--json", "--nologo"], outputWriter, errorWriter, cancellationToken);
+    public Task<int> UserStatusAsync(TextWriter? outputWriter = null, TextWriter? errorWriter = null, ILogger? logger = default, CancellationToken cancellationToken = default)
+        => RunAsync(["user", "show", "--json", "--nologo"], outputWriter, errorWriter, logger, cancellationToken);
 
     public Task<int> CreateTunnelAsync(
         string? tunnelId = null,
         DevTunnelOptions? options = null,
         TextWriter? outputWriter = null,
         TextWriter? errorWriter = null,
+        ILogger? logger = default,
         CancellationToken cancellationToken = default)
     {
         options ??= new DevTunnelOptions();
@@ -56,7 +58,7 @@ internal sealed class DevTunnelCli
             .AddValues("--labels", options.Labels)
             .Add("--json")
             .Add("--nologo")
-        , outputWriter, errorWriter, cancellationToken);
+        , outputWriter, errorWriter, logger, cancellationToken);
     }
 
     public Task<int> UpdateTunnelAsync(
@@ -64,6 +66,7 @@ internal sealed class DevTunnelCli
         DevTunnelOptions? options = null,
         TextWriter? outputWriter = null,
         TextWriter? errorWriter = null,
+        ILogger? logger = default,
         CancellationToken cancellationToken = default)
     {
         options ??= new DevTunnelOptions();
@@ -72,7 +75,7 @@ internal sealed class DevTunnelCli
             .AddValues("--add-labels", options.Labels)
             .Add("--json")
             .Add("--nologo")
-        , outputWriter, errorWriter, cancellationToken);
+        , outputWriter, errorWriter, logger, cancellationToken);
     }
 
     public Task<int> ListAccessAsync(
@@ -80,13 +83,14 @@ internal sealed class DevTunnelCli
         int? portNumber = null,
         TextWriter? outputWriter = null,
         TextWriter? errorWriter = null,
+        ILogger? logger = default,
         CancellationToken cancellationToken = default)
     {
         return RunAsync(new ArgsBuilder(["access", "list", tunnelId])
             .AddIfNotNull("--port-number", portNumber?.ToString(CultureInfo.InvariantCulture))
             .Add("--json")
             .Add("--nologo")
-        , outputWriter, errorWriter, cancellationToken);
+        , outputWriter, errorWriter, logger, cancellationToken);
     }
 
     public Task<int> ResetAccessAsync(
@@ -94,13 +98,14 @@ internal sealed class DevTunnelCli
         int? portNumber = null,
         TextWriter? outputWriter = null,
         TextWriter? errorWriter = null,
+        ILogger? logger = default,
         CancellationToken cancellationToken = default)
     {
         return RunAsync(new ArgsBuilder(["access", "reset", tunnelId])
             .AddIfNotNull("--port-number", portNumber?.ToString(CultureInfo.InvariantCulture))
             .Add("--json")
             .Add("--nologo")
-        , outputWriter, errorWriter, cancellationToken);
+        , outputWriter, errorWriter, logger, cancellationToken);
     }
 
     public Task<int> CreateAccessAsync(
@@ -110,6 +115,7 @@ internal sealed class DevTunnelCli
         bool deny = false,
         TextWriter? outputWriter = null,
         TextWriter? errorWriter = null,
+        ILogger? logger = default,
         CancellationToken cancellationToken = default)
     {
         if (!anonymous && !deny)
@@ -123,14 +129,24 @@ internal sealed class DevTunnelCli
             .AddIfTrue("--anonymous", anonymous)
             .Add("--json")
             .Add("--nologo")
-        , outputWriter, errorWriter, cancellationToken);
+        , outputWriter, errorWriter, logger, cancellationToken);
     }
 
-    public Task<int> DeleteTunnelAsync(string tunnelId, TextWriter? outputWriter = null, TextWriter? errorWriter = null, CancellationToken cancellationToken = default)
-        => RunAsync(["delete", tunnelId, "--json", "--nologo"], outputWriter, errorWriter, cancellationToken);
+    public Task<int> DeleteTunnelAsync(
+        string tunnelId,
+        TextWriter? outputWriter = null,
+        TextWriter? errorWriter = null,
+        ILogger? logger = default,
+        CancellationToken cancellationToken = default)
+        => RunAsync(["delete", tunnelId, "--json", "--nologo"], outputWriter, errorWriter, logger, cancellationToken);
 
-    public Task<int> ShowTunnelAsync(string tunnelId, TextWriter? outputWriter = null, TextWriter? errorWriter = null, CancellationToken cancellationToken = default)
-        => RunAsync(["show", tunnelId, "--json", "--nologo"], outputWriter, errorWriter, cancellationToken);
+    public Task<int> ShowTunnelAsync(
+        string tunnelId,
+        TextWriter? outputWriter = null,
+        TextWriter? errorWriter = null,
+        ILogger? logger = default,
+        CancellationToken cancellationToken = default)
+        => RunAsync(["show", tunnelId, "--json", "--nologo"], outputWriter, errorWriter, logger, cancellationToken);
 
     public Task<int> CreatePortAsync(
         string tunnelId,
@@ -138,6 +154,7 @@ internal sealed class DevTunnelCli
         DevTunnelPortOptions? options = null,
         TextWriter? outputWriter = null,
         TextWriter? errorWriter = null,
+        ILogger? logger = default,
         CancellationToken cancellationToken = default)
     {
         options ??= new DevTunnelPortOptions();
@@ -147,7 +164,7 @@ internal sealed class DevTunnelCli
             .AddValues("--labels", options.Labels)
             .Add("--json")
             .Add("--nologo")
-        , outputWriter, errorWriter, cancellationToken);
+        , outputWriter, errorWriter, logger, cancellationToken);
     }
 
     public Task<int> UpdatePortAsync(
@@ -156,6 +173,7 @@ internal sealed class DevTunnelCli
         DevTunnelPortOptions? options = null,
         TextWriter? outputWriter = null,
         TextWriter? errorWriter = null,
+        ILogger? logger = default,
         CancellationToken cancellationToken = default)
     {
         options ??= new DevTunnelPortOptions();
@@ -165,13 +183,13 @@ internal sealed class DevTunnelCli
             .AddValues("--add-labels", options.Labels)
             .Add("--json")
             .Add("--nologo")
-        , outputWriter, errorWriter, cancellationToken);
+        , outputWriter, errorWriter, logger, cancellationToken);
     }
 
-    private Task<int> RunAsync(string[] args, TextWriter? outputWriter = null, TextWriter? errorWriter = null, CancellationToken cancellationToken = default)
-        => RunAsync(args, outputWriter, errorWriter, useShellExecute: false, cancellationToken);
+    private Task<int> RunAsync(string[] args, TextWriter? outputWriter = null, TextWriter? errorWriter = null, ILogger? logger = default, CancellationToken cancellationToken = default)
+        => RunAsync(args, outputWriter, errorWriter, useShellExecute: false, logger, cancellationToken);
 
-    private Task<int> RunAsync(string[] args, TextWriter? outputWriter = null, TextWriter? errorWriter = null, bool useShellExecute = false, CancellationToken cancellationToken = default)
+    private Task<int> RunAsync(string[] args, TextWriter? outputWriter = null, TextWriter? errorWriter = null, bool useShellExecute = false, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
         return RunAsync((isError, line) =>
         {
@@ -183,10 +201,10 @@ internal sealed class DevTunnelCli
             {
                 outputWriter?.WriteLine(line);
             }
-        }, args, useShellExecute, cancellationToken);
+        }, args, useShellExecute, logger, cancellationToken);
     }
 
-    private async Task<int> RunAsync(Action<bool, string> onOutput, string[] args, bool useShellExecute = false, CancellationToken cancellationToken = default)
+    private async Task<int> RunAsync(Action<bool, string> onOutput, string[] args, bool useShellExecute = false, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
         using var process = new Process
         {
@@ -196,6 +214,8 @@ internal sealed class DevTunnelCli
 
         var stdoutTask = Task.CompletedTask;
         var stderrTask = Task.CompletedTask;
+
+        logger?.LogTrace("Invoking devtunnel CLI{ShellExecuteInfo}: {FileName} {Arguments}", useShellExecute ? " (UseShellExecute=true)" : "", process.StartInfo.FileName, string.Join(' ', process.StartInfo.ArgumentList));
 
         try
         {
@@ -216,6 +236,7 @@ internal sealed class DevTunnelCli
                 {
                     if (!process.HasExited)
                     {
+                        logger?.LogTrace("Cancellation requested, killing devtunnel process tree.");
                         process.Kill(entireProcessTree: true);
                     }
                 }
@@ -226,11 +247,8 @@ internal sealed class DevTunnelCli
             });
 
             await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-            if (!useShellExecute)
-            {
-                await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
-            }
 
+            logger?.LogTrace("devtunnel CLI exited with exit code '{ExitCode}'.", process.ExitCode);
             return process.ExitCode;
         }
         finally
@@ -239,6 +257,7 @@ internal sealed class DevTunnelCli
             {
                 try
                 {
+                    logger?.LogTrace("devtunnel CLI exited, draining stdout/stderr.");
                     await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
                 }
                 catch
@@ -283,7 +302,7 @@ internal sealed class DevTunnelCli
         return psi;
     }
 
-    private static async Task PumpAsync(StreamReader reader, Action<string> onLine, CancellationToken cancellationToken)
+    private static async Task PumpAsync(StreamReader reader, Action<string> onLine, CancellationToken cancellationToken = default)
     {
         while (!reader.EndOfStream && !cancellationToken.IsCancellationRequested)
         {

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
@@ -115,7 +115,7 @@ internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTun
                 }
                 if (exitCode == 0)
                 {
-                    logger?.LogTrace("Dev tunnel '{TunnelId}' created successfully.", tunnelId);
+                    logger?.LogTrace("Port '{PortNumber}' on dev tunnel '{TunnelId}' created successfully.", portNumber, tunnelId);
                     return port;
                 }
             }
@@ -145,7 +145,7 @@ internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTun
 
     public async Task<DevTunnelAccessStatus> GetAccessAsync(string tunnelId, int? portNumber = null, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
-        logger?.LogTrace("Getting access details for {PortInfo}dev tunnel '{TunnelId}'.", tunnelId, portNumber.HasValue ? $"port '{portNumber}' on " : string.Empty);
+        logger?.LogTrace("Getting access details for {PortInfo}dev tunnel '{TunnelId}'.", portNumber.HasValue ? $"port '{portNumber}' on " : string.Empty, tunnelId);
         var (access, exitCode, error) = await CallCliAsJsonAsync<DevTunnelAccessStatus>(
             (stdout, stderr, log, ct) => _cli.ListAccessAsync(tunnelId, portNumber, stdout, stderr, log, ct),
             logger, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
@@ -26,7 +26,7 @@ internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTun
             logger?.LogTrace("Creating dev tunnel '{TunnelId}' with options: {Options}", tunnelId, options.ToLoggerString());
             if (attempts++ > 1)
             {
-                logger?.LogTrace("Attempt {Attempt} of {MaxAttempts} to create dev tunnel '{TunnelId}'", attempts, tunnelId, _maxCliAttempts);
+                logger?.LogTrace("Attempt {Attempt} of {MaxAttempts} to create dev tunnel '{TunnelId}'", attempts, _maxCliAttempts, tunnelId);
             }
             (var tunnel, exitCode, error) = await CallCliAsJsonAsync<DevTunnelStatus>(
                 (stdout, stderr, log, ct) => _cli.CreateTunnelAsync(tunnelId, options, stdout, stderr, log, ct),

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.DevTunnels;
 
@@ -12,58 +13,69 @@ internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTun
     private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
     private readonly DevTunnelCli _cli = new(DevTunnelCli.GetCliPath(configuration));
 
-    public async Task<DevTunnelStatus> CreateOrUpdateTunnelAsync(string tunnelId, DevTunnelOptions options, CancellationToken cancellationToken = default)
+    public async Task<DevTunnelStatus> CreateOrUpdateTunnelAsync(string tunnelId, DevTunnelOptions options, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
+        logger?.LogTrace("Creating dev tunnel '{TunnelId}' with options: {Options}", tunnelId, options.ToLoggerString());
         var (tunnel, exitCode, error) = await CallCliAsJsonAsync<DevTunnelStatus>(
-            (stdout, stderr, ct) => _cli.CreateTunnelAsync(tunnelId, options, stdout, stderr, ct),
+            (stdout, stderr, log, ct) => _cli.CreateTunnelAsync(tunnelId, options, stdout, stderr, log, ct),
             "tunnel",
-            cancellationToken).ConfigureAwait(false);
+            logger, cancellationToken).ConfigureAwait(false);
 
         if (exitCode == DevTunnelCli.ResourceConflictsWithExistingExitCode)
         {
             // Tunnel already exists
+            logger?.LogTrace("Dev tunnel '{TunnelId}' already exists, reset access controls and update tunnel instead.", tunnelId);
 
-            // Reset the access controls to match the updated options
+            // First, reset the access controls
+            logger?.LogTrace("Resetting access controls for dev tunnel '{TunnelId}'.", tunnelId);
             (var access, exitCode, error) = await CallCliAsJsonAsync<DevTunnelAccessStatus>(
-                (stdout, stderr, ct) => _cli.ResetAccessAsync(tunnelId, /* port */ null, stdout, stderr, ct),
-                cancellationToken).ConfigureAwait(false);
-
-            if (options.AllowAnonymous)
-            {
-                var anonymous = true;
-                var deny = false;
-                (access, exitCode, error) = await CallCliAsJsonAsync<DevTunnelAccessStatus>(
-                    (stdout, stderr, ct) => _cli.CreateAccessAsync(tunnelId, /* port */ null, anonymous, deny, stdout, stderr, ct),
-                    cancellationToken).ConfigureAwait(false);
-            }
+                (stdout, stderr, log, ct) => _cli.ResetAccessAsync(tunnelId, /* port */ null, stdout, stderr, log, ct),
+                logger, cancellationToken).ConfigureAwait(false);
 
             if (exitCode == 0)
             {
-                // Do the update
-                (tunnel, exitCode, error) = await CallCliAsJsonAsync<DevTunnelStatus>(
-                    (stdout, stderr, ct) => _cli.UpdateTunnelAsync(tunnelId, options, stdout, stderr, ct),
-                    "tunnel",
-                    cancellationToken).ConfigureAwait(false);
+                // Set the anonymous access policy if specified
+                if (options.AllowAnonymous)
+                {
+                    var anonymous = true;
+                    var deny = false;
+                    logger?.LogTrace("Allowing anonymous access for dev tunnel '{TunnelId}'.", tunnelId);
+                    (access, exitCode, error) = await CallCliAsJsonAsync<DevTunnelAccessStatus>(
+                        (stdout, stderr, log, ct) => _cli.CreateAccessAsync(tunnelId, /* port */ null, anonymous, deny, stdout, stderr, log, ct),
+                        logger, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (exitCode == 0)
+                {
+                    // Do the update
+                    logger?.LogTrace("Updating dev tunnel '{TunnelId}'.", tunnelId);
+                    (tunnel, exitCode, error) = await CallCliAsJsonAsync<DevTunnelStatus>(
+                        (stdout, stderr, log, ct) => _cli.UpdateTunnelAsync(tunnelId, options, stdout, stderr, log, ct),
+                        "tunnel",
+                        logger, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 
-        return tunnel ?? throw new DistributedApplicationException($"Failed to create tunnel '{tunnelId}'. Exit code {exitCode}: {error}");
+        return tunnel ?? throw new DistributedApplicationException($"Failed to create dev tunnel '{tunnelId}'. Exit code {exitCode}: {error}");
     }
 
-    public async Task<DevTunnelStatus> GetTunnelAsync(string tunnelId, CancellationToken cancellationToken = default)
+    public async Task<DevTunnelStatus> GetTunnelAsync(string tunnelId, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
+        logger?.LogTrace("Getting details for dev tunnel '{TunnelId}'.", tunnelId);
         var (tunnel, exitCode, error) = await CallCliAsJsonAsync<DevTunnelStatus>(
-            (stdout, stderr, ct) => _cli.ShowTunnelAsync(tunnelId, stdout, stderr, ct),
+            (stdout, stderr, log, ct) => _cli.ShowTunnelAsync(tunnelId, stdout, stderr, log, ct),
             "tunnel",
-            cancellationToken).ConfigureAwait(false);
-        return tunnel ?? throw new DistributedApplicationException($"Failed to get tunnel '{tunnelId}'. Exit code {exitCode}: {error}");
+            logger, cancellationToken).ConfigureAwait(false);
+        return tunnel ?? throw new DistributedApplicationException($"Failed to get dev tunnel '{tunnelId}'. Exit code {exitCode}: {error}");
     }
 
-    public async Task<DevTunnelPortStatus> CreateOrUpdatePortAsync(string tunnelId, int portNumber, DevTunnelPortOptions options, CancellationToken cancellationToken = default)
+    public async Task<DevTunnelPortStatus> CreateOrUpdatePortAsync(string tunnelId, int portNumber, DevTunnelPortOptions options, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
+        logger?.LogTrace("Creating port '{PortNumber}' on dev tunnel '{TunnelId}' with options: {Options}", portNumber, tunnelId, options.ToLoggerString());
         var (port, exitCode, error) = await CallCliAsJsonAsync<DevTunnelPortStatus>(
-                (outWriter, errWriter, ct) => _cli.CreatePortAsync(tunnelId, portNumber, options, outWriter, errWriter, ct),
-                cancellationToken).ConfigureAwait(false);
+                (outWriter, errWriter, log, ct) => _cli.CreatePortAsync(tunnelId, portNumber, options, outWriter, errWriter, log, ct),
+                logger, cancellationToken).ConfigureAwait(false);
 
         if (exitCode == 0)
         {
@@ -73,108 +85,127 @@ internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTun
                 // AllowAnonymous=false: anonymous=true, deny=true
                 var anonymous = true;
                 var deny = !options.AllowAnonymous.Value;
+                logger?.LogTrace("Allowing anonymous access for port '{PortNumber}' on dev tunnel '{TunnelId}'.", portNumber, tunnelId);
                 (var access, exitCode, error) = await CallCliAsJsonAsync<DevTunnelAccessStatus>(
-                    (stdout, stderr, ct) => _cli.CreateAccessAsync(tunnelId, portNumber, anonymous, deny, stdout, stderr, ct),
-                    cancellationToken).ConfigureAwait(false);
+                    (stdout, stderr, log, ct) => _cli.CreateAccessAsync(tunnelId, portNumber, anonymous, deny, stdout, stderr, log, ct),
+                    logger, cancellationToken).ConfigureAwait(false);
             }
         }
         else if (exitCode == DevTunnelCli.ResourceConflictsWithExistingExitCode)
         {
             // Port already exists
+            logger?.LogTrace("Port '{PortNumber}' for dev tunnel '{TunnelId}' already exists, reset access controls and update port instead.", portNumber, tunnelId);
 
             // Reset the access controls to match the updated options
             (var access, exitCode, error) = await CallCliAsJsonAsync<DevTunnelAccessStatus>(
-                (stdout, stderr, ct) => _cli.ResetAccessAsync(tunnelId, portNumber, stdout, stderr, ct),
-                cancellationToken).ConfigureAwait(false);
+                (stdout, stderr, log, ct) => _cli.ResetAccessAsync(tunnelId, portNumber, stdout, stderr, log, ct),
+                logger, cancellationToken).ConfigureAwait(false);
 
-            if (options.AllowAnonymous.HasValue)
+            if (exitCode == 0 && options.AllowAnonymous.HasValue)
             {
                 // AllowAnonymous=true: anonymous=true, deny=false
                 // AllowAnonymous=false: anonymous=true, deny=true
                 var anonymous = true;
                 var deny = !options.AllowAnonymous.Value;
+                if (deny)
+                {
+                    logger?.LogTrace("Denying anonymous access for port '{PortNumber}' on dev tunnel '{TunnelId}'.", portNumber, tunnelId);
+                }
+                else
+                {
+                    logger?.LogTrace("Allowing anonymous access for port '{PortNumber}' on dev tunnel '{TunnelId}'.", portNumber, tunnelId);
+                }
                 (access, exitCode, error) = await CallCliAsJsonAsync<DevTunnelAccessStatus>(
-                    (stdout, stderr, ct) => _cli.CreateAccessAsync(tunnelId, portNumber, anonymous, deny, stdout, stderr, ct),
-                    cancellationToken).ConfigureAwait(false);
+                    (stdout, stderr, log, ct) => _cli.CreateAccessAsync(tunnelId, portNumber, anonymous, deny, stdout, stderr, log, ct),
+                    logger, cancellationToken).ConfigureAwait(false);
             }
 
             if (exitCode == 0)
             {
+                logger?.LogTrace("Updating port '{PortNumber}' on dev tunnel '{TunnelId}'.", portNumber, tunnelId);
                 (port, exitCode, error) = await CallCliAsJsonAsync<DevTunnelPortStatus>(
-                    (stdout, stderr, ct) => _cli.UpdatePortAsync(tunnelId, portNumber, options, stdout, stderr, ct),
+                    (stdout, stderr, log, ct) => _cli.UpdatePortAsync(tunnelId, portNumber, options, stdout, stderr, log, ct),
                     "port",
-                    cancellationToken).ConfigureAwait(false);
+                    logger, cancellationToken).ConfigureAwait(false);
             }
         }
 
         return port ?? throw new DistributedApplicationException($"Failed to create port '{portNumber}' for tunnel '{tunnelId}'. Exit code {exitCode}: {error}");
     }
 
-    public async Task<DevTunnelAccessStatus> GetAccessAsync(string tunnelId, int? portNumber = null, CancellationToken cancellationToken = default)
+    public async Task<DevTunnelAccessStatus> GetAccessAsync(string tunnelId, int? portNumber = null, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
+        logger?.LogTrace("Getting access details for {PortInfo}dev tunnel '{TunnelId}'.", tunnelId, portNumber.HasValue ? $"port '{portNumber}' on " : string.Empty);
         var (access, exitCode, error) = await CallCliAsJsonAsync<DevTunnelAccessStatus>(
-            (stdout, stderr, ct) => _cli.ListAccessAsync(tunnelId, portNumber, stdout, stderr, ct),
-            cancellationToken).ConfigureAwait(false);
+            (stdout, stderr, log, ct) => _cli.ListAccessAsync(tunnelId, portNumber, stdout, stderr, log, ct),
+            logger, cancellationToken).ConfigureAwait(false);
         return access ?? throw new DistributedApplicationException($"Failed to get access details for '{tunnelId}'{(portNumber.HasValue ? $" port {portNumber}" : "")}. Exit code {exitCode}: {error}");
     }
 
-    public async Task<UserLoginStatus> GetUserLoginStatusAsync(CancellationToken cancellationToken = default)
+    public async Task<UserLoginStatus> GetUserLoginStatusAsync(ILogger? logger = default, CancellationToken cancellationToken = default)
     {
+        logger?.LogTrace("Getting dev tunnel user login status.");
         var (login, exitCode, error) = await CallCliAsJsonAsync<UserLoginStatus>(
             _cli.UserStatusAsync,
-            cancellationToken).ConfigureAwait(false);
+            logger, cancellationToken).ConfigureAwait(false);
         return login ?? throw new DistributedApplicationException($"Failed to get user login status. Exit code {exitCode}: {error}");
     }
 
-    public async Task<UserLoginStatus> UserLoginAsync(LoginProvider provider, CancellationToken cancellationToken = default)
+    public async Task<UserLoginStatus> UserLoginAsync(LoginProvider provider, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
+        logger?.LogTrace("Logging in to dev tunnel service using {LoginProvider}.", provider);
         var exitCode = provider switch
         {
-            LoginProvider.Microsoft => await _cli.UserLoginMicrosoftAsync(cancellationToken).ConfigureAwait(false),
-            LoginProvider.GitHub => await _cli.UserLoginGitHubAsync(cancellationToken).ConfigureAwait(false),
+            LoginProvider.Microsoft => await _cli.UserLoginMicrosoftAsync(logger, cancellationToken).ConfigureAwait(false),
+            LoginProvider.GitHub => await _cli.UserLoginGitHubAsync(logger, cancellationToken).ConfigureAwait(false),
             _ => throw new ArgumentException("Unsupported provider. Supported providers are 'microsoft' and 'github'.", nameof(provider)),
         };
 
         if (exitCode == 0)
         {
             // Login succeeded, get the login status
-            return await GetUserLoginStatusAsync(cancellationToken).ConfigureAwait(false);
+            return await GetUserLoginStatusAsync(logger, cancellationToken).ConfigureAwait(false);
         }
 
         throw new DistributedApplicationException($"Failed to perform user login. Process finished with exit code: {exitCode}");
     }
 
-    private async Task<(T? Result, int ExitCode, string? Error)> CallCliAsJsonAsync<T>(Func<TextWriter, TextWriter, CancellationToken, Task<int>> cliCall, CancellationToken cancellationToken = default)
+    private async Task<(T? Result, int ExitCode, string? Error)> CallCliAsJsonAsync<T>(Func<TextWriter, TextWriter, ILogger?, CancellationToken, Task<int>> cliCall, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
-        return await CallCliAsJsonAsync<T>(cliCall, propertyName: null, cancellationToken).ConfigureAwait(false);
+        return await CallCliAsJsonAsync<T>(cliCall, propertyName: null, logger, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<(T? Result, int ExitCode, string? Error)> CallCliAsJsonAsync<T>(Func<TextWriter, TextWriter, CancellationToken, Task<int>> cliCall, string? propertyName, CancellationToken cancellationToken = default)
+    private async Task<(T? Result, int ExitCode, string? Error)> CallCliAsJsonAsync<T>(Func<TextWriter, TextWriter, ILogger?, CancellationToken, Task<int>> cliCall, string? propertyName, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
         // PERF: Could pool these writers
         using var stdout = new StringWriter();
         using var stderr = new StringWriter();
 
-        var exitCode = await cliCall(stdout, stderr, cancellationToken).ConfigureAwait(false);
+        var exitCode = await cliCall(stdout, stderr, logger, cancellationToken).ConfigureAwait(false);
 
         if (exitCode != 0)
         {
             var error = stderr.ToString().Trim();
+            logger?.LogError("CLI call returned non-zero exit code '{ExitCode}'. stderr output:\n{Error}", exitCode, error);
             return (default, exitCode, error);
         }
 
         var output = stdout.ToString().Trim();
+        logger?.LogTrace("CLI call output:\n{Output}", output);
         try
         {
-            var result = propertyName switch
+            if (!string.IsNullOrEmpty(propertyName))
             {
-                { Length: > 0 } => JsonSerializer.Deserialize<T>(JsonDocument.Parse(output).RootElement.GetProperty(propertyName).GetRawText(), _jsonOptions),
-                _ => JsonSerializer.Deserialize<T>(output, _jsonOptions),
-            };
+                output = JsonDocument.Parse(output).RootElement.GetProperty(propertyName).GetRawText();
+                logger?.LogTrace("Extracted JSON property '{PropertyName}':\n{Output}", propertyName, output);
+            }
+            var result = JsonSerializer.Deserialize<T>(output, _jsonOptions);
+            logger?.LogTrace("JSON output successfully deserialized to '{TypeName}' instance", typeof(T).Name);
             return (result, 0, default);
         }
         catch (JsonException ex)
         {
+            logger?.LogError(ex, "Failed to parse JSON output into type '{TypeName}'", typeof(T).Name);
             throw new DistributedApplicationException($"Failed to parse JSON output into type '{typeof(T).Name}':\n{output}", ex);
         }
     }

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.DevTunnels;
 
 internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTunnelClient
 {
-    private readonly int _maxCliAttempts = configuration.GetValue<int?>("ASPIRE_DEVTUNNEL_MAX_CLI_ATTEMPTS") ?? 3;
+    private readonly int _maxCliAttempts = configuration.GetValue<int?>("ASPIRE_DEVTUNNEL_CLI_MAX_ATTEMPTS") ?? 3;
     private readonly TimeSpan _cliRetryOnErrorDelay = TimeSpan.FromSeconds(2);
     private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
     private readonly DevTunnelCli _cli = new(DevTunnelCli.GetCliPath(configuration));

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
@@ -15,7 +15,7 @@ internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTun
     private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
     private readonly DevTunnelCli _cli = new(DevTunnelCli.GetCliPath(configuration));
 
-    public async Task<DevTunnelStatus> CreateOrUpdateTunnelAsync(string tunnelId, DevTunnelOptions options, ILogger? logger = default, CancellationToken cancellationToken = default)
+    public async Task<DevTunnelStatus> CreateTunnelAsync(string tunnelId, DevTunnelOptions options, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
         var attempts = 0;
         var exitCode = 0;
@@ -74,7 +74,7 @@ internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTun
         return tunnel ?? throw new DistributedApplicationException($"Failed to get dev tunnel '{tunnelId}'. Exit code {exitCode}: {error}");
     }
 
-    public async Task<DevTunnelPortStatus> CreateOrUpdatePortAsync(string tunnelId, int portNumber, DevTunnelPortOptions options, ILogger? logger = default, CancellationToken cancellationToken = default)
+    public async Task<DevTunnelPortStatus> CreatePortAsync(string tunnelId, int portNumber, DevTunnelPortOptions options, ILogger? logger = default, CancellationToken cancellationToken = default)
     {
         var attempts = 0;
         var exitCode = 0;

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelLoginManager.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelLoginManager.cs
@@ -27,7 +27,7 @@ internal sealed class DevTunnelLoginManager(
         while (true)
         {
             _logger.LogDebug("Checking dev tunnel login status");
-            var loginStatus = await _devTunnelClient.GetUserLoginStatusAsync(cancellationToken).ConfigureAwait(false);
+            var loginStatus = await _devTunnelClient.GetUserLoginStatusAsync(_logger, cancellationToken).ConfigureAwait(false);
             if (loginStatus.IsLoggedIn)
             {
                 _logger.LogDebug("User already logged in to dev tunnel service as {Username} with {Provider}", loginStatus.Username, loginStatus.Provider);
@@ -69,13 +69,13 @@ internal sealed class DevTunnelLoginManager(
                     selectedProvider = result.Data ? LoginProvider.Microsoft : LoginProvider.GitHub;
                     _logger.LogDebug("User selected {LoginProvider} for dev tunnel login", selectedProvider);
                     // Check again in case they logged in from another window while we were prompting
-                    loginStatus = await _devTunnelClient.GetUserLoginStatusAsync(cancellationToken).ConfigureAwait(false);
+                    loginStatus = await _devTunnelClient.GetUserLoginStatusAsync(_logger, cancellationToken).ConfigureAwait(false);
                 }
                 if (!loginStatus.IsLoggedIn || loginStatus.Provider != selectedProvider)
                 {
                     // Trigger the login flow
                     _logger.LogInformation("Initiating dev tunnel login via {LoginProvider}", selectedProvider);
-                    loginStatus = await _devTunnelClient.UserLoginAsync(selectedProvider, cancellationToken).ConfigureAwait(false);
+                    loginStatus = await _devTunnelClient.UserLoginAsync(selectedProvider, _logger, cancellationToken).ConfigureAwait(false);
 
                     if (loginStatus.IsLoggedIn)
                     {

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelOptions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelOptions.cs
@@ -22,6 +22,8 @@ public sealed class DevTunnelOptions
     /// Optional labels to attach to the tunnel.
     /// </summary>
     public List<string>? Labels { get; set; }
+
+    internal string ToLoggerString() => $"{{ Description={Description}, AllowAnonymous={AllowAnonymous}, Labels=[{string.Join(", ", Labels ?? [])}] }}";
 }
 
 /// <summary>
@@ -48,4 +50,6 @@ public sealed class DevTunnelPortOptions
     /// Optional labels to attach to this tunnel port.
     /// </summary>
     public List<string>? Labels { get; set; }
+
+    internal string ToLoggerString() => $"{{ Description={Description}, AllowAnonymous={AllowAnonymous}, Protocol={Protocol}, Labels=[{string.Join(", ", Labels ?? [])}] }}";
 }

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -130,7 +130,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
                 }
                 catch (Exception ex)
                 {
-                    var exception = new DistributedApplicationException($"Error trying to create/update the dev tunnel resource '{tunnelResource.TunnelId}' that this resource has a reference to: {ex.Message}", ex);
+                    var exception = new DistributedApplicationException($"Error trying to create/update the dev tunnel resource '{tunnelResource.TunnelId}' this port belongs to: {ex.Message}", ex);
                     foreach (var portResource in tunnelResource.Ports)
                     {
                         portResource.TunnelEndpointAllocatedTcs.SetException(exception);
@@ -142,13 +142,12 @@ public static partial class DevTunnelsResourceBuilderExtensions
                 await Task.WhenAll(tunnelResource.Ports.Select(p => p.TargetEndpointAllocatedTask)).ConfigureAwait(false);
 
                 // Start the tunnel ports
+                var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
                 await Task.WhenAll(tunnelResource.Ports.Select(StartPortAsync)).ConfigureAwait(false);
 
                 async Task StartPortAsync(DevTunnelPortResource portResource)
                 {
                     var portLogger = e.Services.GetRequiredService<ResourceLoggerService>().GetLogger(portResource);
-                    var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
-                    var eventing = e.Services.GetRequiredService<IDistributedApplicationEventing>();
 
                     // Clear any prior port status
                     portLogger.LogInformation("Tunnel starting");

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -124,13 +124,13 @@ public static partial class DevTunnelsResourceBuilderExtensions
                 // Create the dev tunnel
                 try
                 {
-                    logger.LogInformation("Creating or updating dev tunnel '{TunnelId}'", tunnelResource.TunnelId);
-                    var tunnelStatus = await devTunnelClient.CreateOrUpdateTunnelAsync(tunnelResource.TunnelId, tunnelResource.Options, logger, ct).ConfigureAwait(false);
-                    logger.LogDebug("Dev tunnel '{TunnelId}' created/updated", tunnelResource.TunnelId);
+                    logger.LogInformation("Creating dev tunnel '{TunnelId}'", tunnelResource.TunnelId);
+                    var tunnelStatus = await devTunnelClient.CreateTunnelAsync(tunnelResource.TunnelId, tunnelResource.Options, logger, ct).ConfigureAwait(false);
+                    logger.LogDebug("Dev tunnel '{TunnelId}' created", tunnelResource.TunnelId);
                 }
                 catch (Exception ex)
                 {
-                    var exception = new DistributedApplicationException($"Error trying to create/update the dev tunnel resource '{tunnelResource.TunnelId}' this port belongs to: {ex.Message}", ex);
+                    var exception = new DistributedApplicationException($"Error trying to create the dev tunnel resource '{tunnelResource.TunnelId}' this port belongs to: {ex.Message}", ex);
                     foreach (var portResource in tunnelResource.Ports)
                     {
                         portResource.TunnelEndpointAllocatedTcs.SetException(exception);
@@ -156,10 +156,10 @@ public static partial class DevTunnelsResourceBuilderExtensions
                         State = KnownResourceStates.Starting
                     }).ConfigureAwait(false);
 
-                    // Create/update the tunnel port
+                    // Create the tunnel port
                     try
                     {
-                        _ = await devTunnelClient.CreateOrUpdatePortAsync(
+                        _ = await devTunnelClient.CreatePortAsync(
                                 portResource.DevTunnel.TunnelId,
                                 portResource.TargetEndpoint.Port,
                                 portResource.Options,
@@ -167,11 +167,11 @@ public static partial class DevTunnelsResourceBuilderExtensions
                                 ct)
                             .ConfigureAwait(false);
 
-                        portLogger.LogInformation("Created/updated dev tunnel port '{Port}' on tunnel '{Tunnel}' targeting endpoint '{Endpoint}' on resource '{TargetResource}'", portResource.TargetEndpoint.Port, portResource.DevTunnel.TunnelId, portResource.TargetEndpoint.EndpointName, portResource.TargetEndpoint.Resource.Name);
+                        portLogger.LogInformation("Created dev tunnel port '{Port}' on tunnel '{Tunnel}' targeting endpoint '{Endpoint}' on resource '{TargetResource}'", portResource.TargetEndpoint.Port, portResource.DevTunnel.TunnelId, portResource.TargetEndpoint.EndpointName, portResource.TargetEndpoint.Resource.Name);
                     }
                     catch (Exception ex)
                     {
-                        portLogger.LogError(ex, "Error trying to create/update dev tunnel port '{Port}' on tunnel '{Tunnel}': {Error}", portResource.TargetEndpoint.Port, portResource.DevTunnel.TunnelId, ex.Message);
+                        portLogger.LogError(ex, "Error trying to create dev tunnel port '{Port}' on tunnel '{Tunnel}': {Error}", portResource.TargetEndpoint.Port, portResource.DevTunnel.TunnelId, ex.Message);
                         portResource.TunnelEndpointAllocatedTcs.SetException(ex);
                         throw;
                     }

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -85,7 +85,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
         var healtCheckKey = $"{name}-check";
         builder.Services.AddHealthChecks().Add(new HealthCheckRegistration(
             healtCheckKey,
-            services => new DevTunnelHealthCheck(services.GetRequiredService<IDevTunnelClient>(), tunnelResource),
+            services => new DevTunnelHealthCheck(services.GetRequiredService<IDevTunnelClient>(), tunnelResource, services.GetRequiredService<ILogger<DevTunnelHealthCheck>>()),
             failureStatus: default,
             tags: default,
             timeout: default));
@@ -125,7 +125,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
                 try
                 {
                     logger.LogInformation("Creating or updating dev tunnel '{TunnelId}'", tunnelResource.TunnelId);
-                    var tunnelStatus = await devTunnelClient.CreateOrUpdateTunnelAsync(tunnelResource.TunnelId, tunnelResource.Options, ct).ConfigureAwait(false);
+                    var tunnelStatus = await devTunnelClient.CreateOrUpdateTunnelAsync(tunnelResource.TunnelId, tunnelResource.Options, logger, ct).ConfigureAwait(false);
                     logger.LogDebug("Dev tunnel '{TunnelId}' created/updated", tunnelResource.TunnelId);
                 }
                 catch (Exception ex)
@@ -164,6 +164,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
                                 portResource.DevTunnel.TunnelId,
                                 portResource.TargetEndpoint.Port,
                                 portResource.Options,
+                                portLogger,
                                 ct)
                             .ConfigureAwait(false);
 

--- a/src/Aspire.Hosting.DevTunnels/IDevTunnelClient.cs
+++ b/src/Aspire.Hosting.DevTunnels/IDevTunnelClient.cs
@@ -11,9 +11,9 @@ internal interface IDevTunnelClient
 
     Task<UserLoginStatus> UserLoginAsync(LoginProvider provider, ILogger? logger = default, CancellationToken cancellationToken = default);
 
-    Task<DevTunnelStatus> CreateOrUpdateTunnelAsync(string tunnelId, DevTunnelOptions options, ILogger? logger = default, CancellationToken cancellationToken = default);
+    Task<DevTunnelStatus> CreateTunnelAsync(string tunnelId, DevTunnelOptions options, ILogger? logger = default, CancellationToken cancellationToken = default);
 
-    Task<DevTunnelPortStatus> CreateOrUpdatePortAsync(string tunnelId, int portNumber, DevTunnelPortOptions options, ILogger? logger = default, CancellationToken cancellationToken = default);
+    Task<DevTunnelPortStatus> CreatePortAsync(string tunnelId, int portNumber, DevTunnelPortOptions options, ILogger? logger = default, CancellationToken cancellationToken = default);
 
     Task<DevTunnelStatus> GetTunnelAsync(string tunnelId, ILogger? logger = default, CancellationToken cancellationToken = default);
 

--- a/src/Aspire.Hosting.DevTunnels/IDevTunnelClient.cs
+++ b/src/Aspire.Hosting.DevTunnels/IDevTunnelClient.cs
@@ -7,17 +7,17 @@ namespace Aspire.Hosting.DevTunnels;
 
 internal interface IDevTunnelClient
 {
-    Task<UserLoginStatus> GetUserLoginStatusAsync(CancellationToken cancellationToken = default);
+    Task<UserLoginStatus> GetUserLoginStatusAsync(ILogger? logger = default, CancellationToken cancellationToken = default);
 
-    Task<UserLoginStatus> UserLoginAsync(LoginProvider provider, CancellationToken cancellationToken = default);
+    Task<UserLoginStatus> UserLoginAsync(LoginProvider provider, ILogger? logger = default, CancellationToken cancellationToken = default);
 
-    Task<DevTunnelStatus> CreateOrUpdateTunnelAsync(string tunnelId, DevTunnelOptions options, CancellationToken cancellationToken = default);
+    Task<DevTunnelStatus> CreateOrUpdateTunnelAsync(string tunnelId, DevTunnelOptions options, ILogger? logger = default, CancellationToken cancellationToken = default);
 
-    Task<DevTunnelPortStatus> CreateOrUpdatePortAsync(string tunnelId, int portNumber, DevTunnelPortOptions options, CancellationToken cancellationToken = default);
+    Task<DevTunnelPortStatus> CreateOrUpdatePortAsync(string tunnelId, int portNumber, DevTunnelPortOptions options, ILogger? logger = default, CancellationToken cancellationToken = default);
 
-    Task<DevTunnelStatus> GetTunnelAsync(string tunnelId, CancellationToken cancellationToken = default);
+    Task<DevTunnelStatus> GetTunnelAsync(string tunnelId, ILogger? logger = default, CancellationToken cancellationToken = default);
 
-    Task<DevTunnelAccessStatus> GetAccessAsync(string tunnelId, int? portNumber = null, CancellationToken cancellationToken = default);
+    Task<DevTunnelAccessStatus> GetAccessAsync(string tunnelId, int? portNumber = null, ILogger? logger = default, CancellationToken cancellationToken = default);
 }
 
 internal sealed record UserLoginStatus(string Status, LoginProvider Provider, string Username)


### PR DESCRIPTION
## Description

Changes the strategy for when devtunnel tunnels and ports already exist. Instead of switching from a create to an update, tunnels are just deleted if they already exist at create time. Additionally, CLI failures will be retried now. Default is max of 3 attempts but can be changed via configuration. Logic for creating ports has the same improvements, but now that the tunnels are always deleted and recreated if they already exist, the chances a port creation fails due to it already existing should be extremely low.

Added a bunch more logging all the way down to the CLI invocations.

Contributes to #11422

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
