### PR TITLE
Update Aspire.AppHost.Sdk to support simpler file-based app AppHosts

### DIFF
--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -4,16 +4,16 @@
     <!-- Do not import the workload targets as this project is instead using the Aspire.AppHost.Sdk -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
     <IsAspireHost>true</IsAspireHost>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(FileBasedProgram)' == 'true' ">
     <PublishAot>false</PublishAot>
     <PublishTrimmed>false</PublishTrimmed>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <EnableSingleFileAnalyzer>false</EnableSingleFileAnalyzer>
-    <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(UsingMicrosoftNETSdk)' == '' ">
-    <_ImportMicrosoftNETSdkFromAspireSdk>true</_ImportMicrosoftNETSdkFromAspireSdk>
+    <_ImportMicrosoftNETSdkFromAspireSdk Condition=" '$(UsingMicrosoftNETSdk)' == '' ">true</_ImportMicrosoftNETSdkFromAspireSdk>
+    <_ForceAspireFileBasedAppHostDefaults Condition=" '$(IsAspireHost)' == 'true' ">true</_ForceAspireFileBasedAppHostDefaults>
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(_ImportMicrosoftNETSdkFromAspireSdk)' == 'true' " />

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -5,7 +5,6 @@
     the Aspire.AppHost.Sdk -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
     <IsAspireHost>true</IsAspireHost>
-    <PublishAot>false</PublishAot>
     <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
   </PropertyGroup>
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup>
     <AspireHostingSDKVersion>@VERSION@</AspireHostingSDKVersion>
-    <!-- Do not import the workload targets as this project is instead using
-    the Aspire.AppHost.Sdk -->
+    <!-- Do not import the workload targets as this project is instead using the Aspire.AppHost.Sdk -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
     <IsAspireHost>true</IsAspireHost>
     <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -5,6 +5,7 @@
     the Aspire.AppHost.Sdk -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
     <IsAspireHost>true</IsAspireHost>
+    <PublishAot Condition=" '$(PublishAot) == '' ">false</PublishAot>
     <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
   </PropertyGroup>
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -5,7 +5,7 @@
     the Aspire.AppHost.Sdk -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
     <IsAspireHost>true</IsAspireHost>
-    <PublishAot Condition=" '$(PublishAot) == '' ">false</PublishAot>
+    <PublishAot Condition=" '$(PublishAot)' == '' ">false</PublishAot>
     <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
   </PropertyGroup>
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -5,6 +5,8 @@
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
     <IsAspireHost>true</IsAspireHost>
     <PublishAot>false</PublishAot>
+    <PublishTrimmed>false</PublishTrimmed>
+    <EnableAotAnalyzer>false</EnableAotAnalyzer>
     <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
   </PropertyGroup>
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -7,6 +7,7 @@
     <PublishAot>false</PublishAot>
     <PublishTrimmed>false</PublishTrimmed>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
   </PropertyGroup>
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -5,7 +5,7 @@
     the Aspire.AppHost.Sdk -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
     <IsAspireHost>true</IsAspireHost>
-    <PublishAot Condition=" '$(PublishAot)' == '' ">false</PublishAot>
+    <PublishAot>false</PublishAot>
     <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
   </PropertyGroup>
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -5,5 +5,12 @@
     the Aspire.AppHost.Sdk -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
     <IsAspireHost>true</IsAspireHost>
+    <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(UsingMicrosoftNETSdk)' == '' ">
+    <_ImportMicrosoftNETSdkFromAspireSdk>true</_ImportMicrosoftNETSdkFromAspireSdk>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(_ImportMicrosoftNETSdkFromAspireSdk)' == 'true' " />
 </Project>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -8,6 +8,7 @@
     <PublishTrimmed>false</PublishTrimmed>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer>false</EnableSingleFileAnalyzer>
     <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
   </PropertyGroup>
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.props
@@ -4,6 +4,7 @@
     <!-- Do not import the workload targets as this project is instead using the Aspire.AppHost.Sdk -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
     <IsAspireHost>true</IsAspireHost>
+    <PublishAot>false</PublishAot>
     <_ImportMicrosoftNETSdkFromAspireSdk>false</_ImportMicrosoftNETSdkFromAspireSdk>
   </PropertyGroup>
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -51,11 +51,22 @@
     <AspireRidToolExecutable>$(AspireRidToolDirectory)Aspire.RuntimeIdentifier.Tool.dll</AspireRidToolExecutable>
   </PropertyGroup>
 
+  <Target Name="AddImplicitAspireAppHostPackage" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' And '$(SkipImplicitAspireAppHostPackage)' != 'true'">
+    <PropertyGroup>
+      <_ImplicitAppHostVersion>@VERSION@</_ImplicitAppHostVersion>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- Add the reference to the Aspire.Hosting.AppHost package if not already referenced -->
+      <PackageReference Include="Aspire.Hosting.AppHost" Version="$(_ImplicitAppHostVersion)"  IsImplicitlyDefined="true"
+                      Condition="'@(PackageReference->WithMetadataValue('Identity','Aspire.Hosting.AppHost'))' == '' And '@(PackageVersion->WithMetadataValue('Identity','Aspire.Hosting.AppHost'))' == ''" />
+    </ItemGroup>
+  </Target>
+
   <!-- This target extracts the version of Aspire.Hosting.AppHost referenced by the project, and adds
        a reference to Aspire.Dashboard.Sdk and Aspire.Hosting.Orchestration for the build-time platform using
        the same version. This is done here dynamically to avoid having to pull in DCP and Dashboard packages
        for all of the platforms. This mechanism can be disabled by setting `SkipAddAspireDefaultReferences` to `true` -->
-  <Target Name="AddReferenceToDashboardAndDCP" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(SkipAddAspireDefaultReferences)' != 'true'">
+  <Target Name="AddReferenceToDashboardAndDCP" BeforeTargets="Restore;CollectPackageReferences" AfterTargets="AddImplicitAspireAppHostPackage" Condition="'$(SkipAddAspireDefaultReferences)' != 'true'">
 
     <!-- First, we assume project is not using Central Package Management, and we try to extract the version
          from PackageReference Items. -->

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -54,7 +54,7 @@
   <Target Name="DisablePublishAotForAspireHost" BeforeTargets="_ComputeToolPackInputsToProcessFrameworkReferences;_CollectTargetFrameworkForTelemetry;ProcessFrameworkReferences;Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' and '$(DisableAspirePublishAotDefaults)' != 'true'">
     <PropertyGroup>
       <PublishAot>false</PublishAot>
-      <PublishTimmed>false</PublishTimmed>
+      <PublishTrimmed>false</PublishTrimmed>
       <EnableAotAnalyzer>false</EnableAotAnalyzer>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -51,10 +51,15 @@
     <AspireRidToolExecutable>$(AspireRidToolDirectory)Aspire.RuntimeIdentifier.Tool.dll</AspireRidToolExecutable>
   </PropertyGroup>
 
-  <Target Name="DisablePublishAotForAspireHost" BeforeTargets="ProcessFrameworkReferences;Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' and '$(DisableAspirePublishAotDefaults)' != 'true'">
+  <Target Name="DisablePublishAotForAspireHost" BeforeTargets="_ComputeToolPackInputsToProcessFrameworkReferences;_CollectTargetFrameworkForTelemetry;ProcessFrameworkReferences;Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' and '$(DisableAspirePublishAotDefaults)' != 'true'">
     <PropertyGroup>
       <PublishAot>false</PublishAot>
+      <PublishTimmed>false</PublishTimmed>
+      <EnableAotAnalyzer>false</EnableAotAnalyzer>
     </PropertyGroup>
+    <ItemGroup>
+      <ProjectCapability Remove="NativeAOT;PublishAot;PublishTrimmed" />
+    </ItemGroup>
   </Target>
 
   <Target Name="AddImplicitAspireAppHostPackage" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' And '$(SkipAddAspireDefaultReferences)' != 'true'">

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -18,6 +18,7 @@
     <!-- Aspire hosting projects aren't publishable right now until https://github.com/dotnet/aspire/issues/147 is good -->
     <IsPublishable Condition="'$(IsPublishable)' == ''">false</IsPublishable>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
+    <PublishAot Condition="'$(DisableAspirePublishAotDefaults)' != 'true'">false</PublishAot>
   </PropertyGroup>
 
   <!--

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -56,6 +56,7 @@
       <PublishAot>false</PublishAot>
       <PublishTrimmed>false</PublishTrimmed>
       <EnableAotAnalyzer>false</EnableAotAnalyzer>
+      <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     </PropertyGroup>
     <ItemGroup>
       <ProjectCapability Remove="NativeAOT;PublishAot;PublishTrimmed" />

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -6,7 +6,7 @@
   This means they cannot be overridden in the csproj, and may cause ordering issues, particularly StaticWebAssets.
   -->
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(_ImportMicrosoftNETSdkFromAspireSdk)' == 'true' " />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition="'$(_ImportMicrosoftNETSdkFromAspireSdk)' == 'true'" />
 
   <ItemGroup>
     <ProjectCapability Include="DynamicFileNesting" />
@@ -51,7 +51,10 @@
     <AspireRidToolExecutable>$(AspireRidToolDirectory)Aspire.RuntimeIdentifier.Tool.dll</AspireRidToolExecutable>
   </PropertyGroup>
 
-  <Target Name="DisablePublishAotForAspireHost" BeforeTargets="_ComputeToolPackInputsToProcessFrameworkReferences;_CollectTargetFrameworkForTelemetry;ProcessFrameworkReferences;Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' and '$(DisableAspirePublishAotDefaults)' != 'true'">
+  <!-- If the AppHost is a file-based app, then force disable AOT and Trimming.
+       This can be removed once https://github.com/dotnet/sdk/pull/50885 is merged and flows through to .NET 10 SDK as the values set in Sdk.props will be sufficient. -->
+  <Target Name="DisablePublishAotForAspireHost" BeforeTargets="_ComputeToolPackInputsToProcessFrameworkReferences;_CollectTargetFrameworkForTelemetry;ProcessFrameworkReferences;Restore;CollectPackageReferences"
+          Condition="'$(_ForceAspireFileBasedAppHostDefaults)' == 'true'">
     <PropertyGroup>
       <PublishAot>false</PublishAot>
       <PublishTrimmed>false</PublishTrimmed>
@@ -64,14 +67,16 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="AddImplicitAspireAppHostPackage" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' And '$(SkipAddAspireDefaultReferences)' != 'true'">
+  <!-- If the AppHost is a file-based app, add an implicit reference to the Aspire.Hosting.AppHost package if not already referenced.
+       This is done here so that file-based apps only need to set the single #sdk: directive line to make them an Aspire AppHost.
+       This mechanism can be disabled by setting `SkipAddAspireDefaultReferences` to `true` -->
+  <Target Name="AddImplicitAspireAppHostPackage" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(_ForceAspireFileBasedAppHostDefaults)' == 'true' and '$(SkipAddAspireDefaultReferences)' != 'true'">
     <PropertyGroup>
       <_ImplicitAppHostVersion>@VERSION@</_ImplicitAppHostVersion>
     </PropertyGroup>
     <ItemGroup>
-      <!-- Add the reference to the Aspire.Hosting.AppHost package if not already referenced -->
-      <PackageReference Include="Aspire.Hosting.AppHost" Version="$(_ImplicitAppHostVersion)"  IsImplicitlyDefined="true"
-                        Condition="'@(PackageReference->WithMetadataValue('Identity','Aspire.Hosting.AppHost'))' == '' And '@(PackageVersion->WithMetadataValue('Identity','Aspire.Hosting.AppHost'))' == ''" />
+      <PackageReference Include="Aspire.Hosting.AppHost" Version="$(_ImplicitAppHostVersion)" IsImplicitlyDefined="true"
+                        Condition="'@(PackageReference->WithMetadataValue('Identity','Aspire.Hosting.AppHost'))' == ''" />
     </ItemGroup>
   </Target>
 

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -51,7 +51,7 @@
     <AspireRidToolExecutable>$(AspireRidToolDirectory)Aspire.RuntimeIdentifier.Tool.dll</AspireRidToolExecutable>
   </PropertyGroup>
 
-  <Target Name="AddImplicitAspireAppHostPackage" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' And '$(SkipImplicitAspireAppHostPackage)' != 'true'">
+  <Target Name="AddImplicitAspireAppHostPackage" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' And '$(SkipAddAspireDefaultReferences)' != 'true'">
     <PropertyGroup>
       <_ImplicitAppHostVersion>@VERSION@</_ImplicitAppHostVersion>
     </PropertyGroup>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -6,6 +6,8 @@
   This means they cannot be overridden in the csproj, and may cause ordering issues, particularly StaticWebAssets.
   -->
 
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(_ImportMicrosoftNETSdkFromAspireSdk)' == 'true' " />
+
   <ItemGroup>
     <ProjectCapability Include="DynamicFileNesting" />
     <ProjectCapability Include="DynamicFileNestingEnabled" />

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -18,7 +18,6 @@
     <!-- Aspire hosting projects aren't publishable right now until https://github.com/dotnet/aspire/issues/147 is good -->
     <IsPublishable Condition="'$(IsPublishable)' == ''">false</IsPublishable>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
-    <PublishAot Condition="'$(DisableAspirePublishAotDefaults)' != 'true'">false</PublishAot>
   </PropertyGroup>
 
   <!--
@@ -51,6 +50,12 @@
     <AspireRidToolDirectory>$([MSBuild]::NormalizePath('$(AspireRidToolRoot)\'))</AspireRidToolDirectory>
     <AspireRidToolExecutable>$(AspireRidToolDirectory)Aspire.RuntimeIdentifier.Tool.dll</AspireRidToolExecutable>
   </PropertyGroup>
+
+  <Target Name="DisablePublishAotForAspireHost" BeforeTargets="ProcessFrameworkReferences;Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' and '$(DisableAspirePublishAotDefaults)' != 'true'">
+    <PropertyGroup>
+      <PublishAot>false</PublishAot>
+    </PropertyGroup>
+  </Target>
 
   <Target Name="AddImplicitAspireAppHostPackage" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(IsAspireHost)' == 'true' And '$(SkipAddAspireDefaultReferences)' != 'true'">
     <PropertyGroup>

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -57,6 +57,7 @@
       <PublishTrimmed>false</PublishTrimmed>
       <EnableAotAnalyzer>false</EnableAotAnalyzer>
       <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+      <EnableSingleFileAnalyzer>false</EnableSingleFileAnalyzer>
     </PropertyGroup>
     <ItemGroup>
       <ProjectCapability Remove="NativeAOT;PublishAot;PublishTrimmed" />

--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -59,7 +59,7 @@
     <ItemGroup>
       <!-- Add the reference to the Aspire.Hosting.AppHost package if not already referenced -->
       <PackageReference Include="Aspire.Hosting.AppHost" Version="$(_ImplicitAppHostVersion)"  IsImplicitlyDefined="true"
-                      Condition="'@(PackageReference->WithMetadataValue('Identity','Aspire.Hosting.AppHost'))' == '' And '@(PackageVersion->WithMetadataValue('Identity','Aspire.Hosting.AppHost'))' == ''" />
+                        Condition="'@(PackageReference->WithMetadataValue('Identity','Aspire.Hosting.AppHost'))' == '' And '@(PackageVersion->WithMetadataValue('Identity','Aspire.Hosting.AppHost'))' == ''" />
     </ItemGroup>
   </Target>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/9.5/apphost.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/9.5/apphost.cs
@@ -1,7 +1,4 @@
-#:sdk Microsoft.NET.Sdk
 #:sdk Aspire.AppHost.Sdk@!!REPLACE_WITH_LATEST_VERSION!!
-#:package Aspire.Hosting.AppHost@!!REPLACE_WITH_LATEST_VERSION!!
-#:property PublishAot=false
 
 var builder = DistributedApplication.CreateBuilder(args);
 


### PR DESCRIPTION
## Description

Updates the Aspire.AppHost.Sdk to auto-import the Microsoft.NET.Sdk if it detects it isn't already referenced. It also updates the Aspire.AppHost.Sdk to auto include a package reference to Aspire.Hosting.AppHost with the same version as the SDK if it isn't already referenced.

The Aspire.AppHost.Sdk was also updated to ensure the various markers for native AOT and trimming are forcibly disabled so that file-based AppHosts (and others) default to `PublishAot=false`. This can be simplified once https://github.com/dotnet/sdk/pull/50885 is merged.

The enables an AppHost project or file-based app to just reference the Aspire.AppHost.Sdk SDK. The single-file AppHost template has been updated in this PR to reflect this:

```csharp
#:sdk Aspire.AppHost.Sdk@9.5.0

var builder = DistributedApplication.CreateBuilder(args);

builder.Build().Run();
```

The changes are gated to only apply to file-based app AppHosts for now.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No (existing template tests verify this doesn't break existing scenarios)
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No (file-based app host is experimental for now)