### PR TITLE
Ensure OutputPath is created in ResourceContainerImageBuilder

### DIFF
--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -358,6 +358,12 @@ internal sealed class ResourceContainerImageBuilder(
             resolvedBuildSecrets[buildSecret.Key] = await ResolveValue(buildSecret.Value, cancellationToken).ConfigureAwait(false);
         }
 
+        // ensure outputPath is created if specified since docker/podman won't create it for us
+        if (options?.OutputPath is { } outputPath)
+        {
+            Directory.CreateDirectory(outputPath);
+        }
+
         if (publishingTask is not null)
         {
             await using (publishingTask.ConfigureAwait(false))

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageBuilderTests.cs
@@ -243,11 +243,11 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         using var app = builder.Build();
 
-        var tempOutputPath = Path.GetTempPath();
+        using var tempDir = new TempDirectory();
         var options = new ContainerBuildOptions
         {
             ImageFormat = ContainerImageFormat.Oci,
-            OutputPath = tempOutputPath,
+            OutputPath = Path.Combine(tempDir.Path, "NewFolder"), // tests that the folder is created if it doesn't exist
             TargetPlatform = ContainerTargetPlatform.LinuxAmd64
         };
 


### PR DESCRIPTION
When using docker/podman, and specifying an output path, building a docker image will fail if the directory isn't created. Ensure it is created.