### PR TITLE
Give dashboard resource URLs display names

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -8,6 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents an endpoint reference for a resource with endpoints.
 /// </summary>
+[DebuggerDisplay("Resource = {Resource.Name}, EndpointName = {EndpointName}, IsAllocated = {IsAllocated}")]
 public sealed class EndpointReference : IManifestExpressionProvider, IValueProvider, IValueWithReferences
 {
     // A reference to the endpoint annotation if it exists.

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -419,6 +419,31 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             });
         }
 
+        dashboardResource.Annotations.Add(new ResourceUrlsCallbackAnnotation(c =>
+        {
+            foreach (var url in c.Urls)
+            {
+                switch (url.Endpoint?.EndpointName)
+                {
+                    case OtlpGrpcEndpointName:
+                        url.DisplayText = OtlpGrpcEndpointName;
+                        break;
+                    case OtlpHttpEndpointName:
+                        url.DisplayText = OtlpHttpEndpointName;
+                        break;
+                    default:
+                        // Other endpoints are for the dashboard UI. There are typically dashboard UI endpoints for http and https.
+                        // Order these before non-browser usable endpoints.
+                        if (Uri.TryCreate(url.Url, UriKind.Absolute, out var result))
+                        {
+                            url.DisplayText = $"Dashboard ({result.Scheme})";
+                            url.DisplayOrder = 1;
+                        }
+                        break;
+                }
+            }
+        }));
+
         var showDashboardResources = configuration.GetBool(KnownConfigNames.ShowDashboardResources, KnownConfigNames.Legacy.ShowDashboardResources);
         var hideDashboard = !(showDashboardResources ?? false);
 

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -425,20 +425,16 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             {
                 if (url.Endpoint is { } endpoint)
                 {
-                    switch (endpoint.EndpointName)
+                    if (endpoint.EndpointName is "http" or "https")
                     {
-                        case OtlpGrpcEndpointName:
-                            url.DisplayText = OtlpGrpcEndpointName;
-                            break;
-                        case OtlpHttpEndpointName:
-                            url.DisplayText = OtlpHttpEndpointName;
-                            break;
-                        default:
-                            // Other endpoints are for the dashboard UI. There are typically dashboard UI endpoints for http and https.
-                            // Order these before non-browser usable endpoints.
-                            url.DisplayText = $"Dashboard ({endpoint.EndpointName})";
-                            url.DisplayOrder = 1;
-                            break;
+                        // Other endpoints are for the dashboard UI. There are typically dashboard UI endpoints for http and https.
+                        // Order these before non-browser usable endpoints.
+                        url.DisplayText = $"Dashboard ({endpoint.EndpointName})";
+                        url.DisplayOrder = 1;
+                    }
+                    else
+                    {
+                        url.DisplayText = endpoint.EndpointName;
                     }
                 }
             }

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -423,23 +423,23 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         {
             foreach (var url in c.Urls)
             {
-                switch (url.Endpoint?.EndpointName)
+                if (url.Endpoint is { } endpoint)
                 {
-                    case OtlpGrpcEndpointName:
-                        url.DisplayText = OtlpGrpcEndpointName;
-                        break;
-                    case OtlpHttpEndpointName:
-                        url.DisplayText = OtlpHttpEndpointName;
-                        break;
-                    default:
-                        // Other endpoints are for the dashboard UI. There are typically dashboard UI endpoints for http and https.
-                        // Order these before non-browser usable endpoints.
-                        if (Uri.TryCreate(url.Url, UriKind.Absolute, out var result))
-                        {
-                            url.DisplayText = $"Dashboard ({result.Scheme})";
+                    switch (endpoint.EndpointName)
+                    {
+                        case OtlpGrpcEndpointName:
+                            url.DisplayText = OtlpGrpcEndpointName;
+                            break;
+                        case OtlpHttpEndpointName:
+                            url.DisplayText = OtlpHttpEndpointName;
+                            break;
+                        default:
+                            // Other endpoints are for the dashboard UI. There are typically dashboard UI endpoints for http and https.
+                            // Order these before non-browser usable endpoints.
+                            url.DisplayText = $"Dashboard ({endpoint.EndpointName})";
                             url.DisplayOrder = 1;
-                        }
-                        break;
+                            break;
+                    }
                 }
             }
         }));

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -251,7 +251,7 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
             // Verify that the custom runtime config has been updated with current framework versions
             var customConfigContent = File.ReadAllText((string)args[2]);
             var customConfig = JsonSerializer.Deserialize<JsonElement>(customConfigContent);
-            
+
             var frameworks = customConfig.GetProperty("runtimeOptions").GetProperty("frameworks").EnumerateArray().ToArray();
             var netCoreFramework = frameworks.First(f => f.GetProperty("name").GetString() == "Microsoft.NETCore.App");
             var aspNetCoreFramework = frameworks.First(f => f.GetProperty("name").GetString() == "Microsoft.AspNetCore.App");


### PR DESCRIPTION
## Description

<img width="1609" height="158" alt="image" src="https://github.com/user-attachments/assets/cd6e268a-4a85-4f82-91ac-ba2ed77cec47" />

Fixes https://github.com/dotnet/aspire/issues/11604

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
