### PR TITLE
Improve GenAI visualizer error handling

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -190,7 +190,7 @@
                                 {
                                     <div class="display-error-message">
                                         <h5>@Loc[nameof(Dialogs.GenAIDisplayErrorMessageText)]</h5>
-                                        <div>
+                                        <div class="display-error-content">
                                             @Content.DisplayErrorMessage
                                         </div>
                                     </div>

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Model.Markdown;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
+using Aspire.Dashboard.Telemetry;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -49,6 +50,9 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
 
     [Inject]
     public required ILogger<GenAIVisualizerDialog> Logger { get; init; }
+
+    [Inject]
+    public required ITelemetryErrorRecorder ErrorRecorder { get; init; }
 
     protected override void OnInitialized()
     {
@@ -154,7 +158,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
         var selectedIndex = SelectedItem?.Index;
 
         var spanDetailsViewModel = SpanDetailsViewModel.Create(newSpan, TelemetryRepository, TelemetryRepository.GetResources());
-        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, selectedLogEntryId: null, Logger, TelemetryRepository, Content.GetContextGenAISpans);
+        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, selectedLogEntryId: null, ErrorRecorder, TelemetryRepository, Content.GetContextGenAISpans);
 
         if (selectedIndex != null)
         {
@@ -216,7 +220,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
 
     public static async Task OpenDialogAsync(ViewportInformation viewportInformation, IDialogService dialogService,
         IStringLocalizer<Resources.Dialogs> dialogsLoc, OtlpSpan span, long? selectedLogEntryId,
-        TelemetryRepository telemetryRepository, ILogger logger, List<OtlpResource> resources, Func<List<OtlpSpan>> getContextGenAISpans)
+        TelemetryRepository telemetryRepository, ITelemetryErrorRecorder errorRecorder, List<OtlpResource> resources, Func<List<OtlpSpan>> getContextGenAISpans)
     {
         var title = span.Name;
         var width = viewportInformation.IsDesktop ? "75vw" : "100vw";
@@ -232,7 +236,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
 
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, telemetryRepository, resources);
 
-        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, selectedLogEntryId, logger, telemetryRepository, getContextGenAISpans);
+        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, selectedLogEntryId, errorRecorder, telemetryRepository, getContextGenAISpans);
 
         await dialogService.ShowDialogAsync<GenAIVisualizerDialog>(dialogViewModel, parameters);
     }

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -193,6 +193,11 @@
     color: var(--error);
 }
 
+::deep .display-error-content {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 ::deep .no-message-content-content {
     color: var(--foreground-subtext-rest);
     font-size: 12px;

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -76,6 +76,9 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     public required ILogger<StructuredLogs> Logger { get; init; }
 
     [Inject]
+    public required ITelemetryErrorRecorder ErrorRecorder { get; init; }
+
+    [Inject]
     public required DimensionManager DimensionManager { get; set; }
 
     [Inject]
@@ -500,7 +503,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
                 span,
                 logEntry.InternalId,
                 TelemetryRepository,
-                Logger,
+                ErrorRecorder,
                 _resources,
                 () =>
                 {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -58,6 +58,9 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     public required ILogger<TraceDetail> Logger { get; init; }
 
     [Inject]
+    public required ITelemetryErrorRecorder ErrorRecorder { get; init; }
+
+    [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
 
     [Inject]
@@ -521,7 +524,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             span,
             selectedLogEntryId: null,
             TelemetryRepository,
-            Logger,
+            ErrorRecorder,
             _resources,
             () =>
             {

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -261,6 +261,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.TryAddSingleton<DashboardTelemetryService>();
         builder.Services.TryAddSingleton<IDashboardTelemetrySender, DashboardTelemetrySender>();
         builder.Services.AddSingleton<ILoggerProvider, TelemetryLoggerProvider>();
+        builder.Services.AddSingleton<ITelemetryErrorRecorder, TelemetryErrorRecorder>();
 
         // OTLP services.
         builder.Services.AddGrpc();

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -336,12 +336,12 @@ public sealed class GenAIVisualizerDialogViewModel
         }
         catch (Exception ex)
         {
+            // Don't include JSON in exception message because it could contain sensitive data.
             throw new InvalidOperationException(
                 $"""
                 Error deserializing GenAI message content.
                 Error message: {ex.Message}
                 Content description: {description}
-                JSON: {json}
                 """, ex);
         }
     }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -3,11 +3,15 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Microsoft.FluentUI.AspNetCore.Components;
 
@@ -44,7 +48,7 @@ public sealed class GenAIVisualizerDialogViewModel
     public static GenAIVisualizerDialogViewModel Create(
         SpanDetailsViewModel spanDetailsViewModel,
         long? selectedLogEntryId,
-        ILogger logger,
+        ITelemetryErrorRecorder errorRecorder,
         TelemetryRepository telemetryRepository,
         Func<List<OtlpSpan>> getContextGenAISpans)
     {
@@ -73,10 +77,25 @@ public sealed class GenAIVisualizerDialogViewModel
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error reading GenAI telemetry messages for span {SpanId}", viewModel.Span.SpanId);
+            // Record errors from reading message telemetry.
+            // Once we have confidence that we're handling popular content well this will change to just be logged.
+            errorRecorder.RecordError($"Error reading GenAI telemetry messages for span {viewModel.Span.SpanId}", ex, writeToLogging: true);
 
             // There could be invalid or unexpected message JSON that causes deserialization to fail. Display an error message.
-            viewModel.DisplayErrorMessage = $"{ex.GetType().FullName}: {ex.Message}";
+            var sb = new StringBuilder();
+            var current = ex;
+            while (current != null)
+            {
+                if (sb.Length > 0)
+                {
+                    sb.AppendLine();
+                }
+
+                sb.AppendLine(CultureInfo.InvariantCulture, $"{current.GetType().FullName}: {current.Message}");
+                current = current.InnerException;
+            }
+
+            viewModel.DisplayErrorMessage = sb.ToString();
             viewModel.Items.Clear();
 
             return viewModel;
@@ -168,17 +187,17 @@ public sealed class GenAIVisualizerDialogViewModel
         {
             if (systemInstructions != null)
             {
-                var instructionParts = JsonSerializer.Deserialize(systemInstructions, GenAIMessagesContext.Default.ListMessagePart)!;
+                var instructionParts = DeserializeWithErrorHandling(GenAIHelpers.GenAISystemInstructions, systemInstructions, GenAIMessagesContext.Default.ListMessagePart)!;
                 viewModel.Items.Add(CreateMessage(viewModel, currentIndex, GenAIItemType.SystemMessage, instructionParts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList(), internalId: null));
                 currentIndex++;
             }
             if (inputMessages != null)
             {
-                ParseMessages(viewModel, inputMessages, isOutput: false, ref currentIndex);
+                ParseMessages(viewModel, inputMessages, GenAIHelpers.GenAIInputMessages, isOutput: false, ref currentIndex);
             }
             if (outputMessages != null)
             {
-                ParseMessages(viewModel, outputMessages, isOutput: true, ref currentIndex);
+                ParseMessages(viewModel, outputMessages, GenAIHelpers.GenAIOutputInstructions, isOutput: true, ref currentIndex);
             }
 
             return;
@@ -186,11 +205,11 @@ public sealed class GenAIVisualizerDialogViewModel
 
         // Attempt to get messages from log entries.
         var logEntries = GetSpanLogEntries(telemetryRepository, viewModel.Span);
-        foreach (var item in logEntries.OrderBy(i => i.TimeStamp))
+        foreach (var (item, index) in logEntries.OrderBy(i => i.TimeStamp).Select((l, i) => (l, i)))
         {
             if (item.Attributes.GetValue("event.name") is { } name && TryMapEventName(name, out var type))
             {
-                var parts = DeserializeBody(type.Value, item.Message);
+                var parts = DeserializeEventContent(index, type.Value, item.Message);
                 viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type.Value, parts, internalId: item.InternalId));
                 currentIndex++;
             }
@@ -202,22 +221,22 @@ public sealed class GenAIVisualizerDialogViewModel
         }
 
         // Attempt get get messages from span events.
-        foreach (var item in viewModel.Span.Events.OrderBy(i => i.Time))
+        foreach (var (item, index) in viewModel.Span.Events.OrderBy(i => i.Time).Select((l, i) => (l, i)))
         {
             // Detect GenAI messages by event name. Don't check for the gen_ai.system attribute because it's optional on events.
             if (TryMapEventName(item.Name, out var type))
             {
                 var content = item.Attributes.GetValue(GenAIHelpers.GenAIEventContent);
-                var parts = content != null ? DeserializeBody(type.Value, content) : [];
+                var parts = content != null ? DeserializeEventContent(index, type.Value, content) : [];
                 viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type.Value, parts, internalId: null));
                 currentIndex++;
             }
         }
     }
 
-    private static int ParseMessages(GenAIVisualizerDialogViewModel viewModel, string messages, bool isOutput, ref int currentIndex)
+    private static int ParseMessages(GenAIVisualizerDialogViewModel viewModel, string messages, string description, bool isOutput, ref int currentIndex)
     {
-        var inputParts = JsonSerializer.Deserialize(messages, GenAIMessagesContext.Default.ListChatMessage)!;
+        var inputParts = DeserializeWithErrorHandling(description, messages, GenAIMessagesContext.Default.ListChatMessage)!;
         foreach (var msg in inputParts)
         {
             var parts = msg.Parts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
@@ -248,7 +267,7 @@ public sealed class GenAIVisualizerDialogViewModel
         };
     }
 
-    private static List<GenAIItemPartViewModel> DeserializeBody(GenAIItemType type, string message)
+    private static List<GenAIItemPartViewModel> DeserializeEventContent(int index, GenAIItemType type, string message)
     {
         var messagePartViewModels = new List<GenAIItemPartViewModel>();
 
@@ -256,28 +275,35 @@ public sealed class GenAIVisualizerDialogViewModel
         {
             case GenAIItemType.SystemMessage:
             case GenAIItemType.UserMessage:
-                var systemOrUserEvent = JsonSerializer.Deserialize(message, GenAIEventsContext.Default.SystemOrUserEvent)!;
+                var systemOrUserEvent = DeserializeEventJson(message, GenAIEventsContext.Default.SystemOrUserEvent)!;
                 messagePartViewModels.Add(GenAIItemPartViewModel.CreateMessagePart(new TextPart { Content = systemOrUserEvent.Content }));
                 break;
             case GenAIItemType.AssistantMessage:
-                var assistantEvent = JsonSerializer.Deserialize(message, GenAIEventsContext.Default.AssistantEvent)!;
+                var assistantEvent = DeserializeEventJson(message, GenAIEventsContext.Default.AssistantEvent)!;
                 ProcessAssistantEvent(messagePartViewModels, assistantEvent);
                 break;
             case GenAIItemType.ToolMessage:
-                var toolEvent = JsonSerializer.Deserialize(message, GenAIEventsContext.Default.ToolEvent)!;
+                var toolEvent = DeserializeEventJson(message, GenAIEventsContext.Default.ToolEvent)!;
                 var toolResponse = ProcessJsonPayload(toolEvent.Content);
                 messagePartViewModels.Add(GenAIItemPartViewModel.CreateMessagePart(new ToolCallResponsePart { Id = toolEvent.Id, Response = toolResponse }));
                 break;
             case GenAIItemType.OutputMessage:
-                var choiceEvent = JsonSerializer.Deserialize(message, GenAIEventsContext.Default.ChoiceEvent)!;
+                var choiceEvent = DeserializeEventJson(message, GenAIEventsContext.Default.ChoiceEvent)!;
                 if (choiceEvent.Message is { } m)
                 {
                     ProcessAssistantEvent(messagePartViewModels, m);
                 }
                 break;
+            default:
+                throw new InvalidOperationException($"Unexpected type: {type}");
         }
 
         return messagePartViewModels;
+
+        TValue DeserializeEventJson<TValue>(string json, JsonTypeInfo<TValue> jsonTypeInfo)
+        {
+            return DeserializeWithErrorHandling($"{type} event content for message #{index}", json, jsonTypeInfo);
+        }
 
         static void ProcessAssistantEvent(List<GenAIItemPartViewModel> messagePartViewModels, AssistantEvent assistantEvent)
         {
@@ -299,6 +325,23 @@ public sealed class GenAIVisualizerDialogViewModel
                     messagePartViewModels.Add(GenAIItemPartViewModel.CreateMessagePart(new ToolCallRequestPart { Name = function.Name, Arguments = args }));
                 }
             }
+        }
+    }
+
+    private static TValue DeserializeWithErrorHandling<TValue>(string description, string json, JsonTypeInfo<TValue> jsonTypeInfo)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<TValue>(json, jsonTypeInfo)!;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"""
+                Error deserializing GenAI message content.
+                Content description: {description}
+                JSON: {json}
+                """, ex);
         }
     }
 

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -340,7 +340,7 @@ public sealed class GenAIVisualizerDialogViewModel
             throw new InvalidOperationException(
                 $"""
                 Error deserializing GenAI message content.
-                Error message: {ex.Message}
+                Error description: {ex.GetType().FullName}: {ex.Message}
                 Content description: {description}
                 """, ex);
         }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -77,8 +77,8 @@ public sealed class GenAIVisualizerDialogViewModel
         }
         catch (Exception ex)
         {
-            // Record errors from reading message telemetry.
-            // Once we have confidence that we're handling popular content well this will change to just be logged.
+            // We're catching errors here to avoid it going to Blazor global error handling. But we still want to record errors from reading messages to telemetry.
+            // This can be changed to just using logging once we have confidence that we're handling popular content well.
             errorRecorder.RecordError($"Error reading GenAI telemetry messages for span {viewModel.Span.SpanId}", ex, writeToLogging: true);
 
             // There could be invalid or unexpected message JSON that causes deserialization to fail. Display an error message.

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -339,6 +339,7 @@ public sealed class GenAIVisualizerDialogViewModel
             throw new InvalidOperationException(
                 $"""
                 Error deserializing GenAI message content.
+                Error message: {ex.Message}
                 Content description: {description}
                 JSON: {json}
                 """, ex);

--- a/src/Aspire.Dashboard/Telemetry/TelemetryErrorRecorder.cs
+++ b/src/Aspire.Dashboard/Telemetry/TelemetryErrorRecorder.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Utils;
+
+namespace Aspire.Dashboard.Telemetry;
+
+/// <summary>
+/// For recording errors to telemetry. Can be injected into components that handle errors but we still want to record to telemetry.
+/// </summary>
+public interface ITelemetryErrorRecorder
+{
+    void RecordError(string message, Exception exception, bool writeToLogging = false);
+}
+
+public sealed class TelemetryErrorRecorder : ITelemetryErrorRecorder
+{
+    private readonly DashboardTelemetryService _telemetryService;
+    private readonly ILogger<TelemetryErrorRecorder> _logger;
+
+    public TelemetryErrorRecorder(DashboardTelemetryService telemetryService, ILogger<TelemetryErrorRecorder> logger)
+    {
+        _telemetryService = telemetryService;
+        _logger = logger;
+    }
+
+    public void RecordError(string message, Exception exception, bool writeToLogging = false)
+    {
+        if (writeToLogging)
+        {
+            _logger.LogError(exception, message);
+        }
+
+        _telemetryService.PostFault(
+            TelemetryEventKeys.Error,
+            $"{exception.GetType().FullName}: {exception.Message}",
+            FaultSeverity.Critical,
+            new Dictionary<string, AspireTelemetryProperty>
+            {
+                [TelemetryPropertyKeys.ExceptionType] = new AspireTelemetryProperty(exception.GetType().FullName!),
+                [TelemetryPropertyKeys.ExceptionMessage] = new AspireTelemetryProperty(exception.Message),
+                [TelemetryPropertyKeys.ExceptionStackTrace] = new AspireTelemetryProperty(exception.StackTrace ?? string.Empty),
+                [TelemetryPropertyKeys.ExceptionRuntimeVersion] = new AspireTelemetryProperty(VersionHelpers.RuntimeVersion?.ToString() ?? string.Empty),
+            }
+        );
+    }
+}

--- a/src/Aspire.Dashboard/Telemetry/TelemetryLoggerProvider.cs
+++ b/src/Aspire.Dashboard/Telemetry/TelemetryLoggerProvider.cs
@@ -48,7 +48,7 @@ public sealed class TelemetryLoggerProvider : ILoggerProvider
                 try
                 {
                     // Get the telemetry service lazily to avoid a circular reference between resolving telemetry service and logging.
-                    var errorRecorder = _serviceProvider.GetRequiredService<TelemetryErrorRecorder>();
+                    var errorRecorder = _serviceProvider.GetRequiredService<ITelemetryErrorRecorder>();
 
                     errorRecorder.RecordError("Blazor global error", exception);
                 }

--- a/src/Aspire.Dashboard/Telemetry/TelemetryLoggerProvider.cs
+++ b/src/Aspire.Dashboard/Telemetry/TelemetryLoggerProvider.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Utils;
-
 namespace Aspire.Dashboard.Telemetry;
 
 /// <summary>
@@ -50,20 +48,9 @@ public sealed class TelemetryLoggerProvider : ILoggerProvider
                 try
                 {
                     // Get the telemetry service lazily to avoid a circular reference between resolving telemetry service and logging.
-                    var telemetryService = _serviceProvider.GetRequiredService<DashboardTelemetryService>();
+                    var errorRecorder = _serviceProvider.GetRequiredService<TelemetryErrorRecorder>();
 
-                    telemetryService.PostFault(
-                        TelemetryEventKeys.Error,
-                        $"{exception.GetType().FullName}: {exception.Message}",
-                        FaultSeverity.Critical,
-                        new Dictionary<string, AspireTelemetryProperty>
-                        {
-                            [TelemetryPropertyKeys.ExceptionType] = new AspireTelemetryProperty(exception.GetType().FullName!),
-                            [TelemetryPropertyKeys.ExceptionMessage] = new AspireTelemetryProperty(exception.Message),
-                            [TelemetryPropertyKeys.ExceptionStackTrace] = new AspireTelemetryProperty(exception.StackTrace ?? string.Empty),
-                            [TelemetryPropertyKeys.ExceptionRuntimeVersion] = new AspireTelemetryProperty(VersionHelpers.RuntimeVersion?.ToString() ?? string.Empty),
-                        }
-                    );
+                    errorRecorder.RecordError("Blazor global error", exception);
                 }
                 catch
                 {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -41,7 +41,7 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
             span: CreateOtlpSpan(resource, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime),
             selectedLogEntryId: null,
             telemetryRepository: Services.GetRequiredService<TelemetryRepository>(),
-            logger: NullLogger.Instance,
+            errorRecorder: new TestTelemetryErrorRecorder(),
             resources: [],
             getContextGenAISpans: () => []
             );
@@ -109,7 +109,7 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
             span: span,
             selectedLogEntryId: null,
             telemetryRepository: Services.GetRequiredService<TelemetryRepository>(),
-            logger: NullLogger.Instance,
+            errorRecorder: new TestTelemetryErrorRecorder(),
             resources: [],
             getContextGenAISpans: () => []
             );

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -10,6 +10,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.GenAI;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Telemetry;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
@@ -126,6 +127,7 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         Services.AddFluentUIComponents();
         Services.AddSingleton<LibraryConfiguration>();
         Services.AddSingleton<TelemetryRepository>();
+        Services.AddSingleton<ITelemetryErrorRecorder, TestTelemetryErrorRecorder>();
         Services.AddSingleton<PauseManager>();
         Services.AddSingleton(new ThemeManager(new TestThemeResolver()));
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -243,6 +243,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         Services.AddSingleton<StructuredLogsViewModel>();
         Services.AddSingleton<ISessionStorage, TestSessionStorage>();
         Services.AddSingleton<ILocalStorage, TestLocalStorage>();
+        Services.AddSingleton<ITelemetryErrorRecorder, TestTelemetryErrorRecorder>();
         Services.AddSingleton<ShortcutManager>();
         Services.AddSingleton<LibraryConfiguration>();
         Services.AddSingleton<IKeyCodeService, KeyCodeService>();

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -675,6 +675,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         Services.AddSingleton<IDialogService, DialogService>();
         Services.AddSingleton<ISessionStorage, TestSessionStorage>();
         Services.AddSingleton<ILocalStorage, TestLocalStorage>();
+        Services.AddSingleton<ITelemetryErrorRecorder, TestTelemetryErrorRecorder>();
         Services.AddSingleton<ShortcutManager>();
         Services.AddSingleton<LibraryConfiguration>();
         Services.AddSingleton<IKeyCodeService, KeyCodeService>();

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestTelemetryErrorRecorder.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestTelemetryErrorRecorder.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Telemetry;
+
+namespace Aspire.Dashboard.Components.Tests.Shared;
+
+public sealed class TestTelemetryErrorRecorder : ITelemetryErrorRecorder
+{
+    public void RecordError(string message, Exception exception, bool writeToLogging = false)
+    {
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -8,7 +8,6 @@ using Aspire.Dashboard.Model.GenAI;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
-using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
@@ -500,7 +499,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
 
         // Assert
         Assert.Empty(vm.Items);
-        Assert.StartsWith("System.Text.Json.JsonException: ", vm.DisplayErrorMessage);
+        Assert.StartsWith("System.InvalidOperationException: ", vm.DisplayErrorMessage);
     }
 
     [Fact]
@@ -674,7 +673,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         return GenAIVisualizerDialogViewModel.Create(
             spanDetailsViewModel,
             selectedLogEntryId: null,
-            logger: NullLogger.Instance,
+            errorRecorder: new TestTelemetryErrorRecorder(),
             telemetryRepository: repository,
             () => [spanDetailsViewModel.Span]);
     }

--- a/tests/Aspire.Dashboard.Tests/Model/TestTelemetryErrorRecorder.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TestTelemetryErrorRecorder.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Telemetry;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class TestTelemetryErrorRecorder : ITelemetryErrorRecorder
+{
+    public void RecordError(string message, Exception exception, bool writeToLogging = false)
+    {
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Telemetry/TelemetryLoggerProviderTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Telemetry/TelemetryLoggerProviderTests.cs
@@ -22,6 +22,7 @@ public class TelemetryLoggerProviderTests
             .AddSingleton<IDashboardTelemetrySender>(telemetrySender)
             .AddLogging()
             .AddSingleton<ILoggerProvider, TelemetryLoggerProvider>()
+            .AddSingleton<ITelemetryErrorRecorder, TelemetryErrorRecorder>()
             .BuildServiceProvider();
 
         var loggerProvider = serviceProvider.GetRequiredService<ILoggerFactory>();


### PR DESCRIPTION
## Description

Improve error details written when there is a failure to deserialize message content.

- Include description and JSON in error message displayed in UI
- Improve displaying error message to preserve whitespace
- GenAI error is written to telemetry

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
