### PR TITLE
[release/9.5] Remove IServiceProvider from ContainerImageReference 

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
@@ -320,7 +320,7 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
     }
 
     protected ProvisioningParameter AllocateContainerImageParameter()
-        => AllocateParameter(new ContainerImageReference(resource, _containerAppEnvironmentContext.ServiceProvider));
+        => AllocateParameter(new ContainerImageReference(resource));
 
     protected BicepValue<string> AllocateContainerPortParameter()
         => AllocateParameter(new ContainerPortReference(resource));

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -211,7 +211,7 @@ internal sealed class AzureAppServiceWebsiteContext(
         var appServicePlanParameter = environmentContext.Environment.PlanIdOutputReference.AsProvisioningParameter(infra);
         var acrMidParameter = environmentContext.Environment.ContainerRegistryManagedIdentityId.AsProvisioningParameter(infra);
         var acrClientIdParameter = environmentContext.Environment.ContainerRegistryClientId.AsProvisioningParameter(infra);
-        var containerImage = AllocateParameter(new ContainerImageReference(Resource, environmentContext.ServiceProvider));
+        var containerImage = AllocateParameter(new ContainerImageReference(Resource));
 
         var webSite = new WebSite("webapp")
         {

--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -29,7 +29,6 @@ internal sealed class AzureDeployingContext(
     IResourceContainerImageBuilder containerImageBuilder,
     IProcessRunner processRunner,
     ParameterProcessor parameterProcessor,
-    IServiceProvider serviceProvider,
     IConfiguration configuration,
     ITokenCredentialProvider tokenCredentialProvider)
 {
@@ -408,7 +407,7 @@ internal sealed class AzureDeployingContext(
                         .Select(async resource =>
                         {
                             var localImageName = resource.Name.ToLowerInvariant();
-                            IValueProvider cir = new ContainerImageReference(resource, serviceProvider);
+                            IValueProvider cir = new ContainerImageReference(resource);
                             var targetTag = await cir.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
                             var pushTask = await pushStep.CreateTaskAsync($"Pushing {resource.Name} to {registryName}", cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -89,7 +89,6 @@ public sealed class AzureEnvironmentResource : Resource
             containerImageBuilder,
             processRunner,
             parameterProcessor,
-            context.Services,
             configuration,
             tokenCredentialProvider);
 

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentContext.cs
@@ -7,9 +7,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Docker;
 
-internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentResource environment, ILogger logger, IServiceProvider serviceProvider)
+internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentResource environment, ILogger logger)
 {
-    public IServiceProvider ServiceProvider => serviceProvider;
     public async Task<DockerComposeServiceResource> CreateDockerComposeServiceResourceAsync(IResource resource, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
     {
         if (environment.ResourceMapping.TryGetValue(resource, out var existingResource))
@@ -19,7 +18,7 @@ internal sealed class DockerComposeEnvironmentContext(DockerComposeEnvironmentRe
 
         logger.LogInformation("Creating Docker Compose resource for {ResourceName}", resource.Name);
 
-        var serviceResource = new DockerComposeServiceResource(resource.Name, resource, environment, ServiceProvider);
+        var serviceResource = new DockerComposeServiceResource(resource.Name, resource, environment);
         environment.ResourceMapping[resource] = serviceResource;
 
         // Process endpoints

--- a/src/Aspire.Hosting.Docker/DockerComposeInfrastructure.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeInfrastructure.cs
@@ -14,8 +14,7 @@ namespace Aspire.Hosting.Docker;
 /// </summary>
 internal sealed class DockerComposeInfrastructure(
     ILogger<DockerComposeInfrastructure> logger,
-    DistributedApplicationExecutionContext executionContext,
-    IServiceProvider serviceProvider) : IDistributedApplicationLifecycleHook
+    DistributedApplicationExecutionContext executionContext) : IDistributedApplicationLifecycleHook
 {
     public async Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
@@ -35,7 +34,7 @@ internal sealed class DockerComposeInfrastructure(
 
         foreach (var environment in dockerComposeEnvironments)
         {
-            var dockerComposeEnvironmentContext = new DockerComposeEnvironmentContext(environment, logger, serviceProvider);
+            var dockerComposeEnvironmentContext = new DockerComposeEnvironmentContext(environment, logger);
 
             if (environment.DashboardEnabled && environment.Dashboard?.Resource is DockerComposeAspireDashboardResource dashboard)
             {

--- a/src/Aspire.Hosting.Docker/DockerComposeServiceExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeServiceExtensions.cs
@@ -103,7 +103,7 @@ public static class DockerComposeServiceExtensions
         );
     }
 
-    internal static string AsContainerImagePlaceholder(this DockerComposeServiceResource dockerComposeService, IServiceProvider? serviceProvider = null)
+    internal static string AsContainerImagePlaceholder(this DockerComposeServiceResource dockerComposeService)
     {
         var resourceInstance = dockerComposeService.TargetResource;
 
@@ -113,7 +113,7 @@ public static class DockerComposeServiceExtensions
              imageEnvName,
              description: $"Container image name for {resourceInstance.Name}",
              defaultValue: $"{resourceInstance.Name}:latest",
-             source: new ContainerImageReference(resourceInstance, serviceProvider)
+             source: new ContainerImageReference(resourceInstance)
         );
     }
 

--- a/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.Docker;
 /// <summary>
 /// Represents a compute resource for Docker Compose with strongly-typed properties.
 /// </summary>
-public class DockerComposeServiceResource(string name, IResource resource, DockerComposeEnvironmentResource composeEnvironmentResource, IServiceProvider? serviceProvider = null) : Resource(name), IResourceWithParent<DockerComposeEnvironmentResource>
+public class DockerComposeServiceResource(string name, IResource resource, DockerComposeEnvironmentResource composeEnvironmentResource) : Resource(name), IResourceWithParent<DockerComposeEnvironmentResource>
 {
     /// <summary>
     /// Most common shell executables used as container entrypoints in Linux containers.
@@ -45,11 +45,6 @@ public class DockerComposeServiceResource(string name, IResource resource, Docke
     /// Gets the resource that is the target of this Docker Compose service.
     /// </summary>
     internal IResource TargetResource => resource;
-
-    /// <summary>
-    /// Gets the service provider for accessing services during callback execution, if available.
-    /// </summary>
-    internal IServiceProvider? ServiceProvider { get; } = serviceProvider;
 
     /// <summary>
     /// Gets the collection of environment variables for the Docker Compose service.
@@ -101,7 +96,7 @@ public class DockerComposeServiceResource(string name, IResource resource, Docke
         // it will come as a parameter
         if (resourceInstance.TryGetLastAnnotation<DockerfileBuildAnnotation>(out _) || resourceInstance is ProjectResource)
         {
-            containerImageName = this.AsContainerImagePlaceholder(ServiceProvider);
+            containerImageName = this.AsContainerImagePlaceholder();
             return true;
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/DeploymentImageTagAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DeploymentImageTagAnnotation.cs
@@ -21,11 +21,6 @@ public sealed class DeploymentImageTagCallbackAnnotationContext
     /// Gets the cancellation token associated with the callback context.
     /// </summary>
     public required CancellationToken CancellationToken { get; init; }
-
-    /// <summary>
-    /// Gets the execution context associated with this invocation of the AppHost.
-    /// </summary>
-    public required DistributedApplicationExecutionContext ExecutionContext { get; init; }
 }
 
 /// <summary>

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -334,7 +334,6 @@ public class ResourceExtensionsTests
         {
             Resource = containerResource.Resource,
             CancellationToken = CancellationToken.None,
-            //ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
         };
         var result = await annotation.Callback(context);
         Assert.Equal("test-tag", result);
@@ -376,7 +375,6 @@ public class ResourceExtensionsTests
         {
             Resource = containerResource.Resource,
             CancellationToken = CancellationToken.None,
-            //ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
         };
         
         Assert.Equal("tag1", await annotations[0].Callback(context));
@@ -420,7 +418,6 @@ public class ResourceExtensionsTests
         {
             Resource = containerResource.Resource,
             CancellationToken = CancellationToken.None,
-            //ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
         };
         
         // Callback should return different values when called multiple times
@@ -450,7 +447,6 @@ public class ResourceExtensionsTests
         {
             Resource = containerResource.Resource,
             CancellationToken = CancellationToken.None,
-            //ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
         };
         var result = await annotation.Callback(context);
         Assert.Equal("async-tag-test-container", result);

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -334,7 +334,7 @@ public class ResourceExtensionsTests
         {
             Resource = containerResource.Resource,
             CancellationToken = CancellationToken.None,
-            ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
+            //ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
         };
         var result = await annotation.Callback(context);
         Assert.Equal("test-tag", result);
@@ -376,7 +376,7 @@ public class ResourceExtensionsTests
         {
             Resource = containerResource.Resource,
             CancellationToken = CancellationToken.None,
-            ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
+            //ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
         };
         
         Assert.Equal("tag1", await annotations[0].Callback(context));
@@ -420,7 +420,7 @@ public class ResourceExtensionsTests
         {
             Resource = containerResource.Resource,
             CancellationToken = CancellationToken.None,
-            ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
+            //ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
         };
         
         // Callback should return different values when called multiple times
@@ -450,7 +450,7 @@ public class ResourceExtensionsTests
         {
             Resource = containerResource.Resource,
             CancellationToken = CancellationToken.None,
-            ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
+            //ExecutionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
         };
         var result = await annotation.Callback(context);
         Assert.Equal("async-tag-test-container", result);


### PR DESCRIPTION
API Review feedback: https://github.com/dotnet/aspire/pull/10763#discussion_r2363467749 Things inside the app model shouldn't hold on to an IServiceProvider.

This means that DeploymentImageTagCallbackAnnotationContext doesn't get an ExecutionContext (for now). In a future release, we will consider how to flow the ExecutionContext into the callback, if necessary.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
