### PR TITLE
EndpointReference resolution waits for allocation to resolve values

### DIFF
--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResource.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResource.cs
@@ -78,22 +78,9 @@ public sealed class DevTunnelPortResource : Resource, IResourceWithServiceDiscov
     /// Options controlling how this port is exposed.
     /// </summary>
     public DevTunnelPortOptions Options { get; }
-
     internal EndpointReference TunnelEndpoint { get; }
-
     internal EndpointAnnotation TunnelEndpointAnnotation { get; }
-
-    internal TaskCompletionSource TunnelEndpointAllocatedTcs { get; } = new();
-
-    internal Task TunnelEndpointAllocatedTask => TunnelEndpointAllocatedTcs.Task;
-
     internal EndpointReference TargetEndpoint { get; init; }
-
-    internal TaskCompletionSource TargetEndpointAllocatedTcs { get; set; } = new();
-
-    internal Task TargetEndpointAllocatedTask => TargetEndpointAllocatedTcs.Task;
-
     internal DevTunnelPort? LastKnownStatus { get; set; }
-
     internal DevTunnelAccessStatus? LastKnownAccessStatus { get; set; }
 }

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -146,7 +146,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
                 }
 
                 // Wait for target resource endpoints to be allocated
-                await Task.WhenAll(tunnelResource.Ports.Select(p => p.TargetEndpoint.EndpointAnnotation.AllocatedEndpointSnapshot.GetValueAsync(ct))).ConfigureAwait(false);
+                await Task.WhenAll(tunnelResource.Ports.Select(p => p.TargetEndpoint.GetValueAsync(ct).AsTask())).ConfigureAwait(false);
 
                 // Start the tunnel ports
                 var notifications = e.Services.GetRequiredService<ResourceNotificationService>();

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -140,13 +140,13 @@ public static partial class DevTunnelsResourceBuilderExtensions
                     var exception = new DistributedApplicationException($"Error trying to create the dev tunnel resource '{tunnelResource.TunnelId}' this port belongs to: {ex.Message}", ex);
                     foreach (var portResource in tunnelResource.Ports)
                     {
-                        portResource.TunnelEndpointAllocatedTcs.SetException(exception);
+                        portResource.TunnelEndpointAnnotation.AllocatedEndpointSnapshot.SetException(exception);
                     }
                     throw;
                 }
 
                 // Wait for target resource endpoints to be allocated
-                await Task.WhenAll(tunnelResource.Ports.Select(p => p.TargetEndpointAllocatedTask)).ConfigureAwait(false);
+                await Task.WhenAll(tunnelResource.Ports.Select(p => p.TargetEndpoint.EndpointAnnotation.AllocatedEndpointSnapshot.GetValueAsync(ct))).ConfigureAwait(false);
 
                 // Start the tunnel ports
                 var notifications = e.Services.GetRequiredService<ResourceNotificationService>();
@@ -195,7 +195,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
                     catch (Exception ex)
                     {
                         portLogger.LogError(ex, "Error trying to create dev tunnel port '{Port}' on tunnel '{Tunnel}': {Error}", portResource.TargetEndpoint.Port, portResource.DevTunnel.TunnelId, ex.Message);
-                        portResource.TunnelEndpointAllocatedTcs.SetException(ex);
+                        portResource.TunnelEndpointAnnotation.AllocatedEndpointSnapshot.SetException(ex);
                         throw;
                     }
 
@@ -346,13 +346,11 @@ public static partial class DevTunnelsResourceBuilderExtensions
 
         builder
             .WithReferenceRelationship(tunnelResource)
-            .WithEnvironment(async context =>
+            .WithEnvironment(context =>
             {
                 // Add environment variables for each tunnel port that references an endpoint on the target resource
                 foreach (var port in tunnelResource.Resource.Ports.Where(p => p.TargetEndpoint.Resource == targetResource.Resource))
                 {
-                    await port.TunnelEndpointAllocatedTask.ConfigureAwait(false);
-
                     var serviceName = targetResource.Resource.Name;
                     var endpointName = port.TargetEndpoint.EndpointName;
                     context.EnvironmentVariables[$"services__{serviceName}__{endpointName}__0"] = port.TunnelEndpoint;
@@ -501,36 +499,6 @@ public static partial class DevTunnelsResourceBuilderExtensions
                 ]
             });
 
-        // When the target endpoint is allocated, validate it and mark the TCS accordingly
-        var targetResourceBuilder = tunnelBuilder.ApplicationBuilder.CreateResourceBuilder(targetResource);
-        targetResourceBuilder.OnResourceEndpointsAllocated((resource, e, ct) =>
-        {
-            var portLogger = e.Services.GetRequiredService<ResourceLoggerService>().GetLogger(portResource);
-
-            if (!portResource.TargetEndpoint.IsAllocated)
-            {
-                // Target endpoint is not allocated, ignore
-                portLogger.LogWarning("Target resource endpoints allocated event was fired but target endpoint was not allocated.");
-                return Task.CompletedTask;
-            }
-
-            portLogger.LogDebug("Target resource endpoints allocated");
-
-            // We do this check now so that we're verifying the allocated endpoint's address
-            if (!string.Equals(portResource.TargetEndpoint.Host, "localhost", StringComparison.OrdinalIgnoreCase) &&
-                !portResource.TargetEndpoint.Host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
-            {
-                // Target endpoint is not localhost so can't be tunneled
-                portLogger.LogError("Cannot tunnel endpoint '{Endpoint}' with host '{Host}' on resource '{Resource}' because it is not a localhost endpoint.", portResource.TargetEndpoint.EndpointName, portResource.TargetEndpoint.Host, portResource.TargetEndpoint.Resource.Name);
-                portResource.TargetEndpointAllocatedTcs.SetException(new DistributedApplicationException($"Cannot tunnel endpoint '{portResource.TargetEndpoint.EndpointName}' with host '{portResource.TargetEndpoint.Host}' on resource '{portResource.TargetEndpoint.Resource.Name}' because it is not a localhost endpoint."));
-                return Task.CompletedTask;
-            }
-
-            // Signal the target endpoint created
-            portResource.TargetEndpointAllocatedTcs.SetResult();
-            return Task.CompletedTask;
-        });
-
         // Lifecycle from the tunnel
         tunnelBuilder
             .OnResourceReady(async (tunnelResource, e, ct) =>
@@ -567,7 +535,6 @@ public static partial class DevTunnelsResourceBuilderExtensions
                 if (raiseEndpointsAllocatedEvent)
                 {
                     await eventing.PublishAsync<ResourceEndpointsAllocatedEvent>(new(portResource, services), ct).ConfigureAwait(false);
-                    portResource.TunnelEndpointAllocatedTcs.SetResult();
                 }
 
                 // Mark the port as running

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -144,5 +144,36 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// <summary>
     /// Gets or sets the allocated endpoint.
     /// </summary>
-    public AllocatedEndpoint? AllocatedEndpoint { get; set; }
+    public AllocatedEndpoint? AllocatedEndpoint
+    {
+        get
+        {
+            if (!AllocatedEndpointSnapshot.IsValueSet)
+            {
+                return null;
+            }
+
+            // This looks bad *BUT* we check if the value is set before resolving.
+            // This preserves the semantics that if the value is not set, we return null to
+            // the caller.
+            return AllocatedEndpointSnapshot.GetValueAsync().GetAwaiter().GetResult();
+        }
+        set
+        {
+            if (value is null)
+            {
+                // Setting null will proactively set an exception on the snapshot.
+                AllocatedEndpointSnapshot.SetException(new InvalidOperationException($"The endpoint `{Name}` is not allocated"));
+            }
+            else
+            {
+                AllocatedEndpointSnapshot.SetValue(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the allocated endpoint snapshot.
+    /// </summary>
+    public ValueSnapshot<AllocatedEndpoint> AllocatedEndpointSnapshot { get; } = new();
 }

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -16,8 +16,10 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     private EndpointAnnotation? _endpointAnnotation;
     private bool? _isAllocated;
 
-    // TODO: Expose this
-    internal EndpointAnnotation EndpointAnnotation => GetEndpointAnnotation() ?? throw new InvalidOperationException($"The endpoint `{EndpointName}` is not defined for the resource `{Resource.Name}`.");
+    /// <summary>
+    /// Gets the endpoint annotation associated with the endpoint reference.
+    /// </summary>
+    public EndpointAnnotation EndpointAnnotation => GetEndpointAnnotation() ?? throw new InvalidOperationException($"The endpoint `{EndpointName}` is not defined for the resource `{Resource.Name}`.");
 
     /// <summary>
     /// Gets the resource owner of the endpoint reference.
@@ -43,7 +45,12 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
 
     string IManifestExpressionProvider.ValueExpression => GetExpression();
 
-    ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => new(Url);
+    /// <summary>
+    /// Gets the URL of the endpoint asynchronously. Waits for the endpoint to be allocated if necessary.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The URL of the endpoint.</returns>
+    public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default) => Property(EndpointProperty.Url).GetValueAsync(cancellationToken);
 
     /// <summary>
     /// Gets the specified property expression of the endpoint. Defaults to the URL if no property is specified.
@@ -103,6 +110,9 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     /// Gets the URL for this endpoint.
     /// </summary>
     public string Url => AllocatedEndpoint.UriString;
+
+    internal ValueSnapshot<AllocatedEndpoint> AllocatedEndpointSnapshot =>
+        EndpointAnnotation.AllocatedEndpointSnapshot;
 
     internal AllocatedEndpoint AllocatedEndpoint =>
         GetAllocatedEndpoint()
@@ -172,30 +182,38 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="string"/> containing the selected <see cref="EndpointProperty"/> value.</returns>
     /// <exception cref="InvalidOperationException">Throws when the selected <see cref="EndpointProperty"/> enumeration is not known.</exception>
-    public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken) => Property switch
+    public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
     {
-        EndpointProperty.Url => new(Endpoint.Url),
-        EndpointProperty.Host => new(Endpoint.Host),
-        EndpointProperty.IPV4Host => new("127.0.0.1"),
-        EndpointProperty.Port => new(Endpoint.Port.ToString(CultureInfo.InvariantCulture)),
-        EndpointProperty.Scheme => new(Endpoint.Scheme),
-        EndpointProperty.TargetPort => new(ComputeTargetPort()),
-        EndpointProperty.HostAndPort => new($"{Endpoint.Host}:{Endpoint.Port.ToString(CultureInfo.InvariantCulture)}"),
-        _ => throw new InvalidOperationException($"The property '{Property}' is not supported for the endpoint '{Endpoint.EndpointName}'.")
-    };
-
-    private string? ComputeTargetPort()
-    {
-        // We have a target port, so we can return it directly.
-        if (Endpoint.TargetPort is int port)
+        return Property switch
         {
-            return port.ToString(CultureInfo.InvariantCulture);
-        }
+            EndpointProperty.Scheme => new(Endpoint.Scheme),
+            EndpointProperty.IPV4Host => new("127.0.0.1"),
+            EndpointProperty.TargetPort when Endpoint.TargetPort is int port => new(port.ToString(CultureInfo.InvariantCulture)),
+            _ => await ResolveValueWithAllocatedAddress().ConfigureAwait(false)
+        };
 
+        async ValueTask<string?> ResolveValueWithAllocatedAddress()
+        {
+            var allocatedEndpoint = await Endpoint.AllocatedEndpointSnapshot.GetValueAsync(cancellationToken).ConfigureAwait(false);
+
+            return Property switch
+            {
+                EndpointProperty.Url => new(allocatedEndpoint.UriString),
+                EndpointProperty.Host => new(allocatedEndpoint.Address),
+                EndpointProperty.Port => new(allocatedEndpoint.Port.ToString(CultureInfo.InvariantCulture)),
+                EndpointProperty.TargetPort => new(ComputeTargetPort(allocatedEndpoint)),
+                EndpointProperty.HostAndPort => new($"{allocatedEndpoint.Address}:{allocatedEndpoint.Port.ToString(CultureInfo.InvariantCulture)}"),
+                _ => throw new InvalidOperationException($"The property '{Property}' is not supported for the endpoint '{Endpoint.EndpointName}'.")
+            };
+        }
+    }
+
+    private static string? ComputeTargetPort(AllocatedEndpoint allocatedEndpoint)
+    {
         // There is no way to resolve the value of the target port until runtime. Even then, replicas make this very complex because
         // the target port is not known until the replica is allocated.
         // Instead, we return an expression that will be resolved at runtime by the orchestrator.
-        return Endpoint.AllocatedEndpoint.TargetPortExpression
+        return allocatedEndpoint.TargetPortExpression
             ?? throw new InvalidOperationException("The endpoint does not have an associated TargetPortExpression from the orchestrator.");
     }
 

--- a/src/Aspire.Hosting/ApplicationModel/ValueSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ValueSnapshot.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Provides an asynchronously initialized value that:
+/// - Can be awaited via GetValueAsync() until the first value or exception is set.
+/// - Exposes the latest value after it has been set (supports re-setting).
+/// - Tracks whether a value or exception was ever set via IsValueSet.
+/// - Supports setting an exception that will be thrown by GetValueAsync.
+/// 
+/// Thread-safe for concurrent SetValue / SetException / GetValueAsync calls.
+/// </summary>
+public sealed class ValueSnapshot<T> where T : notnull
+{
+    private readonly TaskCompletionSource<T> _firstValueTcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private readonly object _lock = new();
+    private Task<T>? _currentValue;
+
+    /// <summary>
+    /// True once a value or exception has been set at least once.
+    /// </summary>
+    public bool IsValueSet => _firstValueTcs.Task.IsCompleted;
+
+    /// <summary>
+    /// Await the current value:
+    /// - If a value has already been set, returns it immediately.
+    /// - If an exception has been set, throws it.
+    /// - Otherwise waits until the first value or exception is set.
+    /// Always returns the latest value at the moment of completion or throws the exception.
+    /// </summary>
+    public Task<T> GetValueAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            // Return updated value if it exists, otherwise return the first value task
+            return _currentValue ?? _firstValueTcs.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Sets (or updates) the value. The first successful call completes any
+    /// pending GetValueAsync waiters. Subsequent calls replace the current value.
+    /// </summary>
+    public void SetValue(T value)
+    {
+        lock (_lock)
+        {
+            if (!_firstValueTcs.TrySetResult(value))
+            {
+                _currentValue = Task.FromResult(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sets an exception that will be thrown by GetValueAsync.
+    /// The first successful call (either SetValue or SetException) completes any
+    /// pending GetValueAsync waiters.
+    /// </summary>
+    public void SetException(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        lock (_lock)
+        {
+            if (!_firstValueTcs.TrySetException(exception))
+            {
+                _currentValue = Task.FromException<T>(exception);
+            }
+        }
+    }
+}

--- a/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelResourceBuilderExtensionsTests.cs
@@ -24,7 +24,6 @@ public class DevTunnelResourceBuilderExtensionsTests
         Assert.NotNull(tunnelPort);
 
         tunnelPort.TunnelEndpointAnnotation.AllocatedEndpoint = new(tunnelPort.TunnelEndpointAnnotation, "test123.devtunnels.ms", 443);
-        tunnelPort.TunnelEndpointAllocatedTcs.SetResult();
 
         var values = await consumer.Resource.GetEnvironmentVariableValuesAsync();
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -135,7 +135,13 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
 
         // Act
         await hook.OnBeforeStartAsync(new BeforeStartEvent(new TestServiceProvider(), model), CancellationToken.None).DefaultTimeout();
-        var dashboardResource = model.Resources.Single(r => string.Equals(r.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName));
+        var dashboardResource = (IResourceWithEndpoints)model.Resources.Single(r => string.Equals(r.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName));
+
+        var httpEndpoint = new EndpointReference(dashboardResource, "http");
+        httpEndpoint.EndpointAnnotation.AllocatedEndpoint = new(httpEndpoint.EndpointAnnotation, "localhost", 8080);
+        var otlpGrpcEndpoint = new EndpointReference(dashboardResource, DashboardEventHandlers.OtlpGrpcEndpointName);
+        otlpGrpcEndpoint.EndpointAnnotation.AllocatedEndpoint = new(otlpGrpcEndpoint.EndpointAnnotation, "localhost", 4317);
+
         var context = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = TestServiceProvider.Instance });
         var dashboardEnvironmentVariables = new ConcurrentDictionary<string, string?>();
         await dashboardResource.ProcessEnvironmentVariableValuesAsync(context, (key, _, value, _) => dashboardEnvironmentVariables[key] = value, new FakeLogger()).DefaultTimeout();

--- a/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
@@ -1,0 +1,304 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Sockets;
+
+namespace Aspire.Hosting.Tests;
+
+public class EndpointReferenceTests
+{
+    [Fact]
+    public async Task GetValueAsync_WaitsForEndpointAllocation()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+
+        var getValueTask = endpointRef.GetValueAsync(CancellationToken.None);
+        Assert.False(getValueTask.IsCompleted);
+
+        annotation.AllocatedEndpoint = new AllocatedEndpoint(annotation, "localhost", 8080);
+
+        var url = await getValueTask;
+        Assert.Equal("http://localhost:8080", url);
+    }
+
+    [Fact]
+    public async Task GetUrlPropertyValueAsync_WaitsForEndpointAllocation()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var endpointExpr = endpointRef.Property(EndpointProperty.Url);
+
+        var getValueTask = endpointExpr.GetValueAsync(CancellationToken.None);
+        Assert.False(getValueTask.IsCompleted);
+
+        annotation.AllocatedEndpoint = new AllocatedEndpoint(annotation, "localhost", 8080);
+
+        var url = await getValueTask;
+        Assert.Equal("http://localhost:8080", url);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_ReturnsImmediatelyWhenAlreadyAllocated()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+        annotation.AllocatedEndpoint = new AllocatedEndpoint(annotation, "localhost", 8080);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var endpointExpr = endpointRef.Property(EndpointProperty.Url);
+
+        var url = await endpointExpr.GetValueAsync(CancellationToken.None);
+        Assert.Equal("http://localhost:8080", url);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_Host_WaitsForAllocation()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var hostExpr = endpointRef.Property(EndpointProperty.Host);
+
+        var getValueTask = hostExpr.GetValueAsync(CancellationToken.None);
+        Assert.False(getValueTask.IsCompleted);
+
+        annotation.AllocatedEndpoint = new AllocatedEndpoint(annotation, "192.168.1.100", 8080);
+
+        var host = await getValueTask;
+        Assert.Equal("192.168.1.100", host);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_Port_WaitsForAllocation()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var portExpr = endpointRef.Property(EndpointProperty.Port);
+
+        var getValueTask = portExpr.GetValueAsync(CancellationToken.None);
+        Assert.False(getValueTask.IsCompleted);
+
+        annotation.AllocatedEndpoint = new AllocatedEndpoint(annotation, "localhost", 9090);
+
+        var port = await getValueTask;
+        Assert.Equal("9090", port);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_Scheme_ReturnsImmediately()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "https", name: "https");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var schemeExpr = endpointRef.Property(EndpointProperty.Scheme);
+
+        var scheme = await schemeExpr.GetValueAsync(CancellationToken.None);
+        Assert.Equal("https", scheme);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_IPV4Host_ReturnsImmediately()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var ipv4Expr = endpointRef.Property(EndpointProperty.IPV4Host);
+
+        var ipv4 = await ipv4Expr.GetValueAsync(CancellationToken.None);
+        Assert.Equal("127.0.0.1", ipv4);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_TargetPort_WithStaticPort_ReturnsImmediately()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", targetPort: 5000);
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var targetPortExpr = endpointRef.Property(EndpointProperty.TargetPort);
+
+        var targetPort = await targetPortExpr.GetValueAsync(CancellationToken.None);
+        Assert.Equal("5000", targetPort);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_TargetPort_WithExpression_WaitsForAllocation()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var targetPortExpr = endpointRef.Property(EndpointProperty.TargetPort);
+
+        var getValueTask = targetPortExpr.GetValueAsync(CancellationToken.None);
+        Assert.False(getValueTask.IsCompleted);
+
+        annotation.AllocatedEndpoint = new AllocatedEndpoint(annotation, "localhost", 8080, targetPortExpression: "5000");
+
+        var targetPort = await getValueTask;
+        Assert.Equal("5000", targetPort);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_SupportsCancellation()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var endpointExpr = endpointRef.Property(EndpointProperty.Url);
+
+        using var cts = new CancellationTokenSource();
+        var getValueTask = endpointExpr.GetValueAsync(cts.Token);
+
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await getValueTask);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_MultipleWaiters_AllCompleteWhenAllocated()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+        var expr1 = endpointRef.Property(EndpointProperty.Url);
+        var expr2 = endpointRef.Property(EndpointProperty.Host);
+        var expr3 = endpointRef.Property(EndpointProperty.Port);
+
+        var task1 = expr1.GetValueAsync(CancellationToken.None);
+        var task2 = expr2.GetValueAsync(CancellationToken.None);
+        var task3 = expr3.GetValueAsync(CancellationToken.None);
+
+        Assert.False(task1.IsCompleted);
+        Assert.False(task2.IsCompleted);
+        Assert.False(task3.IsCompleted);
+
+        annotation.AllocatedEndpoint = new AllocatedEndpoint(annotation, "localhost", 8080);
+
+        var url = await task1;
+        var host = await task2;
+        var port = await task3;
+
+        Assert.Equal("http://localhost:8080", url);
+        Assert.Equal("localhost", host);
+        Assert.Equal("8080", port);
+    }
+
+    [Fact]
+    public void Port_ThrowsWhenEndpointNotAllocated()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => endpointRef.Port);
+        Assert.Equal("The endpoint `http` is not allocated for the resource `test`.", ex.Message);
+    }
+
+    [Fact]
+    public void Host_ThrowsWhenEndpointNotAllocated()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => endpointRef.Host);
+        Assert.Equal("The endpoint `http` is not allocated for the resource `test`.", ex.Message);
+    }
+
+    [Fact]
+    public void Url_ThrowsWhenEndpointNotAllocated()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => endpointRef.Url);
+        Assert.Equal("The endpoint `http` is not allocated for the resource `test`.", ex.Message);
+    }
+
+    [Fact]
+    public void ContainerHost_ThrowsWhenEndpointNotAllocated()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => endpointRef.ContainerHost);
+        Assert.Equal("The endpoint `http` is not allocated for the resource `test`.", ex.Message);
+    }
+
+    [Fact]
+    public void Scheme_DoesNotThrowWhenEndpointNotAllocated()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "https", name: "https");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+
+        var scheme = endpointRef.Scheme;
+        Assert.Equal("https", scheme);
+    }
+
+    [Fact]
+    public void TargetPort_DoesNotThrowWhenStaticPortDefined()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", targetPort: 5000);
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+
+        var targetPort = endpointRef.TargetPort;
+        Assert.Equal(5000, targetPort);
+    }
+
+    [Fact]
+    public void TargetPort_ReturnsNullWhenNotDefined()
+    {
+        var resource = new TestResource("test");
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
+        resource.Annotations.Add(annotation);
+
+        var endpointRef = new EndpointReference(resource, annotation);
+
+        var targetPort = endpointRef.TargetPort;
+        Assert.Null(targetPort);
+    }
+
+    private sealed class TestResource(string name) : Resource(name), IResourceWithEndpoints
+    {
+    }
+}

--- a/tests/Aspire.Hosting.Tests/ValueSnapshotTests.cs
+++ b/tests/Aspire.Hosting.Tests/ValueSnapshotTests.cs
@@ -1,0 +1,212 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Tests;
+
+public class ValueSnapshotTests
+{
+    [Fact]
+    public async Task GetValueAsync_WaitsForFirstValue()
+    {
+        var snapshot = new ValueSnapshot<string>();
+
+        var getTask = snapshot.GetValueAsync();
+        Assert.False(getTask.IsCompleted);
+
+        snapshot.SetValue("test");
+
+        var result = await getTask;
+        Assert.Equal("test", result);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_ReturnsImmediatelyAfterValueSet()
+    {
+        var snapshot = new ValueSnapshot<string>();
+        snapshot.SetValue("test");
+
+        var getTask = snapshot.GetValueAsync();
+
+        Assert.True(getTask.IsCompleted);
+
+        var result = await getTask;
+
+        Assert.Equal("test", result);
+    }
+
+    [Fact]
+    public async Task SetValue_UpdatesValue()
+    {
+        var snapshot = new ValueSnapshot<string>();
+        snapshot.SetValue("first");
+
+        var firstResult = await snapshot.GetValueAsync();
+        Assert.Equal("first", firstResult);
+
+        snapshot.SetValue("second");
+
+        var secondResult = await snapshot.GetValueAsync();
+        Assert.Equal("second", secondResult);
+    }
+
+    [Fact]
+    public async Task SetValue_CompletesAllWaiters()
+    {
+        var snapshot = new ValueSnapshot<string>();
+
+        var task1 = snapshot.GetValueAsync();
+        var task2 = snapshot.GetValueAsync();
+        var task3 = snapshot.GetValueAsync();
+
+        snapshot.SetValue("test");
+
+        var result1 = await task1;
+        var result2 = await task2;
+        var result3 = await task3;
+
+        Assert.Equal("test", result1);
+        Assert.Equal("test", result2);
+        Assert.Equal("test", result3);
+    }
+
+    [Fact]
+    public async Task SetException_ThrowsException()
+    {
+        var snapshot = new ValueSnapshot<string>();
+        var exception = new InvalidOperationException("Test error");
+
+        snapshot.SetException(exception);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => snapshot.GetValueAsync());
+        Assert.Same(exception, ex);
+    }
+
+    [Fact]
+    public async Task SetException_CompletesAllWaiters()
+    {
+        var snapshot = new ValueSnapshot<string>();
+        var exception = new InvalidOperationException("Test error");
+
+        var task1 = snapshot.GetValueAsync();
+        var task2 = snapshot.GetValueAsync();
+
+        snapshot.SetException(exception);
+
+        var ex1 = await Assert.ThrowsAsync<InvalidOperationException>(() => task1);
+        var ex2 = await Assert.ThrowsAsync<InvalidOperationException>(() => task2);
+
+        Assert.Same(exception, ex1);
+        Assert.Same(exception, ex2);
+    }
+
+    [Fact]
+    public async Task SetException_CanBeReplacedWithValue()
+    {
+        var snapshot = new ValueSnapshot<string>();
+        var exception = new InvalidOperationException("Test error");
+
+        snapshot.SetException(exception);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => snapshot.GetValueAsync());
+
+        snapshot.SetValue("recovered");
+
+        var result = await snapshot.GetValueAsync();
+        Assert.Equal("recovered", result);
+    }
+
+    [Fact]
+    public async Task SetValue_CanBeReplacedWithException()
+    {
+        var snapshot = new ValueSnapshot<string>();
+
+        snapshot.SetValue("test");
+        Assert.Equal("test", await snapshot.GetValueAsync());
+
+        var exception = new InvalidOperationException("Error occurred");
+        snapshot.SetException(exception);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => snapshot.GetValueAsync());
+        Assert.Same(exception, ex);
+    }
+
+    [Fact]
+    public void IsValueSet_FalseBeforeAnySet()
+    {
+        var snapshot = new ValueSnapshot<string>();
+
+        Assert.False(snapshot.IsValueSet);
+    }
+
+    [Fact]
+    public void IsValueSet_TrueAfterSetValue()
+    {
+        var snapshot = new ValueSnapshot<string>();
+
+        snapshot.SetValue("test");
+
+        Assert.True(snapshot.IsValueSet);
+    }
+
+    [Fact]
+    public void IsValueSet_TrueAfterSetException()
+    {
+        var snapshot = new ValueSnapshot<string>();
+
+        snapshot.SetException(new InvalidOperationException());
+
+        Assert.True(snapshot.IsValueSet);
+    }
+
+    [Fact]
+    public void IsValueSet_RemainsTrueAfterUpdate()
+    {
+        var snapshot = new ValueSnapshot<string>();
+
+        snapshot.SetValue("first");
+        Assert.True(snapshot.IsValueSet);
+
+        snapshot.SetValue("second");
+        Assert.True(snapshot.IsValueSet);
+
+        snapshot.SetException(new InvalidOperationException());
+        Assert.True(snapshot.IsValueSet);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_SupportsCancellation()
+    {
+        var snapshot = new ValueSnapshot<string>();
+        using var cts = new CancellationTokenSource();
+
+        var getTask = snapshot.GetValueAsync(cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => getTask);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_CancellationDoesNotAffectOtherWaiters()
+    {
+        var snapshot = new ValueSnapshot<string>();
+        using var cts = new CancellationTokenSource();
+
+        var cancelledTask = snapshot.GetValueAsync(cts.Token);
+        var normalTask = snapshot.GetValueAsync();
+
+        cts.Cancel();
+        await Assert.ThrowsAsync<TaskCanceledException>(() => cancelledTask);
+
+        snapshot.SetValue("test");
+        var result = await normalTask;
+
+        Assert.Equal("test", result);
+    }
+
+    [Fact]
+    public void SetException_ThrowsArgumentNullException_WhenExceptionIsNull()
+    {
+        var snapshot = new ValueSnapshot<string>();
+
+        Assert.Throws<ArgumentNullException>(() => snapshot.SetException(null!));
+    }
+}


### PR DESCRIPTION
## Description

EndpointReference resolution wait for allocation to resolve specific values
- EndpointReference.GetValueAsync would not wait for the endpoint to be allocated before attempting to resolve values. Now it does.
- Updated all of the book keeping logic in DevTunnels to avoid tracking the state of endpoint allocation.
- Introduced ValueSnapshot which is like a TaskCompletionSource but allows updating the value once set.
- Code that relied on this throwing immediately would now hang (breaking change). Code can *always* check IsAllocated manually.

Fixes #11834

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
