### PR TITLE
Allow continuing on individual file copy errors in WithContainerFiles

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerFileSystemCallbackAnnotation.cs
@@ -62,6 +62,11 @@ public abstract class ContainerFileBase : ContainerFileSystemItem
     /// Setting SourcePath is mutually exclusive with <see cref="Contents"/>. If both are set, an exception will be thrown.
     /// </summary>
     public string? SourcePath { get; set; }
+
+    /// <summary>
+    /// If true, errors creating this file will be ignored and the container creation will continue. Defaults to false.
+    /// </summary>
+    public bool? ContinueOnError { get; set; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -2291,6 +2291,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     Name = cert.Thumbprint + ".pem",
                     Type = ContainerFileSystemEntryType.OpenSSL,
                     Contents = cert.ExportCertificatePem(),
+                    ContinueOnError = true,
                 });
             }
 

--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -358,6 +358,7 @@ internal static class ContainerFileSystemItemExtensions
         {
             entry.Source = file.SourcePath;
             entry.Contents = file.Contents;
+            entry.ContinueOnError = file.ContinueOnError;
 
             if (file.Contents is not null && file.SourcePath is not null)
             {
@@ -406,6 +407,10 @@ internal sealed class ContainerFileSystemEntry : IEquatable<ContainerFileSystemE
     // If the file system entry is a directory, this is the list of entries in that directory. Setting Entries for a file is an error.
     [JsonPropertyName("entries")]
     public List<ContainerFileSystemEntry>? Entries { get; set; }
+
+    // If true, errors creating this entry will be ignored (does not apply to directory entries)
+    [JsonPropertyName("continueOnError")]
+    public bool? ContinueOnError { get; set; }
 
     public bool Equals(ContainerFileSystemEntry? other)
     {

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -733,7 +733,6 @@ public class DistributedApplicationTests
         await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         var s = app.Services.GetRequiredService<IKubernetesService>();
-        var dc = app.Services.GetRequiredService<IDeveloperCertificateService>();
         var list = await s.ListAsync<Container>().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         var createdContainer = Assert.Single(list);
         Assert.Equal(ContainerState.Running, createdContainer?.Status?.State);


### PR DESCRIPTION
## Description

Allows specifying individual entries in `WithContainerFiles` as `ContinueOnError` which will cause DCP to log, but continue if any errors occur copying the given file. This is also automatically applied to individual certificates copied over due to the new certificate trust feature (DCP loads the certificates to generate hashes, which can lead to failures for some certificates that are invalid according to OpenSSL but not Windows).