### PR TITLE
support single-file apphosts

### DIFF
--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -30,7 +30,8 @@ export function isProjectLaunchConfiguration(obj: any): obj is ProjectLaunchConf
 
 export interface PythonLaunchConfiguration extends ExecutableLaunchConfiguration {
     type: "python";
-    program_path: string;
+    program_path?: string;
+    project_path?: string; // leftover from 9.5 usage of project path
 }
 
 export function isPythonLaunchConfiguration(obj: any): obj is PythonLaunchConfiguration {

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -1,9 +1,11 @@
 import * as vscode from 'vscode';
 import { extensionLogOutputChannel } from '../../utils/logging';
 import { noCsharpBuildTask, buildFailedWithExitCode, noOutputFromMsbuild, failedToGetTargetPath, invalidLaunchConfiguration } from '../../loc/strings';
-import { execFile } from 'child_process';
+import { ChildProcessWithoutNullStreams, execFile, spawn } from 'child_process';
 import * as util from 'util';
 import * as path from 'path';
+import * as readline from 'readline';
+import * as os from 'os';
 import { doesFileExist } from '../../utils/io';
 import { AspireResourceExtendedDebugConfiguration, isProjectLaunchConfiguration } from '../../dcp/types';
 import { ResourceDebuggerExtension } from '../debuggerExtensions';
@@ -20,6 +22,7 @@ interface IDotNetService {
     getAndActivateDevKit(): Promise<boolean>
     buildDotNetProject(projectFile: string): Promise<void>;
     getDotNetTargetPath(projectFile: string): Promise<string>;
+    getDotNetRunApiOutput(projectFile: string): Promise<string>;
 }
 
 class DotNetService implements IDotNetService {
@@ -112,6 +115,69 @@ class DotNetService implements IDotNetService {
             throw new Error(failedToGetTargetPath(String(err)));
         }
     }
+
+    async getDotNetRunApiOutput(projectPath: string): Promise<string> {
+        return new Promise<string>(async (resolve, reject) => {
+            try {
+                let childProcess: ChildProcessWithoutNullStreams;
+                const timeout = setTimeout(() => {
+                    childProcess?.kill();
+                    reject(new Error('Timeout while waiting for dotnet run-api response'));
+                }, 10_000);
+
+                const logger = extensionLogOutputChannel;
+                logger.info('dotnet run-api - starting process');
+
+                childProcess = spawn('dotnet', ['run-api'], {
+                    cwd: path.dirname(projectPath),
+                    env: process.env,
+                    stdio: ['pipe', 'pipe', 'pipe']
+                });
+
+                childProcess.on('error', reject);
+                childProcess.on('exit', (code, signal) => {
+                    clearTimeout(timeout);
+                    reject(new Error(`dotnet run-api exited with ${code ?? signal}`));
+                });
+
+                const rl = readline.createInterface(childProcess.stdout);
+                rl.on('line', line => {
+                    clearTimeout(timeout);
+                    logger.info(`dotnet run-api - received: ${line}`);
+                    resolve(line);
+                });
+
+                const message = JSON.stringify({ ['$type']: 'GetRunCommand', ['EntryPointFileFullPath']: projectPath });
+                logger.info(`dotnet run-api - sending: ${message}`);
+                childProcess.stdin.write(message + os.EOL);
+                childProcess.stdin.end();
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
+}
+
+function isSingleFileAppHost(projectPath: string): boolean {
+    return path.basename(projectPath).toLowerCase() === 'apphost.cs';
+}
+
+function applyRunApiOutputToDebugConfiguration(runApiOutput: string, debugConfiguration: AspireResourceExtendedDebugConfiguration) {
+    const parsed = JSON.parse(runApiOutput);
+    if (parsed.$type === 'Error') {
+        throw new Error(`dotnet run-api failed: ${parsed.Message}`);
+    }
+    else if (parsed.$type !== 'RunCommand') {
+        throw new Error(`dotnet run-api failed: Unexpected response type '${parsed.$type}'`);
+    }
+
+    debugConfiguration.program = parsed.ExecutablePath;
+    if (parsed.EnvironmentVariables) {
+        debugConfiguration.env = {
+            ...debugConfiguration.env,
+            ...parsed.EnvironmentVariables
+        };
+    }
 }
 
 export function createProjectDebuggerExtension(dotNetService: IDotNetService): ResourceDebuggerExtension {
@@ -148,20 +214,27 @@ export function createProjectDebuggerExtension(dotNetService: IDotNetService): R
                 ? `Using launch profile '${profileName}' for project: ${projectPath}`
                 : `No launch profile selected for project: ${projectPath}`);
 
-            // Build project if needed
-            const outputPath = await dotNetService.getDotNetTargetPath(projectPath);
-            if ((!(await doesFileExist(outputPath)) || launchOptions.forceBuild) && await dotNetService.getAndActivateDevKit()) {
-                await dotNetService.buildDotNetProject(projectPath);
-            }
-
             // Configure debug session with launch profile settings
-            debugConfiguration.program = outputPath;
             debugConfiguration.cwd = determineWorkingDirectory(projectPath, baseProfile);
             debugConfiguration.args = determineArguments(baseProfile?.commandLineArgs, args);
             debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(baseProfile?.environmentVariables, env));
             debugConfiguration.executablePath = baseProfile?.executablePath;
             debugConfiguration.checkForDevCert = baseProfile?.useSSL;
             debugConfiguration.serverReadyAction = determineServerReadyAction(baseProfile?.launchBrowser, baseProfile?.applicationUrl);
+
+            // Build project if needed
+            if (!isSingleFileAppHost(projectPath)) {
+                const outputPath = await dotNetService.getDotNetTargetPath(projectPath);
+                if ((!(await doesFileExist(outputPath)) || launchOptions.forceBuild) && await dotNetService.getAndActivateDevKit()) {
+                    await dotNetService.buildDotNetProject(projectPath);
+                }
+
+                debugConfiguration.program = outputPath;
+            }
+            else {
+                const runApiOutput = await dotNetService.getDotNetRunApiOutput(projectPath);
+                applyRunApiOutputToDebugConfiguration(runApiOutput, debugConfiguration);
+            }
         }
     };
 }

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -125,8 +125,7 @@ class DotNetService implements IDotNetService {
                     reject(new Error('Timeout while waiting for dotnet run-api response'));
                 }, 10_000);
 
-                const logger = extensionLogOutputChannel;
-                logger.info('dotnet run-api - starting process');
+                extensionLogOutputChannel.info('dotnet run-api - starting process');
 
                 childProcess = spawn('dotnet', ['run-api'], {
                     cwd: path.dirname(projectPath),
@@ -143,12 +142,12 @@ class DotNetService implements IDotNetService {
                 const rl = readline.createInterface(childProcess.stdout);
                 rl.on('line', line => {
                     clearTimeout(timeout);
-                    logger.info(`dotnet run-api - received: ${line}`);
+                    extensionLogOutputChannel.info(`dotnet run-api - received: ${line}`);
                     resolve(line);
                 });
 
                 const message = JSON.stringify({ ['$type']: 'GetRunCommand', ['EntryPointFileFullPath']: projectPath });
-                logger.info(`dotnet run-api - sending: ${message}`);
+                extensionLogOutputChannel.info(`dotnet run-api - sending: ${message}`);
                 childProcess.stdin.write(message + os.EOL);
                 childProcess.stdin.end();
             } catch (e) {

--- a/extension/src/debugger/languages/python.ts
+++ b/extension/src/debugger/languages/python.ts
@@ -9,7 +9,10 @@ export const pythonDebuggerExtension: ResourceDebuggerExtension = {
     displayName: 'Python',
     getProjectFile: (launchConfig) => {
         if (isPythonLaunchConfiguration(launchConfig)) {
-            return launchConfig.program_path;
+            const programPath = launchConfig.program_path || launchConfig.project_path;
+            if (programPath) {
+                return programPath;
+            }
         }
 
         throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -317,11 +317,14 @@ export class InteractionService implements IInteractionService {
     }
 
     logMessage(logLevel: CSLogLevel, message: string) {
+        // Unable to log trace or debug messages, these levels are ignored by default
+        // and we cannot set the log level programmatically. So for now, log as info
+        // https://github.com/microsoft/vscode/issues/223536
         if (logLevel === 'Trace') {
-            extensionLogOutputChannel.trace(formatText(message));
+            extensionLogOutputChannel.info(`[trace] ${formatText(message)}`);
         }
         else if (logLevel === 'Debug') {
-            extensionLogOutputChannel.debug(formatText(message));
+            extensionLogOutputChannel.info(`[debug] ${formatText(message)}`);
         }
         else if (logLevel === 'Information') {
             extensionLogOutputChannel.info(formatText(message));
@@ -368,7 +371,8 @@ export class InteractionService implements IInteractionService {
             noDebug: !debug,
         };
 
-        const didDebugStart = await vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], debugConfiguration);
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(workingDirectory));
+        const didDebugStart = await vscode.debug.startDebugging(workspaceFolder, debugConfiguration);
         if (!didDebugStart) {
             throw new Error(failedToStartDebugSession);
         }

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -37,6 +37,10 @@ class TestDotNetService {
     getAndActivateDevKit(): Promise<boolean> {
         return Promise.resolve(this._hasDevKit);
     }
+
+    getDotNetRunApiOutput(projectPath: string): Promise<string> {
+        return Promise.resolve('');
+    }
 }
 
 suite('Dotnet Debugger Extension Tests', () => {

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -3,7 +3,7 @@ import { aspireTerminalName, dcpServerNotInitialized, rpcServerNotInitialized } 
 import { extensionLogOutputChannel } from './logging';
 import { RpcServerConnectionInfo } from '../server/AspireRpcServer';
 import { DcpServerConnectionInfo } from '../dcp/types';
-import { getRunSessionInfo } from '../capabilities';
+import { getRunSessionInfo, getSupportedCapabilities } from '../capabilities';
 
 export interface AspireTerminal {
     terminal: vscode.Terminal;
@@ -114,7 +114,9 @@ export class AspireTerminalProvider implements vscode.Disposable {
             env.ASPIRE_EXTENSION_DEBUG_SESSION_ID = debugSessionId;
             env.DCP_INSTANCE_ID_PREFIX = debugSessionId + '-';
             env.DEBUG_SESSION_RUN_MODE = noDebug === false ? "Debug" : "NoDebug";
+            env.ASPIRE_EXTENSION_DEBUG_RUN_MODE = noDebug === false ? "Debug" : "NoDebug";
             env.DEBUG_SESSION_INFO = JSON.stringify(getRunSessionInfo());
+            env.ASPIRE_EXTENSION_CAPABILITIES = getSupportedCapabilities().join(',');
         }
 
         return env;

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -144,7 +144,7 @@ internal sealed class RunCommand : BaseCommand
 
             if (!watch)
             {
-                if (!isSingleFileAppHost)
+                if (!isSingleFileAppHost || isExtensionHost)
                 {
                     var buildOptions = new DotNetCliRunnerInvocationOptions
                     {
@@ -154,7 +154,8 @@ internal sealed class RunCommand : BaseCommand
 
                     // The extension host will build the app host project itself, so we don't need to do it here if host exists.
                     if (!ExtensionHelper.IsExtensionHost(InteractionService, out _, out var extensionBackchannel)
-                        || !await extensionBackchannel.HasCapabilityAsync(KnownCapabilities.DevKit, cancellationToken))
+                        || !await extensionBackchannel.HasCapabilityAsync(KnownCapabilities.DevKit, cancellationToken)
+                        || isSingleFileAppHost)
                     {
                         var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, InteractionService, effectiveAppHostFile, buildOptions, ExecutionContext.WorkingDirectory, cancellationToken);
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -270,7 +270,7 @@ public class Program
 
             // If the CLI is being launched from the aspire extension, we don't want to use the console logger that's used when including --debug.
             // Instead, we will log to the extension backchannel.
-            builder.Logging.AddFilter("Aspire.Cli", LogLevel.Information);
+            builder.Logging.AddFilter("Aspire.Cli", LogLevel.Trace);
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ExtensionLoggerProvider>());
         }
         else


### PR DESCRIPTION
## Description

Uses `dotnet run-api` to get the output path of the executable, based on c# dev kit.

Also includes a few logging + env variable changes because I accidentally broke support for python in 9.5 apphosts

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
