### PR TITLE
Revamp activity reporter to support multiple steps and tasks in parallel

### DIFF
--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -277,6 +277,7 @@ internal abstract class PublishCommandBase : BaseCommand
 
         await foreach (var activity in publishingActivities.WithCancellation(cancellationToken))
         {
+            StartTerminalProgressBar();
             if (activity.Type == PublishingActivityTypes.PublishComplete)
             {
                 publishingActivity = activity;
@@ -324,7 +325,6 @@ internal abstract class PublishCommandBase : BaseCommand
             }
         }
 
-        StopTerminalProgressBar();
         var hasErrors = publishingActivity is not null && IsCompletionStateError(publishingActivity.Data.CompletionState);
         var hasWarnings = publishingActivity is not null && IsCompletionStateWarning(publishingActivity.Data.CompletionState);
 
@@ -350,6 +350,7 @@ internal abstract class PublishCommandBase : BaseCommand
         {
             await foreach (var activity in publishingActivities.WithCancellation(cancellationToken))
             {
+                StartTerminalProgressBar();
                 if (activity.Type == PublishingActivityTypes.PublishComplete)
                 {
                     publishingActivity = activity;
@@ -464,6 +465,12 @@ internal abstract class PublishCommandBase : BaseCommand
 
             if (publishingActivity is not null)
             {
+                await renderer.StopSpinnerAsync();
+                Console.Write("\r");          // Move to start of line
+                Console.Write("     ");       // Write multiple spaces to clear
+                Console.Write("\r");          // Move back to start of line
+                Console.Out.Flush();
+
                 var hasErrors = IsCompletionStateError(publishingActivity.Data.CompletionState);
                 var hasWarnings = IsCompletionStateWarning(publishingActivity.Data.CompletionState);
 
@@ -484,8 +491,11 @@ internal abstract class PublishCommandBase : BaseCommand
         }
         finally
         {
-            StopTerminalProgressBar();
             await renderer.StopSpinnerAsync();
+            Console.Write("\r");          // Move to start of line
+            Console.Write("     ");       // Write multiple spaces to clear
+            Console.Write("\r");          // Move back to start of line
+            Console.Out.Flush();
         }
     }
 

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -332,6 +332,10 @@ internal abstract class PublishCommandBase : BaseCommand
         {
             var status = hasErrors ? "FAILED" : hasWarnings ? "WARNING" : "COMPLETED";
             InteractionService.DisplaySubtleMessage($"[DEBUG] {OperationCompletedPrefix}: {status} - {publishingActivity.Data.StatusText}");
+
+            // Send visual bell notification when operation is complete
+            Console.Write("\a");
+            Console.Out.Flush();
         }
 
         return !hasErrors;
@@ -483,6 +487,10 @@ internal abstract class PublishCommandBase : BaseCommand
                 AnsiConsole.MarkupLine(
                     $"[dim]{timestamp}[/] [bold white]{operationPrefix,-12}[/] " +
                     $"{prefix}{publishingActivity.Data.StatusText.EscapeMarkup()}[/]");
+
+                // Send visual bell notification when operation is complete
+                Console.Write("\a");
+                Console.Out.Flush();
 
                 return !hasErrors;
             }

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -791,7 +791,7 @@ internal abstract class PublishCommandBase : BaseCommand
                 formattedMessage = $"[red]{formattedMessage}[/]";
             }
 
-            AnsiConsole.MarkupLine($"[dim]{timestamp}[/] [{stepColor}]{stepTitle,-12}[/] {formattedMessage}");
+            AnsiConsole.MarkupLine($"[dim]{timestamp}[/] [{stepColor}]({stepTitle})[/] {formattedMessage}");
 
             if (wasSpinning)
             {

--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -95,7 +95,7 @@ internal sealed class AzureDeployingContext(
             return true;
         }
 
-        var validationStep = await activityReporter.CreateStepAsync("Validating Azure CLI authentication", cancellationToken).ConfigureAwait(false);
+        var validationStep = await activityReporter.CreateStepAsync("validate-auth", cancellationToken).ConfigureAwait(false);
         await using (validationStep.ConfigureAwait(false))
         {
             try
@@ -126,7 +126,7 @@ internal sealed class AzureDeployingContext(
             return true;
         }
 
-        var deployingStep = await activityReporter.CreateStepAsync($"Deploying {bicepResources.Count} Azure resource(s)", cancellationToken).ConfigureAwait(false);
+        var deployingStep = await activityReporter.CreateStepAsync("deploy-resources", cancellationToken).ConfigureAwait(false);
         await using (deployingStep.ConfigureAwait(false))
         {
             try
@@ -254,7 +254,7 @@ internal sealed class AzureDeployingContext(
             return true;
         }
 
-        var computeStep = await activityReporter.CreateStepAsync("Deploying compute resources", cancellationToken).ConfigureAwait(false);
+        var computeStep = await activityReporter.CreateStepAsync("deploy-compute", cancellationToken).ConfigureAwait(false);
         await using (computeStep.ConfigureAwait(false))
         {
             try
@@ -346,7 +346,7 @@ internal sealed class AzureDeployingContext(
             return;
         }
 
-        var loginStep = await activityReporter.CreateStepAsync("Authenticating to container registries", cancellationToken).ConfigureAwait(false);
+        var loginStep = await activityReporter.CreateStepAsync("auth-registries", cancellationToken).ConfigureAwait(false);
         await using (loginStep.ConfigureAwait(false))
         {
             try
@@ -414,7 +414,7 @@ internal sealed class AzureDeployingContext(
     private async Task PushImagesToAllRegistries(Dictionary<IContainerRegistry, List<IResource>> resourcesByRegistry, CancellationToken cancellationToken)
     {
         var totalImageCount = resourcesByRegistry.Values.SelectMany(resources => resources).Count();
-        var pushStep = await activityReporter.CreateStepAsync($"Pushing {totalImageCount} images to container registries", cancellationToken).ConfigureAwait(false);
+        var pushStep = await activityReporter.CreateStepAsync("push-images", cancellationToken).ConfigureAwait(false);
         await using (pushStep.ConfigureAwait(false))
         {
             try

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -89,7 +89,7 @@ public sealed class AzurePublishingContext(
         }
 
         var step = await ActivityReporter.CreateStepAsync(
-            "Publishing Azure Bicep templates",
+            "publish-bicep",
             cancellationToken
         ).ConfigureAwait(false);
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -105,7 +105,7 @@ internal sealed class PublishModeProvisioningContextProvider(
         bool fetchSucceeded = false;
 
         var step = await activityReporter.CreateStepAsync(
-            "Retrieving Azure subscription information",
+            "fetch-subscription",
             cancellationToken).ConfigureAwait(false);
 
         await using (step.ConfigureAwait(false))
@@ -222,7 +222,7 @@ internal sealed class PublishModeProvisioningContextProvider(
         bool fetchSucceeded = false;
 
         var step = await activityReporter.CreateStepAsync(
-            "Retrieving Azure region information",
+            "[fetch-regions]",
             cancellationToken).ConfigureAwait(false);
 
         await using (step.ConfigureAwait(false))

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -222,7 +222,7 @@ internal sealed class PublishModeProvisioningContextProvider(
         bool fetchSucceeded = false;
 
         var step = await activityReporter.CreateStepAsync(
-            "[fetch-regions]",
+            "fetch-regions",
             cancellationToken).ConfigureAwait(false);
 
         await using (step.ConfigureAwait(false))

--- a/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposePublishingContext.cs
@@ -148,7 +148,7 @@ internal sealed class DockerComposePublishingContext(
         }
 
         var step = await activityReporter.CreateStepAsync(
-            "Writing Docker Compose file.",
+            "write-compose",
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await using (step.ConfigureAwait(false))
@@ -177,14 +177,14 @@ internal sealed class DockerComposePublishingContext(
                     foreach (var entry in environment.CapturedEnvironmentVariables ?? [])
                     {
                         var (key, (description, defaultValue, source)) = entry;
-                        
+
                         // If the source is a parameter and there's no explicit default value,
                         // resolve the parameter's default value asynchronously
                         if (defaultValue is null && source is ParameterResource parameter && !parameter.Secret && parameter.Default is not null)
                         {
                             defaultValue = await parameter.GetValueAsync(cancellationToken).ConfigureAwait(false);
                         }
-                        
+
                         envFile.AddIfMissing(key, defaultValue, description);
                     }
 

--- a/src/Aspire.Hosting/Publishing/Publisher.cs
+++ b/src/Aspire.Hosting/Publishing/Publisher.cs
@@ -67,7 +67,7 @@ internal class Publisher(
 
         // Add a step to do model analysis before publishing/deploying
         var step = await progressReporter.CreateStepAsync(
-            "Analyzing model.",
+            "analyze-model",
             cancellationToken).ConfigureAwait(false);
 
         await using (step.ConfigureAwait(false))

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -144,7 +144,7 @@ internal sealed class ResourceContainerImageBuilder(
     public async Task BuildImagesAsync(IEnumerable<IResource> resources, ContainerBuildOptions? options = null, CancellationToken cancellationToken = default)
     {
         var step = await activityReporter.CreateStepAsync(
-            "Building container images for resources",
+            "build-images",
             cancellationToken).ConfigureAwait(false);
 
         await using (step.ConfigureAwait(false))

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -584,8 +584,8 @@ public class AzureDeployerTests(ITestOutputHelper output)
                    cmd.Arguments == "acr login --name testregistry");
 
         // Assert that deploying steps executed
-        Assert.Contains("Deploying compute resources", mockActivityReporter.CreatedSteps);
-        Assert.Contains(("Deploying compute resources", "Deploying cache"), mockActivityReporter.CreatedTasks);
+        Assert.Contains("deploy-compute", mockActivityReporter.CreatedSteps);
+        Assert.Contains(("deploy-compute", "Deploying cache"), mockActivityReporter.CreatedTasks);
     }
 
     [Fact]


### PR DESCRIPTION
Closes https://github.com/dotnet/aspire/issues/11524 and contributes towards https://github.com/dotnet/aspire/issues/11750.

We want to make it easier to model steps and tasks in a deployment pipeline. One of the concrete limitatiosn is the way we map PublishingSteps/PublishingTasks to UI elements. This adjusts the CLI UI so that we can do parallel steps and create new steps while others are in progress.