### PR TITLE
Don't require gen_ai.system attribute on span events

### DIFF
--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -208,8 +208,8 @@ public sealed class GenAIVisualizerDialogViewModel
         // Attempt get get messages from span events.
         foreach (var item in viewModel.Span.Events.OrderBy(i => i.Time))
         {
-            if (GenAIHelpers.IsGenAISpan(item.Attributes) &&
-                TryMapEventName(item.Name, out var type))
+            // Detect GenAI messages by event name. Don't check for the gen_ai.system attribute because it's optional on events.
+            if (TryMapEventName(item.Name, out var type))
             {
                 var content = item.Attributes.GetValue(GenAIHelpers.GenAIEventContent);
                 var parts = content != null ? DeserializeBody(type.Value, content) : [];

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -242,6 +242,12 @@ public sealed class GenAIVisualizerDialogViewModelTests
                 startTime: 2,
                 attributes: [
                     KeyValuePair.Create(GenAIHelpers.GenAIEventContent, JsonSerializer.Serialize(new AssistantEvent { Content = "Assistant!" }, GenAIEventsContext.Default.AssistantEvent)),
+                ]),
+            CreateSpanEvent(
+                name: "other_name_that_is_ignored",
+                startTime: 3,
+                attributes: [
+                    KeyValuePair.Create(GenAIHelpers.GenAIEventContent, JsonSerializer.Serialize(new AssistantEvent { Content = "Assistant!" }, GenAIEventsContext.Default.AssistantEvent)),
                     KeyValuePair.Create(GenAIHelpers.GenAISystem, "System!"),
                 ])
         };


### PR DESCRIPTION
## Description

User reported issue that some GenAI messages weren't displayed in the visualizer. The problem is the dashboard incorrectly requires `gen_ai.system` attribute to be on span events, but the spec says they're only recommended: https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/gen-ai/gen-ai-events.md#event-gen_aichoice

Semantic Kernel sometimes doesn't include the attribute. Its messages end up missing from the UI.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
