### PR TITLE
Enable building of extensions in the internal build pipeline using property directly instead of switch

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -94,7 +94,7 @@ extends:
       autoEnablePREfastWithNewRuleset: false
       autoEnableRoslynWithNewRuleset: false
     sdl:
-      policheck:
+      policheck:-
         enabled: true
         exclusionsFile: $(Build.SourcesDirectory)\.config\PoliCheckExclusions.xml
       eslint:

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -94,7 +94,7 @@ extends:
       autoEnablePREfastWithNewRuleset: false
       autoEnableRoslynWithNewRuleset: false
     sdl:
-      policheck:-
+      policheck:
         enabled: true
         exclusionsFile: $(Build.SourcesDirectory)\.config\PoliCheckExclusions.xml
       eslint:

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -36,7 +36,6 @@ steps:
               -restore -build
               -pack
               -sign $(_SignArgs)
-              -buildExtension
               -publish $(_PublishArgs)
               -configuration ${{ parameters.buildConfig }}
               /bl:${{ parameters.repoLogPath }}/build.binlog
@@ -44,6 +43,7 @@ steps:
               $(_InternalBuildArgs)
               /p:TargetRids=${{ join(':', parameters.targetRids) }}
               /p:SkipTestProjects=true
+              /p:BuildExtension=true
       displayName: 🟣Build
 
     - task: 1ES.PublishBuildArtifacts@1


### PR DESCRIPTION
## Description

Official builds are currently broken since arcade updated the build scripts that were edited in this change: https://github.com/dotnet/aspire/pull/11504 causing the buildExtension switch to not be handled correctly. Instead of trying to pass in a switch, this change just directly passes in the property to the build which will make it so the extension gets built.

FYI: @radical @adamint 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
