### PR TITLE
Support for .fsproj, .vbproj project files next to .csproj

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -22,6 +22,8 @@ internal interface IProjectLocator
 
 internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliRunner runner, CliExecutionContext executionContext, IInteractionService interactionService, IConfigurationService configurationService, AspireCliTelemetry telemetry, IFeatures features) : IProjectLocator
 {
+    private static readonly HashSet<string> s_supportedProjectFileExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".csproj", ".fsproj", ".vbproj" };
+
     public async Task<List<FileInfo>> FindAppHostProjectFilesAsync(string searchDirectory, CancellationToken cancellationToken)
     {
         var allCandidates = await FindAppHostProjectFilesAsync(new DirectoryInfo(searchDirectory), cancellationToken);
@@ -325,7 +327,6 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
                 throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist);
             }
 
-            var supportedProjectFileExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".csproj", ".fsproj", ".vbproj" };
             // Handle explicit apphost.cs files
             if (projectFile.Name.Equals("apphost.cs", StringComparison.OrdinalIgnoreCase))
             {
@@ -347,7 +348,7 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
                 }
             }
             // Handle .cs|fs|vbproj files
-            else if (supportedProjectFileExtensions.Contains(projectFile.Extension))
+            else if (s_supportedProjectFileExtensions.Contains(projectFile.Extension))
             {
                 logger.LogDebug("Using project file {ProjectFile}", projectFile.FullName);
                 return projectFile;

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -352,12 +352,6 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
                 logger.LogDebug("Using project file {ProjectFile}", projectFile.FullName);
                 return projectFile;
             }
-            // Handle .fsproj files
-            else if (projectFile.Extension.Equals(".fsproj", StringComparison.OrdinalIgnoreCase))
-            {
-                logger.LogDebug("Using project file {ProjectFile}", projectFile.FullName);
-                return projectFile;
-            }
             // Reject other extensions
             else
             {

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -351,6 +351,12 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
                 logger.LogDebug("Using project file {ProjectFile}", projectFile.FullName);
                 return projectFile;
             }
+            // Handle .fsproj files
+            else if (projectFile.Extension.Equals(".fsproj", StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogDebug("Using project file {ProjectFile}", projectFile.FullName);
+                return projectFile;
+            }
             // Reject other extensions
             else
             {

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -325,6 +325,7 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
                 throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist);
             }
 
+            var supportedProjectFileExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".csproj", ".fsproj", ".vbproj" };
             // Handle explicit apphost.cs files
             if (projectFile.Name.Equals("apphost.cs", StringComparison.OrdinalIgnoreCase))
             {
@@ -345,8 +346,8 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
                     throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist);
                 }
             }
-            // Handle .csproj files
-            else if (projectFile.Extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase))
+            // Handle .cs|fs|vbproj files
+            else if (supportedProjectFileExtensions.Contains(projectFile.Extension))
             {
                 logger.LogDebug("Using project file {ProjectFile}", projectFile.FullName);
                 return projectFile;

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -976,7 +976,7 @@ builder.Build().Run();");
             }
             return (0, false, null);
         };
-
+        
         var interactionService = new TestConsoleInteractionService();
         var configurationService = new TestConfigurationService();
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -809,7 +809,7 @@ builder.Build().Run();");
             }
             return (0, false, null);
         };
-
+        
         var interactionService = new TestConsoleInteractionService();
         var configurationService = new TestConfigurationService();
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
@@ -871,7 +871,7 @@ builder.Build().Run();");
             }
             return (0, false, null);
         };
-
+        
         var interactionService = new TestConsoleInteractionService();
         var configurationService = new TestConfigurationService();
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
@@ -1173,3 +1173,4 @@ builder.Build().Run();");
         Assert.Contains(executableProjects, p => p.FullName == winExeFile.FullName);
     }
 }
+

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -244,12 +244,15 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
         Assert.Equal("No project file found.", ex.Message);
     }
 
-    [Fact]
-    public async Task UseOrFindAppHostProjectFileReturnsExplicitProjectIfExistsAndProvided()
+    [Theory]
+    [InlineData(".csproj")]
+    [InlineData(".fsproj")]
+    [InlineData(".vbproj")]
+    public async Task UseOrFindAppHostProjectFileReturnsExplicitProjectIfExistsAndProvided(string projectFileExtension)
     {
         var logger = NullLogger<ProjectLocator>.Instance;
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, $"AppHost{projectFileExtension}"));
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var runner = new TestDotNetCliRunner();
@@ -806,7 +809,7 @@ builder.Build().Run();");
             }
             return (0, false, null);
         };
-        
+
         var interactionService = new TestConsoleInteractionService();
         var configurationService = new TestConfigurationService();
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
@@ -868,7 +871,7 @@ builder.Build().Run();");
             }
             return (0, false, null);
         };
-        
+
         var interactionService = new TestConsoleInteractionService();
         var configurationService = new TestConfigurationService();
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
@@ -973,7 +976,7 @@ builder.Build().Run();");
             }
             return (0, false, null);
         };
-        
+
         var interactionService = new TestConsoleInteractionService();
         var configurationService = new TestConfigurationService();
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);


### PR DESCRIPTION
## Description

Previously, up until Aspire 9.4 IIRC, one could use F# to author an AppHost. I presume, when support for single file C# applications was integrated, support for `.fsproj` accidentally got broken. Perhaps there are explicit reasons to not support F# projects for this purpose. If so, I'd like to learn about the motivation for that.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
