### PR TITLE
Fix peer matching with container to host calls

### DIFF
--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -76,8 +76,13 @@ public class ResourceOutgoingPeerResolverTests
         Assert.Equal("test", value);
     }
 
-    [Fact]
-    public void NumberAddressValueAttribute_Match()
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("host.docker.internal")]
+    [InlineData("host.containers.internal")]
+    [InlineData("HOST.DOCKER.INTERNAL")]
+    [InlineData("HOST.CONTAINERS.INTERNAL")]
+    public void NonLocalhostAttribute_Match(string host)
     {
         // Arrange
         var resources = new Dictionary<string, ResourceViewModel>
@@ -86,7 +91,7 @@ public class ResourceOutgoingPeerResolverTests
         };
 
         // Act & Assert
-        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("peer.service", "127.0.0.1:5000")], out var value));
+        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("peer.service", $"{host}:5000")], out var value));
         Assert.Equal("test", value);
     }
 


### PR DESCRIPTION
## Description

Before:
<img width="746" height="342" alt="image" src="https://github.com/user-attachments/assets/3c9774af-53cb-4b2b-ab4e-8295bcdf1bf3" />

After:
<img width="843" height="366" alt="image" src="https://github.com/user-attachments/assets/7dbfb9f4-1dd1-42fc-adca-610da49e7f70" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
