### PR TITLE
Avoid run-mode specific prompts in parameter processing

### DIFF
--- a/src/Aspire.Hosting/Resources/InteractionStrings.Designer.cs
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.Designer.cs
@@ -167,6 +167,15 @@ namespace Aspire.Hosting.Resources {
                 return ResourceManager.GetString("ParametersInputsMessage", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Please provide values for the unresolved parameters..
+        /// </summary>
+        internal static string ParametersInputsMessagePublishMode {
+            get {
+                return ResourceManager.GetString("ParametersInputsMessagePublishMode", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Enter value for {0}.

--- a/src/Aspire.Hosting/Resources/InteractionStrings.resx
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.resx
@@ -130,6 +130,9 @@
     <value>Please provide values for the unresolved parameters. Parameters can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.</value>
     <comment>Contains markdown</comment>
   </data>
+  <data name="ParametersInputsMessagePublishMode" xml:space="preserve">
+    <value>Please provide values for the unresolved parameters.</value>
+  </data>
   <data name="ParametersInputsParameterPlaceholder" xml:space="preserve">
     <value>Enter value for {0}</value>
   </data>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Zadejte prosím hodnoty pro nevyřešené parametry. Parametry lze uložit do [tajných kódů uživatele](https://learn.microsoft.com/aspnet/core/security/app-secrets) pro budoucí použití.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">Zadejte hodnotu pro {0}</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Geben Sie Werte für die nicht aufgelösten Parameter an. Parameter können zur zukünftigen Verwendung in [Benutzergeheimnisse](https://learn.microsoft.com/aspnet/core/security/app-secrets) gespeichert werden.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">Wert für {0} eingeben</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Proporcione valores para los parámetros sin resolver. Los parámetros se pueden guardar en [secretos de usuario](https://learn.microsoft.com/aspnet/core/security/app-secrets) para su uso futuro.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">Escriba el valor de {0}</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Veuillez fournir des valeurs pour les paramètres non résolus. Les paramètres peuvent être enregistrés dans [secrets utilisateur](https://learn.microsoft.com/aspnet/core/security/app-secrets) pour une utilisation future.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">Entrez une valeur pour {0}</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Specifica i valori per i parametri non risolti. I parametri possono essere salvati nei [segreti utente](https://learn.microsoft.com/aspnet/core/security/app-secrets) per un uso futuro.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">Immetti un valore per {0}</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
@@ -62,6 +62,11 @@
         <target state="translated">未解決のパラメーターの値を指定してください。パラメーターは、将来使用のために [ユーザー シークレット](https://learn.microsoft.com/aspnet/core/security/app-secrets) に保存できます。</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">{0} の値を入力してください</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
@@ -62,6 +62,11 @@
         <target state="translated">해결되지 않은 매개 변수에 대한 값을 제공하세요. 나중에 사용할 수 있도록 매개 변수를 [사용자 비밀](https://learn.microsoft.com/aspnet/core/security/app-secrets)에 저장할 수 있습니다.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">{0}에 대한 값 입력</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Podaj wartości dla nierozpoznanych parametrów. Parametry można zapisać we [wpisach tajnych użytkownika](https://learn.microsoft.com/aspnet/core/security/app-secrets) do przyszłego użytku.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">Wprowadź wartość dla {0}</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Insira valores para os parâmetros não resolvidos. Os parâmetros podem ser salvos em [segredos do usuário](https://learn.microsoft.com/aspnet/core/security/app-secrets) para uso futuro.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">Inserir valor para {0}</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Укажите значения для неразрешенных параметров. Параметры можно сохранить в [пользовательских секретах](https://learn.microsoft.com/aspnet/core/security/app-secrets) для дальнейшего использования.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">Введите значение для {0}</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Çözülmemiş parametreler için değerleri girin. Parametreler, ileride kullanılmak üzere [kullanıcı gizli bilgileri](https://learn.microsoft.com/aspnet/core/security/app-secrets) bölümüne kaydedilebilir.</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">{0} için değer girin</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="translated">请为未解析的参数提供值。参数可以保存到[用户机密](https://learn.microsoft.com/aspnet/core/security/app-secrets)以供将来使用。</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">输入 {0} 的值</target>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="translated">請提供未解析參數的值。參數可以儲存到 [使用者秘密](https://learn.microsoft.com/aspnet/core/security/app-secrets) 以供未來使用。</target>
         <note>Contains markdown</note>
       </trans-unit>
+      <trans-unit id="ParametersInputsMessagePublishMode">
+        <source>Please provide values for the unresolved parameters.</source>
+        <target state="new">Please provide values for the unresolved parameters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersInputsParameterPlaceholder">
         <source>Enter value for {0}</source>
         <target state="translated">輸入 {0} 的值</target>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -432,31 +432,17 @@ public class AzureDeployerTests(ITestOutputHelper output)
         using var app = builder.Build();
         var runTask = Task.Run(app.Run);
 
-        // Wait for the notification interaction first
-        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        Assert.Equal("Unresolved parameters", notificationInteraction.Title);
-        Assert.Equal("There are unresolved parameters that need to be set. Please provide values for them.", notificationInteraction.Message);
-
-        // Complete the notification interaction to proceed to inputs dialog
-        notificationInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
-
-        // Wait for the parameter inputs interaction
+        // Wait for the parameter inputs interaction (no notification in publish mode)
         var parameterInputs = await testInteractionService.Interactions.Reader.ReadAsync();
         Assert.Equal("Set unresolved parameters", parameterInputs.Title);
 
-        // Verify the parameter input (should include save to secrets option)
+        // Verify the parameter input (should not include save to secrets option in publish mode)
         Assert.Collection(parameterInputs.Inputs,
             input =>
             {
                 Assert.Equal("test-param", input.Label);
                 Assert.Equal(InputType.Text, input.InputType);
                 Assert.Equal("Enter value for test-param", input.Placeholder);
-            },
-            input =>
-            {
-                Assert.Equal("Save to user secrets", input.Label);
-                Assert.Equal(InputType.Boolean, input.InputType);
-                Assert.False(input.Required);
             });
 
         // Complete the parameter inputs interaction
@@ -517,18 +503,11 @@ public class AzureDeployerTests(ITestOutputHelper output)
         using var app = builder.Build();
         var runTask = Task.Run(app.Run);
 
-        // Wait for the notification interaction first
-        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        Assert.Equal("Unresolved parameters", notificationInteraction.Title);
-
-        // Complete the notification interaction to proceed to inputs dialog
-        notificationInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
-
-        // Wait for the parameter inputs interaction
+        // Wait for the parameter inputs interaction (no notification in publish mode)
         var parameterInputs = await testInteractionService.Interactions.Reader.ReadAsync();
         Assert.Equal("Set unresolved parameters", parameterInputs.Title);
 
-        // Verify the custom input generator is respected (should include save to secrets option)
+        // Verify the custom input generator is respected (should not include save to secrets option in publish mode)
         Assert.Collection(parameterInputs.Inputs,
             input =>
             {
@@ -538,12 +517,6 @@ public class AzureDeployerTests(ITestOutputHelper output)
                 Assert.Equal(InputType.Number, input.InputType);
                 Assert.Equal("8080", input.Placeholder);
                 Assert.False(input.EnableDescriptionMarkdown);
-            },
-            input =>
-            {
-                Assert.Equal("Save to user secrets", input.Label);
-                Assert.Equal(InputType.Boolean, input.InputType);
-                Assert.False(input.Required);
             });
 
         // Complete the parameter inputs interaction
@@ -671,31 +644,17 @@ public class AzureDeployerTests(ITestOutputHelper output)
         using var app = builder.Build();
         var runTask = Task.Run(app.Run);
 
-        // Wait for the notification interaction first
-        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        Assert.Equal("Unresolved parameters", notificationInteraction.Title);
-        Assert.Equal("There are unresolved parameters that need to be set. Please provide values for them.", notificationInteraction.Message);
-
-        // Complete the notification interaction to proceed to inputs dialog
-        notificationInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
-
-        // Wait for the parameter inputs interaction
+        // Wait for the parameter inputs interaction (no notification in publish mode)
         var parameterInputs = await testInteractionService.Interactions.Reader.ReadAsync();
         Assert.Equal("Set unresolved parameters", parameterInputs.Title);
 
-        // Verify the generated parameter is prompted for
+        // Verify the generated parameter is prompted for (should not include save to secrets option in publish mode)
         Assert.Collection(parameterInputs.Inputs,
             input =>
             {
                 Assert.Equal("cache-password", input.Label);
                 Assert.Equal(InputType.SecretText, input.InputType);
                 Assert.Equal("Enter value for cache-password", input.Placeholder);
-                Assert.False(input.Required);
-            },
-            input =>
-            {
-                Assert.Equal("Save to user secrets", input.Label);
-                Assert.Equal(InputType.Boolean, input.InputType);
                 Assert.False(input.Required);
             });
 
@@ -731,30 +690,17 @@ public class AzureDeployerTests(ITestOutputHelper output)
         using var app = builder.Build();
         var runTask = Task.Run(app.Run);
 
-        // Wait for the notification interaction first
-        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        Assert.Equal("Unresolved parameters", notificationInteraction.Title);
-
-        // Complete the notification interaction to proceed to inputs dialog
-        notificationInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
-
-        // Wait for the parameter inputs interaction
+        // Wait for the parameter inputs interaction (no notification in publish mode)
         var parameterInputs = await testInteractionService.Interactions.Reader.ReadAsync();
         Assert.Equal("Set unresolved parameters", parameterInputs.Title);
 
-        // Verify the dependent parameter is discovered and prompted for
+        // Verify the dependent parameter is discovered and prompted for (should not include save to secrets option in publish mode)
         Assert.Collection(parameterInputs.Inputs,
             input =>
             {
                 Assert.Equal("dependent-param", input.Label);
                 Assert.Equal(InputType.Text, input.InputType);
                 Assert.Equal("Enter value for dependent-param", input.Placeholder);
-            },
-            input =>
-            {
-                Assert.Equal("Save to user secrets", input.Label);
-                Assert.Equal(InputType.Boolean, input.InputType);
-                Assert.False(input.Required);
             });
 
         // Complete the parameter inputs interaction
@@ -789,30 +735,17 @@ public class AzureDeployerTests(ITestOutputHelper output)
         using var app = builder.Build();
         var runTask = Task.Run(app.Run);
 
-        // Wait for the notification interaction first
-        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        Assert.Equal("Unresolved parameters", notificationInteraction.Title);
-
-        // Complete the notification interaction to proceed to inputs dialog
-        notificationInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
-
-        // Wait for the parameter inputs interaction
+        // Wait for the parameter inputs interaction (no notification in publish mode)
         var parameterInputs = await testInteractionService.Interactions.Reader.ReadAsync();
         Assert.Equal("Set unresolved parameters", parameterInputs.Title);
 
-        // Verify the dependent parameter is discovered and prompted for
+        // Verify the dependent parameter is discovered and prompted for (should not include save to secrets option in publish mode)
         Assert.Collection(parameterInputs.Inputs,
             input =>
             {
                 Assert.Equal("app-port", input.Label);
                 Assert.Equal(InputType.Text, input.InputType);
                 Assert.Equal("Enter value for app-port", input.Placeholder);
-            },
-            input =>
-            {
-                Assert.Equal("Save to user secrets", input.Label);
-                Assert.Equal(InputType.Boolean, input.InputType);
-                Assert.False(input.Required);
             });
 
         // Complete the parameter inputs interaction


### PR DESCRIPTION
Closes https://github.com/dotnet/aspire/issues/11528 by conditionally rendering run-mode specific interactions during parameter processing.