### PR TITLE
Modify test command and clarify filter usage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,7 +110,7 @@ dotnet test tests/Project.Tests/Project.Tests.csproj -- --filter-method "TestNam
 Never run all tests without the quarantine and outerloop filters in automated environments, as this will include flaky tests that are known to fail intermittently and long-running tests that slow down CI.
 
 Valid test filter switches include: --filter-class, --filter-not-class, --filter-method, --filter-not-method, --filter-namespace, --filter-not-namespace, --filter-not-trait, --filter-trait
-The switches `--filter-class` and `--filter-method` expect fully qualified names, unless a filter is used as a prefix like `--filter-class *.SomeClassName` or `--filter-method *.SomeMethodName`
+The switches `--filter-class` and `--filter-method` expect fully qualified names, unless a filter is used as a prefix like `--filter-class "*.SomeClassName"` or `--filter-method "*.SomeMethodName"`
 
 ### Test Verification Commands
 - **Single Test Project**: Typical runtime ~10-60 seconds per test project

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,7 @@ Note that tests for a project can be executed without first building from the ro
 
 (4) To run specific tests, include the filter after `--`:
 ```bash
-dotnet test tests/Aspire.Hosting.Testing.Tests/Aspire.Hosting.Testing.Tests.csproj -- --filter-method "TestingBuilderHasAllPropertiesFromRealBuilder" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
+dotnet test tests/Aspire.Hosting.Testing.Tests/Aspire.Hosting.Testing.Tests.csproj -- --filter-method "*.TestingBuilderHasAllPropertiesFromRealBuilder" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
 ```
 
 **Important**: Avoid passing `--no-build` unless you have just built in the same session and there have been no code changes since. In automation or while iterating on code, omit `--no-build` so changes are compiled and picked up by the test run.
@@ -110,6 +110,7 @@ dotnet test tests/Project.Tests/Project.Tests.csproj -- --filter-method "TestNam
 Never run all tests without the quarantine and outerloop filters in automated environments, as this will include flaky tests that are known to fail intermittently and long-running tests that slow down CI.
 
 Valid test filter switches include: --filter-class, --filter-not-class, --filter-method, --filter-not-method, --filter-namespace, --filter-not-namespace, --filter-not-trait, --filter-trait
+The switches `--filter-class` and `--filter-method` expect fully qualified names, unless a filter is used as a prefix like `--filter-class *.SomeClassName` or `--filter-method *.SomeMethodName`
 
 ### Test Verification Commands
 - **Single Test Project**: Typical runtime ~10-60 seconds per test project

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,7 +110,8 @@ dotnet test tests/Project.Tests/Project.Tests.csproj -- --filter-method "TestNam
 Never run all tests without the quarantine and outerloop filters in automated environments, as this will include flaky tests that are known to fail intermittently and long-running tests that slow down CI.
 
 Valid test filter switches include: --filter-class, --filter-not-class, --filter-method, --filter-not-method, --filter-namespace, --filter-not-namespace, --filter-not-trait, --filter-trait
-The switches `--filter-class` and `--filter-method` expect fully qualified names, unless a filter is used as a prefix like `--filter-class "*.SomeClassName"` or `--filter-method "*.SomeMethodName"`
+The switches `--filter-class` and `--filter-method` expect fully qualified names, unless a filter is used as a prefix like `--filter-class "*.SomeClassName"` or `--filter-method "*.SomeMethodName"`.
+These switches can be repeated to run tests on multiple classes or methods at once, e.g., `--filter-method "*.SomeMethodName1" --filter-method "*.SomeMethodName2"`.
 
 ### Test Verification Commands
 - **Single Test Project**: Typical runtime ~10-60 seconds per test project


### PR DESCRIPTION
## Description

Updated test filter command to use wildcard for method name and added note about filter expectations.

Current behavior is to run something like 

```
cd d:/aspire/sebros/properties && dotnet test tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj -- --filter-method "ResourceWithConnectionPropertiesExtensionRespectsFlags" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

which results in a build error and is retried multiple times.