### PR TITLE
Add deny list of schemes to not display as links

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
@@ -10,6 +10,7 @@ internal static class ResourceUrlHelpers
 {
     // These are known URL schemes that browsers don't support opening. Don't attempt to display them as a link.
     // Not displaying them as a link makes it clear what can be opened in a browser (http, https) vs what can't (tcp, ws).
+    // This is a deny list because custom schemes could hand off the link to an app registered with the OS. For example, vscode://.
     private static readonly HashSet<string> s_browserUnsupportedSchemes = new(StringComparer.OrdinalIgnoreCase)
     {
         "gopher",

--- a/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
@@ -8,6 +8,19 @@ namespace Aspire.Dashboard.Model;
 
 internal static class ResourceUrlHelpers
 {
+    // These are known URL schemes that browsers don't support opening. Don't attempt to display them as a link.
+    // Not displaying them as a link makes it clear what can be opened in a browser (http, https) vs what can't (tcp, ws).
+    private static readonly HashSet<string> s_browserUnsupportedSchemes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "gopher",
+        "ws",
+        "wss",
+        "news",
+        "nntp",
+        "telnet",
+        "tcp"
+    };
+
     public static List<DisplayedUrl> GetUrls(ResourceViewModel resource, bool includeInternalUrls = false, bool includeNonEndpointUrls = false)
     {
         var urls = new List<DisplayedUrl>(resource.Urls.Length);
@@ -33,7 +46,7 @@ internal static class ResourceUrlHelpers
                     Name = url.EndpointName ?? "-",
                     Address = url.Url.Host,
                     Port = url.Url.Port,
-                    Url = url.Url.OriginalString,
+                    Url = !s_browserUnsupportedSchemes.Contains(url.Url.Scheme) ? url.Url.OriginalString : null,
                     SortOrder = url.DisplayProperties.SortOrder,
                     DisplayName = string.IsNullOrEmpty(url.DisplayProperties.DisplayName) ? null : url.DisplayProperties.DisplayName,
                     OriginalUrlString = url.Url.OriginalString,

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceUrlHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceUrlHelpersTests.cs
@@ -86,7 +86,7 @@ public sealed class ResourceUrlHelpersTests
             {
                 Assert.Equal("tcp://localhost:8081", e.Text);
                 Assert.Equal("Test2", e.Name);
-                Assert.Equal("tcp://localhost:8081", e.Url);
+                Assert.Null(e.Url);
                 Assert.Equal("localhost", e.Address);
                 Assert.Equal(8081, e.Port);
             });
@@ -235,8 +235,8 @@ public sealed class ResourceUrlHelpersTests
         Assert.Collection(endpoints,
             e => Assert.Equal("Z", e.Name),
             e => Assert.Equal("a", e.Name),
-            e => Assert.Equal("B", e.Name),
             e => Assert.Equal("C", e.Name),
+            e => Assert.Equal("B", e.Name),
             e => Assert.Equal("D", e.Name));
     }
 


### PR DESCRIPTION
## Description

There are known URL schemes that browsers don't support opening. Don't attempt to display them as a link. Not displaying them as a link makes it clear what can be opened in a browser (http, https) vs what can't (tcp, ws). Also, ordering places links before text, so this change means links (http/https) are displayed before TCP.

I got this list of copilot but worth extra eyes to check if there are things that should be added or removed.

Before:
<img width="1104" height="368" alt="image" src="https://github.com/user-attachments/assets/475ea6b8-32d5-4bce-b165-d8eec9bdd45c" />

After:
<img width="1070" height="378" alt="image" src="https://github.com/user-attachments/assets/c584a964-be80-4de6-be5b-ee880705157b" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
