### PR TITLE
Use obj instead of string for destinations

### DIFF
--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/IYarpConfigurationBuilder.cs
@@ -46,7 +46,7 @@ public interface IYarpConfigurationBuilder
     /// <param name="clusterName">The name of the cluster.</param>
     /// <param name="destinations">The destinations used by this cluster.</param>
     /// <returns></returns>
-    public YarpCluster AddCluster(string clusterName, string[] destinations);
+    public YarpCluster AddCluster(string clusterName, object[] destinations);
 
     /// <summary>
     /// Add a new cluster to YARP based on a collection of urls.
@@ -54,9 +54,9 @@ public interface IYarpConfigurationBuilder
     /// <param name="clusterName">The name of the cluster.</param>
     /// <param name="destination">The destinations used by this cluster.</param>
     /// <returns></returns>
-    public YarpCluster AddCluster(string clusterName, string destination)
+    public YarpCluster AddCluster(string clusterName, object destination)
     {
-        return AddCluster(clusterName, new[] { destination });
+        return AddCluster(clusterName, [destination]);
     }
 }
 

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -18,7 +18,6 @@ public class YarpCluster
         ClusterConfig = config;
         Targets = targets;
     }
-
     /// <summary>
     /// Construct a new YarpCluster targeting the endpoint in parameter.
     /// </summary>
@@ -49,14 +48,9 @@ public class YarpCluster
     /// <summary>
     /// Creates a new instance of <see cref="YarpCluster"/> with a specified list of addresses.
     /// </summary>
-    /// <param name="clusterName">The name of the cluster.</param>
-    /// <param name="addresses">The external addresses.</param>
-    internal YarpCluster(string clusterName, params string[] addresses)
-        : this(clusterName, (object[]) addresses)
-    {
-    }
-
-    private YarpCluster(string resourceName, params object[] targets)
+    /// <param name="resourceName">The name of the cluster.</param>
+    /// <param name="targets">The external addresses.</param>
+    internal YarpCluster(string resourceName, params object[] targets)
     {
         ClusterConfig = new()
         {

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -48,8 +48,8 @@ public class YarpCluster
     /// <summary>
     /// Creates a new instance of <see cref="YarpCluster"/> with a specified list of addresses.
     /// </summary>
-    /// <param name="resourceName">The name of the cluster.</param>
-    /// <param name="targets">The external addresses.</param>
+    /// <param name="resourceName">The name of the resource.</param>
+    /// <param name="targets">The target objects for the cluster (e.g., addresses, URIs, or other endpoint representations).</param>
     internal YarpCluster(string resourceName, params object[] targets)
     {
         ClusterConfig = new()

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpConfigurationBuilder.cs
@@ -51,7 +51,7 @@ internal class YarpConfigurationBuilder(IResourceBuilder<YarpResource> parent) :
     }
 
     /// <inheritdoc/>
-    public YarpCluster AddCluster(string clusterName, string[] destinations)
+    public YarpCluster AddCluster(string clusterName, object[] destinations)
     {
         var destination = new YarpCluster(clusterName, destinations);
         _parent.Resource.Clusters.Add(destination);


### PR DESCRIPTION
## Description

Follow up for #11368 and #10751

In this PR I replaced the type of the destination from `string` to `object`, to make the API more versatile.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [X] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [X] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No