### PR TITLE
Support prompting for generated values during deploy

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -33,6 +33,8 @@ internal sealed class AzureDeployingContext(
     IConfiguration configuration,
     ITokenCredentialProvider tokenCredentialProvider)
 {
+    private readonly Dictionary<string, ParameterResource> _referencedParameters = [];
+    private readonly HashSet<object?> _currentDependencySet = [];
 
     public async Task DeployModelAsync(DistributedApplicationModel model, CancellationToken cancellationToken = default)
     {
@@ -45,11 +47,17 @@ internal sealed class AzureDeployingContext(
         var userSecrets = await userSecretsManager.LoadUserSecretsAsync(cancellationToken).ConfigureAwait(false);
         var provisioningContext = await provisioningContextProvider.CreateProvisioningContextAsync(userSecrets, cancellationToken).ConfigureAwait(false);
 
-        // Step 1: Resolve parameter resources using ParameterProcessor
-        var parameters = model.Resources.OfType<ParameterResource>();
-        if (parameters.Any())
+        // Step 1: Collect dependent parameter resources from environment variables and command line arguments
+        await CollectDependentParameterResourcesAsync(model, cancellationToken).ConfigureAwait(false);
+
+        // Combine explicit parameters with dependent parameters
+        var explicitParameters = model.Resources.OfType<ParameterResource>();
+        var dependentParameters = _referencedParameters.Values.Where(p => !explicitParameters.Contains(p));
+        var allParameters = explicitParameters.Concat(dependentParameters);
+
+        if (allParameters.Any())
         {
-            await parameterProcessor.InitializeParametersAsync(parameters, waitForResolution: true).ConfigureAwait(false);
+            await parameterProcessor.InitializeParametersAsync(allParameters, waitForResolution: true).ConfigureAwait(false);
         }
 
         // Step 2: Provision Azure Bicep resources from the distributed application model
@@ -579,6 +587,68 @@ internal sealed class AzureDeployingContext(
         }
 
         return string.Empty;
+    }
+
+    private async Task CollectDependentParameterResourcesAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
+    {
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+
+        foreach (var resource in model.Resources)
+        {
+            await ProcessResourceDependenciesAsync(resource, executionContext, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Clear any leftover tracking state
+        _currentDependencySet.Clear();
+    }
+
+    private async Task ProcessResourceDependenciesAsync(IResource resource, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
+    {
+        // Process environment variables
+        await resource.ProcessEnvironmentVariableValuesAsync(
+            executionContext,
+            (key, unprocessed, processed, ex) =>
+            {
+                if (unprocessed is not null)
+                {
+                    TryAddDependentParameters(unprocessed);
+                }
+            },
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // Process command line arguments
+        await resource.ProcessArgumentValuesAsync(
+            executionContext,
+            (unprocessed, expression, ex, _) =>
+            {
+                if (unprocessed is not null)
+                {
+                    TryAddDependentParameters(unprocessed);
+                }
+            },
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private void TryAddDependentParameters(object? value)
+    {
+        if (value is ParameterResource parameter)
+        {
+            _referencedParameters.TryAdd(parameter.Name, parameter);
+        }
+        else if (value is IValueWithReferences objectWithReferences)
+        {
+            _currentDependencySet.Add(value);
+            foreach (var dependency in objectWithReferences.References)
+            {
+                if (!_currentDependencySet.Contains(dependency))
+                {
+                    TryAddDependentParameters(dependency);
+                }
+            }
+            _currentDependencySet.Remove(value);
+        }
     }
 
 }

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -103,8 +103,6 @@ public sealed class ParameterProcessor(
             await ProcessResourceDependenciesAsync(resource, publishExecutionContext, referencedParameters, currentDependencySet, cancellationToken).ConfigureAwait(false);
         }
 
-        // Clear any leftover tracking state
-        currentDependencySet.Clear();
     }
 
     private async Task ProcessResourceDependenciesAsync(IResource resource, DistributedApplicationExecutionContext executionContext, Dictionary<string, ParameterResource> referencedParameters, HashSet<object?> currentDependencySet, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -21,7 +21,8 @@ public sealed class ParameterProcessor(
     ResourceLoggerService loggerService,
     IInteractionService interactionService,
     ILogger<ParameterProcessor> logger,
-    DistributedApplicationOptions options)
+    DistributedApplicationOptions options,
+    DistributedApplicationExecutionContext executionContext)
 {
     private readonly List<ParameterResource> _unresolvedParameters = [];
 
@@ -73,7 +74,7 @@ public sealed class ParameterProcessor(
         {
             var value = parameterResource.ValueInternal ?? "";
 
-            if (parameterResource.Default is GenerateParameterDefault generateDefault)
+            if (parameterResource.Default is GenerateParameterDefault generateDefault && executionContext.IsPublishMode)
             {
                 throw new MissingParameterValueException("GenerateParameterDefault is not supported in this context. Falling back to prompting.");
             }

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -68,6 +68,94 @@ public sealed class ParameterProcessor(
         }
     }
 
+    /// <summary>
+    /// Initializes parameter resources by collecting dependent parameters from the distributed application model
+    /// and handles unresolved parameters if interaction service is available.
+    /// </summary>
+    /// <param name="model">The distributed application model to collect parameters from.</param>
+    /// <param name="waitForResolution">Whether to wait for all parameters to be resolved before completing the returned Task.</param>
+    /// <param name="cancellationToken">The cancellation token to observe while waiting for parameters to be resolved.</param>
+    /// <returns>A task that completes when all parameters are resolved (if waitForResolution is true) or when initialization is complete.</returns>
+    public async Task InitializeParametersAsync(DistributedApplicationModel model, bool waitForResolution = false, CancellationToken cancellationToken = default)
+    {
+        var referencedParameters = new Dictionary<string, ParameterResource>();
+        var currentDependencySet = new HashSet<object?>();
+
+        await CollectDependentParameterResourcesAsync(model, referencedParameters, currentDependencySet, cancellationToken).ConfigureAwait(false);
+
+        // Combine explicit parameters with dependent parameters
+        var explicitParameters = model.Resources.OfType<ParameterResource>();
+        var dependentParameters = referencedParameters.Values.Where(p => !explicitParameters.Contains(p));
+        var allParameters = explicitParameters.Concat(dependentParameters);
+
+        if (allParameters.Any())
+        {
+            await InitializeParametersAsync(allParameters, waitForResolution).ConfigureAwait(false);
+        }
+    }
+
+    private async Task CollectDependentParameterResourcesAsync(DistributedApplicationModel model, Dictionary<string, ParameterResource> referencedParameters, HashSet<object?> currentDependencySet, CancellationToken cancellationToken)
+    {
+        var publishExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+
+        foreach (var resource in model.Resources)
+        {
+            await ProcessResourceDependenciesAsync(resource, publishExecutionContext, referencedParameters, currentDependencySet, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Clear any leftover tracking state
+        currentDependencySet.Clear();
+    }
+
+    private async Task ProcessResourceDependenciesAsync(IResource resource, DistributedApplicationExecutionContext executionContext, Dictionary<string, ParameterResource> referencedParameters, HashSet<object?> currentDependencySet, CancellationToken cancellationToken)
+    {
+        // Process environment variables
+        await resource.ProcessEnvironmentVariableValuesAsync(
+            executionContext,
+            (key, unprocessed, processed, ex) =>
+            {
+                if (unprocessed is not null)
+                {
+                    TryAddDependentParameters(unprocessed, referencedParameters, currentDependencySet);
+                }
+            },
+            logger,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // Process command line arguments
+        await resource.ProcessArgumentValuesAsync(
+            executionContext,
+            (unprocessed, expression, ex, _) =>
+            {
+                if (unprocessed is not null)
+                {
+                    TryAddDependentParameters(unprocessed, referencedParameters, currentDependencySet);
+                }
+            },
+            logger,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void TryAddDependentParameters(object? value, Dictionary<string, ParameterResource> referencedParameters, HashSet<object?> currentDependencySet)
+    {
+        if (value is ParameterResource parameter)
+        {
+            referencedParameters.TryAdd(parameter.Name, parameter);
+        }
+        else if (value is IValueWithReferences objectWithReferences)
+        {
+            currentDependencySet.Add(value);
+            foreach (var dependency in objectWithReferences.References)
+            {
+                if (!currentDependencySet.Contains(dependency))
+                {
+                    TryAddDependentParameters(dependency, referencedParameters, currentDependencySet);
+                }
+            }
+            currentDependencySet.Remove(value);
+        }
+    }
+
     private async Task ProcessParameterAsync(ParameterResource parameterResource)
     {
         try

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -73,6 +73,11 @@ public sealed class ParameterProcessor(
         {
             var value = parameterResource.ValueInternal ?? "";
 
+            if (parameterResource.Default is GenerateParameterDefault generateDefault)
+            {
+                throw new MissingParameterValueException("GenerateParameterDefault is not supported in this context. Falling back to prompting.");
+            }
+
             await notificationService.PublishUpdateAsync(parameterResource, s =>
             {
                 return s with

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -448,6 +448,9 @@ public class ApplicationOrchestratorTests
         var serviceProvider = new ServiceCollection().BuildServiceProvider();
         resourceLoggerService ??= new ResourceLoggerService();
 
+        var executionContext = new DistributedApplicationExecutionContext(
+            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = serviceProvider });
+
         return new ApplicationOrchestrator(
             distributedAppModel,
             new TestDcpExecutor(),
@@ -457,14 +460,14 @@ public class ApplicationOrchestratorTests
             resourceLoggerService,
             applicationEventing ?? new DistributedApplicationEventing(),
             serviceProvider,
-            new DistributedApplicationExecutionContext(
-                new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = serviceProvider }),
+            executionContext,
             new ParameterProcessor(
                 notificationService,
                 resourceLoggerService,
                 CreateInteractionService(),
                 NullLogger<ParameterProcessor>.Instance,
-                new DistributedApplicationOptions())
+                new DistributedApplicationOptions(),
+                executionContext)
             );
     }
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.Resources;
 using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -473,6 +474,209 @@ public class ParameterProcessorTests
         Assert.Equal("This is a secret parameter", secretInput.Description);
         Assert.False(secretInput.EnableDescriptionMarkdown);
         Assert.Equal(InputType.SecretText, secretInput.InputType);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithDistributedApplicationModel_CollectsAndInitializesAllParameters()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var explicitParam = builder.AddParameter("explicitParam", () => "explicitValue");
+        var referencedParam = builder.AddParameter("referencedParam", () => "referencedValue");
+
+        // Create a container that references the parameter in an environment variable
+        builder.AddContainer("testContainer", "nginx")
+               .WithEnvironment("TEST_ENV", referencedParam);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parameterProcessor = CreateParameterProcessor();
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync(model);
+
+        // Assert
+        var explicitParameterResource = model.Resources.OfType<ParameterResource>().First(p => p.Name == "explicitParam");
+        var referencedParameterResource = model.Resources.OfType<ParameterResource>().First(p => p.Name == "referencedParam");
+
+        Assert.NotNull(explicitParameterResource.WaitForValueTcs);
+        Assert.NotNull(referencedParameterResource.WaitForValueTcs);
+        Assert.True(explicitParameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
+        Assert.True(referencedParameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
+        Assert.Equal("explicitValue", await explicitParameterResource.WaitForValueTcs.Task);
+        Assert.Equal("referencedValue", await referencedParameterResource.WaitForValueTcs.Task);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithDistributedApplicationModel_EmptyModel_CompletesSuccessfully()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parameterProcessor = CreateParameterProcessor();
+
+        // Act & Assert - Should not throw
+        await parameterProcessor.InitializeParametersAsync(model);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithDistributedApplicationModel_NoParameterReferences_InitializesExplicitOnly()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var explicitParam = builder.AddParameter("explicitParam", () => "explicitValue");
+
+        // Add a container without parameter references
+        builder.AddContainer("testContainer", "nginx")
+               .WithEnvironment("TEST_ENV", "staticValue");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parameterProcessor = CreateParameterProcessor();
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync(model);
+
+        // Assert
+        var explicitParameterResource = model.Resources.OfType<ParameterResource>().Single();
+        Assert.Equal("explicitParam", explicitParameterResource.Name);
+        Assert.NotNull(explicitParameterResource.WaitForValueTcs);
+        Assert.True(explicitParameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
+        Assert.Equal("explicitValue", await explicitParameterResource.WaitForValueTcs.Task);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithDistributedApplicationModel_WithEnvironmentVariableReferences()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var referencedParam = builder.AddParameter("envParam", () => "envValue");
+
+        builder.AddContainer("testContainer", "nginx")
+               .WithEnvironment("TEST_ENV", referencedParam);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parameterProcessor = CreateParameterProcessor();
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync(model);
+
+        // Assert
+        var parameterResource = model.Resources.OfType<ParameterResource>().Single();
+        Assert.Equal("envParam", parameterResource.Name);
+        Assert.NotNull(parameterResource.WaitForValueTcs);
+        Assert.True(parameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
+        Assert.Equal("envValue", await parameterResource.WaitForValueTcs.Task);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithDistributedApplicationModel_WaitForResolution_True()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var param = builder.AddParameter("testParam", () => "testValue");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parameterProcessor = CreateParameterProcessor();
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync(model, waitForResolution: true);
+
+        // Assert
+        var parameterResource = model.Resources.OfType<ParameterResource>().Single();
+        Assert.NotNull(parameterResource.WaitForValueTcs);
+        Assert.True(parameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
+        Assert.Equal("testValue", await parameterResource.WaitForValueTcs.Task);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithDistributedApplicationModel_WaitForResolution_False()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var param = builder.AddParameter("testParam", () => "testValue");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parameterProcessor = CreateParameterProcessor();
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync(model, waitForResolution: false);
+
+        // Assert
+        var parameterResource = model.Resources.OfType<ParameterResource>().Single();
+        Assert.NotNull(parameterResource.WaitForValueTcs);
+        Assert.True(parameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
+        Assert.Equal("testValue", await parameterResource.WaitForValueTcs.Task);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithDistributedApplicationModel_WithMissingParameterValues_HandlesCorrectly()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var missingParam = builder.AddParameter("missingParam", () => throw new MissingParameterValueException("Parameter 'missingParam' is missing"));
+
+        builder.AddContainer("testContainer", "nginx")
+               .WithEnvironment("TEST_ENV", missingParam);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var interactionService = CreateInteractionService();
+        var parameterProcessor = CreateParameterProcessor(interactionService: interactionService);
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync(model);
+
+        // Assert
+        var parameterResource = model.Resources.OfType<ParameterResource>().Single();
+        Assert.NotNull(parameterResource.WaitForValueTcs);
+        Assert.False(parameterResource.WaitForValueTcs.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task InitializeParametersAsync_WithDistributedApplicationModel_HandlesCircularReferences()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var param1 = builder.AddParameter("param1", () => "value1");
+        var param2 = builder.AddParameter("param2", () => "value2");
+
+        // Create a scenario that could potentially create circular references
+        builder.AddContainer("container1", "nginx")
+               .WithEnvironment("ENV1", param1)
+               .WithEnvironment("ENV2", param2);
+
+        builder.AddContainer("container2", "nginx")
+               .WithEnvironment("ENV3", param1);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parameterProcessor = CreateParameterProcessor();
+
+        // Act - Should not hang or throw due to circular references
+        await parameterProcessor.InitializeParametersAsync(model);
+
+        // Assert
+        var parameters = model.Resources.OfType<ParameterResource>().ToList();
+        Assert.Equal(2, parameters.Count);
+
+        foreach (var param in parameters)
+        {
+            Assert.NotNull(param.WaitForValueTcs);
+            Assert.True(param.WaitForValueTcs.Task.IsCompletedSuccessfully);
+        }
     }
 
     private static ParameterProcessor CreateParameterProcessor(

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -480,14 +480,16 @@ public class ParameterProcessorTests
         ResourceLoggerService? loggerService = null,
         IInteractionService? interactionService = null,
         ILogger<ParameterProcessor>? logger = null,
-        bool disableDashboard = true)
+        bool disableDashboard = true,
+        DistributedApplicationExecutionContext? executionContext = null)
     {
         return new ParameterProcessor(
             notificationService ?? ResourceNotificationServiceTestHelpers.Create(),
             loggerService ?? new ResourceLoggerService(),
             interactionService ?? CreateInteractionService(disableDashboard),
             logger ?? new NullLogger<ParameterProcessor>(),
-            new DistributedApplicationOptions { DisableDashboard = disableDashboard }
+            new DistributedApplicationOptions { DisableDashboard = disableDashboard },
+            executionContext ?? new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
         );
     }
 


### PR DESCRIPTION
This pull request introduces improvements to parameter discovery and prompting during Azure deployment. The key change is that parameters referenced in environment variables and command line arguments are now automatically detected and prompted for, even if they are not explicitly added to the model. This ensures that all required parameters are resolved interactively, improving the deployment experience and reliability.

**Parameter discovery and prompting improvements:**

* Added logic in `AzureDeployingContext` to collect dependent `ParameterResource` instances from environment variables and command line arguments, ensuring all referenced parameters are discovered and prompted for during deployment. [[1]](diffhunk://#diff-e9212cb2aa4e32ec45592c1a281973b3c3529b644b7961d35ac65b67a2e3b3e0R36-R37) [[2]](diffhunk://#diff-e9212cb2aa4e32ec45592c1a281973b3c3529b644b7961d35ac65b67a2e3b3e0L48-R60) [[3]](diffhunk://#diff-e9212cb2aa4e32ec45592c1a281973b3c3529b644b7961d35ac65b67a2e3b3e0R592-R653)
* Updated `ParameterProcessor` to throw a `MissingParameterValueException` for parameters with a `GenerateParameterDefault`, indicating that automatic generation is not supported and prompting is required.

**Testing enhancements:**

* Added new tests in `AzureDeployerTests.cs` to verify that parameters referenced in environment variables and command line arguments are correctly discovered and prompted for, and that generated parameters require user input.