### PR TITLE
Don't add reference to dev tunnel endpoint when publishing

### DIFF
--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -315,6 +315,12 @@ public static partial class DevTunnelsResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(targetResource);
         ArgumentNullException.ThrowIfNull(tunnelResource);
 
+        if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
+        {
+            // Skip DevTunnel operations during publish mode to avoid hanging
+            return builder;
+        }
+
         builder
             .WithReferenceRelationship(tunnelResource)
             .WithEnvironment(async context =>
@@ -397,6 +403,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
             .WithParentRelationship(tunnelBuilder)
             // indicate the target resource relationship
             .WithReferenceRelationship(targetResource)
+            .ExcludeFromManifest() // Dev tunnels do not get deployed
             // NOTE:
             // The endpoint target full host is set by the dev tunnels service and is not known in advance, but the suffix is always devtunnels.ms
             // We might consider updating the central logic that creates endpoint URLs to allow setting a target host like *.devtunnels.ms & if the


### PR DESCRIPTION
## Description

Dev tunnels aren't published so we should exclude the dev tunnel resource and the dev tunnel port resources from the manifest, along with not processing `WithReference` calls to a dev tunnel endpoint when in publish mode.

Fixes #11546 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
