### PR TITLE
[release/9.5] Support prompting for generated values during deploy

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -45,12 +45,8 @@ internal sealed class AzureDeployingContext(
         var userSecrets = await userSecretsManager.LoadUserSecretsAsync(cancellationToken).ConfigureAwait(false);
         var provisioningContext = await provisioningContextProvider.CreateProvisioningContextAsync(userSecrets, cancellationToken).ConfigureAwait(false);
 
-        // Step 1: Resolve parameter resources using ParameterProcessor
-        var parameters = model.Resources.OfType<ParameterResource>();
-        if (parameters.Any())
-        {
-            await parameterProcessor.InitializeParametersAsync(parameters, waitForResolution: true).ConfigureAwait(false);
-        }
+        // Step 1: Initialize parameters by collecting dependencies and resolving values
+        await parameterProcessor.InitializeParametersAsync(model, waitForResolution: true, cancellationToken).ConfigureAwait(false);
 
         // Step 2: Provision Azure Bicep resources from the distributed application model
         var bicepResources = model.Resources.OfType<AzureBicepResource>()
@@ -580,5 +576,4 @@ internal sealed class AzureDeployingContext(
 
         return string.Empty;
     }
-
 }

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -448,6 +448,9 @@ public class ApplicationOrchestratorTests
         var serviceProvider = new ServiceCollection().BuildServiceProvider();
         resourceLoggerService ??= new ResourceLoggerService();
 
+        var executionContext = new DistributedApplicationExecutionContext(
+            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = serviceProvider });
+
         return new ApplicationOrchestrator(
             distributedAppModel,
             new TestDcpExecutor(),
@@ -457,14 +460,14 @@ public class ApplicationOrchestratorTests
             resourceLoggerService,
             applicationEventing ?? new DistributedApplicationEventing(),
             serviceProvider,
-            new DistributedApplicationExecutionContext(
-                new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = serviceProvider }),
+            executionContext,
             new ParameterProcessor(
                 notificationService,
                 resourceLoggerService,
                 CreateInteractionService(),
                 NullLogger<ParameterProcessor>.Instance,
-                new DistributedApplicationOptions())
+                new DistributedApplicationOptions(),
+                executionContext)
             );
     }
 


### PR DESCRIPTION
Risk: Low
Testing: Manual and unit tests
Impact: Make sure that all values that aren't stored in deployment state are prompted for