### PR TITLE
Remove duplicated filters on structured logs page

### DIFF
--- a/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
@@ -80,15 +80,6 @@ public class StructuredLogsViewModel
         if (logs == null)
         {
             var filters = GetFilters();
-            if (!string.IsNullOrWhiteSpace(FilterText))
-            {
-                filters.Add(new FieldTelemetryFilter { Field = nameof(OtlpLogEntry.Message), Condition = FilterCondition.Contains, Value = FilterText });
-            }
-            // If the log level is set and it is not the bottom level, which has no effect, then add a filter.
-            if (_logLevel != null && _logLevel != Microsoft.Extensions.Logging.LogLevel.Trace)
-            {
-                filters.Add(new FieldTelemetryFilter { Field = nameof(OtlpLogEntry.Severity), Condition = FilterCondition.GreaterThanOrEqual, Value = _logLevel.Value.ToString() });
-            }
 
             logs = _telemetryRepository.GetLogs(new GetLogsContext
             {

--- a/src/Aspire.Dashboard/Model/TracesViewModel.cs
+++ b/src/Aspire.Dashboard/Model/TracesViewModel.cs
@@ -79,12 +79,7 @@ public class TracesViewModel
         var traces = _traces;
         if (traces == null)
         {
-            var filters = Filters.Cast<TelemetryFilter>().ToList();
-
-            if (SpanType?.Filter is { } typeFilter)
-            {
-                filters.Add(typeFilter);
-            }
+            var filters = GetFilters();
 
             var result = _telemetryRepository.GetTraces(new GetTracesRequest
             {
@@ -100,6 +95,17 @@ public class TracesViewModel
         }
 
         return traces;
+    }
+
+    private List<TelemetryFilter> GetFilters()
+    {
+        var filters = Filters.Cast<TelemetryFilter>().ToList();
+        if (SpanType?.Filter is { } typeFilter)
+        {
+            filters.Add(typeFilter);
+        }
+
+        return filters;
     }
 
     public void ClearData()


### PR DESCRIPTION
I noticed some filters were duplicated on the structured logs page. Only impact is a small perf cost.