### PR TITLE
Only return the single most valid developer certificate

### DIFF
--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -31,7 +31,8 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
                         .Where(c => c.IsAspNetCoreDevelopmentCertificate())
                         .Where(c => c.NotAfter > DateTime.UtcNow)
                         .OrderByDescending(c => c.GetCertificateVersion())
-                        .ThenByDescending(c => c.NotAfter));
+                        .ThenByDescending(c => c.NotAfter)
+                        .Take(1));
 
                 if (devCerts.Count == 0)
                 {

--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -23,15 +23,16 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
 
                 using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
                 store.Open(OpenFlags.ReadOnly);
+                var now = DateTime.UtcNow;
                 devCerts.AddRange(
                     // Order by version and expiration date descending to get the most recent, highest version first.
                     // OpenSSL will only check the first self-signed certificate in the bundle that matches a given domain,
                     // so we want to ensure the certificate that will be used by ASP.NET Core is the first one in the bundle.
+                    // Match the ordering logic ASP.NET Core uses: https://github.com/dotnet/aspnetcore/blob/0aefdae365ff9b73b52961acafd227309524ce3c/src/Shared/CertificateGeneration/CertificateManager.cs#L122
                     store.Certificates
                         .Where(c => c.IsAspNetCoreDevelopmentCertificate())
-                        .Where(c => c.NotAfter > DateTime.UtcNow)
+                        .Where(c => c.NotBefore <= now && now <= c.NotAfter)
                         .OrderByDescending(c => c.GetCertificateVersion())
-                        .ThenByDescending(c => c.NotAfter)
                         .Take(1));
 
                 if (devCerts.Count == 0)


### PR DESCRIPTION
## Description

OpenSSL doesn't like having more than one available self-signed CA certificate for a given subject (it only checks a single certificate).