### PR TITLE
Make uninitialised parameters warnings not errors

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
@@ -74,7 +74,7 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
         {
             (icon, color) = resource.StateStyle switch
             {
-                "warning" => ((Icon)new Icons.Filled.Size16.Warning(), Color.Warning),
+                "warn" => ((Icon)new Icons.Filled.Size16.Warning(), Color.Warning),
                 "error" => (new Icons.Filled.Size16.ErrorCircle(), Color.Error),
                 "success" => (new Icons.Filled.Size16.CheckmarkCircle(), Color.Success),
                 "info" => (new Icons.Filled.Size16.Info(), Color.Info),

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -185,6 +185,7 @@ public sealed class ParameterProcessor(
         }
         catch (Exception ex)
         {
+            string stateStyle;
             // Missing parameter values throw a MissingParameterValueException.
             if (interactionService.IsAvailable && ex is MissingParameterValueException)
             {
@@ -194,6 +195,7 @@ public sealed class ParameterProcessor(
 
                 loggerService.GetLogger(parameterResource)
                     .LogWarning("Parameter resource {ResourceName} could not be initialized. Waiting for user input.", parameterResource.Name);
+                stateStyle = KnownResourceStateStyles.Warn;
             }
             else
             {
@@ -202,6 +204,7 @@ public sealed class ParameterProcessor(
 
                 loggerService.GetLogger(parameterResource)
                     .LogError(ex, "Failed to initialize parameter resource {ResourceName}.", parameterResource.Name);
+                stateStyle = KnownResourceStateStyles.Error;
             }
 
             var stateText = ex is MissingParameterValueException ?
@@ -212,7 +215,7 @@ public sealed class ParameterProcessor(
             {
                 return s with
                 {
-                    State = new(stateText, KnownResourceStateStyles.Error),
+                    State = new(stateText, stateStyle),
                     Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, ex.Message)
                 };
             })


### PR DESCRIPTION
## Description

- Make uninitalised parameters show up as warnings rather than errors to match the warning icon by the banner.
- Fix `KnownResourceStateStyles.Warn` not matching the style defined in `ResourceStateViewModel` (`warn` vs `warning`)

Note, last is technically a breaking change as anyone who set the style to the string "warning" instead of usign `KnownResourceStyles` will now have their icons show up as white dots, rather than warning triangles.  This breaking change could be mitigated by adding both `warn` and `warning` to `ResourceStateViewModel.cs`.

Fixes #11992 

After: 
<img width="1840" height="1233" alt="image" src="https://github.com/user-attachments/assets/6c8b8cc7-966f-4a4c-b425-3301c45b6d33" />


Before:
<img width="1877" height="991" alt="image" src="https://github.com/user-attachments/assets/56937c1c-c3b9-45e1-ba3e-5f178829574b" />


## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
