### PR TITLE
note about python in linux

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,6 +10,16 @@ See [machine-requirements.md](machine-requirements.md).
 
 `.\build.sh` (macOS and Linux) or `.\build.cmd` (Windows)
 
+### Python requirement
+
+Some playground projects (such as `AspireWithPython`) require Python to be available during the build process to create virtual environments. On Linux systems, you may need to install the `python-is-python3` package to make the `python` command available:
+
+```bash
+sudo apt install python-is-python3
+```
+
+This is because the build process uses `python -m venv` commands, but many Linux distributions only provide `python3` by default.
+
 ## Using the `dotnet` CLI
 
 In building and testing, never use the global `dotnet` copy. Use `./dotnet.sh` on Unix, `.\dotnet.cmd` on Windows.


### PR DESCRIPTION
Adding a note about python for contributing with Linux.
I was having issues running the `build.sh` script from the root because everything was building but there was an error at the end with no description.
Took me some time to figure it was because the sample with python tries to call `python`.

Hopefully this note can help folks to get ready for it since the beginning and save some time.