### PR TITLE
Add local deploy state for provisioning

### DIFF
--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using System.CommandLine;
 
 namespace Aspire.Cli.Commands;
 
@@ -44,7 +45,7 @@ internal sealed class PublishCommand : PublishCommandBase
     protected override string OperationFailedPrefix => PublishCommandStrings.OperationFailedPrefix;
     protected override string GetOutputPathDescription() => PublishCommandStrings.OutputPathArgumentDescription;
 
-    protected override string[] GetRunArguments(string? fullyQualifiedOutputPath, string[] unmatchedTokens)
+    protected override string[] GetRunArguments(ParseResult parseResult, string? fullyQualifiedOutputPath, string[] unmatchedTokens)
     {
         var baseArgs = new List<string> { "--operation", "publish", "--publisher", "default" };
 

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -75,7 +75,7 @@ internal abstract class PublishCommandBase : BaseCommand
     }
 
     protected abstract string GetOutputPathDescription();
-    protected abstract string[] GetRunArguments(string? fullyQualifiedOutputPath, string[] unmatchedTokens);
+    protected abstract string[] GetRunArguments(ParseResult parseResult, string? fullyQualifiedOutputPath, string[] unmatchedTokens);
     protected abstract string GetCanceledMessage();
     protected abstract string GetProgressMessage();
 
@@ -173,7 +173,7 @@ internal abstract class PublishCommandBase : BaseCommand
                 effectiveAppHostFile,
                 false,
                 true,
-                GetRunArguments(fullyQualifiedOutputPath, unmatchedTokens),
+                GetRunArguments(parseResult, fullyQualifiedOutputPath, unmatchedTokens),
                 env,
                 backchannelCompletionSource,
                 operationRunOptions,

--- a/src/Aspire.Cli/Resources/DeployCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DeployCommandStrings.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Aspire.Cli.Resources {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace Aspire.Cli.Resources {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class DeployCommandStrings {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal DeployCommandStrings() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Aspire.Cli.Resources {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Aspire.Cli.Resources {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The deployment was canceled..
         /// </summary>
@@ -68,7 +68,7 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("DeploymentCanceled", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Deploy an Aspire app host project to its supported deployment targets. (Preview).
         /// </summary>
@@ -77,7 +77,7 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The output path for deployment artifacts..
         /// </summary>
@@ -86,7 +86,7 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("OutputPathArgumentDescription", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to DEPLOYMENT COMPLETED.
         /// </summary>
@@ -95,13 +95,22 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("OperationCompletedPrefix", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to DEPLOYMENT FAILED.
         /// </summary>
         public static string OperationFailedPrefix {
             get {
                 return ResourceManager.GetString("OperationFailedPrefix", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Disable reading from and writing to user secrets cache during deployment..
+        /// </summary>
+        public static string NoCacheDescription {
+            get {
+                return ResourceManager.GetString("NoCacheDescription", resourceCulture);
             }
         }
     }

--- a/src/Aspire.Cli/Resources/DeployCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DeployCommandStrings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--  
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -131,5 +131,8 @@
   </data>
   <data name="OperationFailedPrefix" xml:space="preserve">
     <value>DEPLOYMENT FAILED</value>
+  </data>
+  <data name="NoCacheDescription" xml:space="preserve">
+    <value>Disable reading from and writing to user secrets cache during deployment.</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Nasaďte obsah hostitele aplikací Aspire do svých definovaných cílů nasazení. (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">NASAZENÍ SE DOKONČILO.</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Stellen Sie die Inhalte eines Aspire-Apphosts auf den definierten Bereitstellungszielen bereit. (Vorschau)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">DIE BEREITSTELLUNG WURDE ABGESCHLOSSEN</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Implemente el contenido de un apphost de Aspire en sus destinos de implementación definidos. (Versión preliminar)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">IMPLEMENTACIÓN COMPLETADA</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Déployez le contenu d’un Aspire AppHost vers les cibles de déploiement définies. (Préversion)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">DÉPLOIEMENT TERMINÉ</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Distribuire il contenuto di un AppHost Aspire alle destinazioni di distribuzione definite. (Anteprima)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">DISTRIBUZIONE COMPLETATA</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Aspire AppHost のコンテンツを定義された展開先にデプロイします。(プレビュー)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">デプロイが完了しました</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Aspire 앱호스트의 콘텐츠를 정의된 배포 대상에 배포하세요. (미리 보기)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">배포 완료</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Wdróż zawartość hosta AppHost platformy Aspire w zdefiniowanych miejscach docelowych wdrożenia. (Wersja zapoznawcza)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">UKOŃCZONO WDRAŻANIE</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Implante o conteúdo de um Aspire apphost em seus destinos de implantação definidos. (Versão Prévia)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">IMPLANTAÇÃO CONCLUÍDA</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Развернуть содержимое хоста приложений Aspire на заданных целевых объектах развертывания. (Предварительная версия)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">РАЗВЕРТЫВАНИЕ ЗАВЕРШЕНО</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Bir Aspire AppHost içeriğini tanımlanan dağıtım hedeflerine dağıtın. (Önizleme)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">DAĞITIM TAMAMLANDI</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">将 Aspire 应用主机的内容部署到其定义的部署目标。(预览版)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">已完成部署</target>

--- a/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DeployCommandStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">將 Aspire AppHost 的內容部署至其定義的部署目標。(預覽)</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoCacheDescription">
+        <source>Disable reading from and writing to user secrets cache during deployment.</source>
+        <target state="new">Disable reading from and writing to user secrets cache during deployment.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>DEPLOYMENT COMPLETED</source>
         <target state="translated">部署完成</target>

--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -46,8 +46,8 @@ internal sealed class AzureDeployingContext(
         var userSecrets = await userSecretsManager.LoadUserSecretsAsync(cancellationToken).ConfigureAwait(false);
         var provisioningContext = await provisioningContextProvider.CreateProvisioningContextAsync(userSecrets, cancellationToken).ConfigureAwait(false);
 
-        // Save provisioning context values to user secrets (unless NoCache is set)
-        if (!publishingOptions.Value.NoCache)
+        // Save provisioning context values to user secrets (unless NoCache is set or user declined)
+        if (!publishingOptions.Value.NoCache && publishingOptions.Value.SaveToUserSecrets != false)
         {
             await userSecretsManager.SaveUserSecretsAsync(provisioningContext.UserSecrets, cancellationToken).ConfigureAwait(false);
         }
@@ -168,8 +168,8 @@ internal sealed class AzureDeployingContext(
                 }
 
                 await Task.WhenAll(provisioningTasks).ConfigureAwait(false);
-                // Save provisioning state after successful resource deployments (unless NoCache is set)
-                if (!publishingOptions.Value.NoCache)
+                // Save provisioning state after successful resource deployments (unless NoCache is set or user declined)
+                if (!publishingOptions.Value.NoCache && publishingOptions.Value.SaveToUserSecrets != false)
                 {
                     await userSecretsManager.SaveUserSecretsAsync(provisioningContext.UserSecrets, cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzureDeployingContext.cs
@@ -140,12 +140,7 @@ internal sealed class AzureDeployingContext(
                                     else
                                     {
                                         await bicepProvisioner.GetOrCreateResourceAsync(bicepResource, provisioningContext, cancellationToken).ConfigureAwait(false);
-
-                                        // Save provisioning state after each successful resource deployment to user secrets
-                                        await userSecretsManager.SaveUserSecretsAsync(provisioningContext.UserSecrets, cancellationToken).ConfigureAwait(false);
-
                                         bicepResource.ProvisioningTaskCompletionSource?.TrySetResult();
-
                                         await resourceTask.CompleteAsync($"Successfully provisioned {bicepResource.Name}", CompletionState.Completed, cancellationToken).ConfigureAwait(false);
                                     }
                                 }
@@ -168,6 +163,8 @@ internal sealed class AzureDeployingContext(
                 }
 
                 await Task.WhenAll(provisioningTasks).ConfigureAwait(false);
+                // Save provisioning state after successful resource deployments
+                await userSecretsManager.SaveUserSecretsAsync(provisioningContext.UserSecrets, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIRECOMPUTE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREPUBLISHERS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
@@ -80,6 +81,7 @@ public sealed class AzureEnvironmentResource : Resource
         var parameterProcessor = context.Services.GetRequiredService<ParameterProcessor>();
         var configuration = context.Services.GetRequiredService<IConfiguration>();
         var tokenCredentialProvider = context.Services.GetRequiredService<ITokenCredentialProvider>();
+        var publishingOptions = context.Services.GetRequiredService<IOptions<PublishingOptions>>();
 
         var azureCtx = new AzureDeployingContext(
             provisioningContextProvider,
@@ -90,7 +92,8 @@ public sealed class AzureEnvironmentResource : Resource
             processRunner,
             parameterProcessor,
             configuration,
-            tokenCredentialProvider);
+            tokenCredentialProvider,
+            publishingOptions);
 
         return azureCtx.DeployModelAsync(context.Model, context.CancellationToken);
     }

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
@@ -63,6 +63,12 @@ internal interface IUserSecretsManager
     /// Saves user secrets to the current application.
     /// </summary>
     Task SaveUserSecretsAsync(JsonObject userSecrets, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a deployment key to identify user secrets for the current deployment. Returns
+    /// null to store values at the top-level.
+    /// </summary>
+    string? GetDeploymentKey();
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -135,8 +135,8 @@ internal sealed class PublishModeProvisioningContextProvider(
             }
         }
 
-        // Only save to user secrets if NoCache is not set
-        if (!_publishingOptions.Value.NoCache)
+        // Only save to user secrets if NoCache is not set and user didn't decline
+        if (!_publishingOptions.Value.NoCache && _publishingOptions.Value.SaveToUserSecrets != false)
         {
             if (SubscriptionId != existingSubscriptionId)
             {

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -117,7 +117,7 @@ internal sealed class PublishModeProvisioningContextProvider(
         {
             if (_options.SubscriptionId == null)
             {
-                await PromptForSubscriptionAsync(userSecrets, cancellationToken).ConfigureAwait(false);
+                await PromptForSubscriptionAsync(cancellationToken).ConfigureAwait(false);
                 if (_options.SubscriptionId == null)
                 {
                     continue;
@@ -126,16 +126,31 @@ internal sealed class PublishModeProvisioningContextProvider(
 
             if (_options.Location == null)
             {
-                await PromptForLocationAndResourceGroupAsync(userSecrets, cancellationToken).ConfigureAwait(false);
+                await PromptForLocationAndResourceGroupAsync(cancellationToken).ConfigureAwait(false);
                 if (_options.Location == null)
                 {
                     continue;
                 }
             }
         }
+
+        if (_options.SubscriptionId != existingSubscriptionId)
+        {
+            userSecrets[subscriptionKey] = _options.SubscriptionId;
+        }
+
+        if (_options.Location != existingLocation)
+        {
+            userSecrets[locationKey] = _options.Location;
+        }
+
+        if (_options.ResourceGroup != existingResourceGroup)
+        {
+            userSecrets[resourceGroupKey] = _options.ResourceGroup;
+        }
     }
 
-    private async Task PromptForSubscriptionAsync(JsonObject userSecrets, CancellationToken cancellationToken)
+    private async Task PromptForSubscriptionAsync(CancellationToken cancellationToken)
     {
         List<KeyValuePair<string, string>>? subscriptionOptions = null;
         bool fetchSucceeded = false;
@@ -214,8 +229,6 @@ internal sealed class PublishModeProvisioningContextProvider(
             if (!result.Canceled)
             {
                 _options.SubscriptionId = result.Data[SubscriptionIdName].Value;
-                var subscriptionKey = $"Azure:{_deploymentKey}:SubscriptionId";
-                userSecrets[subscriptionKey] = _options.SubscriptionId;
                 return;
             }
         }
@@ -251,12 +264,10 @@ internal sealed class PublishModeProvisioningContextProvider(
         if (!manualResult.Canceled)
         {
             _options.SubscriptionId = manualResult.Data[SubscriptionIdName].Value;
-            var subscriptionKey = $"Azure:{_deploymentKey}:SubscriptionId";
-            userSecrets[subscriptionKey] = _options.SubscriptionId;
         }
     }
 
-    private async Task PromptForLocationAndResourceGroupAsync(JsonObject userSecrets, CancellationToken cancellationToken)
+    private async Task PromptForLocationAndResourceGroupAsync(CancellationToken cancellationToken)
     {
         List<KeyValuePair<string, string>>? locationOptions = null;
         bool fetchSucceeded = false;
@@ -352,11 +363,6 @@ internal sealed class PublishModeProvisioningContextProvider(
                 _options.ResourceGroup = result.Data[ResourceGroupName].Value;
                 _options.AllowResourceGroupCreation = true;
 
-                var locationKey = $"Azure:{_deploymentKey}:Location";
-                var resourceGroupKey = $"Azure:{_deploymentKey}:ResourceGroup";
-                userSecrets[locationKey] = _options.Location;
-                userSecrets[resourceGroupKey] = _options.ResourceGroup;
-
                 return;
             }
         }
@@ -408,11 +414,6 @@ internal sealed class PublishModeProvisioningContextProvider(
             _options.Location = manualResult.Data[LocationName].Value;
             _options.ResourceGroup = manualResult.Data[ResourceGroupName].Value;
             _options.AllowResourceGroupCreation = true;
-
-            var locationKey = $"Azure:{_deploymentKey}:Location";
-            var resourceGroupKey = $"Azure:{_deploymentKey}:ResourceGroup";
-            userSecrets[locationKey] = _options.Location;
-            userSecrets[resourceGroupKey] = _options.ResourceGroup;
         }
     }
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -26,7 +26,8 @@ internal sealed class RunModeProvisioningContextProvider(
     IArmClientProvider armClientProvider,
     IUserPrincipalProvider userPrincipalProvider,
     ITokenCredentialProvider tokenCredentialProvider,
-    DistributedApplicationExecutionContext distributedApplicationExecutionContext) : BaseProvisioningContextProvider(
+    DistributedApplicationExecutionContext distributedApplicationExecutionContext,
+    IUserSecretsManager userSecretsManager) : BaseProvisioningContextProvider(
         interactionService,
         options,
         environment,
@@ -34,7 +35,8 @@ internal sealed class RunModeProvisioningContextProvider(
         armClientProvider,
         userPrincipalProvider,
         tokenCredentialProvider,
-        distributedApplicationExecutionContext)
+        distributedApplicationExecutionContext,
+        userSecretsManager)
 {
     private readonly TaskCompletionSource _provisioningOptionsAvailable = new(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -275,6 +275,14 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
             return new AspireStore(Path.Combine(aspireDir, ".aspire"));
         });
+        // Add configuration values from UserSecrets even in PublishMode which is
+        // typically invoked via the CLI which doesn't set the correct environment
+        // value to load up UserSecrets. We do this because for local deploy, we want
+        // to be able to use UserSecrets as storage for deployment state.
+        if (AppHostAssembly is not null && ExecutionContext.IsPublishMode)
+        {
+            _innerBuilder.Configuration.AddUserSecrets(AppHostAssembly);
+        }
 
         // Shared DCP things (even though DCP isn't used in 'publish' and 'inspect' mode
         // we still honour the DCP options around container runtime selection.

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -490,6 +490,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             { "--operation", "AppHost:Operation" },
             { "--publisher", "Publishing:Publisher" },
             { "--output-path", "Publishing:OutputPath" },
+            { "--no-cache", "Publishing:NoCache" },
             { "--deploy", "Publishing:Deploy" },
             { "--dcp-cli-path", "DcpPublisher:CliPath" },
             { "--dcp-container-runtime", "DcpPublisher:ContainerRuntime" },

--- a/src/Aspire.Hosting/Publishing/PublishingOptions.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingOptions.cs
@@ -30,4 +30,11 @@ public class PublishingOptions
     /// </summary>
     [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public bool Deploy { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether user secrets caching should be disabled during deployment.
+    /// When true, deployment configuration will not be read from or saved to user secrets.
+    /// </summary>
+    [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public bool NoCache { get; set; }
 }

--- a/src/Aspire.Hosting/Publishing/PublishingOptions.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingOptions.cs
@@ -37,4 +37,11 @@ public class PublishingOptions
     /// </summary>
     [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public bool NoCache { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether deployment state should be saved to user secrets.
+    /// This is set based on user interaction and is only applicable when NoCache is false.
+    /// </summary>
+    [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public bool? SaveToUserSecrets { get; set; }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -93,7 +93,8 @@ public class AzureBicepProvisionerTests
             services.GetRequiredService<ResourceLoggerService>(),
             bicepExecutor,
             secretClientProvider,
-            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            ProvisioningTestHelpers.CreateUserSecretsManager());
 
         // Assert
         Assert.NotNull(provisioner);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -858,6 +858,106 @@ public class AzureDeployerTests(ITestOutputHelper output)
             imageName.Contains("aspire-deploy-"));
     }
 
+    [Fact]
+    public async Task DeployAsync_SavesSecretsUnderCorrectDeploymentKey()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
+        var testUserSecretsManager = new TestUserSecretsManager("test-deployment-key");
+        var testInteractionService = new TestInteractionService();
+
+        // Configure services without default user secrets manager
+        ConfigureTestServices(builder,
+            interactionService: testInteractionService,
+            bicepProvisioner: new NoOpBicepProvisioner(),
+            setDefaultProvisioningOptions: false);
+
+        // Replace the default user secrets manager with our test one
+        builder.Services.AddSingleton<IUserSecretsManager>(testUserSecretsManager);
+
+        // Add an Azure environment resource which will trigger the deployment prompting
+        builder.AddAzureEnvironment();
+
+        // Act
+        using var app = builder.Build();
+        var runTask = Task.Run(app.Run);
+
+        // Wait for the first interaction (subscription selection)
+        var subscriptionInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        Assert.Equal("Azure subscription", subscriptionInteraction.Title);
+
+        // Complete the subscription interaction
+        subscriptionInteraction.Inputs[0].Value = "12345678-1234-1234-1234-123456789012";
+        subscriptionInteraction.CompletionTcs.SetResult(InteractionResult.Ok(subscriptionInteraction.Inputs));
+
+        // Wait for the second interaction (location and resource group selection)
+        var locationInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        Assert.Equal("Azure location and resource group", locationInteraction.Title);
+
+        // Complete the location interaction
+        locationInteraction.Inputs[0].Value = "westus2";
+        locationInteraction.Inputs[1].Value = "test-rg";
+        locationInteraction.CompletionTcs.SetResult(InteractionResult.Ok(locationInteraction.Inputs));
+
+        // Wait for the run task to complete (or timeout)
+        await runTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Assert
+        // Verify that user secrets were saved
+        Assert.NotEmpty(testUserSecretsManager.SavedSecrets);
+
+        // Get the last saved user secrets
+        var savedSecrets = testUserSecretsManager.SavedSecrets.Last();
+
+        // Verify that the subscription ID and location were saved using flattened keys
+        Assert.Equal("12345678-1234-1234-1234-123456789012", savedSecrets["Azure:test-deployment-key:SubscriptionId"]?.GetValue<string>());
+        Assert.Equal("westus2", savedSecrets["Azure:test-deployment-key:Location"]?.GetValue<string>());
+        Assert.Equal("test-rg", savedSecrets["Azure:test-deployment-key:ResourceGroup"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task DeployAsync_ReadsExistingValuesFromUserSecrets()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
+        var testUserSecretsManager = new TestUserSecretsManager("test-deployment-key");
+        var testInteractionService = new TestInteractionService();
+
+        // Pre-populate user secrets with existing values using flattened keys
+        var prePopulatedSecrets = new JsonObject
+        {
+            ["Azure:test-deployment-key:SubscriptionId"] = "existing-sub-id",
+            ["Azure:test-deployment-key:Location"] = "eastus",
+            ["Azure:test-deployment-key:ResourceGroup"] = "existing-rg"
+        };
+        testUserSecretsManager.SetLoadedSecrets(prePopulatedSecrets);
+
+        // Configure services without default user secrets manager
+        ConfigureTestServices(builder,
+            interactionService: testInteractionService,
+            bicepProvisioner: new NoOpBicepProvisioner(),
+            setDefaultProvisioningOptions: false);
+
+        // Replace the default user secrets manager with our test one
+        builder.Services.AddSingleton<IUserSecretsManager>(testUserSecretsManager);
+
+        // Add an Azure environment resource
+        builder.AddAzureEnvironment();
+
+        // Act
+        using var app = builder.Build();
+        var runTask = Task.Run(app.Run);
+
+        // Since we have existing values, the provisioning should complete without prompting
+        // Wait for the run task to complete (or timeout)
+        await runTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Assert
+        // The app should have completed without any interactions since values already exist
+        // We should not see any pending interactions in the channel
+        Assert.False(testInteractionService.Interactions.Reader.TryRead(out _));
+    }
+
     private static void ConfigureTestServices(IDistributedApplicationTestingBuilder builder,
         IInteractionService? interactionService = null,
         IBicepProvisioner? bicepProvisioner = null,
@@ -898,9 +998,45 @@ public class AzureDeployerTests(ITestOutputHelper output)
 
     private sealed class NoOpUserSecretsManager : IUserSecretsManager
     {
+        public string GetDeploymentKey() => "test";
+
         public Task<JsonObject> LoadUserSecretsAsync(CancellationToken cancellationToken = default) => Task.FromResult(new JsonObject());
 
         public Task SaveUserSecretsAsync(JsonObject userSecrets, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class TestUserSecretsManager : IUserSecretsManager
+    {
+        private readonly string? _deploymentKey;
+        private JsonObject? _loadedSecrets;
+
+        public TestUserSecretsManager(string? deploymentKey)
+        {
+            _deploymentKey = deploymentKey;
+            SavedSecrets = new List<JsonObject>();
+        }
+
+        public List<JsonObject> SavedSecrets { get; }
+
+        public string? GetDeploymentKey() => _deploymentKey;
+
+        public Task<JsonObject> LoadUserSecretsAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_loadedSecrets ?? new JsonObject());
+        }
+
+        public Task SaveUserSecretsAsync(JsonObject userSecrets, CancellationToken cancellationToken = default)
+        {
+            // Create a deep copy of the secrets to capture the state at this moment
+            var copy = JsonNode.Parse(userSecrets.ToJsonString())!.AsObject();
+            SavedSecrets.Add(copy);
+            return Task.CompletedTask;
+        }
+
+        public void SetLoadedSecrets(JsonObject secrets)
+        {
+            _loadedSecrets = secrets;
+        }
     }
 
     private sealed class NoOpBicepProvisioner : IBicepProvisioner

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
@@ -395,7 +395,8 @@ public class ProvisioningContextProviderTests
             tokenCredentialProvider,
             new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
             new NullPublishingActivityReporter(),
-            ProvisioningTestHelpers.CreateUserSecretsManager());
+            ProvisioningTestHelpers.CreateUserSecretsManager(),
+            ProvisioningTestHelpers.CreatePublishingOptions());
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);
@@ -479,7 +480,8 @@ public class ProvisioningContextProviderTests
             tokenCredentialProvider,
             new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
             new NullPublishingActivityReporter(),
-            userSecretsManager);
+            userSecretsManager,
+            ProvisioningTestHelpers.CreatePublishingOptions());
 
         // Act
         var context = await provider.CreateProvisioningContextAsync(userSecrets);

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
@@ -379,7 +379,6 @@ public class ProvisioningContextProviderTests
     public async Task PublishMode_CreateProvisioningContextAsync_ReturnsValidContext()
     {
         // Arrange
-        var options = ProvisioningTestHelpers.CreateOptions();
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger<PublishModeProvisioningContextProvider>();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -389,7 +388,6 @@ public class ProvisioningContextProviderTests
 
         var provider = new PublishModeProvisioningContextProvider(
             _defaultInteractionService,
-            options,
             environment,
             logger,
             armClientProvider,
@@ -461,7 +459,6 @@ public class ProvisioningContextProviderTests
     public async Task PublishMode_CreateProvisioningContextAsync_SavesSecretsUnderPublishModeKey()
     {
         // Arrange
-        var options = ProvisioningTestHelpers.CreateOptions(resourceGroup: null); // Force resource group generation
         var environment = ProvisioningTestHelpers.CreateEnvironment();
         var logger = ProvisioningTestHelpers.CreateLogger<PublishModeProvisioningContextProvider>();
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider();
@@ -475,7 +472,6 @@ public class ProvisioningContextProviderTests
 
         var provider = new PublishModeProvisioningContextProvider(
             _defaultInteractionService,
-            options,
             environment,
             logger,
             armClientProvider,

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
@@ -63,7 +63,7 @@ internal static class ProvisioningTestHelpers
     public static ITokenCredentialProvider CreateTokenCredentialProvider() => new TestTokenCredentialProvider();
     public static ISecretClientProvider CreateSecretClientProvider() => new TestSecretClientProvider(CreateTokenCredentialProvider());
     public static IBicepCompiler CreateBicepCompiler() => new TestBicepCompiler();
-    public static IUserSecretsManager CreateUserSecretsManager() => new TestUserSecretsManager();
+    public static IUserSecretsManager CreateUserSecretsManager(string? deploymentKey = null) => new TestUserSecretsManager(deploymentKey);
     public static IUserPrincipalProvider CreateUserPrincipalProvider() => new TestUserPrincipalProvider();
     public static TokenCredential CreateTokenCredential() => new TestTokenCredential();
 
@@ -574,6 +574,14 @@ internal sealed class TestBicepCompiler : IBicepCompiler
 internal sealed class TestUserSecretsManager : IUserSecretsManager
 {
     private JsonObject _userSecrets = [];
+    private readonly string _deploymentKey;
+
+    public TestUserSecretsManager(string? deploymentKey = null)
+    {
+        _deploymentKey = deploymentKey ?? "runMode";
+    }
+
+    public string GetDeploymentKey() => _deploymentKey;
 
     public Task<JsonObject> LoadUserSecretsAsync(CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
Contributes towards #11444.

This pull request introduces significant improvements to how Azure deployment and provisioning state are handled and stored, particularly around the use of user secrets. The main focus is to enable deployment-specific scoping of secrets, ensuring that configuration and provisioning data are isolated per deployment. This is achieved by introducing a deployment key mechanism, updating the structure and logic for reading/writing user secrets, and ensuring that all relevant provisioning flows and resource handlers are updated accordingly.

Key changes include:

**Deployment Key and User Secrets Scoping:**

- Added a deployment key mechanism via `IUserSecretsManager.GetDeploymentKey()` to uniquely identify and scope user secrets per deployment. The deployment key is generated using the application host SHA and environment name in publish mode, and is used to nest secrets under `Azure:{deploymentKey}:...` instead of the global `Azure:...` scope. [[1]](diffhunk://#diff-789e8d2ef88505fe31c2c438079e33594417572dc3eea6918cbe8b1d95edd210R36-R47) [[2]](diffhunk://#diff-ff27f0891cf89b8ff7fb5ad49a90f371df203e8d2cc888131653de6ac984564bR66-R71) [[3]](diffhunk://#diff-ed0e6623f0dc6bc09201d1cc2cce54763d54a713e947d34a3cb991076d5f46f6L110-R116) [[4]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24L32-R45)

- Updated all provisioning context providers (`BaseProvisioningContextProvider`, `PublishModeProvisioningContextProvider`, `RunModeProvisioningContextProvider`) and the `DefaultUserSecretsManager` to accept and use the new deployment key for reading and writing secrets. [[1]](diffhunk://#diff-ed0e6623f0dc6bc09201d1cc2cce54763d54a713e947d34a3cb991076d5f46f6L28-R29) [[2]](diffhunk://#diff-ed0e6623f0dc6bc09201d1cc2cce54763d54a713e947d34a3cb991076d5f46f6R43) [[3]](diffhunk://#diff-5a7ac7ecf075ddef1d854ec7c130cbe1bd616ac74c8977bb7bed171b59a92dc6L29-R39) [[4]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24L32-R45)

**Provisioning and Resource Configuration Updates:**

- Modified resource provisioning logic so that all subscription, location, and resource group information is stored and retrieved using deployment-scoped keys. This includes updating prompts and user input flows to write secrets to the correct location. [[1]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24L67-R71) [[2]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24L78-R120) [[3]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24L93-R129) [[4]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24L102-R138) [[5]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24R217-R218) [[6]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24R254-R259) [[7]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24R354-R359) [[8]](diffhunk://#diff-a89d5f4a98e87999ed809f8f3b7bc8ea246c0dea4cfeed1161aa13b588307a24R411-R415)

- Updated the `BicepProvisioner` to read and write deployment outputs and configuration using deployment-scoped keys, ensuring outputs are correctly isolated per deployment. [[1]](diffhunk://#diff-978bce3167afe2c75d4df29db91538126966b2fe98102f7605f6c5f7a3367fdcL21-R29) [[2]](diffhunk://#diff-978bce3167afe2c75d4df29db91538126966b2fe98102f7605f6c5f7a3367fdcL221-R239)

**Persistence and State Management:**

- Ensured that provisioning state is saved to user secrets after each successful resource deployment and when using existing deployments, improving reliability and consistency of state persistence. [[1]](diffhunk://#diff-e9212cb2aa4e32ec45592c1a281973b3c3529b644b7961d35ac65b67a2e3b3e0R47-R49) [[2]](diffhunk://#diff-e9212cb2aa4e32ec45592c1a281973b3c3529b644b7961d35ac65b67a2e3b3e0R135-R151)

**Codebase and API Adjustments:**

- Refactored constructors and method signatures across provisioning-related classes to inject and utilize the new `IUserSecretsManager` and deployment key, ensuring all components are aware of and use the new scoping model. [[1]](diffhunk://#diff-ed0e6623f0dc6bc09201d1cc2cce54763d54a713e947d34a3cb991076d5f46f6L28-R29) [[2]](diffhunk://#diff-5a7ac7ecf075ddef1d854ec7c130cbe1bd616ac74c8977bb7bed171b59a92dc6L29-R39) [[3]](diffhunk://#diff-978bce3167afe2c75d4df29db91538126966b2fe98102f7605f6c5f7a3367fdcL21-R29) [[4]](diffhunk://#diff-789e8d2ef88505fe31c2c438079e33594417572dc3eea6918cbe8b1d95edd210R7-R21)