### PR TITLE
add extension to get-aspire-cli script, don't install by default

### DIFF
--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -8,7 +8,7 @@ If you want the latest, unsupported build of Aspire to try, read on.
 
 See [machine-requirements.md](machine-requirements.md).
 
-## Install the daily CLI
+## Install the daily CLI only
 
 On Windows:
 
@@ -20,6 +20,22 @@ On Linux, or macOS:
 
 ```sh
 curl -sSL https://aspire.dev/install.sh | bash -s -- -q dev
+```
+
+## Install the daily CLI + VS Code extension
+
+The Aspire VS Code extension requires the Aspire CLI to be available on the path to work. You can install both using the installation script.
+
+On Windows:
+
+```powershell
+iex "& { $(irm https://aspire.dev/install.ps1) } -InstallExtension -Quality dev"
+```
+
+On Linux, or macOS:
+
+```sh
+curl -sSL https://aspire.dev/install.sh | bash -s -- --install-extension -q dev
 ```
 
 <!-- break between blocks -->

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -1051,6 +1051,11 @@ function Start-AspireCliInstallation {
             throw "Unsupported Architecture $Architecture. Supported values are: $($Script:Config.SupportedArchitectures -join ", ")"
         }
 
+        # Validate extension installation is only allowed with dev quality
+        if ($InstallExtension -and $Quality -ne "dev") {
+            throw "Extension installation is only supported with -Quality dev. Current quality: $Quality"
+        }
+
         # Determine the installation path
         $resolvedInstallPath = Get-InstallPath -InstallPath $InstallPath
 

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -23,6 +23,12 @@ param(
     [Parameter(HelpMessage = "Keep downloaded archive files and temporary directory after installation")]
     [switch]$KeepArchive,
 
+    [Parameter(HelpMessage = "Install VS Code extension along with the CLI")]
+    [switch]$InstallExtension,
+
+    [Parameter(HelpMessage = "Install extension to VS Code Insiders instead of VS Code")]
+    [switch]$UseInsiders,
+
     [Parameter(HelpMessage = "Show help message")]
     [switch]$Help
 )
@@ -32,6 +38,7 @@ $Script:UserAgent = "get-aspire-cli.ps1/1.0"
 $Script:IsModernPowerShell = $PSVersionTable.PSVersion.Major -ge 6 -and $PSVersionTable.PSEdition -eq "Core"
 $Script:ArchiveDownloadTimeoutSec = 600
 $Script:ChecksumDownloadTimeoutSec = 120
+$Script:ExtensionArtifactName = "aspire-vscode.vsix.zip"
 
 # Configuration constants
 $Script:Config = @{
@@ -130,6 +137,8 @@ PARAMETERS:
     -Version <string>           Version of the Aspire CLI to download (default: unset)
     -OS <string>                Operating system (default: auto-detect)
     -Architecture <string>      Architecture (default: auto-detect)
+    -InstallExtension           Install VS Code extension along with the CLI
+    -UseInsiders                Install extension to VS Code Insiders instead of VS Code (requires -InstallExtension)
     -KeepArchive                Keep downloaded archive files and temporary directory after installation
     -Help                       Show this help message
 
@@ -150,6 +159,8 @@ EXAMPLES:
     .\get-aspire-cli.ps1 -Quality "staging"
     .\get-aspire-cli.ps1 -Version "9.5.0-preview.1.25366.3"
     .\get-aspire-cli.ps1 -OS "linux" -Architecture "x64"
+    .\get-aspire-cli.ps1 -InstallExtension
+    .\get-aspire-cli.ps1 -InstallExtension -UseInsiders
     .\get-aspire-cli.ps1 -KeepArchive
     .\get-aspire-cli.ps1 -WhatIf
     .\get-aspire-cli.ps1 -Help
@@ -498,6 +509,26 @@ function Invoke-FileDownload {
     }
 }
 
+# Function to check VS Code CLI dependency
+function Test-VSCodeCLIDependency {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [switch]$UseInsiders
+    )
+
+    $vscodeCmd = if ($UseInsiders) { "code-insiders" } else { "code" }
+    $vscodeName = if ($UseInsiders) { "VS Code Insiders" } else { "VS Code" }
+
+    if (-not (Get-Command $vscodeCmd -ErrorAction SilentlyContinue)) {
+        Write-Message "$vscodeName CLI ($vscodeCmd) not found in PATH" -Level Warning
+        return $false
+    }
+
+    Write-Message "$vscodeName CLI ($vscodeCmd) found" -Level Verbose
+    return $true
+}
+
 # Enhanced checksum validation with proper error handling
 function Test-FileChecksum {
     [CmdletBinding()]
@@ -681,6 +712,142 @@ function Update-PathEnvironment {
     }
 }
 
+# Function to download VS Code extension
+function Get-AspireExtension {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TempDir,
+
+        [Parameter()]
+        [string]$Version,
+
+        [Parameter()]
+        [string]$Quality
+    )
+
+    Write-Message "Downloading Aspire VS Code extension" -Level Info
+
+    $extensionUrl = Get-AspireExtensionUrl -Version $Version -Quality $Quality
+    $extensionArchive = Join-Path $TempDir $Script:ExtensionArtifactName
+
+    try {
+        if ($PSCmdlet.ShouldProcess($extensionArchive, "Download extension from $extensionUrl")) {
+            Write-Message "Downloading from: $extensionUrl" -Level Info
+            Invoke-FileDownload -Uri $extensionUrl -OutputPath $extensionArchive -TimeoutSec $Script:ArchiveDownloadTimeoutSec
+            Write-Message "Successfully downloaded extension archive" -Level Verbose
+        }
+
+        return $extensionArchive
+    }
+    catch {
+        Write-Message "Failed to download extension: $($_.Exception.Message)" -Level Error
+        throw
+    }
+}
+
+# Function to install VS Code extension
+function Install-AspireExtension {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ExtensionArchive,
+
+        [Parameter()]
+        [switch]$UseInsiders
+    )
+
+    $vscodeCmd = if ($UseInsiders) { "code-insiders" } else { "code" }
+    $vscodeName = if ($UseInsiders) { "VS Code Insiders" } else { "VS Code" }
+
+    Write-Message "Installing Aspire extension to $vscodeName" -Level Info
+
+    # Extract the zip to get the VSIX file
+    $extractDir = Join-Path ([System.IO.Path]::GetTempPath()) "aspire-extension-$([System.Guid]::NewGuid().ToString('N').Substring(0, 8))"
+
+    try {
+        if ($PSCmdlet.ShouldProcess($extractDir, "Extract extension archive")) {
+            # Expand the zip archive
+            if ($Script:IsModernPowerShell) {
+                Expand-Archive -Path $ExtensionArchive -DestinationPath $extractDir -Force
+            } else {
+                Add-Type -AssemblyName System.IO.Compression.FileSystem
+                [System.IO.Compression.ZipFile]::ExtractToDirectory($ExtensionArchive, $extractDir)
+            }
+
+            Write-Message "Extracted extension archive" -Level Verbose
+        }
+
+        # Find the VSIX file
+        $vsixFile = Get-ChildItem -Path $extractDir -Filter "*.vsix" | Select-Object -First 1
+
+        if (-not $vsixFile) {
+            throw "No VSIX file found in extension archive"
+        }
+
+        Write-Message "Found VSIX file: $($vsixFile.Name)" -Level Verbose
+
+        # Install the extension
+        if ($PSCmdlet.ShouldProcess($vsixFile.FullName, "Install extension using $vscodeCmd")) {
+            $installArgs = @("--install-extension", $vsixFile.FullName, "--force")
+            Write-Message "Running: $vscodeCmd $($installArgs -join ' ')" -Level Verbose
+
+            $output = & $vscodeCmd $installArgs 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Extension installation failed with exit code $LASTEXITCODE`: $output"
+            }
+
+            Write-Message "Successfully installed Aspire extension to $vscodeName" -Level Success
+        }
+    }
+    finally {
+        # Clean up extraction directory
+        if (Test-Path $extractDir) {
+            try {
+                Remove-Item -Path $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+                Write-Message "Cleaned up extraction directory" -Level Verbose
+            }
+            catch {
+                Write-Message "Failed to clean up extraction directory: $($_.Exception.Message)" -Level Warning
+            }
+        }
+    }
+}
+
+# Function to construct VS Code extension URL
+function Get-AspireExtensionUrl {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter()]
+        [string]$Version,
+
+        [Parameter()]
+        [string]$Quality
+    )
+
+    $extension = "vsix.zip"
+
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        # Validate quality against supported values
+        if ($Quality -notin $Script:Config.SupportedQualities) {
+            throw "Unsupported quality '$Quality'. Supported values are: $($Script:Config.SupportedQualities -join ", ")."
+        }
+
+        $baseUrl = $Script:Config.BaseUrls[$Quality]
+        if (-not $baseUrl) {
+            throw "No base URL configured for quality: $Quality"
+        }
+
+        return "$baseUrl/aspire-vscode.$extension"
+    }
+    else {
+        # Version-based URL
+        $baseUrl = $Script:Config.BaseUrls["versioned"]
+        return "$baseUrl/$Version/aspire-vscode-$Version.$extension"
+    }
+}
+
 # Enhanced URL construction function with configuration-based URLs
 function Get-AspireCliUrl {
     [CmdletBinding()]
@@ -813,6 +980,27 @@ function Install-AspireCli {
             $cliPath = Join-Path $InstallPath $cliExe
 
             Write-Message "Aspire CLI successfully installed to: $cliPath" -Level Success
+        }
+
+        # Download and install VS Code extension if requested
+        if ($InstallExtension) {
+            Write-Message "" -Level Info
+            Write-Message "Installing VS Code extension" -Level Info
+
+            if (Test-VSCodeCLIDependency -UseInsiders:$UseInsiders) {
+                try {
+                    $extensionArchive = Get-AspireExtension -TempDir $tempDir -Version $Version -Quality $Quality
+                    Install-AspireExtension -ExtensionArchive $extensionArchive -UseInsiders:$UseInsiders
+                }
+                catch {
+                    Write-Message "Failed to install VS Code extension: $($_.Exception.Message)" -Level Warning
+                    Write-Message "The CLI was installed successfully, but the extension installation failed" -Level Warning
+                }
+            }
+            else {
+                Write-Message "Cannot install extension: VS Code CLI not found in PATH" -Level Warning
+                Write-Message "Please ensure VS Code is installed and available in PATH" -Level Info
+            }
         }
 
         # Return the target OS for the caller to use

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -886,6 +886,13 @@ if [[ -z "$QUALITY" ]]; then
     QUALITY="${DEFAULT_QUALITY}"
 fi
 
+# Validate extension installation is only allowed with dev quality
+if [[ "$INSTALL_EXTENSION" == true && "$QUALITY" != "dev" ]]; then
+    say_error "Extension installation is only supported with --quality dev. Current quality: $QUALITY"
+    say_info "Use --help for usage information."
+    exit 1
+fi
+
 # Set default install path if not provided
 if [[ -z "$INSTALL_PATH" ]]; then
     INSTALL_PATH="$HOME/.aspire/bin"

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -25,7 +25,10 @@ SHOW_HELP=false
 VERBOSE=false
 KEEP_ARCHIVE=false
 DRY_RUN=false
+INSTALL_EXTENSION=false
+USE_INSIDERS=false
 DEFAULT_QUALITY="release"
+EXTENSION_ARTIFACT_NAME="aspire-vscode.vsix.zip"
 
 # Function to show help
 show_help() {
@@ -52,6 +55,8 @@ USAGE:
     --version VERSION           Version of the Aspire CLI to download (default: unset)
     --os OS                     Operating system (default: auto-detect)
     --arch ARCH                 Architecture (default: auto-detect)
+    --install-extension         Install VS Code extension along with the CLI
+    --use-insiders              Install extension to VS Code Insiders instead of VS Code (requires --install-extension)
     -k, --keep-archive          Keep downloaded archive files and temporary directory after installation
     --dry-run                   Show what would be done without actually performing any actions
     -v, --verbose               Enable verbose output
@@ -63,6 +68,8 @@ EXAMPLES:
     ./get-aspire-cli.sh --quality "staging"
     ./get-aspire-cli.sh --version "9.5.0-preview.1.25366.3"
     ./get-aspire-cli.sh --os "linux" --arch "x64"
+    ./get-aspire-cli.sh --install-extension
+    ./get-aspire-cli.sh --install-extension --use-insiders
     ./get-aspire-cli.sh --keep-archive
     ./get-aspire-cli.sh --dry-run
     ./get-aspire-cli.sh --help
@@ -122,6 +129,14 @@ parse_args() {
                 fi
                 ARCH="$2"
                 shift 2
+                ;;
+            --install-extension)
+                INSTALL_EXTENSION=true
+                shift
+                ;;
+            --use-insiders)
+                USE_INSIDERS=true
+                shift
                 ;;
             -k|--keep-archive)
                 KEEP_ARCHIVE=true
@@ -557,6 +572,61 @@ add_to_shell_profile() {
     return 0
 }
 
+# Function to check VS Code CLI dependency
+test_vscode_cli() {
+    local vscode_cmd
+    local vscode_name
+
+    if [[ "$USE_INSIDERS" == true ]]; then
+        vscode_cmd="code-insiders"
+        vscode_name="VS Code Insiders"
+    else
+        vscode_cmd="code"
+        vscode_name="VS Code"
+    fi
+
+    if ! command -v "$vscode_cmd" >/dev/null 2>&1; then
+        say_warn "$vscode_name CLI ($vscode_cmd) not found in PATH"
+        return 1
+    fi
+
+    say_verbose "$vscode_name CLI ($vscode_cmd) found"
+    return 0
+}
+
+# Function to construct the URL for VS Code extension download
+construct_aspire_extension_url() {
+    local version="$1"
+    local quality="$2"
+    local base_url
+    local extension="vsix.zip"
+
+    if [[ -z "$version" ]]; then
+        # When version is not set use aka.ms URLs based on quality
+        case "$quality" in
+            dev)
+                base_url="https://aka.ms/dotnet/9/aspire/daily"
+                ;;
+            staging)
+                base_url="https://aka.ms/dotnet/9/aspire/rc/daily"
+                ;;
+            release)
+                base_url="https://aka.ms/dotnet/9/aspire/ga/daily"
+                ;;
+            *)
+                say_error "Unsupported quality '$quality'. Supported values are: dev, staging, release."
+                return 1
+                ;;
+        esac
+
+        printf "${base_url}/aspire-vscode.${extension}"
+    else
+        # When version is set, use ci.dot.net URL
+        base_url="https://ci.dot.net/public/aspire/"
+        printf "${base_url}${version}/aspire-vscode-${version}.${extension}"
+    fi
+}
+
 # Function to construct the base URL for the Aspire CLI download
 construct_aspire_cli_url() {
     local version="$1"
@@ -603,6 +673,95 @@ construct_aspire_cli_url() {
 
         printf "${base_url}/${version}/aspire-cli-${rid}-${version}.${extension}"
     fi
+}
+
+# Function to download VS Code extension
+download_aspire_extension() {
+    local temp_dir="$1"
+    local version="$2"
+    local quality="$3"
+    local url extension_archive
+
+    say_info "Downloading Aspire VS Code extension"
+
+    if ! url=$(construct_aspire_extension_url "$version" "$quality"); then
+        return 1
+    fi
+
+    extension_archive="${temp_dir}/${EXTENSION_ARTIFACT_NAME}"
+
+    say_info "Downloading from: $url"
+    if ! download_file "$url" "$extension_archive" $ARCHIVE_DOWNLOAD_TIMEOUT_SEC; then
+        return 1
+    fi
+
+    say_verbose "Successfully downloaded extension archive"
+    echo "$extension_archive"
+}
+
+# Function to install VS Code extension
+install_aspire_extension() {
+    local extension_archive="$1"
+    local vscode_cmd vscode_name extract_dir vsix_file
+
+    if [[ "$USE_INSIDERS" == true ]]; then
+        vscode_cmd="code-insiders"
+        vscode_name="VS Code Insiders"
+    else
+        vscode_cmd="code"
+        vscode_name="VS Code"
+    fi
+
+    say_info "Installing Aspire extension to $vscode_name"
+
+    # Extract the zip to get the VSIX file
+    extract_dir=$(mktemp -d -t aspire-extension-XXXXXXXX)
+
+    # Extract archive
+    if [[ "$DRY_RUN" != true ]]; then
+        if command -v unzip >/dev/null 2>&1; then
+            if ! unzip -q "$extension_archive" -d "$extract_dir"; then
+                say_error "Failed to extract extension archive"
+                rm -rf "$extract_dir"
+                return 1
+            fi
+        else
+            say_error "unzip command not found"
+            rm -rf "$extract_dir"
+            return 1
+        fi
+
+        say_verbose "Extracted extension archive"
+    fi
+
+    # Find the VSIX file
+    vsix_file=$(find "$extract_dir" -name "*.vsix" | head -n 1)
+
+    if [[ -z "$vsix_file" ]]; then
+        say_error "No VSIX file found in extension archive"
+        rm -rf "$extract_dir"
+        return 1
+    fi
+
+    say_verbose "Found VSIX file: $(basename "$vsix_file")"
+
+    # Install the extension
+    if [[ "$DRY_RUN" == true ]]; then
+        say_info "[DRY RUN] Would run: $vscode_cmd --install-extension $vsix_file --force"
+    else
+        say_verbose "Running: $vscode_cmd --install-extension $vsix_file --force"
+        if ! "$vscode_cmd" --install-extension "$vsix_file" --force; then
+            say_error "Extension installation failed"
+            rm -rf "$extract_dir"
+            return 1
+        fi
+
+        say_info "${GREEN}Successfully installed Aspire extension to $vscode_name${RESET}"
+    fi
+
+    # Clean up extraction directory
+    rm -rf "$extract_dir"
+    return 0
 }
 
 # Function to download and install archive
@@ -683,6 +842,27 @@ download_and_install_archive() {
     cli_path="${INSTALL_PATH}/${cli_exe}"
 
     say_info "Aspire CLI successfully installed to: ${GREEN}$cli_path${RESET}"
+
+    # Download and install VS Code extension if requested
+    if [[ "$INSTALL_EXTENSION" == true ]]; then
+        printf "\n"
+        say_info "Installing VS Code extension"
+
+        if test_vscode_cli; then
+            if extension_archive=$(download_aspire_extension "$temp_dir" "$VERSION" "$QUALITY"); then
+                if ! install_aspire_extension "$extension_archive"; then
+                    say_warn "Failed to install VS Code extension"
+                    say_warn "The CLI was installed successfully, but the extension installation failed"
+                fi
+            else
+                say_warn "Failed to download VS Code extension"
+                say_warn "The CLI was installed successfully, but the extension download failed"
+            fi
+        else
+            say_warn "Cannot install extension: VS Code CLI not found in PATH"
+            say_info "Please ensure VS Code is installed and available in PATH"
+        fi
+    fi
 }
 
 # Parse command line arguments


### PR DESCRIPTION
## Description

Adds options to install the aspire cli and to use code insiders or not. 

The only valid quality is dev, an exception should be raised if any other quality is chosen and InstallExtension is present. The VS Code extension will NOT be installed unless you include the flag.

**Test**

Windows: `.\eng\scripts\get-aspire-cli.ps1 -InstallExtension -Quality dev`
Linux/Mac: `./eng/scripts/get-aspire-cli.sh --install-extension --quality dev`

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
