### PR TITLE
Ensure that the Tool form of the Aspire CLI is platform-independent, framework-dependent.

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -26,7 +26,10 @@
     <RollForward>Major</RollForward>
     <PackageTags>aspire cli</PackageTags>
     <Description>Command line tool for Aspire developers.</Description>
+    <!-- For 9.5 we want to keep the tool platform-independent, framework-dependent.
+         To do this we make sure it doesn't PublishAOT, and ensure that it doesn't publish for any RIDs at all. -->
     <PublishAot>false</PublishAot>
+    <RuntimeIdentifiers></RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(PublishAot)' == 'true'">


### PR DESCRIPTION
## Description

The current 9.5 CLI tool packages are using the .NET 10 RID-specific tool feature because they inherited the `RuntimeIdentifiers` value of the parent `Aspire.Cli.csproj`. This feature limits consumers of the tool to .NET 10+ SDKs. We don't want that quite yet, so this PR ensures that we build a framework-dependent, platform-independent tool package for the Aspire CLI.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
