### PR TITLE
Improve trace details performance with a very large trace

### DIFF
--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -90,6 +90,7 @@ serviceBuilder.WithHttpCommand("/exemplars-no-span", "Examplars with no span", c
 serviceBuilder.WithHttpCommand("/genai-trace", "Gen AI trace", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 serviceBuilder.WithHttpCommand("/genai-trace-display-error", "Gen AI trace display error", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 serviceBuilder.WithHttpCommand("/log-formatting", "Log formatting", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
+serviceBuilder.WithHttpCommand("/big-nested-trace", "Big nested trace", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
 
 builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice")
        .WithUrls(c => c.Urls.Add(new() { Url = "https://someplace.com", DisplayText = "Some place" }))

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -281,6 +281,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     {
         _resources = TelemetryRepository.GetResources();
 
+        // Copying a large trace can be expensive so only do this if required.
         if (_trace == null || _trace.TraceId != TraceId || TelemetryRepository.HasUpdatedTrace(_trace))
         {
             Logger.LogInformation("Getting trace '{TraceId}'.", TraceId);

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -281,8 +281,11 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     {
         _resources = TelemetryRepository.GetResources();
 
-        Logger.LogInformation("Getting trace '{TraceId}'.", TraceId);
-        _trace = (TraceId != null) ? TelemetryRepository.GetTrace(TraceId) : null;
+        if (_trace == null || _trace.TraceId != TraceId || TelemetryRepository.HasUpdatedTrace(_trace))
+        {
+            Logger.LogInformation("Getting trace '{TraceId}'.", TraceId);
+            _trace = (TraceId != null) ? TelemetryRepository.GetTrace(TraceId) : null;
+        }
 
         if (_trace == null)
         {

--- a/src/Aspire.Dashboard/Model/TraceHelpers.cs
+++ b/src/Aspire.Dashboard/Model/TraceHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using Aspire.Dashboard.Otlp.Model;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
@@ -14,26 +15,41 @@ public static class TraceHelpers
     /// </summary>
     public static void VisitSpans<TState>(OtlpTrace trace, Func<OtlpSpan, TState, TState> spanAction, TState state)
     {
-        // TODO: Investigate performance.
-        // A trace's spans are stored in one collection and recursively iterated by matching the span id to its parent.
-        // This behavior could cause excessive iteration over the span collection in large traces. Consider improving if this causes performance issues.
+        // Calculate span hierarchy.
+        var spanLookup = new Dictionary<OtlpSpan, List<OtlpSpan>>();
+        var unrootedSpans = new List<OtlpSpan>();
+        foreach (var item in trace.Spans)
+        {
+            if (string.IsNullOrEmpty(item.ParentSpanId) || !trace.Spans.TryGetValue(item.ParentSpanId, out var parentSpan))
+            {
+                unrootedSpans.Add(item);
+                continue;
+            }
+
+            ref var spans = ref CollectionsMarshal.GetValueRefOrAddDefault(spanLookup, parentSpan, out _);
+            spans ??= [];
+            spans.Add(item);
+        }
 
         var orderByFunc = static (OtlpSpan s) => s.StartTime;
 
-        foreach (var unrootedSpan in trace.Spans.Where(s => s.GetParentSpan() == null).OrderBy(orderByFunc))
+        foreach (var unrootedSpan in unrootedSpans.OrderBy(orderByFunc))
         {
             var newState = spanAction(unrootedSpan, state);
 
-            Visit(trace.Spans, unrootedSpan, spanAction, newState, orderByFunc);
+            Visit(spanLookup, unrootedSpan, spanAction, newState, orderByFunc);
         }
 
-        static void Visit(OtlpSpanCollection allSpans, OtlpSpan span, Func<OtlpSpan, TState, TState> spanAction, TState state, Func<OtlpSpan, DateTime> orderByFunc)
+        static void Visit(Dictionary<OtlpSpan, List<OtlpSpan>> spanLookup, OtlpSpan span, Func<OtlpSpan, TState, TState> spanAction, TState state, Func<OtlpSpan, DateTime> orderByFunc)
         {
-            foreach (var childSpan in OtlpSpan.GetChildSpans(span, allSpans).OrderBy(orderByFunc))
+            if (spanLookup.TryGetValue(span, out var allSpans))
             {
-                var newState = spanAction(childSpan, state);
+                foreach (var childSpan in allSpans.OrderBy(orderByFunc))
+                {
+                    var newState = spanAction(childSpan, state);
 
-                Visit(allSpans, childSpan, spanAction, newState, orderByFunc);
+                    Visit(spanLookup, childSpan, spanAction, newState, orderByFunc);
+                }
             }
         }
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -9,6 +9,7 @@ namespace Aspire.Dashboard.Otlp.Model;
 public class OtlpTrace
 {
     private OtlpSpan? _rootSpan;
+    private TimeSpan? _duration;
 
     public ReadOnlyMemory<byte> Key { get; }
     public string TraceId { get; }
@@ -18,23 +19,7 @@ public class OtlpTrace
     public DateTime TimeStamp => FirstSpan.StartTime;
     public OtlpSpan? RootSpan => _rootSpan;
     public OtlpSpan RootOrFirstSpan => RootSpan ?? FirstSpan;
-    public TimeSpan Duration
-    {
-        get
-        {
-            var start = FirstSpan.StartTime;
-            DateTime end = default;
-            foreach (var span in Spans)
-            {
-                if (span.EndTime > end)
-                {
-                    end = span.EndTime;
-                }
-            }
-            return end - start;
-        }
-    }
-
+    public TimeSpan Duration => _duration ??= CalculateDuration();
     public OtlpSpanCollection Spans { get; } = new OtlpSpanCollection();
     public DateTime LastUpdatedDate { get; private set; }
 
@@ -171,6 +156,20 @@ public class OtlpTrace
         }
 
         return newTrace;
+    }
+
+    private TimeSpan CalculateDuration()
+    {
+        var start = FirstSpan.StartTime;
+        DateTime end = default;
+        foreach (var span in Spans)
+        {
+            if (span.EndTime > end)
+            {
+                end = span.EndTime;
+            }
+        }
+        return end - start;
     }
 
     private string DebuggerToString()


### PR DESCRIPTION
## Description

Traces with 1000s of spans are slow to display or update. For example, expand/collapse items. Filter items, etc.

PR improves performance:

- Don't copy trace from repository again if it hasn't changed
- Create dictionary to lookup children and build trace hierarchy
- Cache trace duration to avoid continiously recalculating

With these changes the time it takes to expand/collapse a node in a trace with 10,000 spans goes from 5+ seconds to under a second.

Fixes https://github.com/dotnet/aspire/issues/11838

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
