### PR TITLE
[release/9.4] Bump KubernetesClient version to 17.0.14

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,7 +82,7 @@
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.71.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.72.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
-    <PackageVersion Include="KubernetesClient" Version="17.0.4" />
+    <PackageVersion Include="KubernetesClient" Version="17.0.14" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="Markdig" Version="0.41.3" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.1.0" />


### PR DESCRIPTION
## Description

Picks up the latest version of KubernetesClient with security fixes for servicing the 9.4 release.

Fixes #11469
