### PR TITLE
Default AZURE_TOKEN_CREDENTIALS env var when running in Azure

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/BaseContainerAppContext.cs
@@ -75,6 +75,13 @@ internal abstract class BaseContainerAppContext(IResource resource, ContainerApp
                 Name = "AZURE_CLIENT_ID",
                 Value = AllocateParameter(appIdentityResource.ClientId)
             });
+
+            // DefaultAzureCredential should only use ManagedIdentityCredential when running in Azure
+            env.Add(new ContainerAppEnvironmentVariable
+            {
+                Name = "AZURE_TOKEN_CREDENTIALS",
+                Value = "ManagedIdentityCredential"
+            });
         }
     }
 

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -311,6 +311,13 @@ internal sealed class AzureAppServiceWebsiteContext(
                 Name = "AZURE_CLIENT_ID",
                 Value = appIdentityResource.ClientId.AsProvisioningParameter(infra)
             });
+
+            // DefaultAzureCredential should only use ManagedIdentityCredential when running in Azure
+            webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+            {
+                Name = "AZURE_TOKEN_CREDENTIALS",
+                Value = "ManagedIdentityCredential"
+            });
         }
 
         // Added appsetting to identify the resource in a specific aspire environment

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.bicep
@@ -94,6 +94,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
           value: api_identity_outputs_clientid
         }
         {
+          name: 'AZURE_TOKEN_CREDENTIALS'
+          value: 'ManagedIdentityCredential'
+        }
+        {
           name: 'ASPIRE_ENVIRONMENT_NAME'
           value: 'env'
         }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsBicepGenerationIsIdempotent.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsBicepGenerationIsIdempotent.verified.bicep
@@ -79,6 +79,10 @@ resource api 'Microsoft.App/containerApps@2025-01-01' = {
               name: 'AZURE_CLIENT_ID'
               value: api_identity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.KeyVaultReferenceHandling.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.KeyVaultReferenceHandling.verified.bicep
@@ -72,6 +72,10 @@ resource api 'Microsoft.App/containerApps@2025-01-01' = {
               name: 'AZURE_CLIENT_ID'
               value: api_identity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
@@ -187,6 +187,10 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: api_identity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
@@ -187,6 +187,10 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: api_identity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#00.verified.bicep
@@ -56,6 +56,10 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: api_identity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingCosmosDB#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingCosmosDB#00.verified.bicep
@@ -62,6 +62,10 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: api_identity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
@@ -62,6 +62,10 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: api_identity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure#00.verified.bicep
@@ -107,6 +107,10 @@ resource funcapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: funcapp_identity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#00.verified.bicep
@@ -61,6 +61,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
           value: myidentity_outputs_clientid
         }
         {
+          name: 'AZURE_TOKEN_CREDENTIALS'
+          value: 'ManagedIdentityCredential'
+        }
+        {
           name: 'ASPIRE_ENVIRONMENT_NAME'
           value: 'appservice'
         }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
@@ -56,6 +56,10 @@ resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: myidentity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
@@ -56,6 +56,10 @@ resource myapp2 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: myidentity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
@@ -56,6 +56,10 @@ resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: myidentity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
@@ -56,6 +56,10 @@ resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_CLIENT_ID'
               value: myidentity_outputs_clientid
             }
+            {
+              name: 'AZURE_TOKEN_CREDENTIALS'
+              value: 'ManagedIdentityCredential'
+            }
           ]
         }
       ]


### PR DESCRIPTION
This environment variable tells DefaultAzureCredential to only use the ManagedIdentityCredential.

[[Breaking change]: DefaultAzureCredential defaults to ManagedIdentityCredential on ACA and App Service (dotnet/docs-aspire#5154)](https://github.com/dotnet/docs-aspire/issues/5154)