### PR TITLE
Improve CLI compatibility with interaction prompts

### DIFF
--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -134,8 +134,9 @@ internal sealed class PublishingPromptInput
 {
     /// <summary>
     /// Gets the name for the input.
+    /// Nullable for backwards compatibility with Aspire 9.5 and older app hosts.
     /// </summary>
-    public required string Name { get; init; }
+    public string? Name { get; init; }
 
     /// <summary>
     /// Gets the label for the input.


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/pull/11635#discussion_r2421258434

The new name property can be made optional. If there's no name provided by the older app host then no name is sent back with the answer. This is ok because answer matching falls back to using index instead of name.