### PR TITLE
Remove memory limit from Kusto emulator

### DIFF
--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -184,8 +184,7 @@ public static class AzureKustoBuilderExtensions
                 Image = AzureKustoEmulatorContainerImageTags.Image,
                 Tag = AzureKustoEmulatorContainerImageTags.Tag
             })
-            .WithEnvironment("ACCEPT_EULA", "Y")
-            .WithContainerRuntimeArgs("--memory", "4G");
+            .WithEnvironment("ACCEPT_EULA", "Y");
 
         configureContainer?.Invoke(surrogateBuilder);
 

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/AddAzureKustoTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/AddAzureKustoTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Testing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Azure.Kusto.Tests;
@@ -103,6 +104,22 @@ public class AddAzureKustoTests
         var annotation = resourceBuilder.Resource.Annotations.OfType<ContainerNameAnnotation>().SingleOrDefault();
         Assert.NotNull(annotation);
         Assert.Equal("custom-kusto-emulator", annotation.Name);
+    }
+
+    [Fact]
+    public async Task RunAsEmulator_SetsEula()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Act
+        var resourceBuilder = builder.AddAzureKustoCluster("kusto").RunAsEmulator();
+
+        // Assert
+        var annotation = resourceBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>().SingleOrDefault();
+        Assert.NotNull(annotation);
+        var env = await builder.GetEnvironmentVariables(annotation);
+        Assert.Equivalent(new Dictionary<string, object>() { { "ACCEPT_EULA", "Y" } }, env);
     }
 
     [Theory]
@@ -351,5 +368,16 @@ public class AddAzureKustoTests
         // Act & Assert
         var exception = Assert.Throws<ArgumentNullException>(() => builder.RunAsEmulator(c => c.WithHostPort(8080)));
         Assert.Equal("builder", exception.ParamName);
+    }
+}
+
+file static class DistrubutedApplicationTestingBuilderExtensions
+{
+    public static async Task<Dictionary<string, object>> GetEnvironmentVariables(this IDistributedApplicationTestingBuilder builder, EnvironmentCallbackAnnotation annotation)
+    {
+        var context = new EnvironmentCallbackContext(builder.ExecutionContext);
+        await annotation.Callback(context);
+
+        return context.EnvironmentVariables;
     }
 }


### PR DESCRIPTION
## Description

Remove the default memory limit from the Kusto emulator; setting the limit too low can result in errors when running big queries / ingestion, so devs should set the value if needed.

Added tests to verify that all the default emulator values are covered.

Contributes to #8233.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
