### PR TITLE
Missed refactoring from dynamic input

### DIFF
--- a/playground/Stress/Stress.AppHost/InteractionCommands.cs
+++ b/playground/Stress/Stress.AppHost/InteractionCommands.cs
@@ -311,7 +311,7 @@ internal static class InteractionCommands
                        }
                    }
                };
-               var dependentOptionsProvider = new InputLoadOptions
+               var sharedDynamicOptions = new InputLoadOptions
                {
                    LoadCallback = async (context) =>
                    {
@@ -344,7 +344,7 @@ internal static class InteractionCommands
                    Placeholder = "Select dynamic value",
                    Required = true,
                    Disabled = true,
-                   DynamicLoading = dependentOptionsProvider
+                   DynamicLoading = sharedDynamicOptions
                };
                var dynamicCustomChoiceInput = new InteractionInput
                {
@@ -355,7 +355,7 @@ internal static class InteractionCommands
                    AllowCustomChoice = true,
                    Required = true,
                    Disabled = true,
-                   DynamicLoading = dependentOptionsProvider
+                   DynamicLoading = sharedDynamicOptions
                };
                var dynamicTextInput = new InteractionInput
                {

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -118,7 +118,9 @@ internal sealed class InputLoadingState(InputLoadOptions options)
 
     public bool Loading { get; private set; }
 
-    internal void QueueLoad(QueueLoadOptions options)
+    public Action<InteractionInput>? OnLoadComplete { get; init; }
+
+    public void QueueLoad(QueueLoadOptions options)
     {
         lock (_lock)
         {
@@ -190,8 +192,6 @@ internal sealed class InputLoadingState(InputLoadOptions options)
             }
         }, currentToken);
     }
-
-    internal Action<InteractionInput>? OnLoadComplete { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
Unsaved changes that were missed from previous PR.