### PR TITLE
Also sort by updated_at  in get-aspire-cli-pr script

### DIFF
--- a/eng/scripts/get-aspire-cli-pr.ps1
+++ b/eng/scripts/get-aspire-cli-pr.ps1
@@ -760,7 +760,7 @@ function Find-WorkflowRun {
 
     Write-Message "Finding ci.yml workflow run for SHA: $HeadSHA" -Level Verbose
 
-    $runId = Invoke-GitHubAPICall -Endpoint "$Script:GHReposBase/actions/workflows/ci.yml/runs?event=pull_request&head_sha=$HeadSHA" -JqFilter ".workflow_runs | sort_by(.created_at) | reverse | .[0].id" -ErrorMessage "Failed to query workflow runs for SHA: $HeadSHA"
+    $runId = Invoke-GitHubAPICall -Endpoint "$Script:GHReposBase/actions/workflows/ci.yml/runs?event=pull_request&head_sha=$HeadSHA" -JqFilter ".workflow_runs | sort_by(.created_at, .updated_at) | reverse | .[0].id" -ErrorMessage "Failed to query workflow runs for SHA: $HeadSHA"
 
     if ([string]::IsNullOrWhiteSpace($runId) -or $runId -eq "null") {
         throw "No ci.yml workflow run found for PR SHA: $HeadSHA. This could mean no workflow has been triggered for this SHA $HeadSHA . Check at https://github.com/dotnet/aspire/actions/workflows/ci.yml"

--- a/eng/scripts/get-aspire-cli-pr.sh
+++ b/eng/scripts/get-aspire-cli-pr.sh
@@ -653,7 +653,7 @@ find_workflow_run() {
     say_verbose "Finding ci.yml workflow run for SHA: $head_sha"
 
     local workflow_run_id
-    if ! workflow_run_id=$(gh_api_call "${GH_REPOS_BASE}/actions/workflows/ci.yml/runs?event=pull_request&head_sha=$head_sha" ".workflow_runs | sort_by(.created_at) | reverse | .[0].id" "Failed to query workflow runs for SHA: $head_sha"); then
+    if ! workflow_run_id=$(gh_api_call "${GH_REPOS_BASE}/actions/workflows/ci.yml/runs?event=pull_request&head_sha=$head_sha" ".workflow_runs | sort_by(.created_at, .updated_at) | reverse | .[0].id" "Failed to query workflow runs for SHA: $head_sha"); then
         return 1
     fi
 


### PR DESCRIPTION
`iex "& { $(irm https://raw.githubusercontent.com/dotnet/aspire/main/eng/scripts/get-aspire-cli-pr.ps1) } 11570 -Verbose"` fails because there are 2 runs with the same `created_at` time. Also sort by `updated_at` to get the real latest run.