### PR TITLE
Add destination to span details

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -189,6 +189,15 @@ public partial class SpanDetails : IDisposable
                 },
             };
 
+            if (_viewModel.Span.GetDestination() is { } destination)
+            {
+                _valueComponents[KnownTraceFields.DestinationField] = new ComponentMetadata
+                {
+                    Type = typeof(ResourceNameButtonValue),
+                    Parameters = { ["Resource"] = destination }
+                };
+            }
+
             UpdateSpanActionsMenu();
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -284,7 +284,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         var result = TelemetryRepository.GetLogs(logsContext);
 
         Logger.LogInformation("Trace '{TraceId}' has {SpanCount} spans.", _trace.TraceId, _trace.Spans.Count);
-        _spanWaterfallViewModels = SpanWaterfallViewModel.Create(_trace, result.Items, new SpanWaterfallViewModel.TraceDetailState(OutgoingPeerResolvers.ToArray(), _collapsedSpanIds));
+        _spanWaterfallViewModels = SpanWaterfallViewModel.Create(_trace, result.Items, new SpanWaterfallViewModel.TraceDetailState(OutgoingPeerResolvers.ToArray(), _collapsedSpanIds, _resources));
         _maxDepth = _spanWaterfallViewModels.Max(s => s.Depth);
 
         var apps = new HashSet<OtlpResource>();

--- a/src/Aspire.Dashboard/Extensions/CollectionExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/CollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Dashboard.Extensions;
@@ -13,5 +13,26 @@ public static class CollectionExtensions
         }
 
         return !array.Where((t, i) => !Equals(t, other[i])).Any();
+    }
+
+    public static T? SingleOrNull<T>(this IEnumerable<T> source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        using var enumerator = source.GetEnumerator();
+
+        if (!enumerator.MoveNext())
+        {
+            return default; // no items
+        }
+
+        var first = enumerator.Current;
+
+        if (enumerator.MoveNext())
+        {
+            return default; // more than one
+        }
+
+        return first; // exactly one
     }
 }

--- a/src/Aspire.Dashboard/Model/Otlp/KnownTraceFields.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/KnownTraceFields.cs
@@ -14,6 +14,7 @@ public static class KnownTraceFields
     // Not used in search.
     public const string StatusMessageField = "trace.statusmessage";
     public const string ParentIdField = "trace.parentid";
+    public const string DestinationField = "trace.destination";
 
     public static readonly List<string> AllFields = [
         NameField,

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -217,7 +217,9 @@ public sealed class SpanWaterfallViewModel
     {
         if (span.UninstrumentedPeer != null)
         {
-            // If the span has a peer name, use it.
+            // If the span has a peer name, use it. Note that when the peer is a resource with replicas, it's possible the uninstrumented peer name returned here isn't the real replica. The first match will be chosen.
+            // We are matching an address, e.g. localhost:8080, to replicas which share the same address. There isn't a way to know exactly which replica was called.
+            // This shouldn't be a big issue because typically project replicas will have OTEL setup, and so a child span is recorded.
             return OtlpResource.GetResourceName(span.UninstrumentedPeer, allResources);
         }
 

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -217,8 +217,8 @@ public sealed class SpanWaterfallViewModel
     {
         if (span.UninstrumentedPeer != null)
         {
-            // If the span has a peer name, use it. Note that when the peer is a resource with replicas, it's possible the uninstrumented peer name returned here isn't the real replica. The first match will be chosen.
-            // We are matching an address, e.g. localhost:8080, to replicas which share the same address. There isn't a way to know exactly which replica was called.
+            // If the span has a peer name, use it. Note that when the peer is a resource with replicas, it's possible the uninstrumented peer name returned here isn't the real replica.
+            // We are matching an address to replicas which share the same address. There isn't a way to know exactly which replica was called. The first replica instance will be chosen.
             // This shouldn't be a big issue because typically project replicas will have OTEL setup, and so a child span is recorded.
             return OtlpResource.GetResourceName(span.UninstrumentedPeer, allResources);
         }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model.Otlp;
 using Grpc.Core;
 
@@ -134,17 +135,17 @@ public class OtlpSpan
 
     public OtlpResource? GetDestination()
     {
-        // Calculate destination. The destination could either be resolved from an uninstrumented peer, or from a single child span.
+        // Calculate destination. The destination could either be resolved from:
+        // - An uninstrumented peer, or
+        // - From single child span when the child span has a different resources and is a server/consumer.
         if (UninstrumentedPeer is { } peer)
         {
             return peer;
         }
         else
         {
-            var childSpans = GetChildSpans().ToList();
-            if (childSpans.Count == 1)
+            if (GetChildSpans().SingleOrNull() is { } childSpan)
             {
-                var childSpan = childSpans[0];
                 if (childSpan.Source.ResourceKey != Source.ResourceKey && childSpan.Kind is OtlpSpanKind.Server or OtlpSpanKind.Consumer)
                 {
                     return childSpan.Source.Resource;

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -138,6 +138,7 @@ public class OtlpSpan
         // Calculate destination. The destination could either be resolved from:
         // - An uninstrumented peer, or
         // - From single child span when the child span has a different resources and is a server/consumer.
+        //   This is the same situation as an uninstrumented peer except in this case the peer is recording telemetry.
         if (UninstrumentedPeer is { } peer)
         {
             return peer;

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -70,47 +70,6 @@ public class OtlpSpan
         return null;
     }
 
-    /*
-    public enum PeerType
-    {
-        None,
-        ChildSpanPeer,
-        UninstrumentedPeer
-    }
-
-    public bool TryGetPeerType(out (OtlpResource? Peer, PeerType Type) result)
-    {
-        if (OtlpHelpers.GetPeerAddress(Attributes) == null)
-        {
-            result = default;
-            return false;
-        }
-        if (!(Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer))
-        {
-            result = default;
-            return false;
-        }
-        var childSpanCount = GetChildSpans().Count();
-        if (childSpanCount > 1)
-        {
-            // Multiple child spans. Can't single one out
-            result = default;
-            return false;
-        }
-        else if (childSpanCount == 0)
-        {
-            result = UninstrumentedPeer != null ? (UninstrumentedPeer, PeerType.UninstrumentedPeer) : default;
-            return result.Peer != null;
-        }
-        else
-        {
-            var childSpan = GetChildSpans().Single();
-            result = (childSpan.Source.Resource, PeerType.ChildSpanPeer);
-            return result.Peer != null;
-        }
-    }
-    */
-
     public OtlpSpan(OtlpResourceView resourceView, OtlpTrace trace, OtlpScope scope)
     {
         Source = resourceView;

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -29,7 +29,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc)));
 
         // Act
-        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], []));
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], []));
 
         // Assert
         Assert.Collection(vm,
@@ -60,7 +60,7 @@ public sealed class SpanWaterfallViewModelTests
         var log = new OtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(traceId: trace.TraceId, spanId: "1"), app1View, scope, context);
 
         // Act
-        var vm = SpanWaterfallViewModel.Create(trace, [log], new SpanWaterfallViewModel.TraceDetailState([], []));
+        var vm = SpanWaterfallViewModel.Create(trace, [log], new SpanWaterfallViewModel.TraceDetailState([], [], []));
 
         // Assert
         Assert.Collection(vm,
@@ -89,7 +89,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "2", parentSpanId: null, startDate: new DateTime(2001, 2, 1, 1, 1, 2, DateTimeKind.Utc), kind: OtlpSpanKind.Client));
 
         // Act
-        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([new BrowserLinkOutgoingPeerResolver()], []));
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([new BrowserLinkOutgoingPeerResolver()], [], []));
 
         // Assert
         Assert.Collection(vm,
@@ -142,7 +142,7 @@ public sealed class SpanWaterfallViewModelTests
         var vm = SpanWaterfallViewModel.Create(
             trace,
             [],
-            new SpanWaterfallViewModel.TraceDetailState([], [])).First();
+            new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
 
         // Act
         var result = vm.MatchesFilter(filter, typeFilter: null, a => a.Resource.ResourceName, out _);
@@ -202,7 +202,7 @@ public sealed class SpanWaterfallViewModelTests
         var vm = SpanWaterfallViewModel.Create(
             trace,
             [],
-            new SpanWaterfallViewModel.TraceDetailState([], [])).First();
+            new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
 
         // Act 1
         var result1 = vm.MatchesFilter(string.Empty, typeFilter: spanType.Id?.Filter, a => a.Resource.ResourceName, out _);
@@ -234,7 +234,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(parentSpan);
         trace.AddSpan(childSpan);
 
-        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], []));
+        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], []));
         var parent = vms[0];
         var child = vms[1];
 
@@ -256,7 +256,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(parentSpan);
         trace.AddSpan(childSpan);
 
-        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], []));
+        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], []));
         var parent = vms[0];
         var child = vms[1];
 

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
@@ -56,11 +56,78 @@ public class OtlpSpanTests
                 Assert.Equal("trace.statusmessage", a.Key);
                 Assert.Equal("Status message!", a.Value);
             });
-        Assert.Collection(knownProperties,
+        Assert.Collection(attributeProperties,
             a =>
             {
                 Assert.Equal("unknown-trace.statusmessage", a.Key);
                 Assert.Equal("value", a.Value);
             });
+    }
+
+    [Fact]
+    public void GetDestination_NoChildOrPeer_Null()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+
+        var span = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime,
+            statusCode: OtlpSpanStatusCode.Ok, statusMessage: "Status message!", attributes: [new KeyValuePair<string, string>(KnownTraceFields.StatusMessageField, "value")]);
+
+        // Act
+        var destination = span.GetDestination();
+
+        // Assert
+        Assert.Null(destination);
+    }
+
+    [Fact]
+    public void GetDestination_HasPeer_ReturnPeerResource()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
+        var app2 = new OtlpResource("app2", "instance", uninstrumentedPeer: true, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+
+        var span = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime,
+            statusCode: OtlpSpanStatusCode.Ok, statusMessage: "Status message!", attributes: [new KeyValuePair<string, string>(KnownTraceFields.StatusMessageField, "value")],
+            kind: OtlpSpanKind.Client, uninstrumentedPeer: app2);
+
+        // Act
+        var destination = span.GetDestination();
+
+        // Assert
+        Assert.Equal(app2, destination);
+    }
+
+    [Fact]
+    public void GetDestination_HasSingleChild_ReturnChildResource()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
+        var app2 = new OtlpResource("app2", "instance", uninstrumentedPeer: true, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+
+        var parentSpan = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime,
+            statusCode: OtlpSpanStatusCode.Ok, statusMessage: "Status message!", attributes: [new KeyValuePair<string, string>(KnownTraceFields.StatusMessageField, "value")],
+            kind: OtlpSpanKind.Client);
+        var childSpan = TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "abc-2", parentSpanId: "abc", startDate: s_testTime,
+            statusCode: OtlpSpanStatusCode.Ok, statusMessage: "Status message!", attributes: [new KeyValuePair<string, string>(KnownTraceFields.StatusMessageField, "value")],
+            kind: OtlpSpanKind.Server);
+
+        trace.AddSpan(parentSpan);
+        trace.AddSpan(childSpan);
+
+        // Act
+        var destination = parentSpan.GetDestination();
+
+        // Assert
+        Assert.Equal(app2, destination);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
@@ -73,8 +73,7 @@ public class OtlpSpanTests
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
 
-        var span = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime,
-            statusCode: OtlpSpanStatusCode.Ok, statusMessage: "Status message!", attributes: [new KeyValuePair<string, string>(KnownTraceFields.StatusMessageField, "value")]);
+        var span = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime);
 
         // Act
         var destination = span.GetDestination();
@@ -94,7 +93,6 @@ public class OtlpSpanTests
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
 
         var span = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime,
-            statusCode: OtlpSpanStatusCode.Ok, statusMessage: "Status message!", attributes: [new KeyValuePair<string, string>(KnownTraceFields.StatusMessageField, "value")],
             kind: OtlpSpanKind.Client, uninstrumentedPeer: app2);
 
         // Act
@@ -115,10 +113,8 @@ public class OtlpSpanTests
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
 
         var parentSpan = TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime,
-            statusCode: OtlpSpanStatusCode.Ok, statusMessage: "Status message!", attributes: [new KeyValuePair<string, string>(KnownTraceFields.StatusMessageField, "value")],
             kind: OtlpSpanKind.Client);
         var childSpan = TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "abc-2", parentSpanId: "abc", startDate: s_testTime,
-            statusCode: OtlpSpanStatusCode.Ok, statusMessage: "Status message!", attributes: [new KeyValuePair<string, string>(KnownTraceFields.StatusMessageField, "value")],
             kind: OtlpSpanKind.Server);
 
         trace.AddSpan(parentSpan);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
@@ -26,10 +26,11 @@ public class OtlpSpanTests
             statusCode: OtlpSpanStatusCode.Ok, statusMessage: "Status message!", attributes: [new KeyValuePair<string, string>(KnownTraceFields.StatusMessageField, "value")]);
 
         // Act
-        var properties = span.AllProperties();
+        var knownProperties = span.GetKnownProperties();
+        var attributeProperties = span.GetAttributeProperties();
 
         // Assert
-        Assert.Collection(properties,
+        Assert.Collection(knownProperties,
             a =>
             {
                 Assert.Equal("trace.spanid", a.Key);
@@ -54,7 +55,8 @@ public class OtlpSpanTests
             {
                 Assert.Equal("trace.statusmessage", a.Key);
                 Assert.Equal("Status message!", a.Value);
-            },
+            });
+        Assert.Collection(knownProperties,
             a =>
             {
                 Assert.Equal("unknown-trace.statusmessage", a.Key);


### PR DESCRIPTION
## Description

Span details now includes a link to the span's destination.

<img width="1816" height="888" alt="image" src="https://github.com/user-attachments/assets/4dae5591-0d23-4bf4-af15-d77ef3170d77" />

Fixes https://github.com/dotnet/aspire/issues/10695

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
