### PR TITLE
Fix text visualizer dialog max height

### DIFF
--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -86,6 +86,7 @@ serviceBuilder.WithHttpCommand("/overflow-counter", "Overflow counter", commandO
 serviceBuilder.WithHttpCommand("/nested-trace-spans", "Out of order nested spans", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 serviceBuilder.WithHttpCommand("/exemplars-no-span", "Examplars with no span", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 serviceBuilder.WithHttpCommand("/genai-trace", "Gen AI trace", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
+serviceBuilder.WithHttpCommand("/log-formatting", "Log formatting", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 
 builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice")
        .WithUrls(c => c.Urls.Add(new() { Url = "https://someplace.com", DisplayText = "Some place" }))

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
@@ -24,7 +24,7 @@
     min-height: 120px;
 }
 
-.text-visualizer-container .log-overflow {
+.text-visualizer-container ::deep.log-overflow {
     max-height: 60vh;
     margin-bottom: 16px;
 }


### PR DESCRIPTION
## Description

Moving the text visualizer logic into a reusable control caused a CSS rule to stop working. The text visualizer dialog was missing a max height.

Before:
<img width="2542" height="1268" alt="image" src="https://github.com/user-attachments/assets/ade9bd52-6349-4585-8213-ae7b3c51bc21" />

After:
<img width="2557" height="1264" alt="image" src="https://github.com/user-attachments/assets/2f074ce3-b337-4aeb-ba41-75920b36e981" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
