### PR TITLE
Move all Kusto types into Aspire.Hosting.Azure namespace

### DIFF
--- a/src/Aspire.Hosting.Azure.Kusto/Aspire.Hosting.Azure.Kusto.csproj
+++ b/src/Aspire.Hosting.Azure.Kusto/Aspire.Hosting.Azure.Kusto.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)StringComparers.cs" LinkBase="Utils" />
-    <Compile Include="$(SharedDir)AzureRoleAssignmentUtils.cs" />
+    <Compile Include="$(SharedDir)AzureRoleAssignmentUtils.cs" LinkBase="Utils" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -5,7 +5,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
-using Aspire.Hosting.Azure.Kusto;
 using Azure.Identity;
 using Azure.Provisioning;
 using Azure.Provisioning.Kusto;

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoClusterResource.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoClusterResource.cs
@@ -10,7 +10,7 @@ using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Kusto;
 using Azure.Provisioning.Primitives;
 
-namespace Aspire.Hosting.Azure.Kusto;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// A resource that represents a Kusto cluster.

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoCreateDatabaseScriptAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoCreateDatabaseScriptAnnotation.cs
@@ -3,7 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 
-namespace Aspire.Hosting.Azure.Kusto;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Annotation to store a Kusto database creation script.

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerDefaults.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerDefaults.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Hosting.Azure.Kusto;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Default values for the Kusto emulator container.

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerImageTags.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Hosting.Azure.Kusto;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Container image configuration for the Kusto emulator.

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorResource.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorResource.cs
@@ -3,7 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 
-namespace Aspire.Hosting.Azure.Kusto;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// A resource that represents a Kusto emulator running as a container.

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoHealthCheck.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoHealthCheck.cs
@@ -6,7 +6,7 @@ using Kusto.Data.Common;
 using Kusto.Data.Net.Client;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-namespace Aspire.Hosting.Azure.Kusto;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// A health check to validate that the Kusto service is available and responsive.

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoHealthCheckBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoHealthCheckBuilderExtensions.cs
@@ -5,7 +5,7 @@ using Kusto.Data;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-namespace Aspire.Hosting.Azure.Kusto;
+namespace Aspire.Hosting.Azure;
 
 internal static class AzureKustoHealthCheckBuilderExtensions
 {

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoReadWriteDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoReadWriteDatabaseResource.cs
@@ -8,7 +8,7 @@ using Azure.Provisioning;
 using Azure.Provisioning.Kusto;
 using Kusto.Data;
 
-namespace Aspire.Hosting.Azure.Kusto;
+namespace Aspire.Hosting.Azure;
 
 /// <summary>
 /// Represents an Azure Kusto read-write database resource, which is a child resource of a <see cref="AzureKustoClusterResource"/>.

--- a/tests/Aspire.Hosting.Azure.Tests/AzureKustoExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureKustoExtensionsTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Azure.Kusto;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using static Aspire.Hosting.Utils.AzureManifestUtils;


### PR DESCRIPTION
## Description

The Kusto types were in the namespace `Aspire.Hosting.Azure.Kusto`, whereas the other packages in the Azure family use `Aspire.Hosting.Azure`. Update namespaces to follow convention.

Follow up from #11639, which already moved the extensions type in to `Aspire.Hosting` to match the convention.

Note that this is a preview package.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
