### PR TITLE
Ensure devtunnels CLI is at least minimum required version

### DIFF
--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
@@ -16,6 +16,8 @@ internal sealed class DevTunnelCli
     public const int ResourceConflictsWithExistingExitCode = 1;
     public const int ResourceNotFoundExitCode = 2;
 
+    public static readonly Version MinimumSupportedVersion = new(1, 0, 1435);
+
     private readonly string _cliPath;
 
     public static string GetCliPath(IConfiguration configuration) => configuration["ASPIRE_DEVTUNNEL_CLI_PATH"] ?? "devtunnel";
@@ -29,6 +31,9 @@ internal sealed class DevTunnelCli
 
         _cliPath = filePath;
     }
+
+    public Task<int> GetVersionAsync(TextWriter? outputWriter = null, TextWriter? errorWriter = null, ILogger? logger = default, CancellationToken cancellationToken = default)
+        => RunAsync(["--version", "--nologo"], outputWriter, errorWriter, logger, cancellationToken);
 
     public Task<int> UserLoginMicrosoftAsync(ILogger? logger = default, CancellationToken cancellationToken = default)
         => RunAsync(["user", "login", "--entra", "--json", "--nologo"], null, null, useShellExecute: true, logger, cancellationToken);

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCliInstallationManager.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCliInstallationManager.cs
@@ -11,6 +11,7 @@ internal sealed class DevTunnelCliInstallationManager : RequiredCommandValidator
     private readonly IDevTunnelClient _devTunnelClient;
     private readonly IConfiguration _configuration;
     private readonly ILogger _logger;
+    private readonly Version _minSupportedVersion;
     private string? _resolvedCommandPath;
 
 #pragma warning disable ASPIREINTERACTION001 // Interaction service is experimental.
@@ -19,12 +20,24 @@ internal sealed class DevTunnelCliInstallationManager : RequiredCommandValidator
         IConfiguration configuration,
         IInteractionService interactionService,
         ILogger<DevTunnelCliInstallationManager> logger)
+        : this(devTunnelClient, configuration, interactionService, logger, DevTunnelCli.MinimumSupportedVersion)
+    {
+
+    }
+
+    public DevTunnelCliInstallationManager(
+        IDevTunnelClient devTunnelClient,
+        IConfiguration configuration,
+        IInteractionService interactionService,
+        ILogger<DevTunnelCliInstallationManager> logger,
+        Version minSupportedVersion)
         : base(interactionService, logger)
 #pragma warning restore ASPIREINTERACTION001
     {
         _devTunnelClient = devTunnelClient ?? throw new ArgumentNullException(nameof(devTunnelClient));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _minSupportedVersion = minSupportedVersion ?? throw new ArgumentNullException(nameof(minSupportedVersion));
     }
 
     /// <summary>
@@ -46,13 +59,13 @@ internal sealed class DevTunnelCliInstallationManager : RequiredCommandValidator
 
     protected override string GetCommandPath() => DevTunnelCli.GetCliPath(_configuration);
 
-    protected override async Task<(bool IsValid, string? ValidationMessage)> OnResolvedAsync(string resolvedCommandPath, CancellationToken cancellationToken)
+    protected internal override async Task<(bool IsValid, string? ValidationMessage)> OnResolvedAsync(string resolvedCommandPath, CancellationToken cancellationToken)
     {
         // Verify the version is supported
         var version = await _devTunnelClient.GetVersionAsync(_logger, cancellationToken).ConfigureAwait(false);
-        if (version < DevTunnelCli.MinimumSupportedVersion)
+        if (version < _minSupportedVersion)
         {
-            return (false, $"The installed devtunnel CLI version {version} is not supported. Version {DevTunnelCli.MinimumSupportedVersion} or higher is required.");
+            return (false, $"The installed devtunnel CLI version {version} is not supported. Version {_minSupportedVersion} or higher is required.");
         }
         return (true, null);
     }

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCliInstallationManager.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCliInstallationManager.cs
@@ -8,18 +8,23 @@ namespace Aspire.Hosting.DevTunnels;
 
 internal sealed class DevTunnelCliInstallationManager : RequiredCommandValidator
 {
+    private readonly IDevTunnelClient _devTunnelClient;
     private readonly IConfiguration _configuration;
+    private readonly ILogger _logger;
     private string? _resolvedCommandPath;
 
 #pragma warning disable ASPIREINTERACTION001 // Interaction service is experimental.
     public DevTunnelCliInstallationManager(
+        IDevTunnelClient devTunnelClient,
         IConfiguration configuration,
         IInteractionService interactionService,
         ILogger<DevTunnelCliInstallationManager> logger)
         : base(interactionService, logger)
 #pragma warning restore ASPIREINTERACTION001
     {
+        _devTunnelClient = devTunnelClient ?? throw new ArgumentNullException(nameof(devTunnelClient));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     /// <summary>
@@ -40,6 +45,17 @@ internal sealed class DevTunnelCliInstallationManager : RequiredCommandValidator
     public Task EnsureInstalledAsync(CancellationToken cancellationToken = default) => RunAsync(cancellationToken);
 
     protected override string GetCommandPath() => DevTunnelCli.GetCliPath(_configuration);
+
+    protected override async Task<(bool IsValid, string? ValidationMessage)> OnResolvedAsync(string resolvedCommandPath, CancellationToken cancellationToken)
+    {
+        // Verify the version is supported
+        var version = await _devTunnelClient.GetVersionAsync(_logger, cancellationToken).ConfigureAwait(false);
+        if (version < DevTunnelCli.MinimumSupportedVersion)
+        {
+            return (false, $"The installed devtunnel CLI version {version} is not supported. Version {DevTunnelCli.MinimumSupportedVersion} or higher is required.");
+        }
+        return (true, null);
+    }
 
     protected override Task OnValidatedAsync(string resolvedCommandPath, CancellationToken cancellationToken)
     {

--- a/src/Aspire.Hosting.DevTunnels/IDevTunnelClient.cs
+++ b/src/Aspire.Hosting.DevTunnels/IDevTunnelClient.cs
@@ -7,6 +7,8 @@ namespace Aspire.Hosting.DevTunnels;
 
 internal interface IDevTunnelClient
 {
+    Task<Version> GetVersionAsync(ILogger? logger = default, CancellationToken cancellationToken = default);
+
     Task<UserLoginStatus> GetUserLoginStatusAsync(ILogger? logger = default, CancellationToken cancellationToken = default);
 
     Task<UserLoginStatus> UserLoginAsync(LoginProvider provider, ILogger? logger = default, CancellationToken cancellationToken = default);

--- a/src/Aspire.Hosting.DevTunnels/RequiredCommandValidator.cs
+++ b/src/Aspire.Hosting.DevTunnels/RequiredCommandValidator.cs
@@ -40,7 +40,7 @@ internal abstract class RequiredCommandValidator(IInteractionService interaction
     /// <remarks>
     /// Overrides can perform additional validation to verify the command is usable.
     /// </remarks>
-    protected virtual Task<(bool IsValid, string? ValidationMessage)> OnResolvedAsync(string resolvedCommandPath, CancellationToken cancellationToken) => Task.FromResult((true, (string?)null));
+    protected internal virtual Task<(bool IsValid, string? ValidationMessage)> OnResolvedAsync(string resolvedCommandPath, CancellationToken cancellationToken) => Task.FromResult((true, (string?)null));
 
     /// <summary>
     /// Called after the command has been successfully validated and resolved to a full path.

--- a/src/Aspire.Hosting.DevTunnels/RequiredCommandValidator.cs
+++ b/src/Aspire.Hosting.DevTunnels/RequiredCommandValidator.cs
@@ -26,11 +26,21 @@ internal abstract class RequiredCommandValidator(IInteractionService interaction
     private readonly ILogger _logger = logger;
 
     private Task? _notificationTask;
+    private string? _notificationMessage;
 
     /// <summary>
     /// Returns the command string (file name or path) that should be validated.
     /// </summary>
     protected abstract string GetCommandPath();
+
+    /// <summary>
+    /// Called after the command has been successfully resolved to a full path.
+    /// Default implementation does nothing.
+    /// </summary>
+    /// <remarks>
+    /// Overrides can perform additional validation to verify the command is usable.
+    /// </remarks>
+    protected virtual Task<(bool IsValid, string? ValidationMessage)> OnResolvedAsync(string resolvedCommandPath, CancellationToken cancellationToken) => Task.FromResult((true, (string?)null));
 
     /// <summary>
     /// Called after the command has been successfully validated and resolved to a full path.
@@ -49,7 +59,7 @@ internal abstract class RequiredCommandValidator(IInteractionService interaction
         if (notificationTask is { IsCompleted: false })
         {
             // Failure notification is still being shown so just throw again.
-            throw GetCommandNotFoundException(command);
+            throw new DistributedApplicationException(_notificationMessage ?? $"Required command '{command}' was not found on PATH, at the specified location, or failed validation.");
         }
 
         if (string.IsNullOrWhiteSpace(command))
@@ -57,15 +67,26 @@ internal abstract class RequiredCommandValidator(IInteractionService interaction
             throw new InvalidOperationException("Command path cannot be null or empty.");
         }
         var resolved = ResolveCommand(command);
-        if (resolved is null)
+        var isValid = true;
+        string? validationMessage = null;
+        if (resolved is not null)
+        {
+            (isValid, validationMessage) = await OnResolvedAsync(resolved, cancellationToken).ConfigureAwait(false);
+        }
+        if (resolved is null || !isValid)
         {
             var link = GetHelpLink();
-            var message = link is null
-                ? $"Required command '{command}' was not found on PATH or at a specified location."
-                : $"Required command '{command}' was not found. See installation instructions for more details.";
+            var message = (link, validationMessage) switch
+            {
+                (null, not null) => validationMessage,
+                (not null, not null) => $"{validationMessage} See installation instructions for more details.",
+                (not null, null) => $"Required command '{command}' was not found. See installation instructions for more details.",
+                _ => $"Required command '{command}' was not found on PATH or at a specified location."
+            };
 
             _logger.LogWarning("{Message}", message);
 
+            _notificationMessage = message;
             if (_interactionService.IsAvailable == true)
             {
                 try
@@ -91,14 +112,12 @@ internal abstract class RequiredCommandValidator(IInteractionService interaction
                     _logger.LogDebug(ex, "Failed to show missing command notification");
                 }
             }
-            throw GetCommandNotFoundException(command);
+            throw new DistributedApplicationException(message);
         }
 
+        _notificationMessage = null;
         await OnValidatedAsync(resolved, cancellationToken).ConfigureAwait(false);
     }
-
-    private static DistributedApplicationException GetCommandNotFoundException(string command) =>
-        new($"Required command '{command}' was not found on PATH or at the specified location.");
 
     /// <summary>
     /// Optional link returned to guide users when the command is missing. Return null for no link.

--- a/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelCliInstallationManagerTests.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelCliInstallationManagerTests.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Hosting.DevTunnels.Tests;
+
+public class DevTunnelCliInstallationManagerTests
+{
+    [Theory]
+    [InlineData("1.0.1435", "1.0.1435", true)]
+    [InlineData("1.0.1435", "1.0.1436", true)]
+    [InlineData("1.0.1435", "1.1.1234", true)]
+    [InlineData("1.0.1435", "2.0.0", true)]
+    [InlineData("1.0.1435", "10.0.0", true)]
+    [InlineData("1.9.0", "1.10.0", true)]
+    [InlineData("1.0.1435", "1.0.1434", false)]
+    [InlineData("1.0.1435", "1.0.0", false)]
+    [InlineData("1.0.1435", "0.0.1", false)]
+    [InlineData("1.2.0", "1.1.999", false)]
+    public async Task OnResolvedAsync_ReturnsInvalidForUnsupportedVersion(string minVersion, string testVersion, bool expectedIsValid)
+    {
+        var logger = NullLoggerFactory.Instance.CreateLogger<DevTunnelCliInstallationManager>();
+        var configuration = new ConfigurationBuilder().Build();
+        var testCliVersion = Version.Parse(testVersion);
+        var devTunnelClient = new TestDevTunnelClient(testCliVersion);
+
+        var manager = new DevTunnelCliInstallationManager(devTunnelClient, configuration, new TestInteractionService(), logger, Version.Parse(minVersion));
+
+        var (isValid, validationMessage) = await manager.OnResolvedAsync("thepath", CancellationToken.None);
+
+        Assert.Equal(expectedIsValid, isValid);
+        if (expectedIsValid)
+        {
+            Assert.Null(validationMessage);
+        }
+        else
+        {
+            Assert.Contains(minVersion, validationMessage);
+            Assert.Contains(testVersion, validationMessage);
+        }
+    }
+
+#pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private sealed class TestInteractionService : IInteractionService
+    {
+        public bool IsAvailable => true;
+
+        public Task<InteractionResult<bool>> PromptConfirmationAsync(string title, string message, MessageBoxInteractionOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<InteractionResult<InteractionInput>> PromptInputAsync(string title, string? message, string inputLabel, string placeHolder, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<InteractionResult<InteractionInput>> PromptInputAsync(string title, string? message, InteractionInput input, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<InteractionResult<InteractionInputCollection>> PromptInputsAsync(string title, string? message, IReadOnlyList<InteractionInput> inputs, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<InteractionResult<bool>> PromptMessageBoxAsync(string title, string message, MessageBoxInteractionOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<InteractionResult<bool>> PromptNotificationAsync(string title, string message, NotificationInteractionOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+#pragma warning restore ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+    private sealed class TestDevTunnelClient(Version cliVersion) : IDevTunnelClient
+    {
+        public Task<Version> GetVersionAsync(ILogger? logger = null, CancellationToken cancellationToken = default) => Task.FromResult(cliVersion);
+
+        public Task<DevTunnelPortStatus> CreatePortAsync(string tunnelId, int portNumber, DevTunnelPortOptions options, ILogger? logger = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DevTunnelStatus> CreateTunnelAsync(string tunnelId, DevTunnelOptions options, ILogger? logger = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DevTunnelAccessStatus> GetAccessAsync(string tunnelId, int? portNumber = null, ILogger? logger = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DevTunnelStatus> GetTunnelAsync(string tunnelId, ILogger? logger = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<UserLoginStatus> GetUserLoginStatusAsync(ILogger? logger = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<UserLoginStatus> UserLoginAsync(LoginProvider provider, ILogger? logger = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Updates the devtunnel CLI installation checker to ensure the version installed is equal to or higher than the minimum version.

Fixes #11342 

<img width="808" height="39" alt="image" src="https://github.com/user-attachments/assets/46ae1343-5da4-4679-b811-9dc708221227" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
