### PR TITLE
Fix HTTP display summary with newer HTTP client telemetry

### DIFF
--- a/src/Aspire.Dashboard/Model/GenAI/GenAIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIHelpers.cs
@@ -19,7 +19,6 @@ public static class GenAIHelpers
 
     public static bool IsGenAISpan(KeyValuePair<string, string>[] attributes)
     {
-        return attributes.GetValue(GenAISystem) is { Length: > 0 } ||
-            attributes.GetValue(GenAIProviderName) is { Length: > 0 };
+        return attributes.GetValueWithFallback(GenAISystem, GenAIProviderName) is { Length: > 0 };
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -332,6 +332,20 @@ public static class OtlpHelpers
         return null;
     }
 
+    public static string? GetValueWithFallback(this KeyValuePair<string, string>[] values, params ReadOnlySpan<string> names)
+    {
+        // Attempt each name in order and return the first match.
+        foreach (var name in names)
+        {
+            if (values.GetValue(name) is { } value)
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
     public static int? GetValueAsInteger(this KeyValuePair<string, string>[] values, string name)
     {
         var value = values.GetValue(name);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpSpanTests.cs
@@ -126,4 +126,62 @@ public class OtlpSpanTests
         // Assert
         Assert.Equal(app2, destination);
     }
+
+    public static IEnumerable<object[]> DisplaySummary_SpanData =>
+        new List<object[]>
+        {
+            new object[]
+            {
+                "HTTP GET 200",
+                "SpanName!",
+                OtlpSpanKind.Client,
+                new KeyValuePair<string, string>[]
+                {
+                    KeyValuePair.Create("http.request.method", "GET"),
+                    KeyValuePair.Create("http.response.status_code", "200")
+                }
+            },
+            new object[]
+            {
+                "HTTP GET 200",
+                "SpanName!",
+                OtlpSpanKind.Client,
+                new KeyValuePair<string, string>[]
+                {
+                    KeyValuePair.Create("http.method", "GET"),
+                    KeyValuePair.Create("http.status_code", "200")
+                }
+            },
+            new object[]
+            {
+                "SpanName!",
+                "SpanName!",
+                OtlpSpanKind.Server,
+                new KeyValuePair<string, string>[]
+                {
+                    KeyValuePair.Create("http.method", "GET"),
+                    KeyValuePair.Create("http.status_code", "200")
+                }
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(DisplaySummary_SpanData))]
+    public void GetDisplaySummary_SpanData_ReturnExpectedDisplaySummary(string expectedDisplaySummary, string spanName, OtlpSpanKind kind, KeyValuePair<string, string>[] attributes)
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app = new OtlpResource("app", "instance", uninstrumentedPeer: false, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+
+        var span = TelemetryTestHelpers.CreateOtlpSpan(app, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime,
+            kind: kind, attributes: attributes, spanName: spanName);
+
+        // Act
+        var displaySummary = span.GetDisplaySummary();
+
+        // Assert
+        Assert.Equal(expectedDisplaySummary, displaySummary);
+    }
 }

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -305,7 +305,7 @@ internal static class TelemetryTestHelpers
 
     public static OtlpSpan CreateOtlpSpan(OtlpResource resource, OtlpTrace trace, OtlpScope scope, string spanId, string? parentSpanId, DateTime startDate,
         KeyValuePair<string, string>[]? attributes = null, OtlpSpanStatusCode? statusCode = null, string? statusMessage = null, OtlpSpanKind kind = OtlpSpanKind.Unspecified,
-        OtlpResource? uninstrumentedPeer = null, DateTime? endDate = null)
+        OtlpResource? uninstrumentedPeer = null, DateTime? endDate = null, string? spanName = null)
     {
         return new OtlpSpan(resource.GetView([]), trace, scope)
         {
@@ -315,7 +315,7 @@ internal static class TelemetryTestHelpers
             Events = [],
             Kind = kind,
             Links = [],
-            Name = "Test",
+            Name = spanName ?? "Test",
             ParentSpanId = parentSpanId,
             SpanId = spanId,
             StartTime = startDate,


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/11684

After:
<img width="676" height="410" alt="image" src="https://github.com/user-attachments/assets/2ac4062a-97e9-4054-8002-5734cf10872f" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
