### PR TITLE
Fix ai foundry model gen

### DIFF
--- a/src/Aspire.Hosting.Azure.AIFoundry/AIFoundryModel.Generated.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/AIFoundryModel.Generated.cs
@@ -235,54 +235,9 @@ public partial class AIFoundryModel
         public static readonly AIFoundryModel ModelRouter = new() { Name = "model-router", Version = "2025-08-07", Format = "Microsoft" };
 
         /// <summary>
-        /// Same Phi-3-medium model, but with a larger context size for RAG or few shot prompting.
-        /// </summary>
-        public static readonly AIFoundryModel Phi3Medium128kInstruct = new() { Name = "Phi-3-medium-128k-instruct", Version = "7", Format = "Microsoft" };
-
-        /// <summary>
-        /// A 14B parameters model, proves better quality than Phi-3-mini, with a focus on high-quality, reasoning-dense data.
-        /// </summary>
-        public static readonly AIFoundryModel Phi3Medium4kInstruct = new() { Name = "Phi-3-medium-4k-instruct", Version = "6", Format = "Microsoft" };
-
-        /// <summary>
-        /// Same Phi-3-mini model, but with a larger context size for RAG or few shot prompting.
-        /// </summary>
-        public static readonly AIFoundryModel Phi3Mini128kInstruct = new() { Name = "Phi-3-mini-128k-instruct", Version = "13", Format = "Microsoft" };
-
-        /// <summary>
-        /// Tiniest member of the Phi-3 family. Optimized for both quality and low latency.
-        /// </summary>
-        public static readonly AIFoundryModel Phi3Mini4kInstruct = new() { Name = "Phi-3-mini-4k-instruct", Version = "15", Format = "Microsoft" };
-
-        /// <summary>
-        /// Same Phi-3-small model, but with a larger context size for RAG or few shot prompting.
-        /// </summary>
-        public static readonly AIFoundryModel Phi3Small128kInstruct = new() { Name = "Phi-3-small-128k-instruct", Version = "5", Format = "Microsoft" };
-
-        /// <summary>
-        /// A 7B parameters model, proves better quality than Phi-3-mini, with a focus on high-quality, reasoning-dense data.
-        /// </summary>
-        public static readonly AIFoundryModel Phi3Small8kInstruct = new() { Name = "Phi-3-small-8k-instruct", Version = "6", Format = "Microsoft" };
-
-        /// <summary>
-        /// Refresh of Phi-3-mini model.
-        /// </summary>
-        public static readonly AIFoundryModel Phi35MiniInstruct = new() { Name = "Phi-3.5-mini-instruct", Version = "6", Format = "Microsoft" };
-
-        /// <summary>
-        /// A new mixture of experts model
-        /// </summary>
-        public static readonly AIFoundryModel Phi35MoeInstruct = new() { Name = "Phi-3.5-MoE-instruct", Version = "5", Format = "Microsoft" };
-
-        /// <summary>
-        /// Refresh of Phi-3-vision model.
-        /// </summary>
-        public static readonly AIFoundryModel Phi35VisionInstruct = new() { Name = "Phi-3.5-vision-instruct", Version = "2", Format = "Microsoft" };
-
-        /// <summary>
         /// Phi-4 14B, a highly capable model for low latency scenarios.
         /// </summary>
-        public static readonly AIFoundryModel Phi4 = new() { Name = "Phi-4", Version = "8", Format = "Microsoft" };
+        public static readonly AIFoundryModel Phi4 = new() { Name = "Phi-4", Version = "7", Format = "Microsoft" };
 
         /// <summary>
         /// 3.8B parameters Small Language Model outperforming larger models in reasoning, math, coding, and function-calling
@@ -293,11 +248,6 @@ public partial class AIFoundryModel
         /// Lightweight math reasoning model optimized for multi-step problem solving
         /// </summary>
         public static readonly AIFoundryModel Phi4MiniReasoning = new() { Name = "Phi-4-mini-reasoning", Version = "1", Format = "Microsoft" };
-
-        /// <summary>
-        /// First small multimodal model to have 3 modality inputs (text, audio, image), excelling in quality and efficiency
-        /// </summary>
-        public static readonly AIFoundryModel Phi4MultimodalInstruct = new() { Name = "Phi-4-multimodal-instruct", Version = "2", Format = "Microsoft" };
 
         /// <summary>
         /// State-of-the-art open-weight reasoning model.

--- a/src/Aspire.Hosting.Azure.AIFoundry/tools/GenModel.cs
+++ b/src/Aspire.Hosting.Azure.AIFoundry/tools/GenModel.cs
@@ -100,6 +100,8 @@ public class ModelClient : IDisposable
         Console.WriteLine($"Total pages fetched: {pageCount}");
         Console.WriteLine($"Total models collected: {allModels.Count}");
 
+        RunFixups(allModels);
+
         // Return the consolidated response using our model
         return new ConsolidatedResponse
         {
@@ -162,7 +164,7 @@ public class ModelClient : IDisposable
                     {"field": "annotations/archived", "operator": "ne", "values": ["true"]},
                     {"field": "properties/userProperties/is-promptflow", "operator": "notexists"},
                     {"field": "labels", "operator": "eq", "values": ["latest"]},
-                    {"field": "properties/name", "operator": "eq", "values": ["dall-e-3", "gpt-35-turbo", "gpt-35-turbo-16k", "gpt-4", "gpt-4-32k", "gpt-4o", "gpt-4o-mini", "gpt-4o-audio-preview", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "o1", "o3-mini", "o4-mini", "ada", "text-embedding-ada-002", "babbage", "curie", "davinci", "text-embedding-3-small", "text-embedding-3-large", "AI21-Jamba-1.5-Large", "AI21-Jamba-1.5-Mini", "AI21-Jamba-Instruct", "Codestral-2501", "cohere-command-a", "Cohere-command-r", "Cohere-command-r-08-2024", "Cohere-command-r-plus", "Cohere-command-r-plus-08-2024", "Cohere-embed-v3-english", "Cohere-embed-v3-multilingual", "DeepSeek-R1", "DeepSeek-R1-0528", "DeepSeek-V3", "DeepSeek-V3-0324", "embed-v-4-0", "jais-30b-chat", "Llama-3.2-11B-Vision-Instruct", "Llama-3.2-90B-Vision-Instruct", "Llama-3.3-70B-Instruct", "MAI-DS-R1", "Meta-Llama-3-70B-Instruct", "Meta-Llama-3-8B-Instruct", "Meta-Llama-3.1-405B-Instruct", "Meta-Llama-3.1-70B-Instruct", "Meta-Llama-3.1-8B-Instruct", "Ministral-3B", "Mistral-large-2407", "Mistral-Large-2411", "Mistral-Nemo", "Mistral-small", "mistral-small-2503", "Phi-3-medium-128k-instruct", "Phi-3-medium-4k-instruct", "Phi-3-mini-128k-instruct", "Phi-3-mini-4k-instruct", "Phi-3-small-128k-instruct", "Phi-3-small-8k-instruct", "Phi-3.5-mini-instruct", "Phi-3.5-MoE-instruct", "Phi-3.5-vision-instruct", "Phi-4", "Phi-4-mini-instruct", "Phi-4-multimodal-instruct", "Phi-4-reasoning", "Phi-4-mini-reasoning", "Llama-4-Maverick-17B-128E-Instruct-FP8", "Llama-4-Scout-17B-16E-Instruct", "mistral-medium-2505", "mistral-document-ai-2505", "grok-3", "grok-3-mini", "FLUX-1.1-pro", "FLUX.1-Kontext-pro", "gpt-oss-120b", "code-cushman-001", "code-cushman-fine-tune-002", "whisper", "text-ada-001", "text-similarity-ada-001", "text-search-ada-doc-001", "text-search-ada-query-001", "code-search-ada-code-001", "code-search-ada-text-001", "text-babbage-001", "text-similarity-babbage-001", "text-search-babbage-doc-001", "text-search-babbage-query-001", "code-search-babbage-code-001", "code-search-babbage-text-001", "text-curie-001", "text-similarity-curie-001", "text-search-curie-doc-001", "text-search-curie-query-001", "text-davinci-001", "text-davinci-002", "text-davinci-003", "text-davinci-fine-tune-002", "code-davinci-002", "code-davinci-fine-tune-002", "text-similarity-davinci-001", "text-search-davinci-doc-001", "text-search-davinci-query-001", "dall-e-2", "gpt-35-turbo-instruct", "gpt-4o-mini-audio-preview", "o1-mini", "gpt-4o-mini-realtime-preview", "gpt-4o-realtime-preview", "gpt-4o-transcribe", "gpt-4o-mini-transcribe", "gpt-4o-mini-tts", "gpt-5-mini", "gpt-5-nano", "gpt-5-chat", "model-router", "codex-mini", "sora", "tts", "tts-hd", "babbage-002", "davinci-002", "Azure-AI-Speech", "Azure-AI-Language", "Azure-AI-Vision", "Azure-AI-Translator", "Azure-AI-Content-Understanding", "Azure-AI-Document-Intelligence", "Azure-AI-Content-Safety"]}
+                    {"field": "properties/name", "operator": "eq", "values": ["dall-e-3", "gpt-35-turbo", "gpt-35-turbo-16k", "gpt-4", "gpt-4-32k", "gpt-4o", "gpt-4o-mini", "gpt-4o-audio-preview", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "o1", "o3-mini", "o4-mini", "ada", "text-embedding-ada-002", "babbage", "curie", "davinci", "text-embedding-3-small", "text-embedding-3-large", "AI21-Jamba-1.5-Large", "AI21-Jamba-1.5-Mini", "AI21-Jamba-Instruct", "Codestral-2501", "cohere-command-a", "Cohere-command-r", "Cohere-command-r-08-2024", "Cohere-command-r-plus", "Cohere-command-r-plus-08-2024", "Cohere-embed-v3-english", "Cohere-embed-v3-multilingual", "DeepSeek-R1", "DeepSeek-R1-0528", "DeepSeek-V3", "DeepSeek-V3-0324", "embed-v-4-0", "jais-30b-chat", "Llama-3.2-11B-Vision-Instruct", "Llama-3.2-90B-Vision-Instruct", "Llama-3.3-70B-Instruct", "MAI-DS-R1", "Meta-Llama-3-70B-Instruct", "Meta-Llama-3-8B-Instruct", "Meta-Llama-3.1-405B-Instruct", "Meta-Llama-3.1-70B-Instruct", "Meta-Llama-3.1-8B-Instruct", "Ministral-3B", "Mistral-large-2407", "Mistral-Large-2411", "Mistral-Nemo", "Mistral-small", "mistral-small-2503", "Phi-4", "Phi-4-mini-instruct", "Phi-4-reasoning", "Phi-4-mini-reasoning", "Llama-4-Maverick-17B-128E-Instruct-FP8", "Llama-4-Scout-17B-16E-Instruct", "mistral-medium-2505", "mistral-document-ai-2505", "grok-3", "grok-3-mini", "FLUX-1.1-pro", "FLUX.1-Kontext-pro", "gpt-oss-120b", "code-cushman-001", "code-cushman-fine-tune-002", "whisper", "text-ada-001", "text-similarity-ada-001", "text-search-ada-doc-001", "text-search-ada-query-001", "code-search-ada-code-001", "code-search-ada-text-001", "text-babbage-001", "text-similarity-babbage-001", "text-search-babbage-doc-001", "text-search-babbage-query-001", "code-search-babbage-code-001", "code-search-babbage-text-001", "text-curie-001", "text-similarity-curie-001", "text-search-curie-doc-001", "text-search-curie-query-001", "text-davinci-001", "text-davinci-002", "text-davinci-003", "text-davinci-fine-tune-002", "code-davinci-002", "code-davinci-fine-tune-002", "text-similarity-davinci-001", "text-search-davinci-doc-001", "text-search-davinci-query-001", "dall-e-2", "gpt-35-turbo-instruct", "gpt-4o-mini-audio-preview", "o1-mini", "gpt-4o-mini-realtime-preview", "gpt-4o-realtime-preview", "gpt-4o-transcribe", "gpt-4o-mini-transcribe", "gpt-4o-mini-tts", "gpt-5-mini", "gpt-5-nano", "gpt-5-chat", "model-router", "codex-mini", "sora", "tts", "tts-hd", "babbage-002", "davinci-002", "Azure-AI-Speech", "Azure-AI-Language", "Azure-AI-Vision", "Azure-AI-Translator", "Azure-AI-Content-Understanding", "Azure-AI-Document-Intelligence", "Azure-AI-Content-Safety"]}
                 ],
                 "freeTextSearch": "",
                 "order": [{"field": "properties/name", "direction": "Asc"}],
@@ -202,6 +204,19 @@ public class ModelClient : IDisposable
     {
         _httpClient?.Dispose();
         _handler?.Dispose();
+    }
+
+    private static void RunFixups(List<ModelEntity> allModels)
+    {
+        foreach (var model in allModels)
+        {
+            // Fix up Phi-4 version to 7 since 8 doesn't work in Azure.
+            if (model.Annotations?.Name == "Phi-4")
+            {
+                model.Properties!.AlphanumericVersion = "7";
+                model.Version = "7";
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This pull request fixes the AI Foundry model generation tool and the generated model definitions.

* Removed all "Phi-3" and "Phi-3.5" model definitions since that model is retired.
* Updated the version of the `Phi-4` model from `"8"` to `"7"` in `AIFoundryModel.Generated.cs`, ensuring the generated code references the correct model version.
* Removed the `Phi-4-multimodal-instruct` model definition since it doesn't work.

Fix #11288

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
