### PR TITLE
Truncate span name with ellipsis

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -172,6 +172,9 @@
 
 ::deep .resource-name {
     margin-left: 16px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 ::deep .trace-header {


### PR DESCRIPTION
## Description

It triggered me that this column didn't truncate with an ellipsis.

<img width="1060" height="543" alt="image" src="https://github.com/user-attachments/assets/8789ef37-f63c-44e4-900b-8ba88dbdba65" />