### PR TITLE
Fix console logs race condition

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -308,6 +308,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 {
                     if (lineNumber != null)
                     {
+                        // Set the base line number using the reported line number of the first log line.
                         _logEntries.BaseLineNumber ??= lineNumber;
                     }
 


### PR DESCRIPTION
## Description

Telemetry shows some 9.5 errors on the console logs page:

```
System.InvalidOperationException: Nullable object must have a value.
at Aspire.Hosting.ConsoleLogs.LogEntries.<InsertSortedCore>g__InsertAt|15_0(Int32 index, <>c__DisplayClass15_0&) in /_/src/Shared/ConsoleLogs/LogEntries.cs:line 178
   at Aspire.Hosting.ConsoleLogs.LogEntries.InsertSortedCore(LogEntry logEntry) in /_/src/Shared/ConsoleLogs/LogEntries.cs:line 173
   at Aspire.Dashboard.Components.Pages.ConsoleLogs.StartLogEntryChannelReaderTask() in /_/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs:line 328
   at Aspire.Dashboard.Components.Pages.ConsoleLogs.StartLogEntryChannelReaderTask() in /_/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs:line 307
   at Aspire.Dashboard.Utils.TaskHelpers.WaitIgnoreCancelCoreAsync(Task task, ILogger logger, String logMessage) in /_/src/Shared/TaskHelpers.cs:line 29
   at Aspire.Dashboard.Components.Pages.ConsoleLogs.DisposeAsync() in /_/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs:line 1009
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.<ProcessDisposalQueueInExistingBatch>g__GetH...
```

Fix is to always modify the log entries collection in a lock.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
