### PR TITLE
Ensure adding custom certificate references to a resource is idempotent

### DIFF
--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -2093,7 +2093,13 @@ public static class ResourceBuilderExtensions
         };
         if (builder.Resource.TryGetLastAnnotation<CertificateAuthorityCollectionAnnotation>(out var existingAnnotation))
         {
-            annotation.CertificateAuthorityCollections.AddRange(existingAnnotation.CertificateAuthorityCollections);
+            foreach (var existingCollection in existingAnnotation.CertificateAuthorityCollections)
+            {
+                if (existingCollection != certificateAuthorityCollection.Resource)
+                {
+                    annotation.CertificateAuthorityCollections.Add(existingCollection);
+                }
+            }
             annotation.TrustDeveloperCertificates ??= existingAnnotation.TrustDeveloperCertificates;
             annotation.Scope ??= existingAnnotation.Scope;
         }

--- a/tests/Aspire.Hosting.Tests/WithCertificateAuthorityCollection.cs
+++ b/tests/Aspire.Hosting.Tests/WithCertificateAuthorityCollection.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Utils;
+
 namespace Aspire.Hosting.Tests;
 
 public class WithCertificateAuthorityCollectionTests
 {
     [Fact]
-    public async Task AddingCertificateAuthorityCollectionsIsIdempotent()
+    public Task AddingCertificateAuthorityCollectionsIsIdempotent()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
@@ -25,9 +27,12 @@ public class WithCertificateAuthorityCollectionTests
                                .WithCertificateAuthorityCollection(bundle2)
                                .WithCertificateAuthorityCollection(bundle1); // Add bundle1 again to test idempotency
 
-        Assert.True(container.Resource.TryGetAnnotationsOfType<CertificateAuthorityCollectionAnnotation>(out var annotation));
+        Assert.True(container.Resource.TryGetAnnotationsOfType<CertificateAuthorityCollectionAnnotation>(out var annotations));
+        var annotation = Assert.Single(annotations);
         Assert.Equal(2, annotation.CertificateAuthorityCollections.Count);
         Assert.Contains(bundle1.Resource, annotation.CertificateAuthorityCollections);
         Assert.Contains(bundle2.Resource, annotation.CertificateAuthorityCollections);
+
+        return Task.CompletedTask;
     }
 }

--- a/tests/Aspire.Hosting.Tests/WithCertificateAuthorityCollection.cs
+++ b/tests/Aspire.Hosting.Tests/WithCertificateAuthorityCollection.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Tests;
+
+public class WithCertificateAuthorityCollectionTests
+{
+    [Fact]
+    public async Task AddingCertificateAuthorityCollectionsIsIdempotent()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var bundle1 = builder.AddCertificateAuthorityCollection("bundle1");
+        var bundle2 = builder.AddCertificateAuthorityCollection("bundle2");
+
+        var container = builder.AddContainer("container", "image")
+                               .WithEnvironment(context =>
+                               {
+                                   Assert.NotNull(context.Resource);
+
+                                   var sp = context.ExecutionContext.ServiceProvider;
+                                   context.EnvironmentVariables["SP_AVAILABLE"] = sp is not null ? "true" : "false";
+                               })
+                               .WithCertificateAuthorityCollection(bundle1)
+                               .WithCertificateAuthorityCollection(bundle2)
+                               .WithCertificateAuthorityCollection(bundle1); // Add bundle1 again to test idempotency
+
+        Assert.True(container.Resource.TryGetAnnotationsOfType<CertificateAuthorityCollectionAnnotation>(out var annotation));
+        Assert.Equal(2, annotation.CertificateAuthorityCollections.Count);
+        Assert.Contains(bundle1.Resource, annotation.CertificateAuthorityCollections);
+        Assert.Contains(bundle2.Resource, annotation.CertificateAuthorityCollections);
+    }
+}


### PR DESCRIPTION
## Description

In case a user references the same CertificateAuthorityCollection multiple times for a given resource, ensure that only a single reference is preserved in the underlying annotation.

Fixes #12018 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
