### PR TITLE
Reactor and add XML comments to dynamic input API

### DIFF
--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -296,7 +296,7 @@ internal static class InteractionCommands
                    Placeholder = "Placeholder!",
                    AllowCustomChoice = true,
                    Required = true,
-                   DynamicLoading = new DynamicInputLoading
+                   DynamicLoading = new InputLoadOptions
                    {
                        LoadCallback = async (context) =>
                        {
@@ -311,7 +311,7 @@ internal static class InteractionCommands
                        }
                    }
                };
-               var dependentOptionsProvider = new DynamicInputLoading
+               var dependentOptionsProvider = new InputLoadOptions
                {
                    LoadCallback = async (context) =>
                    {
@@ -364,7 +364,7 @@ internal static class InteractionCommands
                    Placeholder = "Placeholder!",
                    Required = true,
                    Disabled = true,
-                   DynamicLoading = new DynamicInputLoading
+                   DynamicLoading = new InputLoadOptions
                    {
                        DependsOnInputs = ["Dynamic"],
                        LoadCallback = async (context) =>
@@ -435,7 +435,7 @@ internal static class InteractionCommands
                    Placeholder = "Placeholder!",
                    AllowCustomChoice = true,
                    Required = true,
-                   DynamicLoading = new DynamicInputLoading
+                   DynamicLoading = new InputLoadOptions
                    {
                        LoadCallback = async (context) =>
                        {
@@ -452,7 +452,7 @@ internal static class InteractionCommands
                    Label = "Dynamic",
                    Placeholder = "Select dynamic value",
                    Required = true,
-                   DynamicLoading = new DynamicInputLoading
+                   DynamicLoading = new InputLoadOptions
                    {
                        LoadCallback = async (context) =>
                        {

--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -296,9 +296,9 @@ internal static class InteractionCommands
                    Placeholder = "Placeholder!",
                    AllowCustomChoice = true,
                    Required = true,
-                   DynamicOptions = new DynamicInputOptions
+                   DynamicLoading = new DynamicInputLoading
                    {
-                       UpdateInputCallback = async (context) =>
+                       LoadCallback = async (context) =>
                        {
                            await Task.Delay(5000, context.CancellationToken);
 
@@ -311,9 +311,9 @@ internal static class InteractionCommands
                        }
                    }
                };
-               var dependentOptionsProvider = new DynamicInputOptions
+               var dependentOptionsProvider = new DynamicInputLoading
                {
-                   UpdateInputCallback = async (context) =>
+                   LoadCallback = async (context) =>
                    {
                        var dependsOnInput = context.AllInputs["PredefinedOptions"];
 
@@ -344,7 +344,7 @@ internal static class InteractionCommands
                    Placeholder = "Select dynamic value",
                    Required = true,
                    Disabled = true,
-                   DynamicOptions = dependentOptionsProvider
+                   DynamicLoading = dependentOptionsProvider
                };
                var dynamicCustomChoiceInput = new InteractionInput
                {
@@ -355,7 +355,7 @@ internal static class InteractionCommands
                    AllowCustomChoice = true,
                    Required = true,
                    Disabled = true,
-                   DynamicOptions = dependentOptionsProvider
+                   DynamicLoading = dependentOptionsProvider
                };
                var dynamicTextInput = new InteractionInput
                {
@@ -364,10 +364,10 @@ internal static class InteractionCommands
                    Placeholder = "Placeholder!",
                    Required = true,
                    Disabled = true,
-                   DynamicOptions = new DynamicInputOptions
+                   DynamicLoading = new DynamicInputLoading
                    {
                        DependsOnInputs = ["Dynamic"],
-                       UpdateInputCallback = async (context) =>
+                       LoadCallback = async (context) =>
                        {
                            await Task.Delay(5000, context.CancellationToken);
                            var dependsOnInput = context.AllInputs["Dynamic"];
@@ -435,9 +435,9 @@ internal static class InteractionCommands
                    Placeholder = "Placeholder!",
                    AllowCustomChoice = true,
                    Required = true,
-                   DynamicOptions = new DynamicInputOptions
+                   DynamicLoading = new DynamicInputLoading
                    {
-                       UpdateInputCallback = async (context) =>
+                       LoadCallback = async (context) =>
                        {
                            await Task.Delay(1000, context.CancellationToken);
 
@@ -452,9 +452,9 @@ internal static class InteractionCommands
                    Label = "Dynamic",
                    Placeholder = "Select dynamic value",
                    Required = true,
-                   DynamicOptions = new DynamicInputOptions
+                   DynamicLoading = new DynamicInputLoading
                    {
-                       UpdateInputCallback = async (context) =>
+                       LoadCallback = async (context) =>
                        {
                            await Task.Delay(1000, context.CancellationToken);
 

--- a/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
+++ b/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
@@ -69,10 +69,10 @@ internal static class IDistributedApplicationBuilderExtensions
                         Label = "More certificate details",
                         InputType = InputType.Choice,
                         Required = true,
-                        DynamicOptions = new DynamicInputOptions
+                        DynamicLoading = new DynamicInputLoading
                         {
                             DependsOnInputs = ["SSLCertificateType"],
-                            UpdateInputCallback = async (c) =>
+                            LoadCallback = async (c) =>
                             {
                                 await Task.Delay(5000);
                                 var dependsOnInput = c.AllInputs["SSLCertificateType"];

--- a/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
+++ b/playground/publishers/Publishers.AppHost/DistributedApplicationBuilderExtensions.cs
@@ -69,7 +69,7 @@ internal static class IDistributedApplicationBuilderExtensions
                         Label = "More certificate details",
                         InputType = InputType.Choice,
                         Required = true,
-                        DynamicLoading = new DynamicInputLoading
+                        DynamicLoading = new InputLoadOptions
                         {
                             DependsOnInputs = ["SSLCertificateType"],
                             LoadCallback = async (c) =>

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -132,9 +132,9 @@ internal sealed class RunModeProvisioningContextProvider(
                             Required = true,
                             AllowCustomChoice = true,
                             Placeholder = AzureProvisioningStrings.SubscriptionIdPlaceholder,
-                            DynamicOptions = new DynamicInputOptions
+                            DynamicLoading = new DynamicInputLoading
                             {
-                                UpdateInputCallback = async (context) =>
+                                LoadCallback = async (context) =>
                                 {
                                     var (subscriptionOptions, fetchSucceeded) =
                                         await TryGetSubscriptionsAsync(cancellationToken).ConfigureAwait(false);
@@ -153,9 +153,9 @@ internal sealed class RunModeProvisioningContextProvider(
                             Placeholder = AzureProvisioningStrings.LocationPlaceholder,
                             Required = true,
                             Disabled = true,
-                            DynamicOptions = new DynamicInputOptions
+                            DynamicLoading = new DynamicInputLoading
                             {
-                                UpdateInputCallback = async (context) =>
+                                LoadCallback = async (context) =>
                                 {
                                     var subscriptionId = context.AllInputs[SubscriptionIdName].Value ?? string.Empty;
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -132,7 +132,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             Required = true,
                             AllowCustomChoice = true,
                             Placeholder = AzureProvisioningStrings.SubscriptionIdPlaceholder,
-                            DynamicLoading = new DynamicInputLoading
+                            DynamicLoading = new InputLoadOptions
                             {
                                 LoadCallback = async (context) =>
                                 {
@@ -153,7 +153,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             Placeholder = AzureProvisioningStrings.LocationPlaceholder,
                             Required = true,
                             Disabled = true,
-                            DynamicLoading = new DynamicInputLoading
+                            DynamicLoading = new InputLoadOptions
                             {
                                 LoadCallback = async (context) =>
                                 {

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -155,7 +155,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                                 {
                                     dto.Options.Add(input.Options.ToDictionary());
                                 }
-                                if (input.DynamicState is { } providerState)
+                                if (input.DynamicLoadingState is { } providerState)
                                 {
                                     dto.Loading = providerState.Loading;
                                 }

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -118,7 +118,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                             // Find all the inputs that are depended on.
                             // These inputs value changing will cause the interaction to be sent to the server.
                             var updateStateOnChangeInputs = inputs.Inputs
-                                .SelectMany(i => i.DynamicOptions?.DependsOnInputs ?? [])
+                                .SelectMany(i => i.DynamicLoading?.DependsOnInputs ?? [])
                                 .ToList();
 
                             var inputInstances = inputs.Inputs.Select(input =>

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -219,8 +219,8 @@ internal sealed class DashboardServiceData : IDisposable
                 if (dependencyChange)
                 {
                     var dependentInputs = inputsInfo.Inputs.Where(
-                        i => i.DynamicOptions is { } dynamicOptions &&
-                        (dynamicOptions.DependsOnInputs?.Any(d => string.Equals(modelInput.Name, d, StringComparisons.InteractionInputName)) ?? false));
+                        i => i.DynamicLoading is { } dynamic &&
+                        (dynamic.DependsOnInputs?.Any(d => string.Equals(modelInput.Name, d, StringComparisons.InteractionInputName)) ?? false));
 
                     foreach (var dependentInput in dependentInputs)
                     {

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -233,8 +233,8 @@ internal sealed class DashboardServiceData : IDisposable
         // Refresh options for choice inputs that depend on other inputs.
         foreach (var inputToUpdate in choiceInteractionsToUpdate)
         {
-            var refreshOptions = new DynamicRefreshOptions(logger, cancellationToken, inputToUpdate, inputsInfo.Inputs, serviceProvider);
-            inputToUpdate.DynamicState!.RefreshInput(refreshOptions);
+            var options = new QueueLoadOptions(logger, cancellationToken, inputToUpdate, inputsInfo.Inputs, serviceProvider);
+            inputToUpdate.DynamicLoadingState!.QueueLoad(options);
         }
     }
 }

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -205,7 +205,7 @@ internal sealed class InputLoadingState(InputLoadOptions options)
 public sealed class InputLoadOptions
 {
     /// <summary>
-    /// Gets or sets the callback function that is invoked to perform a load operation using the specified input context.
+    /// Gets the callback function that is invoked to perform a load operation using the specified input context.
     /// </summary>
     public required Func<LoadInputContext, Task> LoadCallback { get; init; }
 
@@ -300,7 +300,7 @@ public sealed class InteractionInput
     public IReadOnlyList<KeyValuePair<string, string>>? Options { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="InputLoadOptions"/> for the input.
+    /// Gets the <see cref="InputLoadOptions"/> for the input.
     /// Dynamic loading is used to load data and update inputs after a prompt has started.
     /// It can also be used to reload data and update inputs after a dependant input has changed.
     /// </summary>
@@ -312,12 +312,12 @@ public sealed class InteractionInput
     public string? Value { get; set; }
 
     /// <summary>
-    /// Gets or sets the placeholder text for the input.
+    /// Gets the placeholder text for the input.
     /// </summary>
     public string? Placeholder { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether a custom choice is allowed. Only used by <see cref="InputType.Choice"/> inputs.
+    /// Gets a value indicating whether a custom choice is allowed. Only used by <see cref="InputType.Choice"/> inputs.
     /// </summary>
     public bool AllowCustomChoice { get; init; }
 

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -109,21 +109,21 @@ internal class InteractionService : IInteractionService
         for (var i = 0; i < inputs.Count; i++)
         {
             var input = inputs[i];
-            if (input.DynamicOptions is { } dynamicOptions)
+            if (input.DynamicLoading is { } dynamic)
             {
-                if (dynamicOptions.DependsOnInputs != null)
+                if (dynamic.DependsOnInputs != null)
                 {
-                    foreach (var dependsOnInputName in dynamicOptions.DependsOnInputs)
+                    foreach (var dependsOnInputName in dynamic.DependsOnInputs)
                     {
                         // Validate dependency input exists and is defined before this input.
                         // We check that the dependency is defined before this input so that experiences such as the CLI, where inputs are forward only, work correctly.
                         if (!inputCollection.TryGetByName(dependsOnInputName, out var dependsOnInput))
                         {
-                            throw new InvalidOperationException($"The input '{input.Name}' has {nameof(InteractionInput.DynamicOptions)} that depends on an input named '{dependsOnInputName}', but no such input exists.");
+                            throw new InvalidOperationException($"The input '{input.Name}' has {nameof(InteractionInput.DynamicLoading)} that depends on an input named '{dependsOnInputName}', but no such input exists.");
                         }
                         if (inputCollection.IndexOf(dependsOnInput) >= i)
                         {
-                            throw new InvalidOperationException($"The input '{input.Name}' has {nameof(InteractionInput.DynamicOptions)} that depends on an input named '{dependsOnInputName}', but that input is not defined before it. Inputs must be defined in order so that dependencies are always to earlier inputs.");
+                            throw new InvalidOperationException($"The input '{input.Name}' has {nameof(InteractionInput.DynamicLoading)} that depends on an input named '{dependsOnInputName}', but that input is not defined before it. Inputs must be defined in order so that dependencies are always to earlier inputs.");
                         }
                     }
                 }
@@ -143,9 +143,9 @@ internal class InteractionService : IInteractionService
 
             foreach (var input in inputs)
             {
-                if (input.DynamicOptions is { } dynamicOptions)
+                if (input.DynamicLoading is { } dynamic)
                 {
-                    var dynamicState = new DynamicInputState(dynamicOptions)
+                    var dynamicState = new DynamicInputState(dynamic)
                     {
                         OnDataRefresh = (input) =>
                         {
@@ -174,7 +174,7 @@ internal class InteractionService : IInteractionService
                     // Refresh input on start if:
                     // -The dynamic input doesn't depend on other inputs, or
                     // -Has been configured to always update
-                    if (dynamicOptions.DependsOnInputs == null || dynamicOptions.DependsOnInputs.Count == 0 || dynamicOptions.AlwaysUpdateOnStart)
+                    if (dynamic.DependsOnInputs == null || dynamic.DependsOnInputs.Count == 0 || dynamic.AlwaysLoadOnStart)
                     {
                         var refreshOptions = new DynamicRefreshOptions(_logger, interactionCts.Token, input, inputCollection, _serviceProvider);
                         input.DynamicState.RefreshInput(refreshOptions);

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -145,9 +145,9 @@ internal class InteractionService : IInteractionService
             {
                 if (input.DynamicLoading is { } dynamic)
                 {
-                    var dynamicState = new DynamicInputState(dynamic)
+                    var dynamicState = new InputLoadingState(dynamic)
                     {
-                        OnDataRefresh = (input) =>
+                        OnLoadComplete = (input) =>
                         {
                             // Options or value on a choice could have changed. Ensure the value is still valid.
                             if (input.InputType == InputType.Choice)
@@ -169,15 +169,15 @@ internal class InteractionService : IInteractionService
                         }
                     };
 
-                    input.DynamicState = dynamicState;
+                    input.DynamicLoadingState = dynamicState;
 
                     // Refresh input on start if:
                     // -The dynamic input doesn't depend on other inputs, or
                     // -Has been configured to always update
                     if (dynamic.DependsOnInputs == null || dynamic.DependsOnInputs.Count == 0 || dynamic.AlwaysLoadOnStart)
                     {
-                        var refreshOptions = new DynamicRefreshOptions(_logger, interactionCts.Token, input, inputCollection, _serviceProvider);
-                        input.DynamicState.RefreshInput(refreshOptions);
+                        var refreshOptions = new QueueLoadOptions(_logger, interactionCts.Token, input, inputCollection, _serviceProvider);
+                        input.DynamicLoadingState.QueueLoad(refreshOptions);
                     }
                 }
             }

--- a/src/Aspire.Hosting/Publishing/PublishingActivityReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityReporter.cs
@@ -267,7 +267,7 @@ internal sealed class PublishingActivityReporter : IPublishingActivityReporter, 
                 // Find all the inputs that are depended on.
                 // These inputs value changing will cause the interaction to be sent to the server.
                 var updateStateOnChangeInputs = inputsInfo.Inputs
-                    .SelectMany(i => i.DynamicOptions?.DependsOnInputs ?? [])
+                    .SelectMany(i => i.DynamicLoading?.DependsOnInputs ?? [])
                     .ToList();
 
                 var promptInputs = inputsInfo.Inputs.Select(input => new PublishingPromptInput

--- a/src/Aspire.Hosting/Publishing/PublishingActivityReporter.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingActivityReporter.cs
@@ -281,7 +281,7 @@ internal sealed class PublishingActivityReporter : IPublishingActivityReporter, 
                     ValidationErrors = input.ValidationErrors,
                     AllowCustomChoice = input.AllowCustomChoice,
                     UpdateStateOnChange = updateStateOnChangeInputs.Any(i => string.Equals(i, input.Name, StringComparisons.InteractionInputName)),
-                    Loading = input.DynamicState?.Loading ?? false,
+                    Loading = input.DynamicLoadingState?.Loading ?? false,
                     Disabled = input.Disabled
                 }).ToList();
 

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
@@ -302,7 +302,7 @@ public class ProvisioningContextProviderTests
         inputsInteraction.Inputs[BaseProvisioningContextProvider.SubscriptionIdName].Value = "12345678-1234-1234-1234-123456789012";
 
         // Trigger dynamic update of locations based on subscription.
-        await inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].DynamicOptions!.UpdateInputCallback(new UpdateInputContext
+        await inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].DynamicLoading!.LoadCallback(new LoadInputContext
         {
             AllInputs = inputsInteraction.Inputs,
             CancellationToken = CancellationToken.None,
@@ -361,7 +361,7 @@ public class ProvisioningContextProviderTests
         inputsInteraction.Inputs[BaseProvisioningContextProvider.SubscriptionIdName].Value = "not a guid";
 
         // Trigger dynamic update of locations based on subscription.
-        await inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].DynamicOptions!.UpdateInputCallback(new UpdateInputContext
+        await inputsInteraction.Inputs[BaseProvisioningContextProvider.LocationName].DynamicLoading!.LoadCallback(new LoadInputContext
         {
             AllInputs = inputsInteraction.Inputs,
             CancellationToken = CancellationToken.None,

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -729,7 +729,7 @@ public class InteractionServiceTests
             {
                 Name = "Dynamic",
                 InputType = InputType.Choice,
-                DynamicLoading = new DynamicInputLoading
+                DynamicLoading = new InputLoadOptions
                 {
                     LoadCallback = async c =>
                     {
@@ -747,7 +747,7 @@ public class InteractionServiceTests
         var interaction = await updates.Reader.ReadAsync().DefaultTimeout();
         var inputsInteractionInfo = (Interaction.InputsInteractionInfo)interaction.InteractionInfo;
 
-        Assert.True(inputsInteractionInfo.Inputs["Dynamic"].DynamicState!.Loading);
+        Assert.True(inputsInteractionInfo.Inputs["Dynamic"].DynamicLoadingState!.Loading);
         Assert.Null(inputsInteractionInfo.Inputs["Dynamic"].Options);
 
         // Assert
@@ -756,7 +756,7 @@ public class InteractionServiceTests
         interaction = await updates.Reader.ReadAsync().DefaultTimeout();
         inputsInteractionInfo = (Interaction.InputsInteractionInfo)interaction.InteractionInfo;
 
-        Assert.False(inputsInteractionInfo.Inputs["Dynamic"].DynamicState!.Loading);
+        Assert.False(inputsInteractionInfo.Inputs["Dynamic"].DynamicLoadingState!.Loading);
         Assert.Equal("loaded", inputsInteractionInfo.Inputs["Dynamic"].Options![0].Key);
     }
 
@@ -783,7 +783,7 @@ public class InteractionServiceTests
             {
                 Name = "Dynamic",
                 InputType = InputType.Choice,
-                DynamicLoading = new DynamicInputLoading
+                DynamicLoading = new InputLoadOptions
                 {
                     LoadCallback = async c =>
                     {
@@ -802,7 +802,7 @@ public class InteractionServiceTests
         var interaction = await updates.Reader.ReadAsync().DefaultTimeout();
         var inputsInteractionInfo = (Interaction.InputsInteractionInfo)interaction.InteractionInfo;
 
-        Assert.False(inputsInteractionInfo.Inputs["Dynamic"].DynamicState!.Loading);
+        Assert.False(inputsInteractionInfo.Inputs["Dynamic"].DynamicLoadingState!.Loading);
         Assert.Null(inputsInteractionInfo.Inputs["Dynamic"].Options);
 
         await CompleteInteractionAsync(
@@ -815,14 +815,14 @@ public class InteractionServiceTests
         interaction = await updates.Reader.ReadAsync().DefaultTimeout();
         inputsInteractionInfo = (Interaction.InputsInteractionInfo)interaction.InteractionInfo;
 
-        Assert.True(inputsInteractionInfo.Inputs["Dynamic"].DynamicState!.Loading);
+        Assert.True(inputsInteractionInfo.Inputs["Dynamic"].DynamicLoadingState!.Loading);
 
         updateTcs.SetResult();
 
         interaction = await updates.Reader.ReadAsync().DefaultTimeout();
         inputsInteractionInfo = (Interaction.InputsInteractionInfo)interaction.InteractionInfo;
 
-        Assert.False(inputsInteractionInfo.Inputs["Dynamic"].DynamicState!.Loading);
+        Assert.False(inputsInteractionInfo.Inputs["Dynamic"].DynamicLoadingState!.Loading);
         Assert.Equal("loaded", inputsInteractionInfo.Inputs["Dynamic"].Options![0].Key);
     }
 
@@ -891,7 +891,7 @@ public class InteractionServiceTests
                 Label = "Choice",
                 InputType = InputType.Choice,
                 Required = true,
-                DynamicLoading = new DynamicInputLoading
+                DynamicLoading = new InputLoadOptions
                 {
                     DependsOnInputs = ["DoesNotExist"],
                     LoadCallback = c => Task.FromResult<IReadOnlyList<KeyValuePair<string, string>>>(new Dictionary<string, string>
@@ -924,7 +924,7 @@ public class InteractionServiceTests
                 Label = "Choice",
                 InputType = InputType.Choice,
                 Required = true,
-                DynamicLoading = new DynamicInputLoading
+                DynamicLoading = new InputLoadOptions
                 {
                     DependsOnInputs = ["Age"],
                     LoadCallback = c => Task.FromResult<IReadOnlyList<KeyValuePair<string, string>>>(new Dictionary<string, string>

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -729,9 +729,9 @@ public class InteractionServiceTests
             {
                 Name = "Dynamic",
                 InputType = InputType.Choice,
-                DynamicOptions = new DynamicInputOptions
+                DynamicLoading = new DynamicInputLoading
                 {
-                    UpdateInputCallback = async c =>
+                    LoadCallback = async c =>
                     {
                         await updateTcs.Task;
                         c.Input.Options = [KeyValuePair.Create("loaded", "Loaded option")];
@@ -783,9 +783,9 @@ public class InteractionServiceTests
             {
                 Name = "Dynamic",
                 InputType = InputType.Choice,
-                DynamicOptions = new DynamicInputOptions
+                DynamicLoading = new DynamicInputLoading
                 {
-                    UpdateInputCallback = async c =>
+                    LoadCallback = async c =>
                     {
                         await updateTcs.Task;
                         c.Input.Options = [KeyValuePair.Create("loaded", "Loaded option")];
@@ -891,10 +891,10 @@ public class InteractionServiceTests
                 Label = "Choice",
                 InputType = InputType.Choice,
                 Required = true,
-                DynamicOptions = new DynamicInputOptions
+                DynamicLoading = new DynamicInputLoading
                 {
                     DependsOnInputs = ["DoesNotExist"],
-                    UpdateInputCallback = c => Task.FromResult<IReadOnlyList<KeyValuePair<string, string>>>(new Dictionary<string, string>
+                    LoadCallback = c => Task.FromResult<IReadOnlyList<KeyValuePair<string, string>>>(new Dictionary<string, string>
                     {
                         ["option1"] = "Option 1",
                         ["option2"] = "Option 2"
@@ -924,10 +924,10 @@ public class InteractionServiceTests
                 Label = "Choice",
                 InputType = InputType.Choice,
                 Required = true,
-                DynamicOptions = new DynamicInputOptions
+                DynamicLoading = new DynamicInputLoading
                 {
                     DependsOnInputs = ["Age"],
-                    UpdateInputCallback = c => Task.FromResult<IReadOnlyList<KeyValuePair<string, string>>>(new Dictionary<string, string>
+                    LoadCallback = c => Task.FromResult<IReadOnlyList<KeyValuePair<string, string>>>(new Dictionary<string, string>
                     {
                         ["option1"] = "Option 1",
                         ["option2"] = "Option 2"


### PR DESCRIPTION
## Description

- Some XML comments were missing from public API. Fixed.
- I renamed some of the API around dynamic inputs. `Option` is removed from type name so people don't think dynamic is just for setting options. I also changed it from "Update" to "Loading" because the feature is easier to understand when talking about loading and reloading.