### PR TITLE
Fix message bar display when sidebar is open

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -84,6 +84,10 @@
 
     <div class="messagebar-container">
         <FluentMessageBarProvider Section="@DashboardUIHelpers.MessageBarSection" Class="top-messagebar" MaxMessageCount="null" NewestOnTop="true" />
+        @if (AIContextProvider.AssistantChatViewModel is not null && AIContextProvider.ShowAssistantSidebarDialog)
+        {
+            <div class="layout-sidebar-spacer"></div>
+        }
     </div>
     <div class="layout-body-container">
         <FluentBodyContent Class="custom-body-content body-content">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -49,6 +49,7 @@
         grid-area: messagebar;
         border-top: 1px solid var(--neutral-stroke-rest);
         border-left: 1px solid var(--neutral-stroke-rest);
+        display: flex;
     }
 
     ::deep .header-right {
@@ -126,6 +127,7 @@
         grid-area: messagebar;
         border-top: 1px solid var(--neutral-stroke-rest);
         border-left: 1px solid var(--neutral-stroke-rest);
+        display: flex;
     }
 
     ::deep .header-right {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -317,6 +317,7 @@ h1 {
     padding: calc(var(--design-unit) * 4px);
     padding-top: calc(var(--design-unit) * 2px);
     padding-bottom: 0 !important;
+    width: 100%;
 }
 
 .fluent-messagebar.intent-success {


### PR DESCRIPTION
Message bar is hidden under sidebar. Quick fix.

Before:
<img width="1538" height="907" alt="image" src="https://github.com/user-attachments/assets/10171ca4-fb4c-4778-9854-20a6b2d99484" />

After:
<img width="1533" height="902" alt="image" src="https://github.com/user-attachments/assets/4bf9a681-f424-48f8-8959-9b32bd6f8a02" />
