### PR TITLE
Remove Traces from the Python OTel Cert variable

### DIFF
--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -291,7 +291,7 @@ public static class PythonAppResourceBuilderExtensions
 
             // Override default opentelemetry-python certificate bundle path
             // See: https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html#module-opentelemetry.exporter.otlp
-            ctx.CertificateBundleEnvironment.Add("OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE");
+            ctx.CertificateBundleEnvironment.Add("OTEL_EXPORTER_OTLP_CERTIFICATE");
 
             return Task.CompletedTask;
         });


### PR DESCRIPTION
We are only supporting traces, but we want metrics and logs too.