### PR TITLE
Update to FluentUI 4.13.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -94,8 +94,8 @@
     <PackageVersion Include="Markdig" Version="0.42.0" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.2.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.12.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.12.1" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.13.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.13.0" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
     <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.4" />
     <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -1,4 +1,5 @@
 ﻿@using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 
 <FluentInputLabel Label="@Loc[nameof(ControlsStrings.ResourceLabel)]"
                   ForId="@_selectId"
@@ -11,6 +12,7 @@
               Id="@_selectId"
               OptionValue="@(c => c!.Name)"
               OptionDisabled="@(c => !CanSelectGrouping && c!.Id?.Type is Otlp.Model.OtlpResourceType.ResourceGrouping)"
+              OptionTitle="@(c => DashboardUIHelpers.ResolveTooltip(c!.Name))"
               @bind-SelectedOption="SelectedResource"
               @bind-SelectedOption:after="SelectedResourceChangedCore"
               ValueChanged="ValuedChanged"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelectOptionTemplate.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelectOptionTemplate.razor
@@ -5,9 +5,7 @@
 
 @inject IStringLocalizer<ControlsStrings> Loc
 
-@* Allows long values to be viewed in option popup by adding a tooltip to options. *@
-@* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
-<FluentStack Orientation="Orientation.Horizontal" HorizontalGap="3" title="@(ViewModel.Name?.Length > 30 ? ViewModel.Name : null)">
+<FluentStack Orientation="Orientation.Horizontal" HorizontalGap="3">
     @if (ViewModel.Id?.Type is OtlpResourceType.ResourceGrouping)
     {
         <FluentIcon Icon="Icons.Regular.Size20.AppsList"

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -1,6 +1,7 @@
 ﻿@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 @implements IDialogContentComponent<FilterDialogViewModel>
 
 @inject IStringLocalizer<Dialogs> Loc
@@ -20,14 +21,8 @@
                           Width="100%"
                           Height="400px"
                           OptionText="@(c => c.Name)"
-                          OptionDisabled="@(c => c.Id is null)">
-                <OptionTemplate Context="optionContext">
-                    @* Allows long values to be viewed in option popup by adding a tooltip to options. *@
-                    @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
-                    <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
-                        @optionContext.Name
-                    </span>
-                </OptionTemplate>
+                          OptionDisabled="@(c => c.Id is null)"
+                          OptionTitle="@(c => DashboardUIHelpers.ResolveTooltip(c.Name))">
             </FluentSelect>
         </div>
 
@@ -49,6 +44,7 @@
                             Height="400px"
                             OptionText="@(c => c.Name)"
                             OptionValue="@(c => c.Name)"
+                            OptionTitle="@(c => DashboardUIHelpers.ResolveTooltip(c.Name))"
                             Immediate="true"
                             ImmediateDelay="@FluentUIExtensions.InputDelay"
                             Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]">
@@ -59,11 +55,7 @@
                         @* Workaround this issue by inserting extra text using CSS. *@
                         <span data-filtercount="@optionContext.Id!.Count"></span>
                     </FluentBadge>
-                    @* Allows long values to be viewed in option popup by adding a tooltip to options. *@
-                    @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
-                    <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
-                        <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" />
-                    </span>
+                    <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" />
                 </OptionTemplate>
             </FluentCombobox>
             <ValidationMessage For="() => _formModel.Value" />

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor
@@ -94,17 +94,11 @@
                                                   Items="input.ViewModel.SelectOptions"
                                                   OptionValue="@(vm => vm.Id)"
                                                   OptionText="@(vm => vm.Name)"
+                                                  OptionTitle="@(vm => DashboardUIHelpers.ResolveTooltip(vm.Name))"
                                                   Height="250px"
                                                   Position="SelectPosition.Below"
                                                   Disabled="input.ViewModel.InputDisabled"
                                                   aria-describedby="@input.DescriptionId">
-                                        <OptionTemplate Context="optionContext">
-                                            @* Allows long values to be viewed in option popup by adding a tooltip to options. *@
-                                            @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
-                                            <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
-                                                @optionContext.Name
-                                            </span>
-                                        </OptionTemplate>
                                     </FluentSelect>
                                 }
                                 else
@@ -117,6 +111,7 @@
                                                     Items="@input.ViewModel.FilteredOptions()"
                                                     OptionValue="@(vm => vm.Id)"
                                                     OptionText="@(vm => vm.Name)"
+                                                    OptionTitle="@(vm => DashboardUIHelpers.ResolveTooltip(vm.Name))"
                                                     Height="250px"
                                                     Position="SelectPosition.Below"
                                                     Disabled="input.ViewModel.InputDisabled"
@@ -124,11 +119,7 @@
                                                     ImmediateDelay="@FluentUIExtensions.InputDelay"
                                                     aria-describedby="@input.DescriptionId">
                                         <OptionTemplate Context="optionContext">
-                                            @* Allows long values to be viewed in option popup by adding a tooltip to options. *@
-                                            @* Better improvements could come from new FluentUI features. See https://github.com/microsoft/fluentui-blazor/issues/4136 *@
-                                            <span title="@(optionContext.Name?.Length > 30 ? optionContext.Name : null)">
-                                                <FluentHighlighter Text="@optionContext.Name" HighlightedText="@input.ViewModel.Value" />
-                                            </span>
+                                            <FluentHighlighter Text="@optionContext.Name" HighlightedText="@input.ViewModel.Value" />
                                         </OptionTemplate>
                                     </FluentCombobox>
                                 }

--- a/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
@@ -93,6 +93,15 @@ internal static class DashboardUIHelpers
             };
         }).ConfigureAwait(false);
     }
+
+    public static string? ResolveTooltip(string value)
+    {
+        // FluentSelects in the dashboard are wide enough to display at least 30 characters.
+        // Only display a tooltip if the value length is greater.
+        const int TooltipLengthThreshold = 30;
+
+        return value is { Length: > TooltipLengthThreshold } ? value : null;
+    }
 }
 
 internal record TextMask(MarkupString MarkupString, string Text);

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -134,6 +134,9 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         Services.AddLocalization();
         Services.AddSingleton<BrowserTimeProvider, TestTimeProvider>();
 
+        var dialogProviderModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Dialog/FluentDialogProvider.razor.js", version));
+        dialogProviderModule.SetupModule("getActiveElement", _ => true);
+
         var cut = Render(builder =>
         {
             builder.OpenComponent<FluentDialogProvider>(0);
@@ -147,5 +150,10 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
 
         dialogService = Services.GetRequiredService<IDialogService>();
         return cut;
+    }
+
+    private static string GetFluentFile(string filePath, Version version)
+    {
+        return $"{filePath}?v={version}";
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -207,7 +207,13 @@ public class TextVisualizerDialogTests : DashboardTestContext
         var module = JSInterop.SetupModule("/Components/Controls/TextVisualizer.razor.js");
         module.SetupVoid();
 
-        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js", version));
+
+        var menuModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        menuModule.SetupVoid("initialize", _ => true);
+
+        var dialogProviderModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Dialog/FluentDialogProvider.razor.js", version));
+        dialogProviderModule.SetupModule("getActiveElement", _ => true);
 
         var cut = Render(builder =>
         {

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -210,6 +210,8 @@ public partial class MainLayoutTests : DashboardTestContext
 
         var version = typeof(FluentMain).Assembly.GetName().Version!;
 
+        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Dialog/FluentDialogProvider.razor.js", version));
+
         var overflowModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Overflow/FluentOverflow.razor.js", version));
         overflowModule.SetupVoid("fluentOverflowInitialize", _ => true);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -808,7 +808,8 @@ public partial class ConsoleLogsTests : DashboardTestContext
         var keycodeModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/KeyCode/FluentKeyCode.razor.js", version));
         keycodeModule.Setup<string>("RegisterKeyCode", _ => true);
 
-        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        var menuModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        menuModule.SetupVoid("initialize", _ => true);
 
         JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Anchor/FluentAnchor.razor.js", version));
         JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js", version));

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -226,9 +226,11 @@ public partial class StructuredLogsTests : DashboardTestContext
         var keycodeModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/KeyCode/FluentKeyCode.razor.js", version));
         keycodeModule.Setup<string>("RegisterKeyCode", _ => true);
 
-        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Toolbar/FluentToolbar.razor.js", version));
+        var menuModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        menuModule.SetupVoid("initialize", _ => true);
 
-        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Toolbar/FluentToolbar.razor.js", version));
+        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js", version));
 
         JSInterop.SetupVoid("initializeContinuousScroll");
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -647,7 +647,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         gridReference.SetupVoid("stop", _ => true);
 
         JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Anchor/FluentAnchor.razor.js", version));
-
+        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js", version));
         JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/List/ListComponentBase.razor.js", version));
 
         var searchModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Search/FluentSearch.razor.js", version));
@@ -659,7 +659,9 @@ public partial class TraceDetailsTests : DashboardTestContext
         var toolbarModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Toolbar/FluentToolbar.razor.js", version));
         toolbarModule.SetupVoid("removePreventArrowKeyNavigation", _ => true);
 
-        JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        var menuModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        menuModule.SetupVoid("initialize", _ => true);
+        menuModule.SetupVoid("dispose", _ => true);
 
         JSInterop.SetupVoid("initializeContinuousScroll");
 

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/MetricsSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/MetricsSetupHelpers.cs
@@ -75,9 +75,11 @@ internal static class MetricsSetupHelpers
         var overflowModule = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Overflow/FluentOverflow.razor.js", version));
         overflowModule.SetupVoid("fluentOverflowInitialize", _ => true);
 
-        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Toolbar/FluentToolbar.razor.js", version));
+        var menuModule = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        menuModule.SetupVoid("initialize", _ => true);
 
-        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Toolbar/FluentToolbar.razor.js", version));
+        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js", version));
 
         SetupChartContainer(context);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -59,7 +59,8 @@ internal static class ResourceSetupHelpers
 
         context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Toolbar/FluentToolbar.razor.js", version));
 
-        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        var menuModule = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        menuModule.SetupVoid("initialize", _ => true);
     }
 
     public static void SetupResourcesPage(TestContext context, ViewportInformation viewport, IDashboardClient? dashboardClient = null)
@@ -97,7 +98,8 @@ internal static class ResourceSetupHelpers
         var overflowModule = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Overflow/FluentOverflow.razor.js", version));
         overflowModule.SetupVoid("fluentOverflowInitialize", _ => true);
 
-        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        var menuModule = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        menuModule.SetupVoid("initialize", _ => true);
 
         context.Services.AddLocalization();
         context.Services.AddSingleton<IAIContextProvider, TestAIContextProvider>();

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/StructuredLogsSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/StructuredLogsSetupHelpers.cs
@@ -48,9 +48,11 @@ internal static class StructuredLogsSetupHelpers
         var keycodeModule = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/KeyCode/FluentKeyCode.razor.js", version));
         keycodeModule.Setup<string>("RegisterKeyCode", _ => true);
 
-        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Toolbar/FluentToolbar.razor.js", version));
+        var menuModule = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        menuModule.SetupVoid("initialize", _ => true);
 
-        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Menu/FluentMenu.razor.js", version));
+        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Toolbar/FluentToolbar.razor.js", version));
+        context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js", version));
     }
 
     private static string GetFluentFile(string filePath, Version version)

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestDialogService.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestDialogService.cs
@@ -82,7 +82,7 @@ public class TestDialogService : IDialogService
             throw new InvalidOperationException("No dialog callback specified.");
         }
         var reference = await _onShowDialog.Invoke(data, parameters);
-        reference.Instance = new DialogInstance(dialogComponent, parameters, data);
+        reference.Instance = new DialogInstance(dialogComponent, parameters, data, previouslyFocusedElement: null);
         return reference;
     }
 


### PR DESCRIPTION
## Description

- Update to FluentUI 4.13.0
- Use new `OptionTitle` property to remove workaround code

I spent 10 minutes testing the dashboard and didn't notice any regressions. If there are regressions we'll hopefully catch them between now and v13 release.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
