### PR TITLE
Improve Azure provisioning interaction dialog

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/BaseProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/BaseProvisioningContextProvider.cs
@@ -179,4 +179,73 @@ internal abstract partial class BaseProvisioningContextProvider(
     }
 
     protected abstract string GetDefaultResourceGroupName();
+
+    protected async Task<(List<KeyValuePair<string, string>>? subscriptionOptions, bool fetchSucceeded)> TryGetSubscriptionsAsync(CancellationToken cancellationToken)
+    {
+        List<KeyValuePair<string, string>>? subscriptionOptions = null;
+        var fetchSucceeded = false;
+
+        try
+        {
+            var credential = _tokenCredentialProvider.TokenCredential;
+            var armClient = _armClientProvider.GetArmClient(credential);
+            var availableSubscriptions = await armClient.GetAvailableSubscriptionsAsync(cancellationToken).ConfigureAwait(false);
+            var subscriptionList = availableSubscriptions.ToList();
+
+            if (subscriptionList.Count > 0)
+            {
+                subscriptionOptions = [.. subscriptionList
+                                .Select(sub => KeyValuePair.Create(sub.Id.SubscriptionId ?? "", $"{sub.DisplayName ?? sub.Id.SubscriptionId} ({sub.Id.SubscriptionId})"))
+                                .OrderBy(kvp => kvp.Value)];
+                fetchSucceeded = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to enumerate available subscriptions. Falling back to manual input.");
+        }
+
+        return (subscriptionOptions, fetchSucceeded);
+    }
+
+    protected async Task<(List<KeyValuePair<string, string>>? locationOptions, bool fetchSucceeded)> TryGetLocationsAsync(string subscriptionId, CancellationToken cancellationToken)
+    {
+        List<KeyValuePair<string, string>>? locationOptions = null;
+        var fetchSucceeded = false;
+
+        try
+        {
+            var credential = _tokenCredentialProvider.TokenCredential;
+            var armClient = _armClientProvider.GetArmClient(credential);
+            var availableLocations = await armClient.GetAvailableLocationsAsync(subscriptionId, cancellationToken).ConfigureAwait(false);
+            var locationList = availableLocations.ToList();
+
+            if (locationList.Count > 0)
+            {
+                locationOptions = locationList
+                    .Select(loc => KeyValuePair.Create(loc.Name, loc.DisplayName))
+                    .ToList();
+                fetchSucceeded = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to enumerate available locations. Falling back to manual input.");
+        }
+
+        return (locationOptions, fetchSucceeded);
+    }
+
+    /// <summary>
+    /// Gets static Azure locations as fallback when dynamic loading fails.
+    /// </summary>
+    protected static List<KeyValuePair<string, string>> GetStaticAzureLocations()
+    {
+        return typeof(AzureLocation).GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .Where(p => p.PropertyType == typeof(AzureLocation))
+            .Select(p => (AzureLocation)p.GetValue(null)!)
+            .Select(location => KeyValuePair.Create(location.Name, location.DisplayName ?? location.Name))
+            .OrderBy(kvp => kvp.Value)
+            .ToList();
+    }
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -233,13 +233,11 @@ internal sealed class PublishModeProvisioningContextProvider(
             }
         }
 
-        if (locationOptions?.Count > 0)
-        {
-            var result = await _interactionService.PromptInputsAsync(
-                AzureProvisioningStrings.LocationDialogTitle,
-                AzureProvisioningStrings.LocationSelectionMessage,
-                [
-                    new InteractionInput
+        var result = await _interactionService.PromptInputsAsync(
+            AzureProvisioningStrings.LocationDialogTitle,
+            AzureProvisioningStrings.LocationSelectionMessage,
+            [
+                new InteractionInput
                     {
                         Name = LocationName,
                         InputType = InputType.Choice,
@@ -254,52 +252,6 @@ internal sealed class PublishModeProvisioningContextProvider(
                         Label = AzureProvisioningStrings.ResourceGroupLabel,
                         Value = GetDefaultResourceGroupName()
                     }
-                ],
-                new InputsDialogInteractionOptions
-                {
-                    EnableMessageMarkdown = false,
-                    ValidationCallback = static (validationContext) =>
-                    {
-                        var resourceGroupInput = validationContext.Inputs[ResourceGroupName];
-                        if (!IsValidResourceGroupName(resourceGroupInput.Value))
-                        {
-                            validationContext.AddValidationError(resourceGroupInput, AzureProvisioningStrings.ValidationResourceGroupNameInvalid);
-                        }
-                        return Task.CompletedTask;
-                    }
-                },
-                cancellationToken).ConfigureAwait(false);
-
-            if (!result.Canceled)
-            {
-                _options.Location = result.Data[LocationName].Value;
-                _options.ResourceGroup = result.Data[ResourceGroupName].Value;
-                _options.AllowResourceGroupCreation = true;
-                return;
-            }
-        }
-
-        var locations = GetStaticAzureLocations();
-
-        var manualResult = await _interactionService.PromptInputsAsync(
-            AzureProvisioningStrings.LocationDialogTitle,
-            AzureProvisioningStrings.LocationSelectionMessage,
-            [
-                new InteractionInput
-                {
-                    Name = LocationName,
-                    InputType = InputType.Choice,
-                    Label = AzureProvisioningStrings.LocationLabel,
-                    Required = true,
-                    Options = [..locations]
-                },
-                new InteractionInput
-                {
-                    Name = ResourceGroupName,
-                    InputType = InputType.Text,
-                    Label = AzureProvisioningStrings.ResourceGroupLabel,
-                    Value = GetDefaultResourceGroupName()
-                }
             ],
             new InputsDialogInteractionOptions
             {
@@ -316,10 +268,10 @@ internal sealed class PublishModeProvisioningContextProvider(
             },
             cancellationToken).ConfigureAwait(false);
 
-        if (!manualResult.Canceled)
+        if (!result.Canceled)
         {
-            _options.Location = manualResult.Data[LocationName].Value;
-            _options.ResourceGroup = manualResult.Data[ResourceGroupName].Value;
+            _options.Location = result.Data[LocationName].Value;
+            _options.ResourceGroup = result.Data[ResourceGroupName].Value;
             _options.AllowResourceGroupCreation = true;
         }
     }

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -170,7 +170,7 @@ internal sealed class RunModeProvisioningContextProvider(
                              Name = LocationName,
                              InputType = InputType.Choice,
                              Label = AzureProvisioningStrings.LocationLabel,
-                             Placeholder = "Select location",
+                             Placeholder = AzureProvisioningStrings.LocationPlaceholder,
                              Required = true,
                              Disabled = true,
                              DynamicOptions = new DynamicInputOptions

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
@@ -279,16 +279,16 @@ public class ProvisioningContextProviderTests
         Assert.Collection(inputsInteraction.Inputs,
             input =>
             {
-                Assert.Equal(BaseProvisioningContextProvider.LocationName, input.Name);
-                Assert.Equal("Location", input.Label);
+                Assert.Equal(BaseProvisioningContextProvider.SubscriptionIdName, input.Name);
+                Assert.Equal("Subscription ID", input.Label);
                 Assert.Equal(InputType.Choice, input.InputType);
                 Assert.True(input.Required);
             },
             input =>
             {
-                Assert.Equal(BaseProvisioningContextProvider.SubscriptionIdName, input.Name);
-                Assert.Equal("Subscription ID", input.Label);
-                Assert.Equal(InputType.SecretText, input.InputType);
+                Assert.Equal(BaseProvisioningContextProvider.LocationName, input.Name);
+                Assert.Equal("Location", input.Label);
+                Assert.Equal(InputType.Choice, input.InputType);
                 Assert.True(input.Required);
             },
             input =>
@@ -299,8 +299,18 @@ public class ProvisioningContextProviderTests
                 Assert.False(input.Required);
             });
 
-        inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].Value = inputsInteraction.Inputs[0].Options!.First(kvp => kvp.Key == "westus").Value;
         inputsInteraction.Inputs[BaseProvisioningContextProvider.SubscriptionIdName].Value = "12345678-1234-1234-1234-123456789012";
+
+        // Trigger dynamic update of locations based on subscription.
+        await inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].DynamicOptions!.UpdateInputCallback(new UpdateInputContext
+        {
+            AllInputs = inputsInteraction.Inputs,
+            CancellationToken = CancellationToken.None,
+            Input = inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName],
+            ServiceProvider = new ServiceCollection().BuildServiceProvider()
+        });
+
+        inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].Value = inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].Options!.First(kvp => kvp.Key == "westus").Value;
         inputsInteraction.Inputs[BaseProvisioningContextProvider.ResourceGroupName].Value = "rg-myrg";
 
         inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
@@ -348,8 +358,18 @@ public class ProvisioningContextProviderTests
 
         // Wait for the inputs interaction
         var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].Value = inputsInteraction.Inputs[0].Options!.First(kvp => kvp.Key == "westus").Value;
         inputsInteraction.Inputs[BaseProvisioningContextProvider.SubscriptionIdName].Value = "not a guid";
+
+        // Trigger dynamic update of locations based on subscription.
+        await inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].DynamicOptions!.UpdateInputCallback(new UpdateInputContext
+        {
+            AllInputs = inputsInteraction.Inputs,
+            CancellationToken = CancellationToken.None,
+            Input = inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName],
+            ServiceProvider = new ServiceCollection().BuildServiceProvider()
+        });
+
+        inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].Value = inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].Options!.First(kvp => kvp.Key == "westus").Value;
         inputsInteraction.Inputs[BaseProvisioningContextProvider.ResourceGroupName].Value = "invalid group";
 
         var context = new InputsDialogValidationContext


### PR DESCRIPTION
## Description

Use new interaction input features in Azure provisioning:

- Load subscriptions as dialog opens
- Allow custom choice in subscription ID
- Combine location and resource group inputs into the same input as subscription
- Disable location choice until a subscription value is entered
- Dynamically load locations based on subscription

**Not** in this PR is merging run-mode and publish-mode Azure deployment. Will possibly do a follow up PR based on discussion with @captainsafia and @eerhardt about removing duplication.

![azure-deploy-dialog](https://github.com/user-attachments/assets/e8eb446b-d9f5-4161-8b45-ca254aea4f28)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
