### PR TITLE
Add noProfileSwitch to run command in DotNetCliRunner

### DIFF
--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -248,7 +248,7 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
         string[] cliArgs = isSingleFile switch
         {
             false => [watchOrRunCommand, nonInteractiveSwitch, verboseSwitch, noBuildSwitch, noProfileSwitch, "--project", projectFile.FullName, "--", .. args],
-            true => ["run", noProfileSwitch, projectFile.FullName, "--", .. args]
+            true => ["run", noProfileSwitch, "--file", projectFile.FullName, "--", .. args]
         };
 
         cliArgs = [.. cliArgs.Where(arg => !string.IsNullOrWhiteSpace(arg))];

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -248,7 +248,7 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
         string[] cliArgs = isSingleFile switch
         {
             false => [watchOrRunCommand, nonInteractiveSwitch, verboseSwitch, noBuildSwitch, noProfileSwitch, "--project", projectFile.FullName, "--", .. args],
-            true => ["run", projectFile.FullName, "--", ..args]
+            true => ["run", noProfileSwitch, projectFile.FullName, "--", ..args]
         };
 
         // Inject DOTNET_CLI_USE_MSBUILD_SERVER when noBuild == false - we copy the

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -248,8 +248,10 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
         string[] cliArgs = isSingleFile switch
         {
             false => [watchOrRunCommand, nonInteractiveSwitch, verboseSwitch, noBuildSwitch, noProfileSwitch, "--project", projectFile.FullName, "--", .. args],
-            true => ["run", noProfileSwitch, projectFile.FullName, "--", ..args]
+            true => ["run", noProfileSwitch, projectFile.FullName, "--", .. args]
         };
+
+        cliArgs = [.. cliArgs.Where(arg => !string.IsNullOrWhiteSpace(arg))];
 
         // Inject DOTNET_CLI_USE_MSBUILD_SERVER when noBuild == false - we copy the
         // dictionary here because we don't want to mutate the input.

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -24,7 +24,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
         var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
         var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-    return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory);
+        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory);
     }
 
     [Fact]
@@ -380,7 +380,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             provider.GetRequiredService<IInteractionService>(),
             provider.GetRequiredService<CliExecutionContext>(),
             new NullDiskCache(),
-            (args, env, _, _, _, _) => 
+            (args, env, _, _, _, _) =>
             {
                 Assert.NotNull(env);
                 Assert.True(env.ContainsKey("ASPIRE_VERSION_CHECK_DISABLED"));
@@ -428,7 +428,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             provider.GetRequiredService<IInteractionService>(),
             provider.GetRequiredService<CliExecutionContext>(),
             new NullDiskCache(),
-            (args, env, _, _, _, _) => 
+            (args, env, _, _, _, _) =>
             {
                 // When the feature is enabled (default), the version check env var should NOT be set
                 if (env != null)
@@ -478,7 +478,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             provider.GetRequiredService<IInteractionService>(),
             provider.GetRequiredService<CliExecutionContext>(),
             new NullDiskCache(),
-            (args, env, _, _, _, _) => 
+            (args, env, _, _, _, _) =>
             {
                 Assert.NotNull(env);
                 Assert.True(env.ContainsKey("ASPIRE_VERSION_CHECK_DISABLED"));
@@ -570,7 +570,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
         await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.EnabledFeatures = [KnownFeatures.SingleFileAppHostEnabled];
+        });
         var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
         var interactionService = provider.GetRequiredService<IInteractionService>();
@@ -596,14 +599,14 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 Assert.Contains(appHostFile.FullName, args);
                 Assert.Contains("Aspire.Hosting.Redis@9.2.0", args);
                 Assert.Contains("--no-restore", args);
-                
+
                 // Verify the order: add package PackageName --file FilePath --version Version --no-restore
                 var addIndex = Array.IndexOf(args, "add");
                 var packageIndex = Array.IndexOf(args, "package");
                 var fileIndex = Array.IndexOf(args, "--file");
                 var filePathIndex = Array.IndexOf(args, appHostFile.FullName);
                 var packageNameIndex = Array.IndexOf(args, "Aspire.Hosting.Redis@9.2.0");
-                
+
                 Assert.True(addIndex < packageIndex);
                 Assert.True(packageIndex < fileIndex);
                 Assert.True(fileIndex < filePathIndex);
@@ -659,7 +662,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 Assert.Contains("9.2.0", args);
                 Assert.Contains("--source", args);
                 Assert.Contains("https://api.nuget.org/v3/index.json", args);
-                
+
                 // Verify the order: add ProjectFile package PackageName --version Version --source Source
                 var addIndex = Array.IndexOf(args, "add");
                 var projectIndex = Array.IndexOf(args, projectFile.FullName);
@@ -667,13 +670,13 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 var packageNameIndex = Array.IndexOf(args, "Aspire.Hosting.Redis");
                 var versionFlagIndex = Array.IndexOf(args, "--version");
                 var versionValueIndex = Array.IndexOf(args, "9.2.0");
-                
+
                 Assert.True(addIndex < projectIndex);
                 Assert.True(projectIndex < packageIndex);
                 Assert.True(packageIndex < packageNameIndex);
                 Assert.True(packageNameIndex < versionFlagIndex);
                 Assert.True(versionFlagIndex < versionValueIndex);
-                
+
                 // Should NOT contain --file or the @version format
                 Assert.DoesNotContain("--file", args);
                 Assert.DoesNotContain("Aspire.Hosting.Redis@9.2.0", args);
@@ -727,7 +730,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 Assert.Contains("--version", args);
                 Assert.Contains("9.2.0", args);
                 Assert.Contains("--no-restore", args);
-                
+
                 // Verify the order: add ProjectFile package PackageName --version Version --no-restore
                 var addIndex = Array.IndexOf(args, "add");
                 var projectIndex = Array.IndexOf(args, projectFile.FullName);
@@ -736,14 +739,14 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 var versionFlagIndex = Array.IndexOf(args, "--version");
                 var versionValueIndex = Array.IndexOf(args, "9.2.0");
                 var noRestoreIndex = Array.IndexOf(args, "--no-restore");
-                
+
                 Assert.True(addIndex < projectIndex);
                 Assert.True(projectIndex < packageIndex);
                 Assert.True(packageIndex < packageNameIndex);
                 Assert.True(packageNameIndex < versionFlagIndex);
                 Assert.True(versionFlagIndex < versionValueIndex);
                 Assert.True(versionValueIndex < noRestoreIndex);
-                
+
                 // Should NOT contain --file, --source, or the @version format
                 Assert.DoesNotContain("--file", args);
                 Assert.DoesNotContain("--source", args);
@@ -768,7 +771,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
     public async Task GetSolutionProjectsAsync_ParsesOutputCorrectly()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        
+
         // Create a fake solution file
         var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
         await File.WriteAllTextAsync(solutionFile.FullName, "Not a real solution file.");
@@ -825,7 +828,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
     public async Task AddProjectReferenceAsync_ExecutesCorrectCommand()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        
+
         var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
@@ -871,7 +874,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
         await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.EnabledFeatures = [KnownFeatures.SingleFileAppHostEnabled];
+        });
         var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
         var interactionService = provider.GetRequiredService<IInteractionService>();
@@ -894,9 +900,13 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             (args, _, _, _, _, _) =>
             {
                 // For single-file .cs files, should include --no-launch-profile
-                Assert.Contains("run", args);
-                Assert.Contains("--no-launch-profile", args);
-                Assert.Contains(appHostFile.FullName, args);
+                Assert.Collection(args,
+                    arg => Assert.Equal("run", arg),
+                    arg => Assert.Equal("--no-launch-profile", arg),
+                    arg => Assert.Equal("--file", arg),
+                    arg => Assert.Equal(appHostFile.FullName, arg),
+                    arg => Assert.Equal("--", arg)
+                );
             },
             0
         );
@@ -922,7 +932,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
         await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.EnabledFeatures = [KnownFeatures.SingleFileAppHostEnabled];
+        });
         var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
         var interactionService = provider.GetRequiredService<IInteractionService>();
@@ -945,9 +958,12 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             (args, _, _, _, _, _) =>
             {
                 // For single-file .cs files, should NOT include --no-launch-profile when false
-                Assert.Contains("run", args);
-                Assert.DoesNotContain("--no-launch-profile", args);
-                Assert.Contains(appHostFile.FullName, args);
+                Assert.Collection(args,
+                    arg => Assert.Equal("run", arg),
+                    arg => Assert.Equal("--file", arg),
+                    arg => Assert.Equal(appHostFile.FullName, arg),
+                    arg => Assert.Equal("--", arg)
+                );
             },
             0
         );
@@ -1027,7 +1043,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs"));
         await File.WriteAllTextAsync(appHostFile.FullName, "// Single-file AppHost");
 
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.EnabledFeatures = [KnownFeatures.SingleFileAppHostEnabled];
+        });
         var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
         var interactionService = provider.GetRequiredService<IInteractionService>();
@@ -1054,11 +1073,14 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 {
                     Assert.False(string.IsNullOrWhiteSpace(arg), $"Found empty or whitespace argument in args: [{string.Join(", ", args)}]");
                 }
-                
+
                 // Ensure the correct arguments are present
-                Assert.Contains("run", args);
-                Assert.Contains(appHostFile.FullName, args);
-                Assert.Contains("--", args);
+                Assert.Collection(args,
+                    arg => Assert.Equal("run", arg),
+                    arg => Assert.Equal("--file", arg),
+                    arg => Assert.Equal(appHostFile.FullName, arg),
+                    arg => Assert.Equal("--", arg)
+                );
             },
             0
         );
@@ -1108,18 +1130,15 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             (args, _, _, _, _, _) =>
             {
                 // With watch=true and Debug=true, should include --verbose
-                Assert.Contains("watch", args);
-                Assert.Contains("--non-interactive", args);
-                Assert.Contains("--verbose", args);
-                Assert.Contains("--no-launch-profile", args);
-                Assert.Contains("--project", args);
-                Assert.Contains(projectFile.FullName, args);
-                
-                // Verify no empty or whitespace-only arguments exist
-                foreach (var arg in args)
-                {
-                    Assert.False(string.IsNullOrWhiteSpace(arg), $"Found empty or whitespace argument in args: [{string.Join(", ", args)}]");
-                }
+                Assert.Collection(args,
+                    arg => Assert.Equal("watch", arg),
+                    arg => Assert.Equal("--non-interactive", arg),
+                    arg => Assert.Equal("--verbose", arg),
+                    arg => Assert.Equal("--no-launch-profile", arg),
+                    arg => Assert.Equal("--project", arg),
+                    arg => Assert.Equal(projectFile.FullName, arg),
+                    arg => Assert.Equal("--", arg)
+                );
             },
             0
         );
@@ -1169,18 +1188,14 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             (args, _, _, _, _, _) =>
             {
                 // With watch=true but Debug=false, should NOT include --verbose
-                Assert.Contains("watch", args);
-                Assert.Contains("--non-interactive", args);
-                Assert.DoesNotContain("--verbose", args);
-                Assert.Contains("--no-launch-profile", args);
-                Assert.Contains("--project", args);
-                Assert.Contains(projectFile.FullName, args);
-                
-                // Verify no empty or whitespace-only arguments exist
-                foreach (var arg in args)
-                {
-                    Assert.False(string.IsNullOrWhiteSpace(arg), $"Found empty or whitespace argument in args: [{string.Join(", ", args)}]");
-                }
+                Assert.Collection(args,
+                    arg => Assert.Equal("watch", arg),
+                    arg => Assert.Equal("--non-interactive", arg),
+                    arg => Assert.Equal("--no-launch-profile", arg),
+                    arg => Assert.Equal("--project", arg),
+                    arg => Assert.Equal(projectFile.FullName, arg),
+                    arg => Assert.Equal("--", arg)
+                );
             },
             0
         );


### PR DESCRIPTION
This pull request makes a targeted update to the way single-file projects are run in the `DotNetCliRunner`. Specifically, it ensures that the `noProfileSwitch` argument is included when running single-file projects, aligning the behavior with multi-file project runs.

- Command-line argument handling:
  * Updated the single-file project run command in `DotNetCliRunner.cs` to include the `noProfileSwitch` argument, ensuring consistent profiling behavior across different project types.