### PR TITLE
[release/9.5] Update dependencies from https://github.com/microsoft/usvc-apiserver build 0.17.3

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.17.2">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.17.3">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>87a04b7b68549eb11b9bf3ef5a2ad42845656d31</Sha>
+      <Sha>3ec086b4558f6e06c841e7d20c6dc8c637b7677a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.17.2">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.17.3">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>87a04b7b68549eb11b9bf3ef5a2ad42845656d31</Sha>
+      <Sha>3ec086b4558f6e06c841e7d20c6dc8c637b7677a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.17.2">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.17.3">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>87a04b7b68549eb11b9bf3ef5a2ad42845656d31</Sha>
+      <Sha>3ec086b4558f6e06c841e7d20c6dc8c637b7677a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.17.2">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.17.3">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>87a04b7b68549eb11b9bf3ef5a2ad42845656d31</Sha>
+      <Sha>3ec086b4558f6e06c841e7d20c6dc8c637b7677a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.17.2">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.17.3">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>87a04b7b68549eb11b9bf3ef5a2ad42845656d31</Sha>
+      <Sha>3ec086b4558f6e06c841e7d20c6dc8c637b7677a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.17.2">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.17.3">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>87a04b7b68549eb11b9bf3ef5a2ad42845656d31</Sha>
+      <Sha>3ec086b4558f6e06c841e7d20c6dc8c637b7677a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.17.2">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.17.3">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>87a04b7b68549eb11b9bf3ef5a2ad42845656d31</Sha>
+      <Sha>3ec086b4558f6e06c841e7d20c6dc8c637b7677a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.17.2">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.17.3">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>87a04b7b68549eb11b9bf3ef5a2ad42845656d31</Sha>
+      <Sha>3ec086b4558f6e06c841e7d20c6dc8c637b7677a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="9.9.0">
       <Uri>https://github.com/dotnet/extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,14 +28,14 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.17.2</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.17.2</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.17.2</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.17.2</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.17.2</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindows386Version>0.17.2</MicrosoftDeveloperControlPlanewindows386Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.17.2</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.17.2</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.17.3</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.17.3</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.17.3</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.17.3</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.17.3</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindows386Version>0.17.3</MicrosoftDeveloperControlPlanewindows386Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.17.3</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.17.3</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>11.0.0-beta.25457.1</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>11.0.0-beta.25457.1</MicrosoftDotNetXUnitV3ExtensionsVersion>


### PR DESCRIPTION
Backport of DCP fixes for symlink handling and PID creation time mismatch to release/9.5.