### PR TITLE
Update default Kusto emulator db creation script to be persistent

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="Azure.Storage.Queues" Version="12.23.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.53.1" />
     <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="14.0.1" />
+    <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="14.0.1" />
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.32.0" />
     <PackageVersion Include="Microsoft.Azure.SignalR.Management" Version="1.32.0" />
     <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.2.1" />

--- a/playground/AzureKusto/AzureKusto.AppHost/AzureKustoReadWriteDatabaseResourceBuilderExtensions.cs
+++ b/playground/AzureKusto/AzureKusto.AppHost/AzureKustoReadWriteDatabaseResourceBuilderExtensions.cs
@@ -5,6 +5,8 @@ using Aspire.Hosting.Azure;
 using Kusto.Cloud.Platform.Utils;
 using Kusto.Data;
 using Kusto.Data.Net.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Polly;
 
 internal static class AzureKustoReadWriteDatabaseResourceBuilderExtensions
@@ -26,7 +28,8 @@ internal static class AzureKustoReadWriteDatabaseResourceBuilderExtensions
         {
             if (!dbBuilder.Resource.Parent.IsEmulator)
             {
-                Console.WriteLine("Skipping Kusto DB control command for non-emulator.");
+                var logger = evt.Services.GetRequiredService<ResourceLoggerService>().GetLogger(dbBuilder.Resource);
+                logger.LogInformation("Skipping Kusto DB control command for non-emulator.");
                 return;
             }
 

--- a/playground/AzureKusto/AzureKusto.AppHost/AzureKustoReadWriteDatabaseResourceBuilderExtensions.cs
+++ b/playground/AzureKusto/AzureKusto.AppHost/AzureKustoReadWriteDatabaseResourceBuilderExtensions.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Azure;
+using Kusto.Cloud.Platform.Utils;
+using Kusto.Data;
+using Kusto.Data.Net.Client;
+using Polly;
+
+internal static class AzureKustoReadWriteDatabaseResourceBuilderExtensions
+{
+    private static readonly ResiliencePipeline s_resiliencePipeline = new ResiliencePipelineBuilder()
+        .AddRetry(new()
+        {
+            // Retry any non-permanent exceptions
+            MaxRetryAttempts = 10,
+            Delay = TimeSpan.FromMilliseconds(100),
+            BackoffType = DelayBackoffType.Exponential,
+            ShouldHandle = new PredicateBuilder().Handle<Exception>(e => e is ICloudPlatformException cpe && !cpe.IsPermanent),
+        })
+        .Build();
+
+    public static IResourceBuilder<AzureKustoReadWriteDatabaseResource> WithControlCommand(this IResourceBuilder<AzureKustoReadWriteDatabaseResource> dbBuilder, string command)
+    {
+        dbBuilder.OnResourceReady(async (dbResource, evt, ct) =>
+        {
+            if (!dbBuilder.Resource.Parent.IsEmulator)
+            {
+                Console.WriteLine("Skipping Kusto DB control command for non-emulator.");
+                return;
+            }
+
+            var connectionString = await dbResource.ConnectionStringExpression.GetValueAsync(ct);
+            var kcsb = new KustoConnectionStringBuilder(connectionString);
+
+            using var admin = KustoClientFactory.CreateCslAdminProvider(kcsb);
+
+            await s_resiliencePipeline.ExecuteAsync(async cancellationToken =>
+            {
+                return await admin.ExecuteControlCommandAsync(admin.DefaultDatabaseName, command);
+            },
+            ct);
+        });
+
+        return dbBuilder;
+    }
+}

--- a/playground/AzureKusto/AzureKusto.Worker/AzureKusto.Worker.csproj
+++ b/playground/AzureKusto/AzureKusto.Worker/AzureKusto.Worker.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Azure.Kusto.Data" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" />
     <PackageReference Include="Polly.Extensions" />
-    <PackageReference Include="System.Text.Json" VersionOverride="9.0.7" /><!-- TODO: Required by Ingest; what to do here? -->
+    <PackageReference Include="System.Text.Json" VersionOverride="9.0.7" /><!-- Microsoft.Azure.Kusto.Ingest requires STJ 9 -->
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/playground/AzureKusto/AzureKusto.Worker/AzureKusto.Worker.csproj
+++ b/playground/AzureKusto/AzureKusto.Worker/AzureKusto.Worker.csproj
@@ -9,6 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Kusto.Data" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" />
+    <PackageReference Include="Polly.Extensions" />
+    <PackageReference Include="System.Text.Json" VersionOverride="9.0.7" /><!-- TODO: Required by Ingest; what to do here? -->
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/playground/AzureKusto/AzureKusto.Worker/Program.cs
+++ b/playground/AzureKusto/AzureKusto.Worker/Program.cs
@@ -1,7 +1,10 @@
 using Azure.Identity;
 using AzureKusto.Worker;
+using Kusto.Cloud.Platform.Utils;
 using Kusto.Data;
 using Kusto.Data.Net.Client;
+using Kusto.Ingest;
+using Polly;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.AddServiceDefaults();
@@ -22,6 +25,21 @@ builder.Services.AddSingleton(sp =>
 {
     return KustoClientFactory.CreateCslAdminProvider(connectionStringBuilder);
 });
+builder.Services.AddSingleton(sp =>
+{
+    return KustoIngestFactory.CreateStreamingIngestClient(connectionStringBuilder);
+});
+
+builder.Services.AddResiliencePipeline("kusto-resilience", builder =>
+    builder.AddRetry(new()
+    {
+        // Retry any non-permanent exceptions
+        MaxRetryAttempts = 10,
+        Delay = TimeSpan.FromMilliseconds(100),
+        BackoffType = DelayBackoffType.Exponential,
+        ShouldHandle = new PredicateBuilder().Handle<Exception>(e => e is ICloudPlatformException cpe && ! cpe.IsPermanent),
+    })
+);
 
 builder.Services.AddOptions<WorkerOptions>();
 

--- a/playground/AzureKusto/AzureKusto.Worker/QueryWorker.cs
+++ b/playground/AzureKusto/AzureKusto.Worker/QueryWorker.cs
@@ -4,21 +4,25 @@
 using Kusto.Cloud.Platform.Data;
 using Kusto.Data.Common;
 using Microsoft.Extensions.Options;
+using Polly;
 
 namespace AzureKusto.Worker;
 
 internal sealed class QueryWorker : BackgroundService
 {
     private readonly ICslQueryProvider _queryClient;
+    private readonly ResiliencePipeline _pipeline;
     private readonly IOptionsMonitor<WorkerOptions> _workerOptions;
     private readonly ILogger<QueryWorker> _logger;
 
     public QueryWorker(
         ICslQueryProvider queryClient,
+        [FromKeyedServices("kusto-resilience")] ResiliencePipeline pipeline,
         IOptionsMonitor<WorkerOptions> workerOptions,
         ILogger<QueryWorker> logger)
     {
         _queryClient = queryClient;
+        _pipeline = pipeline;
         _workerOptions = workerOptions;
         _logger = logger;
     }
@@ -31,9 +35,12 @@ internal sealed class QueryWorker : BackgroundService
             await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
         }
 
-        var reader = await _queryClient.ExecuteQueryAsync(_queryClient.DefaultDatabaseName, _workerOptions.CurrentValue.TableName, new ClientRequestProperties(), stoppingToken);
-        var results = string.Join(",", reader.ToJObjects());
+        using var reader = await _pipeline.ExecuteAsync(async ct =>
+        {
+            return await _queryClient.ExecuteQueryAsync(_queryClient.DefaultDatabaseName, _workerOptions.CurrentValue.TableName, new ClientRequestProperties(), ct);
+        }, stoppingToken);
 
+        var results = string.Join(",", reader.ToJObjects());
         _logger.LogInformation("Query Results: {results}", results);
     }
 }

--- a/playground/AzureKusto/AzureKusto.Worker/WorkerOptions.cs
+++ b/playground/AzureKusto/AzureKusto.Worker/WorkerOptions.cs
@@ -5,6 +5,8 @@ namespace AzureKusto.Worker;
 
 public class WorkerOptions
 {
+    public string DatabaseName { get; } = "testdb";
+
     public string TableName { get; } = "TestTable";
 
     public bool IsIngestionComplete { get; set; }

--- a/src/Aspire.Hosting.Azure.Kusto/Aspire.Hosting.Azure.Kusto.csproj
+++ b/src/Aspire.Hosting.Azure.Kusto/Aspire.Hosting.Azure.Kusto.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <RootNamespace>Aspire.Hosting.Azure</RootNamespace>
     <IsPackable>true</IsPackable>
     <PackageTags>aspire integration hosting azure kusto</PackageTags>
     <Description>Azure Kusto support for .NET Aspire.</Description>

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -10,7 +10,6 @@ using Azure.Provisioning;
 using Azure.Provisioning.Kusto;
 using Kusto.Data;
 using Kusto.Data.Common;
-using Kusto.Data.Exceptions;
 using Kusto.Data.Net.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -185,7 +184,8 @@ public static class AzureKustoBuilderExtensions
     /// </summary>
     /// <remarks>
     /// This script will only be executed when the Kusto resource is running in emulator mode. In production scenarios, the database creation should be handled as part of the provisioning process.
-    /// <value>Default script is <code>.create database DATABASE_NAME volatile</code></value>
+    /// The default script is <code>.create database DATABASE_NAME persist (PERSISTENCE_PATH, PERSISTENCE_PATH) ifnotexists</code> where DATABASE_NAME is the database name and PERSISTENCE_PATH
+    /// is <inheritdoc cref="AzureKustoEmulatorContainerDefaults.DefaultPersistencePath"/>.
     /// </remarks>
     /// <param name="builder">The resource builder to configure.</param>
     /// <param name="script">KQL script to create databases, tables, or data.</param>
@@ -274,7 +274,7 @@ public static class AzureKustoBuilderExtensions
         crp.SetParameter(ClientRequestProperties.OptionQueryConsistency, ClientRequestProperties.OptionQueryConsistency_Strong);
 
         var scriptAnnotation = databaseResource.Annotations.OfType<AzureKustoCreateDatabaseScriptAnnotation>().LastOrDefault();
-        var script = scriptAnnotation?.Script ?? $".create database {databaseResource.DatabaseName} volatile;";
+        var script = scriptAnnotation?.Script ?? CslCommandGenerator.GenerateDatabaseCreateCommand(databaseResource.DatabaseName, AzureKustoEmulatorContainerDefaults.DefaultPersistencePath, ifNotExists: true);
 
         var logger = serviceProvider.GetRequiredService<ResourceLoggerService>().GetLogger(databaseResource);
         var rns = serviceProvider.GetRequiredService<ResourceNotificationService>();
@@ -285,11 +285,6 @@ public static class AzureKustoBuilderExtensions
         {
             await AzureKustoEmulatorResiliencePipelines.Default.ExecuteAsync(async ct => await adminProvider.ExecuteControlCommandAsync(databaseResource.DatabaseName, script, crp).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
             logger.LogDebug("Database '{DatabaseName}' created successfully", databaseResource.DatabaseName);
-        }
-        catch (KustoBadRequestException e) when (e.Message.Contains("EntityNameAlreadyExistsException"))
-        {
-            // Ignore the error if the database already exists.
-            logger.LogDebug("Database '{DatabaseName}' already exists", databaseResource.DatabaseName);
         }
         catch (Exception e)
         {

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -274,7 +274,7 @@ public static class AzureKustoBuilderExtensions
         crp.SetParameter(ClientRequestProperties.OptionQueryConsistency, ClientRequestProperties.OptionQueryConsistency_Strong);
 
         var scriptAnnotation = databaseResource.Annotations.OfType<AzureKustoCreateDatabaseScriptAnnotation>().LastOrDefault();
-        var script = scriptAnnotation?.Script ?? CslCommandGenerator.GenerateDatabaseCreateCommand(databaseResource.DatabaseName, AzureKustoEmulatorContainerDefaults.DefaultPersistencePath, ifNotExists: true);
+        var script = scriptAnnotation?.Script ?? AzureKustoEmulatorContainerDefaults.DefaultCreateDatabaseCommand(databaseResource.DatabaseName);
 
         var logger = serviceProvider.GetRequiredService<ResourceLoggerService>().GetLogger(databaseResource);
         var rns = serviceProvider.GetRequiredService<ResourceNotificationService>();

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -184,8 +184,7 @@ public static class AzureKustoBuilderExtensions
     /// </summary>
     /// <remarks>
     /// This script will only be executed when the Kusto resource is running in emulator mode. In production scenarios, the database creation should be handled as part of the provisioning process.
-    /// The default script is <code>.create database DATABASE_NAME persist (PERSISTENCE_PATH, PERSISTENCE_PATH) ifnotexists</code> where DATABASE_NAME is the database name and PERSISTENCE_PATH
-    /// is <inheritdoc cref="AzureKustoEmulatorContainerDefaults.DefaultPersistencePath"/>.
+    /// <inheritdoc cref="AzureKustoReadWriteDatabaseResourceExtensions.GetDatabaseCreationScript(AzureKustoReadWriteDatabaseResource)"/>
     /// </remarks>
     /// <param name="builder">The resource builder to configure.</param>
     /// <param name="script">KQL script to create databases, tables, or data.</param>
@@ -273,8 +272,7 @@ public static class AzureKustoBuilderExtensions
         };
         crp.SetParameter(ClientRequestProperties.OptionQueryConsistency, ClientRequestProperties.OptionQueryConsistency_Strong);
 
-        var scriptAnnotation = databaseResource.Annotations.OfType<AzureKustoCreateDatabaseScriptAnnotation>().LastOrDefault();
-        var script = scriptAnnotation?.Script ?? AzureKustoEmulatorContainerDefaults.DefaultCreateDatabaseCommand(databaseResource.DatabaseName);
+        var script = databaseResource.GetDatabaseCreationScript();
 
         var logger = serviceProvider.GetRequiredService<ResourceLoggerService>().GetLogger(databaseResource);
         var rns = serviceProvider.GetRequiredService<ResourceNotificationService>();

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerDefaults.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerDefaults.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Kusto.Data.Common;
+
 namespace Aspire.Hosting.Azure;
 
 /// <summary>
@@ -20,4 +22,15 @@ internal static class AzureKustoEmulatorContainerDefaults
     /// </summary>
     /// <remarks>/kustodata/dbs/</remarks>
     public const string DefaultPersistencePath = "/kustodata/dbs/";
+
+    public static string DefaultCreateDatabaseCommand(string dbName, string persistencePathRoot = DefaultPersistencePath)
+    {
+        var root = persistencePathRoot.AsSpan().TrimEnd('/');
+
+        return CslCommandGenerator.GenerateDatabaseCreateCommand(
+            dbName,
+            metadataPersistentPath: $"{root}/{dbName}/md",
+            dataPersistentPath: $"{root}/{dbName}/data",
+            ifNotExists: true);
+    }
 }

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerDefaults.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerDefaults.cs
@@ -13,4 +13,11 @@ internal static class AzureKustoEmulatorContainerDefaults
     /// Based on Azure Data Explorer emulator documentation, it typically uses port 8080.
     /// </summary>
     public const int DefaultTargetPort = 8080;
+
+    /// <summary>
+    /// The default (emulator local) path used for persisting Kusto databases. This path
+    /// can be mounted as a volume to persist database data across container restarts.
+    /// </summary>
+    /// <remarks>/kustodata/dbs/</remarks>
+    public const string DefaultPersistencePath = "/kustodata/dbs/";
 }

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoReadWriteDatabaseResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoReadWriteDatabaseResourceExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
 namespace Aspire.Hosting.Azure;
 
 internal static class AzureKustoReadWriteDatabaseResourceExtensions

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoReadWriteDatabaseResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoReadWriteDatabaseResourceExtensions.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+namespace Aspire.Hosting.Azure;
+
+internal static class AzureKustoReadWriteDatabaseResourceExtensions
+{
+    /// <summary>
+    /// Gets the database creation script from the resource annotation if it exists. If not, creates the default database creation script.
+    /// </summary>
+    /// <param name="databaseResource">
+    /// The <see cref="AzureKustoReadWriteDatabaseResource"/> resource to inspect for annotations.
+    /// </param>
+    /// <remarks>
+    /// The default script is <code>.create database DATABASE_NAME persist (PERSISTENCE_PATH/DATABASE_NAME/md, PERSISTENCE_PATH/DATABASE_NAME/data) ifnotexists</code> where
+    /// DATABASE_NAME is the database name and PERSISTENCE_PATH is <inheritdoc cref="AzureKustoEmulatorContainerDefaults.DefaultPersistencePath"/>.
+    /// </remarks>
+    /// <returns></returns>
+    public static string GetDatabaseCreationScript(this AzureKustoReadWriteDatabaseResource databaseResource)
+    {
+        var scriptAnnotation = databaseResource.Annotations.OfType<AzureKustoCreateDatabaseScriptAnnotation>().LastOrDefault();
+        return scriptAnnotation?.Script ?? AzureKustoEmulatorContainerDefaults.DefaultCreateDatabaseCommand(databaseResource.DatabaseName);
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
@@ -234,19 +234,13 @@ public class KustoFunctionalTests
         using var builder = TestDistributedApplicationBuilder.Create(_testOutputHelper);
 
         const string dbName = "TestDb";
-        const string dbPath = "/kustodata";
+        const string dbPath = "/kustodata/";
+        var script = AzureKustoEmulatorContainerDefaults.DefaultCreateDatabaseCommand(dbName, dbPath);
         var kusto = builder.AddAzureKustoCluster("kusto").RunAsEmulator(configureContainer: container =>
         {
             container.WithBindMount(temp.Path, dbPath);
         });
-        var kustoDb = kusto.AddReadWriteDatabase("TestDb")
-            .WithCreationScript(
-            $"""
-            .create database {dbName} persist (
-                @"{dbPath}/dbs/{dbName}/md",
-                @"{dbPath}/dbs/{dbName}/data"
-            )
-            """);
+        var kustoDb = kusto.AddReadWriteDatabase(dbName).WithCreationScript(script);
 
         // Ensure the directory is empty before starting the application
         Assert.Empty(GetFilesInMount());


### PR DESCRIPTION
## Description

The intent of this change is to make it easier to write tests or use client projects that do Kusto ingestion.

The main change is to change the default db creation script used by the emulator from a volatile database to a persistent one. That fixes the error "Failed to initialize cursor tracker". As part of that change, I also refactored to create an internal `GetDatabaseCreationScript`. Also added tests to validate the behavior.

Next, I updated the playground app. I added a sample of streaming ingestion in `IngestionWorker` and refactored the AppHost to use an internal helper `WithControlCommand`. I also updated both the AppHost and the Worker app to use a resilience pipeline that retries all transient errors.

It's probably worthwhile to lift both the retry policy and the `WithControlCommand` helpers into Hosting and client integrations, but I wanted to avoid multiple simultaneous API changes.

Contributes to #8233 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
