### PR TITLE
Move SelectViewModel out of Otlp namespace

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;

--- a/src/Aspire.Dashboard/Components/Controls/LogLevelSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogLevelSelect.razor.cs
@@ -1,7 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components.Controls;

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;

--- a/src/Aspire.Dashboard/Components/Controls/SignalsActionsDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SignalsActionsDisplay.razor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.AspNetCore.Components;
 

--- a/src/Aspire.Dashboard/Components/Controls/SpanTypeSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanTypeSelect.razor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Model.Otlp;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Interaction;
 using Aspire.Dashboard.Model.Markdown;
-using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Resources;
 using Aspire.DashboardService.Proto.V1;
 using Microsoft.AspNetCore.Components;

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;

--- a/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using Aspire.Dashboard.Model.Otlp;
 using Aspire.DashboardService.Proto.V1;
 
 namespace Aspire.Dashboard.Model.Interaction;

--- a/src/Aspire.Dashboard/Model/SelectViewModel.cs
+++ b/src/Aspire.Dashboard/Model/SelectViewModel.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics;
 
-namespace Aspire.Dashboard.Model.Otlp;
+namespace Aspire.Dashboard.Model;
 
 [DebuggerDisplay(@"Name = {Name}, Id = \{{Id}\}")]
 public class SelectViewModel<T> : IEquatable<SelectViewModel<T>>

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Concurrent;
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Tests.Shared.DashboardModel;
 using Xunit;


### PR DESCRIPTION
This type is used across the dashboard, not just OTLP pages.