### PR TITLE
Add interaction service comboxbox filtering

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -114,18 +114,20 @@
                                                     @bind-Value="input.ViewModel.Value"
                                                     Placeholder="@input.ViewModel.Input.Placeholder"
                                                     Required="input.ViewModel.Input.Required"
-                                                    Items="input.ViewModel.SelectOptions"
+                                                    Items="@input.ViewModel.FilteredOptions()"
                                                     OptionValue="@(vm => vm.Id)"
                                                     OptionText="@(vm => vm.Name)"
                                                     Height="250px"
                                                     Position="SelectPosition.Below"
                                                     Disabled="input.ViewModel.InputDisabled"
+                                                    Immediate="true"
+                                                    ImmediateDelay="@FluentUIExtensions.InputDelay"
                                                     aria-describedby="@input.DescriptionId">
                                         <OptionTemplate Context="optionContext">
                                             @* Allows long values to be viewed in option popup by adding a tooltip to options. *@
                                             @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
                                             <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
-                                                @optionContext.Name
+                                                <FluentHighlighter Text="@optionContext.Name" HighlightedText="@input.ViewModel.Value" />
                                             </span>
                                         </OptionTemplate>
                                     </FluentCombobox>

--- a/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
@@ -57,6 +57,16 @@ public sealed class InputViewModel
 
     public List<SelectViewModel<string>> SelectOptions { get; private set; } = [];
 
+    public IEnumerable<SelectViewModel<string>> FilteredOptions()
+    {
+        if (Value is not { Length: > 0 } value)
+        {
+            return SelectOptions;
+        }
+
+        return SelectOptions.Where(vm => vm.Name.Contains(value, StringComparison.OrdinalIgnoreCase));
+    }
+
     public string? Value
     {
         get => Input.Value;


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/11985

For some reason I thought filtering happened automatically. But it was custom logic that had been added to the filter dialog (other place with comboboxes).

Add filtering logic to interaction service dialog.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
