### PR TITLE
Improve log entry tooltip

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -292,3 +292,8 @@
     align-content: center;
     border-bottom: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-divider-rest);
 }
+
+::deep.log-tooltip-table tr:last-child td {
+    border-bottom: none;
+    padding-bottom: calc(var(--design-unit) * 0.5px);
+}


### PR DESCRIPTION
Remove bottom border line from log entry tooltip.

After:
<img width="518" height="254" alt="image" src="https://github.com/user-attachments/assets/97038909-173b-4ea1-a5dc-392514934cfa" />