### PR TITLE
Fix duplicate meters in metrics tree

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/TreeMetricSelector.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TreeMetricSelector.razor
@@ -14,12 +14,12 @@
 
 <FluentTreeView Id="metric-selector" Class="metrics-tree" @bind-CurrentSelected="@PageViewModel.SelectedTreeItem" @bind-CurrentSelected:after="HandleSelectedTreeItemChangedAsync">
     <ChildContent>
-        @foreach (var meterGroup in PageViewModel.Instruments.GroupBy(i => i.Parent).OrderBy(g => g.Key.Name))
+        @foreach (var meterGroup in PageViewModel.Instruments.GroupBy(i => i.Parent.Name).OrderBy(g => g.Key))
         {
-            <FluentTreeItem @key="meterGroup.Key" Text="@meterGroup.Key.Name" Data="@meterGroup.Key" title="@meterGroup.Key.Name" InitiallyExpanded="true" InitiallySelected="@(PageViewModel.SelectedInstrument == null && meterGroup.Key.Name == PageViewModel.SelectedMeter?.Name)">
+            <FluentTreeItem @key="meterGroup.Key" Text="@meterGroup.Key" Data="@meterGroup.Key" title="@meterGroup.Key" InitiallyExpanded="true" InitiallySelected="@(PageViewModel.SelectedInstrument == null && meterGroup.Key == PageViewModel.SelectedMeter)">
                 @foreach (var instrument in meterGroup.OrderBy(i => i.Name))
                 {
-                    <FluentTreeItem @key="instrument" Class="nested" Text="@instrument.Name" Data="@instrument" title="@instrument.Name" InitiallySelected="@(instrument.Name == PageViewModel.SelectedInstrument?.Name && instrument.Parent.Name == PageViewModel.SelectedMeter?.Name)"/>
+                    <FluentTreeItem @key="instrument" Class="nested" Text="@instrument.Name" Data="@instrument" title="@instrument.Name" InitiallySelected="@(instrument.Name == PageViewModel.SelectedInstrument?.Name && instrument.Parent.Name == PageViewModel.SelectedMeter)"/>
                 }
             </FluentTreeItem>
         }

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -107,7 +107,7 @@
                                     {
                                         <ChartContainer
                                             ResourceKey="@(PageViewModel.SelectedResource.Id.GetResourceKey())"
-                                            MeterName="@(PageViewModel.SelectedMeter.Name)"
+                                            MeterName="@(PageViewModel.SelectedMeter)"
                                             InstrumentName="@(PageViewModel.SelectedInstrument.Name)"
                                             Duration="PageViewModel.SelectedDuration.Id"
                                             ActiveView="@(PageViewModel.SelectedViewKind ?? Metrics.MetricViewKind.Graph)"
@@ -117,16 +117,16 @@
                                     }
                                     else if (PageViewModel.SelectedMeter != null)
                                     {
-                                        <h3 class="meter-name-title">@PageViewModel.SelectedMeter.Name</h3>
+                                        <h3 class="meter-name-title">@PageViewModel.SelectedMeter</h3>
                                         <FluentDataGrid
                                             Style="max-width:1100px;"
-                                            Items="@PageViewModel.Instruments.Where(i => i.Parent == PageViewModel.SelectedMeter).OrderBy(i => i.Name).AsQueryable()"
+                                            Items="@PageViewModel.Instruments.Where(i => i.Parent.Name == PageViewModel.SelectedMeter).OrderBy(i => i.Name).AsQueryable()"
                                             GridTemplateColumns="3fr 5fr"
                                             RowSize="DataGridRowSize.Medium"
                                             TGridItem="OtlpInstrumentSummary">
                                             <ChildContent>
                                                 <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Metrics.MetricsInsturementNameGridNameColumnHeader)]">
-                                                    <FluentAnchor Href="@DashboardUrls.MetricsUrl(resource: PageViewModel.SelectedResource.Name, meter: context.Parent.Name, instrument: context.Name, duration: DurationMinutes, view: ViewKindName)" Appearance="Appearance.Lightweight">
+                                                    <FluentAnchor Class="button-hyperlink-no-icon" Href="@DashboardUrls.MetricsUrl(resource: PageViewModel.SelectedResource.Name, meter: context.Parent.Name, instrument: context.Name, duration: DurationMinutes, view: ViewKindName)" Appearance="Appearance.Lightweight">
                                                         @context.Name
                                                     </FluentAnchor>
                                                 </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -130,7 +130,7 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
         return new MetricsPageState
         {
             ResourceName = PageViewModel.SelectedResource.Id is not null ? PageViewModel.SelectedResource.Name : null,
-            MeterName = PageViewModel.SelectedMeter?.Name,
+            MeterName = PageViewModel.SelectedMeter,
             InstrumentName = PageViewModel.SelectedInstrument?.Name,
             DurationMinutes = (int)PageViewModel.SelectedDuration.Id.TotalMinutes,
             ViewKind = PageViewModel.SelectedViewKind?.ToString()
@@ -158,7 +158,7 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
 
         if (viewModel.Instruments != null && !string.IsNullOrEmpty(MeterName))
         {
-            viewModel.SelectedMeter = viewModel.Instruments.FirstOrDefault(i => i.Parent.Name == MeterName)?.Parent;
+            viewModel.SelectedMeter = viewModel.Instruments.FirstOrDefault(i => i.Parent.Name == MeterName)?.Parent.Name;
             if (viewModel.SelectedMeter != null && !string.IsNullOrEmpty(InstrumentName))
             {
                 viewModel.SelectedInstrument = viewModel.Instruments.FirstOrDefault(i => i.Parent.Name == MeterName && i.Name == InstrumentName);
@@ -222,7 +222,7 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
 
     private bool ShouldClearSelectedMetrics(List<OtlpInstrumentSummary> instruments)
     {
-        if (PageViewModel.SelectedMeter != null && !instruments.Any(i => i.Parent.Name == PageViewModel.SelectedMeter.Name))
+        if (PageViewModel.SelectedMeter != null && !instruments.Any(i => i.Parent.Name == PageViewModel.SelectedMeter))
         {
             return true;
         }
@@ -255,7 +255,7 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
     public sealed class MetricsViewModel
     {
         public FluentTreeItem? SelectedTreeItem { get; set; }
-        public OtlpScope? SelectedMeter { get; set; }
+        public string? SelectedMeter { get; set; }
         public OtlpInstrumentSummary? SelectedInstrument { get; set; }
         public required SelectViewModel<ResourceTypeDetails> SelectedResource { get; set; }
         public SelectViewModel<TimeSpan> SelectedDuration { get; set; } = null!;
@@ -280,14 +280,14 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
 
     private Task HandleSelectedTreeItemChangedAsync()
     {
-        if (PageViewModel.SelectedTreeItem?.Data is OtlpScope meter)
+        if (PageViewModel.SelectedTreeItem?.Data is string meter)
         {
             PageViewModel.SelectedMeter = meter;
             PageViewModel.SelectedInstrument = null;
         }
         else if (PageViewModel.SelectedTreeItem?.Data is OtlpInstrumentSummary instrument)
         {
-            PageViewModel.SelectedMeter = instrument.Parent;
+            PageViewModel.SelectedMeter = instrument.Parent.Name;
             PageViewModel.SelectedInstrument = instrument;
         }
         else

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -229,7 +229,7 @@ public partial class MetricsTests : DashboardTestContext
             foreach (var instrument in cut.Instance.PageViewModel.Instruments!)
             {
                 Assert.Single(items1, i => i.Instance.Data as OtlpInstrumentSummary == instrument);
-                Assert.Single(items1, i => i.Instance.Data as OtlpScope == instrument.Parent);
+                Assert.Single(items1, i => i.Instance.Data as string == instrument.Parent.Name);
             }
         });
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -343,7 +343,7 @@ public partial class MetricsTests : DashboardTestContext
         var viewModel = cut.Instance.PageViewModel;
 
         // Assert 1
-        Assert.Equal("test-meter", viewModel.SelectedMeter!.Name);
+        Assert.Equal("test-meter", viewModel.SelectedMeter);
         Assert.Equal(app1InstrumentName, viewModel.SelectedInstrument!.Name);
 
         // Act 2
@@ -354,7 +354,7 @@ public partial class MetricsTests : DashboardTestContext
         cut.WaitForAssertion(() => Assert.Equal("TestApp2", viewModel.SelectedResource.Name));
 
         Assert.Equal(expectedInstrumentNameAfterChange, viewModel.SelectedInstrument?.Name);
-        Assert.Equal(expectedMeterNameAfterChange, viewModel.SelectedMeter?.Name);
+        Assert.Equal(expectedMeterNameAfterChange, viewModel.SelectedMeter);
 
         Assert.Equal(MetricViewKind.Table, viewModel.SelectedViewKind);
         Assert.Equal(TimeSpan.FromMinutes(720), viewModel.SelectedDuration.Id);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -274,7 +274,7 @@ public partial class MetricsTests : DashboardTestContext
             foreach (var instrument in cut.Instance.PageViewModel.Instruments!)
             {
                 Assert.Single(items2, i => i.Instance.Data as OtlpInstrumentSummary == instrument);
-                Assert.Single(items2, i => i.Instance.Data as OtlpScope == instrument.Parent);
+                Assert.Single(items2, i => i.Instance.Data as string == instrument.Parent.Name);
             }
         });
     }


### PR DESCRIPTION
## Description

I noticed duplicate meter tree items. It happens when viewing metrics for replicas and not all meters are in each replica.

Problem is the meters are grouped by scope. But scope instances are different from different replicas. Fix by using the meter string name as the group key.

<img width="520" height="382" alt="image" src="https://github.com/user-attachments/assets/3fec799d-3a65-4d30-85f5-f0fa0437689f" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
