### PR TITLE
Add dashboard language icons for Python, JavaScript and C#

### DIFF
--- a/playground/AspireWithNode/AspireWithNode.AppHost/AppHost.cs
+++ b/playground/AspireWithNode/AspireWithNode.AppHost/AppHost.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -21,5 +21,15 @@ if (builder.Environment.IsDevelopment() && launchProfile == "https")
 {
     frontend.RunWithHttpsDevCertificate("HTTPS_CERT_FILE", "HTTPS_CERT_KEY_FILE");
 }
+
+#if !SKIP_DASHBOARD_REFERENCE
+// This project is only added in playground projects to support development/debugging
+// of the dashboard. It is not required in end developer code. Comment out this code
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
+builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
 
 builder.Build().Run();

--- a/playground/AspireWithNode/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
+++ b/playground/AspireWithNode/AspireWithNode.AppHost/AspireWithNode.AppHost.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AspireWithNode.AspNetCoreApi\AspireWithNode.AspNetCoreApi.csproj" />
   </ItemGroup>
 

--- a/playground/python/Python.AppHost/Program.cs
+++ b/playground/python/Python.AppHost/Program.cs
@@ -8,4 +8,14 @@ var builder = DistributedApplication.CreateBuilder(args);
 builder.AddPythonApp("script-only", "../script_only", "main.py");
 builder.AddPythonApp("instrumented-script", "../instrumented_script", "main.py");
 
+#if !SKIP_DASHBOARD_REFERENCE
+// This project is only added in playground projects to support development/debugging
+// of the dashboard. It is not required in end developer code. Comment out this code
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
+builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
+
 builder.Build().Run();

--- a/src/Aspire.Dashboard/Model/IconResolver.cs
+++ b/src/Aspire.Dashboard/Model/IconResolver.cs
@@ -10,6 +10,7 @@ namespace Aspire.Dashboard.Model;
 public sealed class IconResolver
 {
     private sealed record IconKey(string IconName, IconSize DesiredIconSize, IconVariant IconVariant);
+    private static readonly List<IconSize> s_iconSizes = [IconSize.Size16, IconSize.Size20, IconSize.Size24];
     private readonly ConcurrentDictionary<IconKey, Icon?> _iconCache = new();
     private readonly ILogger<IconResolver> _logger;
 
@@ -25,31 +26,60 @@ public sealed class IconResolver
         {
             // Try to get the desired size.
             CustomIcon? icon;
-            if (TryGetIcon(key, key.DesiredIconSize, out icon))
+            if (TryGetIconCore(key, key.DesiredIconSize, out icon))
             {
                 return icon;
             }
 
+            var iconSizesTried = new List<IconSize>
+            {
+                key.DesiredIconSize
+            };
+
             // Some icons aren't available in all sizes. Try until we find a match. Prefer size bigger than desired.
-            if (key.DesiredIconSize <= IconSize.Size16 && TryGetIcon(key, IconSize.Size16, out icon))
+            if (key.DesiredIconSize <= IconSize.Size16 && TryGetIcon(iconSizesTried, key, IconSize.Size16, out icon))
             {
                 return icon;
             }
-            if (key.DesiredIconSize <= IconSize.Size20 && TryGetIcon(key, IconSize.Size20, out icon))
+            if (key.DesiredIconSize <= IconSize.Size20 && TryGetIcon(iconSizesTried, key, IconSize.Size20, out icon))
             {
                 return icon;
             }
-            if (key.DesiredIconSize <= IconSize.Size24 && TryGetIcon(key, IconSize.Size24, out icon))
+            if (key.DesiredIconSize <= IconSize.Size24 && TryGetIcon(iconSizesTried, key, IconSize.Size24, out icon))
             {
                 return icon;
+            }
+
+            // Usually icons are always available in bigger sizes and smaller sizes are removed.
+            // This is because it isn't possible to scale down the detail. For example, BrainCircuit has a size 20 icon, but not a size 16 icon.
+            // There are some rare icons that only have smaller sizes, For example, CodePyRetangle only has size 16 icon.
+            // To handle the situation where we ask for a bigger than available icon, fall back to try any remaining icon sizes, including smaller.
+            foreach (var size in s_iconSizes)
+            {
+                if (TryGetIcon(iconSizesTried, key, size, out icon))
+                {
+                    return icon;
+                }
             }
 
             _logger.LogWarning("Icon '{IconName}' (variant: {IconVariant}, size: {IconSize}) could not be resolved.", key.IconName, key.IconVariant, key.DesiredIconSize);
             return null;
         });
+
+        static bool TryGetIcon(List<IconSize> triedSizes, IconKey key, IconSize size, [NotNullWhen(true)] out CustomIcon? icon)
+        {
+            if (triedSizes.Contains(size))
+            {
+                icon = null;
+                return false;
+            }
+
+            triedSizes.Add(size);
+            return TryGetIconCore(key, size, out icon);
+        }
     }
 
-    private static bool TryGetIcon(IconKey key, IconSize size, [NotNullWhen(true)] out CustomIcon? icon)
+    private static bool TryGetIconCore(IconKey key, IconSize size, [NotNullWhen(true)] out CustomIcon? icon)
     {
         var iconInfo = new IconInfo
         {

--- a/src/Aspire.Dashboard/Model/IconResolver.cs
+++ b/src/Aspire.Dashboard/Model/IconResolver.cs
@@ -52,7 +52,7 @@ public sealed class IconResolver
 
             // Usually icons are always available in bigger sizes and smaller sizes are removed.
             // This is because it isn't possible to scale down the detail. For example, BrainCircuit has a size 20 icon, but not a size 16 icon.
-            // There are some rare icons that only have smaller sizes, For example, CodePyRetangle only has size 16 icon.
+            // There are some rare icons that only have smaller sizes, For example, CodePyRectangle only has size 16 icon.
             // To handle the situation where we ask for a bigger than available icon, fall back to try any remaining icon sizes, including smaller.
             foreach (var size in s_iconSizes)
             {

--- a/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
@@ -28,7 +28,7 @@ internal static class ResourceIconHelpers
         var icon = resource.ResourceType switch
         {
             KnownResourceTypes.Executable => iconResolver.ResolveIconName("Apps", desiredSize, desiredVariant),
-            KnownResourceTypes.Project => iconResolver.ResolveIconName("CodeCircle", desiredSize, desiredVariant),
+            KnownResourceTypes.Project => ResolveProjectIcon(iconResolver, resource, desiredSize, desiredVariant),
             KnownResourceTypes.Container => iconResolver.ResolveIconName("Box", desiredSize, desiredVariant),
             KnownResourceTypes.Parameter => iconResolver.ResolveIconName("Key", desiredSize, desiredVariant),
             KnownResourceTypes.ConnectionString => iconResolver.ResolveIconName("PlugConnectedSettings", desiredSize, desiredVariant),
@@ -43,6 +43,22 @@ internal static class ResourceIconHelpers
         }
 
         return icon;
+
+        static Icon? ResolveProjectIcon(IconResolver iconResolver, ResourceViewModel resource, IconSize desiredSize, IconVariant desiredVariant = IconVariant.Filled)
+        {
+            if (resource.TryGetProjectPath(out var projectPath) && !string.IsNullOrEmpty(projectPath))
+            {
+                var extension = Path.GetExtension(projectPath);
+                return extension?.ToLowerInvariant() switch
+                {
+                    ".csproj" => iconResolver.ResolveIconName("CodeCsRectangle", desiredSize, desiredVariant),
+                    ".fsproj" => iconResolver.ResolveIconName("CodeFsRectangle", desiredSize, desiredVariant),
+                    ".vbproj" => iconResolver.ResolveIconName("CodeVbRectangle", desiredSize, desiredVariant),
+                    _ => iconResolver.ResolveIconName("CodeCircle", desiredSize, desiredVariant)
+                };
+            }
+            return null;
+        }
     }
 
     public static (Icon? icon, Color color) GetHealthStatusIcon(HealthStatus? healthStatus)

--- a/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
@@ -57,7 +57,8 @@ internal static class ResourceIconHelpers
                     _ => iconResolver.ResolveIconName("CodeCircle", desiredSize, desiredVariant)
                 };
             }
-            return null;
+
+            return iconResolver.ResolveIconName("CodeCircle", desiredSize, desiredVariant);
         }
     }
 

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -336,7 +336,7 @@ class ResourceGraph {
             .append("title")
             .text(n => n.resourceIcon.tooltip);
 
-        // Icon paths could be mixed size. We need to transform icons to always be displayed at a consistant size.
+        // Icon paths could be mixed size. We need to transform icons to always be displayed at a consistent size.
         iconPath.each(function (d) {
             const iconSize = 48;
 

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -325,14 +325,35 @@ class ResourceGraph {
             .append("circle")
             .attr("r", 53)
             .attr("class", "resource-node-border");
-        newNodesContainer
+        var iconTransform = newNodesContainer
             .append("g")
-            .attr("transform", "scale(2.1) translate(-12,-17)")
-            .append("path")
+            .attr("transform", "translate(-24,-35)")
+        var iconPath = iconTransform
+            .append("path");
+        iconPath
             .attr("fill", n => n.resourceIcon.color)
             .attr("d", n => n.resourceIcon.path)
             .append("title")
             .text(n => n.resourceIcon.tooltip);
+
+        // Icon paths could be mixed size. We need to transform icons to always be displayed at a consistant size.
+        iconPath.each(function (d) {
+            const iconSize = 48;
+
+            const path = d3.select(this);
+            const node = path.node();
+            const bbox = node.getBBox();
+
+            const available = Math.max(1, iconSize - 2);
+            const scale = available / Math.max(bbox.width, bbox.height);
+
+            const cx = bbox.x + bbox.width / 2;
+            const cy = bbox.y + bbox.height / 2;
+
+            // apply scaling & centering inside this group
+            path.attr("transform",
+                `translate(${iconSize / 2},${iconSize / 2}) scale(${scale}) translate(${-cx},${-cy})`);
+        });
 
         var endpointGroup = newNodesContainer
             .append("g")

--- a/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-resourcegraph.js
@@ -327,7 +327,7 @@ class ResourceGraph {
             .attr("class", "resource-node-border");
         var iconTransform = newNodesContainer
             .append("g")
-            .attr("transform", "translate(-24,-35)")
+            .attr("transform", "translate(-24,-37)")
         var iconPath = iconTransform
             .append("path");
         iconPath

--- a/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
+++ b/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
@@ -36,7 +36,7 @@ public static class NodeAppHostingExtension
         return builder.AddResource(resource)
                       .WithNodeDefaults()
                       .WithArgs(effectiveArgs)
-                      .WithIconName("CodeJsRectangle", IconVariant.Regular);
+                      .WithIconName("CodeJsRectangle");
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public static class NodeAppHostingExtension
         return builder.AddResource(resource)
                       .WithNodeDefaults()
                       .WithArgs(allArgs)
-                      .WithIconName("CodeJsRectangle", IconVariant.Regular);
+                      .WithIconName("CodeJsRectangle");
     }
 
     private static IResourceBuilder<NodeAppResource> WithNodeDefaults(this IResourceBuilder<NodeAppResource> builder) =>

--- a/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
+++ b/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
@@ -35,7 +35,8 @@ public static class NodeAppHostingExtension
 
         return builder.AddResource(resource)
                       .WithNodeDefaults()
-                      .WithArgs(effectiveArgs);
+                      .WithArgs(effectiveArgs)
+                      .WithIconName("CodeJsRectangle", IconVariant.Regular);
     }
 
     /// <summary>
@@ -64,7 +65,8 @@ public static class NodeAppHostingExtension
 
         return builder.AddResource(resource)
                       .WithNodeDefaults()
-                      .WithArgs(allArgs);
+                      .WithArgs(allArgs)
+                      .WithIconName("CodeJsRectangle", IconVariant.Regular);
     }
 
     private static IResourceBuilder<NodeAppResource> WithNodeDefaults(this IResourceBuilder<NodeAppResource> builder) =>

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -142,7 +142,7 @@ public static class PythonAppResourceBuilderExtensions
             context.Args.Add(scriptPath);
         });
 
-        resourceBuilder.WithIconName("CodePyRectangle", IconVariant.Regular);
+        resourceBuilder.WithIconName("CodePyRectangle");
 
         resourceBuilder.WithOtlpExporter();
 

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -142,6 +142,8 @@ public static class PythonAppResourceBuilderExtensions
             context.Args.Add(scriptPath);
         });
 
+        resourceBuilder.WithIconName("CodePyRectangle", IconVariant.Regular);
+
         resourceBuilder.WithOtlpExporter();
 
         // Configure OpenTelemetry exporters using environment variables


### PR DESCRIPTION
## Description

PR changes:

- Add custom icons for Python and Node/NPM resources.
- Fix not resolving icon when it's smaller than desired size
- Fix graph view to display icons with a consistant size if they're larger/smaller than size 24

Bike shedding:
* Icons could be regular or filled? Which do people prefer?
* Should C# apps use C# icon? (can also hook up F# and VB icons, based on the project file extension)

**Update:** I think filled are better. And I added .NET language icons for projects.

### Regular:

<img width="1485" height="495" alt="image" src="https://github.com/user-attachments/assets/6e5ae4da-11b8-4c2d-a94e-2e6c71c75713" />

<img width="710" height="625" alt="image" src="https://github.com/user-attachments/assets/e498b5a7-fe49-406e-85dd-db43ee3f292c" />

### Filled:

<img width="1472" height="404" alt="image" src="https://github.com/user-attachments/assets/093ba9f4-9cef-450b-b157-2df9b9b50c97" />

<img width="661" height="632" alt="image" src="https://github.com/user-attachments/assets/494cd54c-67e6-4b8f-b2ad-bc6f36bfc374" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
