### PR TITLE
Record errors in AI subscription callbacks to telemetry

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -181,9 +181,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         TelemetryContextProvider.Initialize(TelemetryContext);
         _resourceSubscriptionToken = _resourceSubscriptionCts.Token;
         _logEntries = new(Options.Value.Frontend.MaxConsoleLogCount);
-        _aiContext = CreateAIContext();
         _allResource = new() { Id = null, Name = ControlsStringsLoc[nameof(ControlsStrings.LabelAll)] };
         PageViewModel = new ConsoleLogsViewModel { SelectedResource = _allResource, Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLoadingResources)] };
+        _aiContext = CreateAIContext();
         _logEntryChannelReaderTask = StartLogEntryChannelReaderTask();
 
         _consoleLogsFiltersChangedSubscription = ConsoleLogsManager.OnFiltersChanged(async () =>
@@ -526,7 +526,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
     private ResourceViewModel? GetSelectedResource()
     {
-        var name = PageViewModel.SelectedResource.Id?.InstanceId;
+        var name = PageViewModel?.SelectedResource.Id?.InstanceId;
         if (name == null)
         {
             return null;

--- a/src/Aspire.Dashboard/Model/Assistant/AIContextProvider.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIContextProvider.cs
@@ -5,6 +5,7 @@ using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model.Assistant.Ghcp;
 using Aspire.Dashboard.Model.Assistant.Prompts;
+using Aspire.Dashboard.Telemetry;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 
@@ -17,6 +18,7 @@ public class AIContextProvider : IAIContextProvider
     private readonly ILogger<AIContextProvider> _logger;
     private readonly IOptionsMonitor<DashboardOptions> _dashboardOptions;
     private readonly ChatClientFactory _chatClientFactory;
+    private readonly ITelemetryErrorRecorder _telemetryErrorRecorder;
     private readonly List<AIContext> _contextsStack = new List<AIContext>();
     private readonly List<ModelSubscription> _contextChangedSubscriptions = [];
     private readonly List<ModelSubscription> _displayChangedSubscriptions = [];
@@ -27,13 +29,15 @@ public class AIContextProvider : IAIContextProvider
         ILogger<AIContextProvider> logger,
         IOptionsMonitor<DashboardOptions> dashboardOptions,
         ChatClientFactory chatClientFactory,
-        IceBreakersBuilder iceBreakersBuilder)
+        IceBreakersBuilder iceBreakersBuilder,
+        ITelemetryErrorRecorder telemetryErrorRecorder)
     {
         _serviceProvider = serviceProvider;
         _logger = logger;
         _dashboardOptions = dashboardOptions;
         _chatClientFactory = chatClientFactory;
         IceBreakersBuilder = iceBreakersBuilder;
+        _telemetryErrorRecorder = telemetryErrorRecorder;
         Enabled = IsEnabled();
     }
 
@@ -119,7 +123,7 @@ public class AIContextProvider : IAIContextProvider
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error while executing subscriptions.");
+            _telemetryErrorRecorder.RecordError("Error while executing AIContextProvider subscriptions.", ex, writeToLogging: true);
         }
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AIContextProviderTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AIContextProviderTests.cs
@@ -127,6 +127,7 @@ public class AIContextProviderTests
             NullLogger<AIContextProvider>.Instance,
             testOptionsMonitor,
             new ChatClientFactory(new ConfigurationManager(), NullLoggerFactory.Instance, testOptionsMonitor),
-            new IceBreakersBuilder(new TestStringLocalizer<AIPrompts>()));
+            new IceBreakersBuilder(new TestStringLocalizer<AIPrompts>()),
+            new TestTelemetryErrorRecorder());
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspire/pull/12000

Record errors to telemetry. If errors happen in this place again then we'll see them and can fix quickly.