### PR TITLE
Added check for single exposed port and handle startup command and target port in app service

### DIFF
--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -95,7 +95,7 @@ internal sealed class AzureAppServiceWebsiteContext(
         var targetPortEndpoints = endpoints.Where(e => e.IsExternal && e.TargetPort is not null).Select(e => e.TargetPort).Distinct().ToList();
         if (targetPortEndpoints.Count > 1)
         {
-            throw new NotSupportedException("App Service only supports one target port.");
+            throw new NotSupportedException("App Service does not support resources with multiple external endpoints.");
         }
 
         _targetPort = targetPortEndpoints.FirstOrDefault();

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -92,8 +92,8 @@ internal sealed class AzureAppServiceWebsiteContext(
         }
 
         // App Service supports only one target port
-        var targetPortEndpoints = endpoints.Where(e => e.IsExternal && e.TargetPort is not null).Select(e => e.TargetPort).Distinct();
-        if (targetPortEndpoints.Count() > 1)
+        var targetPortEndpoints = endpoints.Where(e => e.IsExternal && e.TargetPort is not null).Select(e => e.TargetPort).Distinct().ToList();
+        if (targetPortEndpoints.Count > 1)
         {
             throw new NotSupportedException("App Service only supports one target port.");
         }

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -603,19 +603,6 @@ public sealed class AzureEnvironmentResource : Resource
             }
         }
 
-        // Check if the compute environment is Azure App Service Environment by checking for app service specific output planId
-        if (azureComputeEnv is AzureProvisioningResource appServiceResource &&
-            appServiceResource.Outputs.TryGetValue("planId", out var uniqueIdentifier))
-        {
-            var hostname = $"{computeResource.Name.ToLowerInvariant()}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}";
-            if (hostname.Length > 60)
-            {
-                hostname = hostname.Substring(0, 60);
-            }
-            var endpoint = $"https://{hostname}.azurewebsites.net";
-            return $" to {endpoint}";
-        }
-
         return string.Empty;
     }
 

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -18,7 +18,6 @@ using Aspire.Hosting.Publishing;
 using Azure;
 using Azure.Core;
 using Azure.Identity;
-using Azure.Provisioning.Expressions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -573,7 +573,7 @@ public class AzureAppServiceTests
 
         var project2 = builder.AddProject<Project>("project2", launchProfileName: null)
             .WithHttpsEndpoint(targetPort: 8000)
-            .WithHttpEndpoint(targetPort: 9000)
+            .WithHttpEndpoint(targetPort: 8800)
             .WithExternalHttpEndpoints()
             .WithReference(project1);
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -581,7 +581,7 @@ public class AzureAppServiceTests
 
         var ex = await Assert.ThrowsAsync<NotSupportedException>(() => ExecuteBeforeStartHooksAsync(app, default));
 
-        Assert.Equal("App Service only supports one target port.", ex.Message);
+        Assert.Equal("App Service does not support resources with multiple external endpoints.", ex.Message);
     }
 
     private static Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource) =>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -453,6 +453,137 @@ public class AzureAppServiceTests
               .AppendContentAsFile(bicep, "bicep");
     }
 
+    [Fact]
+    public async Task AddAppServiceWithArgs()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureAppServiceEnvironment("env");
+
+        // Add 2 projects with endpoints
+        var project1 = builder.AddProject<Project>("project1", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+
+        var project2 = builder.AddProject<Project>("project2", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithArgs("--myarg", "myvalue")
+            .WithExternalHttpEndpoints()
+            .WithReference(project1);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        project2.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AddAppServiceWithTargetPort()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureAppServiceEnvironment("env");
+
+        // Add 2 projects with endpoints
+        var project1 = builder.AddProject<Project>("project1", launchProfileName: null)
+            .WithHttpsEndpoint(targetPort:8000)
+            .WithHttpEndpoint(targetPort: 8000)
+            .WithExternalHttpEndpoints();
+
+        var project2 = builder.AddProject<Project>("project2", launchProfileName: null)
+            .WithHttpEndpoint(targetPort:9000)
+            .WithExternalHttpEndpoints()
+            .WithReference(project1);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        project2.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+                .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AddAppServiceWithTargetPortMultipleEndpoints()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureAppServiceEnvironment("env");
+
+        // Add 2 projects with endpoints
+        var project1 = builder.AddProject<Project>("project1", launchProfileName: null)
+            .WithExternalHttpEndpoints();
+
+        var project2 = builder.AddProject<Project>("project2", launchProfileName: null)
+            .WithHttpsEndpoint(targetPort: 8000)
+            .WithHttpEndpoint(targetPort: 8000)
+            .WithExternalHttpEndpoints()
+            .WithReference(project1);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        project2.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+                .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AddAppServiceWithMultipleTargetPortsThrowsNotSupportedException()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureAppServiceEnvironment("env");
+
+        // Add 2 projects with endpoints
+        var project1 = builder.AddProject<Project>("project1", launchProfileName: null)
+            .WithExternalHttpEndpoints();
+
+        var project2 = builder.AddProject<Project>("project2", launchProfileName: null)
+            .WithHttpsEndpoint(targetPort: 8000)
+            .WithHttpEndpoint(targetPort: 9000)
+            .WithExternalHttpEndpoints()
+            .WithReference(project1);
+
+        using var app = builder.Build();
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(() => ExecuteBeforeStartHooksAsync(app, default));
+
+        Assert.Equal("App Service only supports one target port.", ex.Message);
+    }
+
     private static Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource) =>
         AzureManifestUtils.GetManifestWithBicep(resource, skipPreparer: true);
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
@@ -9,17 +9,9 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param env_outputs_azure_container_registry_managed_identity_client_id string
 
-param api_containerimage string
+param project2_containerimage string
 
-param mydb_kv_outputs_name string
-
-param kvName string
-
-param sharedRg string
-
-param api_identity_outputs_id string
-
-param api_identity_outputs_clientid string
+param project2_containerport string
 
 param env_outputs_azure_app_service_dashboard_uri string
 
@@ -27,42 +19,26 @@ param env_outputs_azure_website_contributor_managed_identity_id string
 
 param env_outputs_azure_website_contributor_managed_identity_principal_id string
 
-resource mydb_kv 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
-  name: mydb_kv_outputs_name
-}
-
-resource mydb_kv_connectionstrings__mydb 'Microsoft.KeyVault/vaults/secrets@2024-11-01' existing = {
-  name: 'connectionstrings--mydb'
-  parent: mydb_kv
-}
-
-resource existingKv 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
-  name: kvName
-  scope: resourceGroup(sharedRg)
-}
-
-resource existingKv_secret 'Microsoft.KeyVault/vaults/secrets@2024-11-01' existing = {
-  name: 'secret'
-  parent: existingKv
-}
-
 resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
   name: 'main'
   properties: {
     authType: 'UserAssigned'
-    image: api_containerimage
+    image: project2_containerimage
     isMain: true
+    startUpCommand: join([
+      '--myarg'
+      'myvalue'
+    ], ' ')
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
 }
 
 resource webapp 'Microsoft.Web/sites@2024-11-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
     serverFarmId: env_outputs_planid
-    keyVaultReferenceIdentity: api_identity_outputs_id
     siteConfig: {
       numberOfWorkers: 30
       linuxFxVersion: 'SITECONTAINERS'
@@ -82,20 +58,16 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
           value: 'in_memory'
         }
         {
-          name: 'ConnectionStrings__mydb'
-          value: '@Microsoft.KeyVault(SecretUri=${mydb_kv_connectionstrings__mydb.properties.secretUri})'
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
         }
         {
-          name: 'SECRET_VALUE'
-          value: '@Microsoft.KeyVault(SecretUri=${existingKv_secret.properties.secretUri})'
+          name: 'HTTP_PORTS'
+          value: project2_containerport
         }
         {
-          name: 'AZURE_CLIENT_ID'
-          value: api_identity_outputs_clientid
-        }
-        {
-          name: 'AZURE_TOKEN_CREDENTIALS'
-          value: 'ManagedIdentityCredential'
+          name: 'services__project1__http__0'
+          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -103,7 +75,7 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
         }
         {
           name: 'OTEL_SERVICE_NAME'
-          value: 'api'
+          value: 'project2'
         }
         {
           name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
@@ -132,12 +104,11 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
     type: 'UserAssigned'
     userAssignedIdentities: {
       '${env_outputs_azure_container_registry_managed_identity_id}': { }
-      '${api_identity_outputs_id}': { }
     }
   }
 }
 
-resource api_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource project2_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
   properties: {
     principalId: env_outputs_azure_website_contributor_managed_identity_principal_id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.json
@@ -1,0 +1,15 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "project2.module.bicep",
+  "params": {
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "project2_containerimage": "{project2.containerImage}",
+    "project2_containerport": "{project2.containerPort}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.bicep
@@ -9,17 +9,7 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param env_outputs_azure_container_registry_managed_identity_client_id string
 
-param api_containerimage string
-
-param mydb_kv_outputs_name string
-
-param kvName string
-
-param sharedRg string
-
-param api_identity_outputs_id string
-
-param api_identity_outputs_clientid string
+param project2_containerimage string
 
 param env_outputs_azure_app_service_dashboard_uri string
 
@@ -27,48 +17,33 @@ param env_outputs_azure_website_contributor_managed_identity_id string
 
 param env_outputs_azure_website_contributor_managed_identity_principal_id string
 
-resource mydb_kv 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
-  name: mydb_kv_outputs_name
-}
-
-resource mydb_kv_connectionstrings__mydb 'Microsoft.KeyVault/vaults/secrets@2024-11-01' existing = {
-  name: 'connectionstrings--mydb'
-  parent: mydb_kv
-}
-
-resource existingKv 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
-  name: kvName
-  scope: resourceGroup(sharedRg)
-}
-
-resource existingKv_secret 'Microsoft.KeyVault/vaults/secrets@2024-11-01' existing = {
-  name: 'secret'
-  parent: existingKv
-}
-
 resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
   name: 'main'
   properties: {
     authType: 'UserAssigned'
-    image: api_containerimage
+    image: project2_containerimage
     isMain: true
+    targetPort: '9000'
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
 }
 
 resource webapp 'Microsoft.Web/sites@2024-11-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
     serverFarmId: env_outputs_planid
-    keyVaultReferenceIdentity: api_identity_outputs_id
     siteConfig: {
       numberOfWorkers: 30
       linuxFxVersion: 'SITECONTAINERS'
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: '9000'
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'
@@ -82,20 +57,20 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
           value: 'in_memory'
         }
         {
-          name: 'ConnectionStrings__mydb'
-          value: '@Microsoft.KeyVault(SecretUri=${mydb_kv_connectionstrings__mydb.properties.secretUri})'
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
         }
         {
-          name: 'SECRET_VALUE'
-          value: '@Microsoft.KeyVault(SecretUri=${existingKv_secret.properties.secretUri})'
+          name: 'HTTP_PORTS'
+          value: '9000'
         }
         {
-          name: 'AZURE_CLIENT_ID'
-          value: api_identity_outputs_clientid
+          name: 'services__project1__https__0'
+          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
-          name: 'AZURE_TOKEN_CREDENTIALS'
-          value: 'ManagedIdentityCredential'
+          name: 'services__project1__http__0'
+          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -103,7 +78,7 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
         }
         {
           name: 'OTEL_SERVICE_NAME'
-          value: 'api'
+          value: 'project2'
         }
         {
           name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
@@ -132,12 +107,11 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
     type: 'UserAssigned'
     userAssignedIdentities: {
       '${env_outputs_azure_container_registry_managed_identity_id}': { }
-      '${api_identity_outputs_id}': { }
     }
   }
 }
 
-resource api_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource project2_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
   properties: {
     principalId: env_outputs_azure_website_contributor_managed_identity_principal_id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.json
@@ -1,0 +1,14 @@
+{
+  "type": "azure.bicep.v0",
+  "path": "project2.module.bicep",
+  "params": {
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "project2_containerimage": "{project2.containerImage}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPortMultipleEndpoints.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPortMultipleEndpoints.verified.json
@@ -1,0 +1,14 @@
+{
+  "type": "azure.bicep.v0",
+  "path": "project2.module.bicep",
+  "params": {
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "project2_containerimage": "{project2.containerImage}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddDockerfileWithAppServiceInfrastructureAddsDeploymentTargetWithAppServiceToContainerResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddDockerfileWithAppServiceInfrastructureAddsDeploymentTargetWithAppServiceToContainerResources.verified.bicep
@@ -23,6 +23,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
     authType: 'UserAssigned'
     image: api_containerimage
     isMain: true
+    targetPort: '85'
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -39,6 +40,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: '85'
+        }
         {
           name: 'PORT'
           value: '85'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceSupportBaitAndSwitchResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceSupportBaitAndSwitchResources.verified.bicep
@@ -23,6 +23,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
     authType: 'UserAssigned'
     image: api_containerimage
     isMain: true
+    targetPort: '80'
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -39,6 +40,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: '80'
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'


### PR DESCRIPTION
## Description

- Added check that there can only be one TargetPort specified for an app service, irrespective of Scheme. No external port is fine, we will use the platform default.
- The command line arguments specified with `WithArgs` extension on ProjectResource should be used to create the StartupCommand of the main container. This is a change due to use of new SITECONTAINERS config.
- The target port specified with `WithHttpEndpoint` should be set as the target port of the main container and WEBSITES_PORT app setting.

Fixes #9659

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
