### PR TITLE
Add session message notification type to IDE protocol

### DIFF
--- a/docs/specs/IDE-execution.md
+++ b/docs/specs/IDE-execution.md
@@ -266,7 +266,6 @@ Properties specific to session message notification are:
 | `code` | The error code. See [error reporting](#error-reporting) for more information. Only valid for error messages (`level == error`). | `string` (required for error messages) |
 | `details` | Error details. See [error reporting](#error-reporting) for more information. Only valid for error messages (`level == error`). | `ErrorDetail[]` (optional) |
 
-
 ## Error reporting
 
 When the IDE encounters an error during request processing, the request response should include a body in JSON format, with a single property named "error", for example:

--- a/docs/specs/IDE-execution.md
+++ b/docs/specs/IDE-execution.md
@@ -254,7 +254,7 @@ The log notification is emitted when the service program writes something to sta
 
 ### Session message notification
 
-The session message notification is emitted when the IDE needs to notify the client (and the Aspire developer) about asynchronous event related to a debug session. Session messages have 3 levels: error, info, and debug. By default errors and info messages are displayed to the developer; debug messages are suppressed unless the client was started in debug mode.
+The session message notification is emitted when the IDE needs to notify the client (and the Aspire developer) about asynchronous events related to a debug session. Session messages have 3 levels: error, info, and debug. By default errors and info messages are displayed to the developer; debug messages are suppressed unless the client was started in debug mode.
 
 Properties specific to session message notification are:
 
@@ -263,8 +263,8 @@ Properties specific to session message notification are:
 | `notification_type` | Must be `sessionMessage` | `string` |
 | `level` | Must be `error`, `info`, or `debug` | `string` |
 | `message` | The content of the message. | `string` |
-| `code` | For messages with `level == error`: the error code. See [error reporting](#error-reporting) for more information. | `string` (required for error messages) |
-| `details` | For messages with `level == error`: error details. See [error reporting](#error-reporting) for more information. | `ErrorDetail[]` (optional) |
+| `code` | The error code. See [error reporting](#error-reporting) for more information. Only valid for error messages (`level == error`). | `string` (required for error messages) |
+| `details` | Error details. See [error reporting](#error-reporting) for more information. Only valid for error messages (`level == error`). | `ErrorDetail[]` (optional) |
 
 
 ## Error reporting

--- a/docs/specs/IDE-execution.md
+++ b/docs/specs/IDE-execution.md
@@ -219,7 +219,7 @@ Every run change notification has the following properties:
 
 | Property | Description | Type |
 | --- | --------- | --- |
-| `notification_type` | One of `processRestarted`, `sessionTerminated`, or `serviceLogs`: indicates the type of notification. | `string` (limited set of values) |
+| `notification_type` | One of `processRestarted`, `sessionTerminated`, `serviceLogs`, or `sessionMessage`: indicates the type of notification. | `string` (limited set of values) |
 | `session_id` | The ID of the run session that the notification is related to. | `string` |
 
 ### Process restarted notification
@@ -240,7 +240,7 @@ Session terminated notification is emitted when the session is terminated (the p
 | Property | Description | Type |
 | --- | --------- | --- |
 | `notification_type` | Must be `sessionTerminated` | `string` |
-| `exit_code` | The exit code of the process associated with the run session. | `number` (representing unsigned 32-bit integer) |
+| `exit_code` | The exit code of the process associated with the run session. <br/><br/> Can be omitted, indicating exit code could not be captured, or is not applicable, e.g. when a debug session ended for a reason other than program exit. | `number` (representing unsigned 32-bit integer) |
 
 ### Log notification
 
@@ -251,6 +251,21 @@ The log notification is emitted when the service program writes something to sta
 | `notification_type` | Must be `serviceLogs` | `string` |
 | `is_std_err` | True if the output comes from standard error stream, otherwise false (implying standard output stream). | `boolean` |
 | `log_message` | The text written by the service program. | `string` |
+
+### Session message notification
+
+The session message notification is emitted when the IDE needs to notify the client (and the Aspire developer) about asynchronous event related to a debug session. Session messages have 3 levels: error, info, and debug. By default errors and info messages are displayed to the developer; debug messages are suppressed unless the client was started in debug mode.
+
+Properties specific to session message notification are:
+
+| Property | Description | Type |
+| --- | --------- | --- |
+| `notification_type` | Must be `sessionMessage` | `string` |
+| `level` | Must be `error`, `info`, or `debug` | `string` |
+| `message` | The content of the message. | `string` |
+| `code` | For messages with `level == error`: the error code. See [error reporting](#error-reporting) for more information. | `string` (required for error messages) |
+| `details` | For messages with `level == error`: error details. See [error reporting](#error-reporting) for more information. | `ErrorDetail[]` (optional) |
+
 
 ## Error reporting
 
@@ -269,11 +284,11 @@ When the IDE encounters an error during request processing, the request response
 
 The value of the `error` property is an `ErrorDetail` object with the following properties:
 
-| Property | Description | Required? |
+| Property | Description | Type, required? |
 | --- | --------- | --- |
-| `code` | A machine-readable code that corresponds to distinctive error condition. If the cause of an error can be narrowed down reliably (e.g. file referenced by launch configuration was not found, or the request body does not parse as valid JSON), the corresponding error should be unique. <br/><br/> There will be cases when the cause for the error cannot be pinpointed, and in these cases it is OK to return a catch-all error code e.g. `UnexpectedError`. | Required |
-| `message` | A human-readable message explaining the nature of the error, and providing suggestions for resolution. DCP will display this message as part of the Aspire application host execution log. | Required |
-| `details` | An array of `ErrorDetail` objects providing additional information about the error. | Optional |
+| `code` | A machine-readable code that corresponds to distinctive error condition. If the cause of an error can be narrowed down reliably (e.g. file referenced by launch configuration was not found, or the request body does not parse as valid JSON), the corresponding error should be unique. <br/><br/> There will be cases when the cause for the error cannot be pinpointed, and in these cases it is OK to return a catch-all error code e.g. `UnexpectedError`. | `string` (required) |
+| `message` | A human-readable message explaining the nature of the error, and providing suggestions for resolution. DCP will display this message as part of the Aspire application host execution log. | `string` (required) |
+| `details` | An array of `ErrorDetail` objects providing additional information about the error. | `ErrorDetail[]` (optional) |
 
 ## Protocol versioning
 


### PR DESCRIPTION
## Description

The IDE protocol has provision for reporting errors from requests, but there is no mechanism to report asynchronous errors related to debug sessions. This PR adds that.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
