### PR TITLE
Pass open apphost.cs file to aspire cli command

### DIFF
--- a/extension/src/commands/add.ts
+++ b/extension/src/commands/add.ts
@@ -1,10 +1,10 @@
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
-import { isWorkspaceOpen } from '../utils/workspace';
+import { getOpenApphostFile, isWorkspaceOpen } from '../utils/workspace';
 
 export async function addCommand(terminalProvider: AspireTerminalProvider) {
     if (!isWorkspaceOpen()) {
         return;
     }
 
-    terminalProvider.sendToAspireTerminal("aspire add");
+    terminalProvider.sendToAspireTerminal("aspire add", getOpenApphostFile());
 }

--- a/extension/src/commands/deploy.ts
+++ b/extension/src/commands/deploy.ts
@@ -1,10 +1,10 @@
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
-import { isWorkspaceOpen } from '../utils/workspace';
+import { getOpenApphostFile, isWorkspaceOpen } from '../utils/workspace';
 
 export async function deployCommand(terminalProvider: AspireTerminalProvider) {
     if (!isWorkspaceOpen()) {
         return;
     }
 
-    terminalProvider.sendToAspireTerminal("aspire deploy");
+    terminalProvider.sendToAspireTerminal("aspire deploy", getOpenApphostFile());
 }

--- a/extension/src/commands/init.ts
+++ b/extension/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { AspireTerminalProvider } from "../utils/AspireTerminalProvider";
+import { getOpenApphostFile } from "../utils/workspace";
 
 export async function initCommand(terminalProvider: AspireTerminalProvider) {
     terminalProvider.sendToAspireTerminal("aspire init");

--- a/extension/src/commands/new.ts
+++ b/extension/src/commands/new.ts
@@ -1,5 +1,6 @@
 import { AspireTerminalProvider } from "../utils/AspireTerminalProvider";
+import { getOpenApphostFile } from "../utils/workspace";
 
 export async function newCommand(terminalProvider: AspireTerminalProvider) {
-    terminalProvider.sendToAspireTerminal("aspire new");
+    terminalProvider.sendToAspireTerminal("aspire new", getOpenApphostFile());
 };

--- a/extension/src/commands/publish.ts
+++ b/extension/src/commands/publish.ts
@@ -1,10 +1,10 @@
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
-import { isWorkspaceOpen } from '../utils/workspace';
+import { getOpenApphostFile, isWorkspaceOpen } from '../utils/workspace';
 
 export async function publishCommand(terminalProvider: AspireTerminalProvider) {
     if (!isWorkspaceOpen()) {
         return;
     }
 
-    terminalProvider.sendToAspireTerminal("aspire publish");
+    terminalProvider.sendToAspireTerminal("aspire publish", getOpenApphostFile());
 }

--- a/extension/src/commands/update.ts
+++ b/extension/src/commands/update.ts
@@ -1,10 +1,10 @@
 import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
-import { isWorkspaceOpen } from '../utils/workspace';
+import { getOpenApphostFile, isWorkspaceOpen } from '../utils/workspace';
 
 export async function updateCommand(terminalProvider: AspireTerminalProvider) {
     if (!isWorkspaceOpen()) {
         return;
     }
 
-    terminalProvider.sendToAspireTerminal('aspire update');
+    terminalProvider.sendToAspireTerminal('aspire update', getOpenApphostFile());
 }

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -50,7 +50,10 @@ export class AspireTerminalProvider implements vscode.Disposable {
         this._dcpServerConnectionInfo = value;
     }
 
-    sendToAspireTerminal(command: string, showTerminal: boolean = true) {
+    sendToAspireTerminal(command: string, project?: string, showTerminal: boolean = true) {
+        if (project) {
+            command += ` --project "${project}"`;
+        }
         const aspireTerminal = this.getAspireTerminal();
         extensionLogOutputChannel.info(`Sending command to Aspire terminal: ${command}`);
         aspireTerminal.terminal.sendText(command);

--- a/extension/src/utils/workspace.ts
+++ b/extension/src/utils/workspace.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { noWorkspaceOpen } from '../loc/strings';
+import path from 'path';
 
 export function isWorkspaceOpen(showErrorMessage: boolean = true): boolean {
     const isOpen = !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0;
@@ -30,4 +31,25 @@ export function getRelativePathToWorkspace(filePath: string): string {
     }
 
     return filePath;
+}
+
+/**
+ * Returns the file path of the currently open apphost.cs file in the editor, or null if none is open.
+ */
+export function getOpenApphostFile(): string | undefined {
+    if (!isWorkspaceOpen(false)) {
+        return;
+    }
+
+        const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        return;
+    }
+
+    const document = editor.document;
+    if (path.basename(document.uri.fsPath).toLowerCase() !== 'apphost.cs') {
+        return;
+    }
+
+    return document.fileName;
 }


### PR DESCRIPTION
## Description

The `ProjectLocator` handles single-file apphosts correctly, but should also search for a csproj in the parent directory if passed a path to a non-single-file apphost.

I made this change because `aspire run --project MyAppHost/AppHost.cs` will not work while `aspire run --project MyAppHost` will. I then used it in the extension, to set the `--project` parameter to an open `AppHost.cs` file when calling the aspire cli.

Fixes #11024

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
