### PR TITLE
Fix GenAI visualizer when span is missing peer attribute

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -400,6 +400,15 @@ app.MapGet("/genai-trace", async () =>
                 ]
               },
               {
+                "role": "assistant",
+                "parts": [
+                  {
+                    "type": "text",
+                    "content": "Assistant content"
+                  }
+                ]
+              },
+              {
                 "role": "user",
                 "parts": [
                   {

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -16,7 +16,8 @@ namespace Aspire.Dashboard.Model.GenAI;
 [DebuggerDisplay("Span = {Span.SpanId}, Title = {Title}, Items = {Items.Count}")]
 public sealed class GenAIVisualizerDialogViewModel
 {
-    private const string UnknownPeerName = "unknown";
+    // The exact name doesn't matter. A value is required when resolving color for peer.
+    private const string UnknownPeerName = "unknown-peer";
 
     public required OtlpSpan Span { get; init; }
     public required string Title { get; init; }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -16,6 +16,8 @@ namespace Aspire.Dashboard.Model.GenAI;
 [DebuggerDisplay("Span = {Span.SpanId}, Title = {Title}, Items = {Items.Count}")]
 public sealed class GenAIVisualizerDialogViewModel
 {
+    private const string UnknownPeerName = "unknown";
+
     public required OtlpSpan Span { get; init; }
     public required string Title { get; init; }
     public required SpanDetailsViewModel SpanDetailsViewModel { get; init; }
@@ -57,7 +59,7 @@ public sealed class GenAIVisualizerDialogViewModel
             SourceName = OtlpResource.GetResourceName(spanDetailsViewModel.Span.Source, resources),
             PeerName = telemetryRepository.GetPeerResource(spanDetailsViewModel.Span) is { } peerResource
                 ? OtlpResource.GetResourceName(peerResource, resources)
-                : OtlpHelpers.GetPeerAddress(spanDetailsViewModel.Span.Attributes) ?? "unknown"
+                : OtlpHelpers.GetPeerAddress(spanDetailsViewModel.Span.Attributes) ?? UnknownPeerName
         };
 
         viewModel.ModelName = viewModel.Span.Attributes.GetValue(GenAIHelpers.GenAIResponseModel);

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -51,7 +51,7 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         Assert.Null(instance.Content.DisplayErrorMessage);
         Assert.Empty(instance.Content.Items);
         Assert.Equal("app", instance.Content.SourceName);
-        Assert.Equal("unknown", instance.Content.PeerName);
+        Assert.Equal("unknown-peer", instance.Content.PeerName);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Dashboard.Components.Dialogs;
+using Aspire.Dashboard.Components.Resize;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.GenAI;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Xunit;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
+
+namespace Aspire.Dashboard.Components.Tests.Controls;
+
+public class GenAIVisualizerDialogTests : DashboardTestContext
+{
+    private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Render_NoGenAIAttributes_Success()
+    {
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var resource = new OtlpResource("app", "instance", uninstrumentedPeer: false, context);
+
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = CreateOtlpScope(context);
+
+        var cut = SetUpDialog(out var dialogService);
+        await GenAIVisualizerDialog.OpenDialogAsync(
+            viewportInformation: new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false),
+            dialogService: dialogService,
+            dialogsLoc: Services.GetRequiredService<IStringLocalizer<Aspire.Dashboard.Resources.Dialogs>>(),
+            span: CreateOtlpSpan(resource, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime),
+            selectedLogEntryId: null,
+            telemetryRepository: Services.GetRequiredService<TelemetryRepository>(),
+            logger: NullLogger.Instance,
+            resources: [],
+            getContextGenAISpans: () => []
+            );
+
+        var instance = cut.FindComponent<GenAIVisualizerDialog>().Instance;
+
+        Assert.Null(instance.Content.DisplayErrorMessage);
+        Assert.Empty(instance.Content.Items);
+        Assert.Equal("app", instance.Content.SourceName);
+        Assert.Equal("unknown", instance.Content.PeerName);
+    }
+
+    [Fact]
+    public async Task Render_HasGenAIMessages_Success()
+    {
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var resource = new OtlpResource("app", "instance", uninstrumentedPeer: false, context);
+
+        var systemInstruction = JsonSerializer.Serialize(new List<MessagePart>
+        {
+            new TextPart { Content = "System!" }
+        }, GenAIMessagesContext.Default.ListMessagePart);
+
+        var inputMessages = JsonSerializer.Serialize(new List<ChatMessage>
+        {
+            new ChatMessage
+            {
+                Role = "user",
+                Parts = [new TextPart { Content = "User!" }]
+            },
+            new ChatMessage
+            {
+                Role = "assistant",
+                Parts = [new ToolCallRequestPart { Name = "generate_names", Arguments = JsonNode.Parse(@"{""count"":2}") }]
+            },
+            new ChatMessage
+            {
+                Role = "user",
+                Parts = [new ToolCallResponsePart { Response = JsonNode.Parse(@"[""Jack"",""Jane""]") }]
+            }
+        }, GenAIMessagesContext.Default.ListChatMessage);
+
+        var outputMessages = JsonSerializer.Serialize(new List<ChatMessage>
+        {
+            new ChatMessage
+            {
+                Role = "assistant",
+                Parts = [new TextPart { Content = "Output!" }]
+            }
+        }, GenAIMessagesContext.Default.ListChatMessage);
+
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = CreateOtlpScope(context);
+        var span = CreateOtlpSpan(resource, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime, attributes: [
+            KeyValuePair.Create(GenAIHelpers.GenAISystemInstructions, systemInstruction),
+            KeyValuePair.Create(GenAIHelpers.GenAIInputMessages, inputMessages),
+            KeyValuePair.Create(GenAIHelpers.GenAIOutputInstructions, outputMessages)
+        ]);
+
+        var cut = SetUpDialog(out var dialogService);
+        await GenAIVisualizerDialog.OpenDialogAsync(
+            viewportInformation: new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false),
+            dialogService: dialogService,
+            dialogsLoc: Services.GetRequiredService<IStringLocalizer<Aspire.Dashboard.Resources.Dialogs>>(),
+            span: span,
+            selectedLogEntryId: null,
+            telemetryRepository: Services.GetRequiredService<TelemetryRepository>(),
+            logger: NullLogger.Instance,
+            resources: [],
+            getContextGenAISpans: () => []
+            );
+
+        var instance = cut.FindComponent<GenAIVisualizerDialog>().Instance;
+
+        Assert.Equal(5, instance.Content.Items.Count);
+    }
+
+    private IRenderedFragment SetUpDialog(out IDialogService dialogService)
+    {
+        var version = typeof(FluentMain).Assembly.GetName().Version!;
+
+        Services.AddFluentUIComponents();
+        Services.AddSingleton<LibraryConfiguration>();
+        Services.AddSingleton<TelemetryRepository>();
+        Services.AddSingleton<PauseManager>();
+        Services.AddSingleton(new ThemeManager(new TestThemeResolver()));
+
+        Services.AddLocalization();
+        Services.AddSingleton<BrowserTimeProvider, TestTimeProvider>();
+
+        var cut = Render(builder =>
+        {
+            builder.OpenComponent<FluentDialogProvider>(0);
+            builder.CloseComponent();
+        });
+
+        // Setting a provider ID on menu service is required to simulate <FluentMenuProvider> on the page.
+        // This makes FluentMenu render without error.
+        var menuService = Services.GetRequiredService<IMenuService>();
+        menuService.ProviderId = "Test";
+
+        dialogService = Services.GetRequiredService<IDialogService>();
+        return cut;
+    }
+}


### PR DESCRIPTION
## Description

Fix user reported issue when using Semantic Kernel telemetry with GenAI visualizer. Recorded telemetry doesn't have a peer attribute, which later causes a NRE when rendering the page.

The fix is to default the peer name to `unknown` (exact name doesn't matter, as long as it has a name). It now always has a value and there is no chance of NRE.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
