### PR TITLE
Suppress Docker security warnings for playground applications

### DIFF
--- a/playground/AspireWithJavaScript/AspireJavaScript.Angular/Dockerfile
+++ b/playground/AspireWithJavaScript/AspireJavaScript.Angular/Dockerfile
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Playground/demo application used for testing Aspire features"
 FROM node:20 as build
 
 WORKDIR /app

--- a/playground/AspireWithJavaScript/AspireJavaScript.React/Dockerfile
+++ b/playground/AspireWithJavaScript/AspireJavaScript.React/Dockerfile
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Playground/demo application used for testing Aspire features"
 FROM node:20 as build
 
 WORKDIR /app

--- a/playground/AspireWithJavaScript/AspireJavaScript.Vite/Dockerfile
+++ b/playground/AspireWithJavaScript/AspireJavaScript.Vite/Dockerfile
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Playground/demo application used for testing Aspire features"
 FROM node:20 as build
 
 WORKDIR /app

--- a/playground/AspireWithJavaScript/AspireJavaScript.Vue/Dockerfile
+++ b/playground/AspireWithJavaScript/AspireJavaScript.Vue/Dockerfile
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Playground/demo application used for testing Aspire features"
 FROM node:20 as build
 
 WORKDIR /app

--- a/playground/AspireWithNode/NodeFrontend/Dockerfile
+++ b/playground/AspireWithNode/NodeFrontend/Dockerfile
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Playground/demo application used for testing Aspire features"
 FROM node:20
  
 WORKDIR /app

--- a/playground/AspireWithPython/InstrumentedPythonProject/Dockerfile
+++ b/playground/AspireWithPython/InstrumentedPythonProject/Dockerfile
@@ -1,3 +1,4 @@
+# DisableDockerDetector "Playground/demo application used for testing Aspire features"
 FROM python:3.12.11-slim AS base
 
 # Set the working directory, the app files could be bind-mounted here


### PR DESCRIPTION
## Description

Problem
Official builds started showing Docker security warnings after a new DockerFile analysis check was introduced. The warnings flagged references to images from external registries (Docker Hub) that violate Microsoft's security policies for containers:

node:20 images used in JavaScript/Node playground apps
nginx:alpine images used for serving static content
python:3.12.11-slim images used in Python playground apps
All warnings originated from playground applications, which are sample/demo code used for testing Aspire features, not production code shipped to customers.

Solution
Added DisableDockerDetector comments to suppress security warnings for playground Dockerfiles that legitimately use external registry images for development and testing purposes.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
