### PR TITLE
Display multiple log lines in tooltip

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -293,7 +293,7 @@
                                                                         </tr>
                                                                         <tr>
                                                                             <td>@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]</td>
-                                                                            <td>@OtlpHelpers.TruncateString(item.LogEntry.Message, maxLength: 200)</td>
+                                                                            <td>@FormatHelpers.TruncateText(item.LogEntry.Message, maxLength: 150)</td>
                                                                         </tr>
                                                                     </table>
                                                                 </FluentTooltip>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -284,15 +284,15 @@
                                                                     </div>
                                                                     <table class="log-tooltip-table">
                                                                         <tr>
-                                                                            <td>@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]</td>
+                                                                            <td class="label-column">@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]</td>
                                                                             <td>@item.LogEntry.Severity</td>
                                                                         </tr>
                                                                         <tr>
-                                                                            <td>@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]</td>
+                                                                            <td class="label-column">@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]</td>
                                                                             <td>@FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, item.LogEntry.TimeStamp, MillisecondsDisplay.Truncated)</td>
                                                                         </tr>
                                                                         <tr>
-                                                                            <td>@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]</td>
+                                                                            <td class="label-column">@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]</td>
                                                                             <td>@FormatHelpers.TruncateText(item.LogEntry.Message, maxLength: 150)</td>
                                                                         </tr>
                                                                     </table>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -285,12 +285,11 @@
 }
 
 ::deep.log-tooltip-table td {
-    padding: calc((var(--design-unit) + var(--focus-stroke-width) - var(--stroke-width))* 1px) 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    padding: calc((var(--design-unit) + var(--focus-stroke-width) - var(--stroke-width))* 0.7px) 0;
     align-content: center;
     border-bottom: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-divider-rest);
+    align-content: start;
+    word-break: break-word;
 }
 
 ::deep.log-tooltip-table tr:last-child td {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -276,17 +276,16 @@
 ::deep.log-tooltip-table {
     margin-bottom: 0;
     width: 100%;
-    table-layout: fixed;
     font-size: 12px;
 }
 
-::deep.log-tooltip-table td:nth-child(1) {
-    width: 25%;
+::deep.log-tooltip-table td.label-column {
+    text-wrap-mode: nowrap;
+    padding-right: calc(var(--design-unit)* 4px)
 }
 
 ::deep.log-tooltip-table td {
     padding: calc((var(--design-unit) + var(--focus-stroke-width) - var(--stroke-width))* 0.7px) 0;
-    align-content: center;
     border-bottom: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-divider-rest);
     align-content: start;
     word-break: break-word;

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -281,7 +281,8 @@
 
 ::deep.log-tooltip-table td.label-column {
     text-wrap-mode: nowrap;
-    padding-right: calc(var(--design-unit)* 4px)
+    padding-right: calc(var(--design-unit)* 4px);
+    width: 20%;
 }
 
 ::deep.log-tooltip-table td {


### PR DESCRIPTION
## Description

Refactor log entry tooltip to display multiple log lines. I think this is better:

<img width="844" height="387" alt="image" src="https://github.com/user-attachments/assets/b6f7549a-1629-4cb5-a6c0-5c2113d2eb47" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
