### PR TITLE
Refactor dashboard accent colors

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GenAIItemTitle.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GenAIItemTitle.razor
@@ -4,7 +4,7 @@
 @if (_titleBadge is { } titleBadge)
 {
     <span class="message-name">
-        <FluentIcon Value="@titleBadge.Icon" Width="18px" Color="Color.Custom" CustomColor="@ColorGenerator.Instance.GetColorHexByKey(ResourceName)" />
+        <FluentIcon Value="@titleBadge.Icon" Width="18px" Color="Color.Custom" CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(ResourceName)" />
         @titleBadge.Text
     </span>
 }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -10,7 +10,8 @@
 
 @implements IAsyncDisposable
 
-<div class="log-overflow console-overflow continuous-scroll-overflow">
+@* Console logs always have a dark background. Set data-theme="dark" so dark theme accent colors are used *@
+<div class="log-overflow console-overflow continuous-scroll-overflow" data-theme="dark">
     <div class="@GetLogContainerClass()" id="logContainer">
         @if (LogEntries is { } logEntries)
         {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -37,7 +37,7 @@
                                         {
                                             @s_spaceMarkup
                                         }
-                                        <span class="resource-prefix" style="background: @ColorGenerator.Instance.GetColorHexByKey(resourcePrefix);">@resourcePrefix</span>
+                                        <span class="resource-prefix" style="background: @ColorGenerator.Instance.GetColorVariableByKey(resourcePrefix);">@resourcePrefix</span>
                                     }
                                     @if (DisplayPrefix(ref hasPrefix))
                                     {
@@ -73,7 +73,7 @@
                                         {
                                             @s_spaceMarkup
                                         }
-                                        <span class="resource-prefix" style="background: @ColorGenerator.Instance.GetColorHexByKey(resourcePrefix);">@resourcePrefix</span>
+                                        <span class="resource-prefix" style="background: @ColorGenerator.Instance.GetColorVariableByKey(resourcePrefix);">@resourcePrefix</span>
                                     }
                                     @if (context.Type == LogEntryType.Error)
                                     {

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameValue.razor
@@ -6,7 +6,7 @@
     <FluentIcon Width="16px"
                 Class="resource-icon"
                 Color="Color.Custom"
-                CustomColor="@ColorGenerator.Instance.GetColorHexByKey(FormatName(Resource))"
+                CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(FormatName(Resource))"
                 Value="@ResourceIconHelpers.GetIconForResource(Resource, IconSize.Size16)" />
 }
 <FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -173,7 +173,7 @@
             ? SpanWaterfallViewModel.GetTitle(context.Span, ViewModel.Resources)
             : $"{Loc[nameof(ControlsStrings.SpanDetailsSpanPrefix)]}: {OtlpHelpers.ToShortenedId(context.SpanId)}";
         var color = context.Span != null
-            ? ColorGenerator.Instance.GetColorHexByKey(OtlpResource.GetResourceName(context.Span.Source, ViewModel.Resources))
+            ? ColorGenerator.Instance.GetColorVariableByKey(OtlpResource.GetResourceName(context.Span.Source, ViewModel.Resources))
             : "transparent";
 
         return @<div>

--- a/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor
@@ -19,7 +19,7 @@
                     TGridItem="ChartExemplar">
         <ChildContent>
             <TemplateColumn Title="@Loc[nameof(Dialogs.ExemplarsDialogTraceColumnHeader)]" TooltipText="@(context => GetTitle(context))" Tooltip="true">
-                <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(context.Span != null ? ColorGenerator.Instance.GetColorHexByKey(OtlpResource.GetResourceName(context.Span.Source, Content.Resources)) : "transparent");">
+                <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(context.Span != null ? ColorGenerator.Instance.GetColorVariableByKey(OtlpResource.GetResourceName(context.Span.Source, Content.Resources)) : "transparent");">
                     @GetTitle(context)
                 </span>
             </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -134,7 +134,7 @@
                                                 Class="main-grid enable-row-click">
                                     <ChildContent>
                                         <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.ResourceView))">
-                                            <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.ResourceView)));">
+                                            <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.ResourceView)));">
                                                 @GetResourceName(context.ResourceView)
                                             </span>
                                         </AspireTemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -143,7 +143,7 @@
                                                     // - 5px extra margin-left
                                                     // - 5px border
                                                     // - 9px padding-left
-                                                    spanNameContainerStyle = $"margin-left: 5px; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
+                                                    spanNameContainerStyle = $"margin-left: 5px; border-left-color: {ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
                                                 }
                                             else
                                             {
@@ -168,7 +168,7 @@
                                                 {
                                                     <FluentIcon Class="span-kind-icon"
                                                                 Color="Color.Custom"
-                                                                CustomColor="@ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))"
+                                                                CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source))"
                                                                 Value="@TraceHelpers.TryGetSpanIcon(context.Span, IconVariant.Filled)"/>
                                                 }
 
@@ -197,7 +197,7 @@
                                                             }
                                                         }
                                                         <FluentIcon
-                                                            Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")"
+                                                            Style="@($"fill: {ColorGenerator.Instance.GetColorVariableByKey(context.UninstrumentedPeer)};")"
                                                             Value="icon"
                                                             Class="uninstrumented-peer-icon"/>
                                                         <FluentHighlighter HighlightedText="@_filter" Text="@context.UninstrumentedPeer" />
@@ -249,7 +249,7 @@
                                         </HeaderCellItemTemplate>
                                         <ChildContent>
                                             @{
-                                                var spanColor = @ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source));
+                                                var spanColor = @ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Span.Source));
                                             }
                                             <div class="ticks">
                                                 <div class="span-container" style="position: relative; grid-template-columns: @context.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)% @context.Width.ToString("F2", CultureInfo.InvariantCulture)% min-content;">

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -114,7 +114,7 @@
                                 @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)
                             </AspireTemplateColumn>
                             <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@(trace => GetNameTooltip(trace))">
-                                <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName((context.RootOrFirstSpan).Source)));">
+                                <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName((context.RootOrFirstSpan).Source)));">
                                     <FluentHighlighter HighlightedText="@(TracesViewModel.FilterText)" Text="@(context.FullName)" />
                                 </span>
                                 <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
@@ -125,7 +125,7 @@
                                         @foreach (var item in TraceHelpers.GetOrderedResources(context))
                                         {
                                             <FluentOverflowItem>
-                                                <span class="trace-tag trace-service-tag" title="@(GetSpansTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(item.Resource)));">
+                                                <span class="trace-tag trace-service-tag" title="@(GetSpansTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(item.Resource)));">
                                                     @if (item.ErroredSpans > 0)
                                                     {
                                                         <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -12,7 +12,7 @@
         <FluentIcon Width="16px"
                     Class="resource-icon"
                     Color="Color.Custom"
-                    CustomColor="@ColorGenerator.Instance.GetColorHexByKey(FormatName(Resource))"
+                    CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(FormatName(Resource))"
                     Value="@ResourceIconHelpers.GetIconForResource(Resource, IconSize.Size16)" />
     }
     @{

--- a/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
@@ -37,7 +37,7 @@ public static class ResourceGraphMapper
             ?? ResourceUrlHelpers.GetUrls(r, includeInternalUrls: false, includeNonEndpointUrls: true).FirstOrDefault();
         var resolvedEndpointText = ResolvedEndpointText(endpoint);
         var resourceName = ResourceViewModel.GetResourceName(r, resourcesByName);
-        var color = ColorGenerator.Instance.GetColorHexByKey(resourceName);
+        var color = ColorGenerator.Instance.GetColorVariableByKey(resourceName);
 
         var icon = GetIconPathData(ResourceIconHelpers.GetIconForResource(r, IconSize.Size24));
 

--- a/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
@@ -7,12 +7,19 @@ namespace Aspire.Dashboard.Otlp.Model;
 
 public sealed class AccentColor
 {
-    public required string VariableName { get; init; }
+    public AccentColor(string variableName)
+    {
+        VariableName = variableName;
+        ReferencedVariableName = $"var({variableName})";
+    }
+
+    public string VariableName { get; }
+    public string ReferencedVariableName { get; }
 }
 
 public class ColorGenerator
 {
-    private static readonly string[] s_colorsHex =
+    private static readonly string[] s_variableNames =
     [
         "--accent-teal",
         "--accent-marigold",
@@ -47,12 +54,9 @@ public class ColorGenerator
         _colorIndexByKey = new ConcurrentDictionary<string, Lazy<int>>(StringComparer.OrdinalIgnoreCase);
         _currentIndex = 0;
 
-        foreach (var hex in s_colorsHex)
+        foreach (var name in s_variableNames)
         {
-            _colors.Add(new AccentColor
-            {
-                VariableName = hex
-            });
+            _colors.Add(new AccentColor(name));
         }
     }
 
@@ -71,7 +75,7 @@ public class ColorGenerator
         }).Value;
     }
 
-    public string GetColorHexByKey(string key)
+    public string GetColorVariableByKey(string key)
     {
         var i = GetColorIndex(key);
         return $"var({_colors[i].VariableName})";

--- a/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
@@ -2,64 +2,58 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using System.Globalization;
 
 namespace Aspire.Dashboard.Otlp.Model;
 
-public sealed class GeneratedColor
+public sealed class AccentColor
 {
-    public required string Hex { get; init; }
-    public required int Red { get; init; }
-    public required int Green { get; init; }
-    public required int Blue { get; init; }
+    public required string VariableName { get; init; }
 }
 
 public class ColorGenerator
 {
     private static readonly string[] s_colorsHex =
     [
-        "#17B8BE", "#F8DCA1", "#B7885E", "#FFCB99", "#F89570",
-        "#829AE3", "#E79FD5", "#1E96BE", "#89DAC1", "#B3AD9E",
-        "#12939A", "#DDB27C", "#88572C", "#FF9833", "#EF5D28",
-        "#162A65", "#DA70BF", "#125C77", "#4DC19C", "#776E57"
+        "--accent-teal",
+        "--accent-marigold",
+        "--accent-brass",
+        "--accent-peach",
+        "--accent-coral",
+        "--accent-royal-blue",
+        "--accent-orchid",
+        "--accent-brand-blue",
+        "--accent-seafoam",
+        "--accent-mink",
+        "--accent-cyan",
+        "--accent-gold",
+        "--accent-bronze",
+        "--accent-orange",
+        "--accent-rust",
+        "--accent-navy",
+        "--accent-berry",
+        "--accent-ocean",
+        "--accent-jade",
+        "--accent-olive"
     ];
     public static readonly ColorGenerator Instance = new ColorGenerator();
 
-    private readonly List<GeneratedColor> _colors;
+    private readonly List<AccentColor> _colors;
     private readonly ConcurrentDictionary<string, Lazy<int>> _colorIndexByKey;
     private int _currentIndex;
 
     private ColorGenerator()
     {
-        _colors = new List<GeneratedColor>();
+        _colors = new List<AccentColor>();
         _colorIndexByKey = new ConcurrentDictionary<string, Lazy<int>>(StringComparer.OrdinalIgnoreCase);
         _currentIndex = 0;
 
         foreach (var hex in s_colorsHex)
         {
-            var rgb = GetHexRgb(hex);
-            _colors.Add(new GeneratedColor
+            _colors.Add(new AccentColor
             {
-                Hex = hex,
-                Red = rgb.Red,
-                Green = rgb.Green,
-                Blue = rgb.Blue
+                VariableName = hex
             });
         }
-    }
-
-    private static (int Red, int Green, int Blue) GetHexRgb(string s)
-    {
-        if (s.Length != 7)
-        {
-            return (0, 0, 0);
-        }
-
-        var r = int.Parse(s.AsSpan(1, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-        var g = int.Parse(s.AsSpan(3, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-        var b = int.Parse(s.AsSpan(5, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-
-        return (r, g, b);
     }
 
     private int GetColorIndex(string key)
@@ -80,7 +74,7 @@ public class ColorGenerator
     public string GetColorHexByKey(string key)
     {
         var i = GetColorIndex(key);
-        return _colors[i].Hex;
+        return $"var({_colors[i].VariableName})";
     }
 
     public void Clear()

--- a/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
@@ -17,9 +17,9 @@ public sealed class AccentColor
     public string ReferencedVariableName { get; }
 }
 
-<summary>
-Provides a stable color for a named element. When <see cref="GetColorVariableByKey(string)" /> is invoked a new color is returned if the key was not used previously. An instance of this class is thread-safe and multiple threads can query colors concurrently without collisions.
-</summary>
+/// <summary>
+/// Provides a stable color for a named element. When <see cref="GetColorVariableByKey(string)" /> is invoked a new color is returned if the key was not used previously. An instance of this class is thread-safe and multiple threads can query colors concurrently without collisions.
+/// </summary>
 public class ColorGenerator
 {
     private static readonly string[] s_variableNames =

--- a/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
@@ -78,7 +78,7 @@ public class ColorGenerator
     public string GetColorVariableByKey(string key)
     {
         var i = GetColorIndex(key);
-        return $"var({_colors[i].VariableName})";
+        return _colors[i].ReferencedVariableName;
     }
 
     public void Clear()

--- a/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/ColorGenerator.cs
@@ -17,6 +17,9 @@ public sealed class AccentColor
     public string ReferencedVariableName { get; }
 }
 
+<summary>
+Provides a stable color for a named element. When <see cref="GetColorVariableByKey(string)" /> is invoked a new color is returned if the key was not used previously. An instance of this class is thread-safe and multiple threads can query colors concurrently without collisions.
+</summary>
 public class ColorGenerator
 {
     private static readonly string[] s_variableNames =

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -108,6 +108,27 @@ fluent-toolbar::part(end) {
     --tool-calls-color: #11910d;
     --output-background-color: #f4bfab;
     --output-color: #7a2101;
+    /* accent variables */
+    --accent-teal: #14959B;
+    --accent-marigold: #E9C877;
+    --accent-brass: #9F724F;
+    --accent-peach: #F39E67;
+    --accent-coral: #E1694E;
+    --accent-royal-blue: #5F79DE;
+    --accent-orchid: #C764BA;
+    --accent-brand-blue: #0E62AD;
+    --accent-seafoam: #55BFA9;
+    --accent-mink: #9C9587;
+    --accent-cyan: #0E858B;
+    --accent-gold: #D7A763;
+    --accent-bronze: #7B4F2E;
+    --accent-orange: #F57D1A;
+    --accent-rust: #E0522A;
+    --accent-navy: #1B3A70;
+    --accent-berry: #C239B3;
+    --accent-ocean: #0E5E77;
+    --accent-jade: #3BAB8E;
+    --accent-olive: #6F6652;
 }
 
 [data-theme="dark"] {
@@ -157,6 +178,27 @@ fluent-toolbar::part(end) {
     --tool-calls-color: #62abf5;
     --output-background-color: #7a2101;
     --output-color: #f4bfab;
+    /* accent variables */
+    --accent-teal: #2CB7BD;
+    --accent-marigold: #F3D58E;
+    --accent-brass: #BF8B64;
+    --accent-peach: #FFC18F;
+    --accent-coral: #F89170;
+    --accent-royal-blue: #88A1F0;
+    --accent-orchid: #E19AD4;
+    --accent-brand-blue: #1A7ECF;
+    --accent-seafoam: #74D6C6;
+    --accent-mink: #B9B2A4;
+    --accent-cyan: #17A0A6;
+    --accent-gold: #E3BA7A;
+    --accent-bronze: #8E6038;
+    --accent-orange: #FFA44A;
+    --accent-rust: #EA6A3E;
+    --accent-navy: #2A4C8A;
+    --accent-berry: #D150C3;
+    --accent-ocean: #16728F;
+    --accent-jade: #51C0A5;
+    --accent-olive: #847B63;
 }
 
 .fluent-data-grid-row.hover:not([row-type='header'],[row-type='sticky-header']):hover td {


### PR DESCRIPTION
- Tweak colors to be more like FluentUI colors
- Use CSS variables to set accents
- Have light and dark accents. Avoid too light accents on a light background and too dark accents on a dark background.

Fixes https://github.com/dotnet/aspire/issues/9107

Dark before:
<img width="2034" height="1035" alt="image" src="https://github.com/user-attachments/assets/7f75cd1f-24ed-4a4f-a58e-bdd20303e1ce" />

Dark after:
<img width="2084" height="1024" alt="image" src="https://github.com/user-attachments/assets/926ada41-d6e2-4892-8e0e-a32e67b32173" />

Light before:
<img width="2024" height="1025" alt="image" src="https://github.com/user-attachments/assets/d325defe-018b-48c6-850e-a31a439d3f86" />

Light after:
<img width="2049" height="1026" alt="image" src="https://github.com/user-attachments/assets/c89a6be6-f9d5-40f8-99d7-5a3f3b67d710" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
