### PR TITLE
Added prompting for tenant to azure config experiences

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerOptions.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerOptions.cs
@@ -7,6 +7,8 @@ namespace Aspire.Hosting.Azure.Provisioning;
 
 internal sealed class AzureProvisionerOptions
 {
+    public string? TenantId { get; set; }
+
     public string? SubscriptionId { get; set; }
 
     public string? ResourceGroup { get; set; }

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultTokenCredentialProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultTokenCredentialProvider.cs
@@ -15,34 +15,38 @@ internal class DefaultTokenCredentialProvider : ITokenCredentialProvider
 
     public DefaultTokenCredentialProvider(
         ILogger<DefaultTokenCredentialProvider> logger,
-        IOptions<AzureProvisionerOptions> options,
-        DistributedApplicationExecutionContext distributedApplicationExecutionContext)
+        IOptions<AzureProvisionerOptions> options)
     {
         _logger = logger;
 
         // Optionally configured in AppHost appSettings under "Azure" : { "CredentialSource": "AzureCli" }
-        var credentialSetting = options.Value.CredentialSource;
 
-        // Use AzureCli as default for publish mode when no explicit credential source is set
-        var credentialSource = credentialSetting switch
+        TokenCredential credential = options.Value.CredentialSource switch
         {
-            null or "Default" when distributedApplicationExecutionContext.IsPublishMode => "AzureCli",
-            _ => credentialSetting ?? "Default"
-        };
-
-        TokenCredential credential = credentialSource switch
-        {
-            "AzureCli" => new AzureCliCredential(),
-            "AzurePowerShell" => new AzurePowerShellCredential(),
-            "VisualStudio" => new VisualStudioCredential(),
-            "AzureDeveloperCli" => new AzureDeveloperCliCredential(),
+            "AzureCli" => new AzureCliCredential(new()
+            {
+                AdditionallyAllowedTenants = { "*" }
+            }),
+            "AzurePowerShell" => new AzurePowerShellCredential(new()
+            {
+                AdditionallyAllowedTenants = { "*" }
+            }),
+            "VisualStudio" => new VisualStudioCredential(new()
+            {
+                AdditionallyAllowedTenants = { "*" }
+            }),
+            "AzureDeveloperCli" => new AzureDeveloperCliCredential(new()
+            {
+                AdditionallyAllowedTenants = { "*" }
+            }),
             "InteractiveBrowser" => new InteractiveBrowserCredential(),
             _ => new DefaultAzureCredential(new DefaultAzureCredentialOptions()
             {
                 ExcludeManagedIdentityCredential = true,
                 ExcludeWorkloadIdentityCredential = true,
                 ExcludeAzurePowerShellCredential = true,
-                CredentialProcessTimeout = TimeSpan.FromSeconds(15)
+                CredentialProcessTimeout = TimeSpan.FromSeconds(15),
+                AdditionallyAllowedTenants = { "*" }
             })
         };
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/IProvisioningServices.cs
@@ -71,9 +71,19 @@ internal interface IArmClient
     Task<(ISubscriptionResource subscription, ITenantResource tenant)> GetSubscriptionAndTenantAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets all tenants accessible to the current user.
+    /// </summary>
+    Task<IEnumerable<ITenantResource>> GetAvailableTenantsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets all subscriptions accessible to the current user.
     /// </summary>
     Task<IEnumerable<ISubscriptionResource>> GetAvailableSubscriptionsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all subscriptions accessible to the current user filtered by tenant ID.
+    /// </summary>
+    Task<IEnumerable<ISubscriptionResource>> GetAvailableSubscriptionsAsync(string? tenantId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets all available locations for the specified subscription.
@@ -173,6 +183,11 @@ internal interface ITenantResource
     /// Gets the tenant ID.
     /// </summary>
     Guid? TenantId { get; }
+
+    /// <summary>
+    /// Gets the display name.
+    /// </summary>
+    string? DisplayName { get; }
 
     /// <summary>
     /// Gets the default domain.

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -77,6 +77,16 @@ internal sealed class PublishModeProvisioningContextProvider(
     {
         while (_options.Location == null || _options.SubscriptionId == null)
         {
+            // Skip tenant prompting if subscription ID is already set
+            if (_options.TenantId == null && _options.SubscriptionId == null)
+            {
+                await PromptForTenantAsync(cancellationToken).ConfigureAwait(false);
+                if (_options.TenantId == null)
+                {
+                    continue;
+                }
+            }
+
             if (_options.SubscriptionId == null)
             {
                 await PromptForSubscriptionAsync(cancellationToken).ConfigureAwait(false);
@@ -97,6 +107,105 @@ internal sealed class PublishModeProvisioningContextProvider(
         }
     }
 
+    private async Task PromptForTenantAsync(CancellationToken cancellationToken)
+    {
+        List<KeyValuePair<string, string>>? tenantOptions = null;
+        var fetchSucceeded = false;
+
+        var step = await activityReporter.CreateStepAsync(
+            "fetch-tenant",
+            cancellationToken).ConfigureAwait(false);
+
+        await using (step.ConfigureAwait(false))
+        {
+            try
+            {
+                var task = await step.CreateTaskAsync("Fetching available tenants", cancellationToken).ConfigureAwait(false);
+
+                await using (task.ConfigureAwait(false))
+                {
+                    (tenantOptions, fetchSucceeded) = await TryGetTenantsAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                if (fetchSucceeded)
+                {
+                    await step.SucceedAsync($"Found {tenantOptions!.Count} available tenant(s)", cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await step.WarnAsync("Failed to fetch tenants, falling back to manual entry", cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve Azure tenant information.");
+                await step.FailAsync($"Failed to retrieve tenant information: {ex.Message}", cancellationToken).ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        if (tenantOptions?.Count > 0)
+        {
+            var result = await _interactionService.PromptInputsAsync(
+                AzureProvisioningStrings.TenantDialogTitle,
+                AzureProvisioningStrings.TenantSelectionMessage,
+                [
+                    new InteractionInput
+                    {
+                        Name = TenantName,
+                        InputType = InputType.Choice,
+                        Label = AzureProvisioningStrings.TenantLabel,
+                        Required = true,
+                        Options = [..tenantOptions]
+                    }
+                ],
+                new InputsDialogInteractionOptions
+                {
+                    EnableMessageMarkdown = false
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Canceled)
+            {
+                _options.TenantId = result.Data[TenantName].Value;
+                return;
+            }
+        }
+
+        var manualResult = await _interactionService.PromptInputsAsync(
+            AzureProvisioningStrings.TenantDialogTitle,
+            AzureProvisioningStrings.TenantManualEntryMessage,
+            [
+                new InteractionInput
+                {
+                    Name = TenantName,
+                    InputType = InputType.SecretText,
+                    Label = AzureProvisioningStrings.TenantLabel,
+                    Placeholder = AzureProvisioningStrings.TenantPlaceholder,
+                    Required = true
+                }
+            ],
+            new InputsDialogInteractionOptions
+            {
+                EnableMessageMarkdown = false,
+                ValidationCallback = static (validationContext) =>
+                {
+                    var tenantInput = validationContext.Inputs[TenantName];
+                    if (!Guid.TryParse(tenantInput.Value, out var _))
+                    {
+                        validationContext.AddValidationError(tenantInput, AzureProvisioningStrings.ValidationTenantIdInvalid);
+                    }
+                    return Task.CompletedTask;
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (!manualResult.Canceled)
+        {
+            _options.TenantId = manualResult.Data[TenantName].Value;
+        }
+    }
+
     private async Task PromptForSubscriptionAsync(CancellationToken cancellationToken)
     {
         List<KeyValuePair<string, string>>? subscriptionOptions = null;
@@ -114,7 +223,7 @@ internal sealed class PublishModeProvisioningContextProvider(
 
                 await using (task.ConfigureAwait(false))
                 {
-                    (subscriptionOptions, fetchSucceeded) = await TryGetSubscriptionsAsync(cancellationToken).ConfigureAwait(false);
+                    (subscriptionOptions, fetchSucceeded) = await TryGetSubscriptionsAsync(_options.TenantId, cancellationToken).ConfigureAwait(false);
                 }
 
                 if (fetchSucceeded)

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -148,22 +148,27 @@ internal sealed class RunModeProvisioningContextProvider(
                     });
                 }
 
+                // If the subscription ID is already set
+                // show the value as from the configuration and disable the input
+                // there should be no option to change it
+
                 inputs.Add(new InteractionInput
                 {
                     Name = SubscriptionIdName,
-                    InputType = InputType.Choice,
+                    InputType = string.IsNullOrEmpty(_options.SubscriptionId) ? InputType.Choice : InputType.Text,
                     Label = AzureProvisioningStrings.SubscriptionIdLabel,
                     Required = true,
                     AllowCustomChoice = true,
                     Placeholder = AzureProvisioningStrings.SubscriptionIdPlaceholder,
-                    Disabled = string.IsNullOrEmpty(_options.SubscriptionId),
+                    Disabled = !string.IsNullOrEmpty(_options.SubscriptionId),
+                    Value = _options.SubscriptionId,
                     DynamicLoading = new InputLoadOptions
                     {
                         LoadCallback = async (context) =>
                         {
                             if (!string.IsNullOrEmpty(_options.SubscriptionId))
                             {
-                                context.Input.Options = [KeyValuePair.Create(_options.SubscriptionId, $"From Configuration ({_options.SubscriptionId})")];
+                                // If subscription ID is not set, we don't need to load options
                                 return;
                             }
 
@@ -266,7 +271,7 @@ internal sealed class RunModeProvisioningContextProvider(
                         _options.TenantId = result.Data[TenantName].Value;
                     }
                     _options.Location = result.Data[LocationName].Value;
-                    _options.SubscriptionId = result.Data[SubscriptionIdName].Value;
+                    _options.SubscriptionId ??= result.Data[SubscriptionIdName].Value;
                     _options.ResourceGroup = result.Data[ResourceGroupName].Value;
                     _options.AllowResourceGroupCreation = true; // Allow the creation of the resource group if it does not exist.
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -172,13 +172,8 @@ internal sealed class RunModeProvisioningContextProvider(
                                 return;
                             }
 
-                            string? tenantId = null;
-
                             // Get tenant ID from input if tenant selection is enabled, otherwise use configured value
-                            if (string.IsNullOrEmpty(_options.SubscriptionId))
-                            {
-                                tenantId = context.AllInputs[TenantName].Value ?? string.Empty;
-                            }
+                            var tenantId = context.AllInputs[TenantName].Value ?? string.Empty;
 
                             var (subscriptionOptions, fetchSucceeded) =
                                 await TryGetSubscriptionsAsync(tenantId, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -261,9 +261,9 @@ internal sealed class RunModeProvisioningContextProvider(
                 if (!result.Canceled)
                 {
                     // Only set tenant ID if it was part of the input (when subscription ID wasn't already set)
-                    if (string.IsNullOrEmpty(_options.SubscriptionId))
+                    if (result.Data.TryGetByName(TenantName, out var tenantInput))
                     {
-                        _options.TenantId = result.Data[TenantName].Value;
+                        _options.TenantId = tenantInput.Value;
                     }
                     _options.Location = result.Data[LocationName].Value;
                     _options.SubscriptionId ??= result.Data[SubscriptionIdName].Value;

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -233,17 +233,12 @@ internal sealed class RunModeProvisioningContextProvider(
                         ValidationCallback = (validationContext) =>
                         {
                             // Only validate tenant if it's included in the inputs
-                            try
+                            if (validationContext.Inputs.TryGetByName(TenantName, out var tenantInput))
                             {
-                                var tenantInput = validationContext.Inputs[TenantName];
                                 if (!string.IsNullOrWhiteSpace(tenantInput.Value) && !Guid.TryParse(tenantInput.Value, out _))
                                 {
                                     validationContext.AddValidationError(tenantInput, AzureProvisioningStrings.ValidationTenantIdInvalid);
                                 }
-                            }
-                            catch (KeyNotFoundException)
-                            {
-                                // Tenant input not present, skip validation
                             }
 
                             var subscriptionInput = validationContext.Inputs[SubscriptionIdName];

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -62,7 +62,7 @@ internal sealed class RunModeProvisioningContextProvider(
     private void EnsureProvisioningOptions()
     {
         if (!_interactionService.IsAvailable ||
-            (!string.IsNullOrEmpty(_options.Location) && !string.IsNullOrEmpty(_options.SubscriptionId) && !string.IsNullOrEmpty(_options.TenantId)))
+            (!string.IsNullOrEmpty(_options.Location) && !string.IsNullOrEmpty(_options.SubscriptionId)))
         {
             // If the interaction service is not available, or
             // if all options are already set, we can skip the prompt

--- a/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.Designer.cs
+++ b/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.Designer.cs
@@ -214,5 +214,59 @@ namespace Aspire.Hosting.Azure.Resources {
                 return ResourceManager.GetString("LocationSelectionMessage", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Azure tenant.
+        /// </summary>
+        internal static string TenantDialogTitle {
+            get {
+                return ResourceManager.GetString("TenantDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select your Azure tenant:.
+        /// </summary>
+        internal static string TenantSelectionMessage {
+            get {
+                return ResourceManager.GetString("TenantSelectionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter your Azure tenant ID:.
+        /// </summary>
+        internal static string TenantManualEntryMessage {
+            get {
+                return ResourceManager.GetString("TenantManualEntryMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tenant ID.
+        /// </summary>
+        internal static string TenantLabel {
+            get {
+                return ResourceManager.GetString("TenantLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select tenant ID.
+        /// </summary>
+        internal static string TenantPlaceholder {
+            get {
+                return ResourceManager.GetString("TenantPlaceholder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tenant ID must be a valid GUID.
+        /// </summary>
+        internal static string ValidationTenantIdInvalid {
+            get {
+                return ResourceManager.GetString("ValidationTenantIdInvalid", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.resx
+++ b/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.resx
@@ -171,4 +171,22 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
   <data name="LocationSelectionMessage" xml:space="preserve">
     <value>Select your Azure location and specify resource group:</value>
   </data>
+  <data name="TenantDialogTitle" xml:space="preserve">
+    <value>Azure tenant</value>
+  </data>
+  <data name="TenantSelectionMessage" xml:space="preserve">
+    <value>Select your Azure tenant:</value>
+  </data>
+  <data name="TenantManualEntryMessage" xml:space="preserve">
+    <value>Enter your Azure tenant ID:</value>
+  </data>
+  <data name="TenantLabel" xml:space="preserve">
+    <value>Tenant ID</value>
+  </data>
+  <data name="TenantPlaceholder" xml:space="preserve">
+    <value>Select tenant ID</value>
+  </data>
+  <data name="ValidationTenantIdInvalid" xml:space="preserve">
+    <value>Tenant ID must be a valid GUID.</value>
+  </data>
 </root>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.cs.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.cs.xlf
@@ -81,6 +81,31 @@ Zjistěte více v [dokumentaci k nasazení Azure](https://aka.ms/dotnet/aspire/a
         <target state="translated">Vyberte předplatné Azure:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">Název skupiny prostředků musí být platný název skupiny prostředků Azure.</target>
@@ -89,6 +114,11 @@ Zjistěte více v [dokumentaci k nasazení Azure](https://aka.ms/dotnet/aspire/a
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">ID předplatného musí být platným identifikátorem GUID.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.de.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.de.xlf
@@ -81,6 +81,31 @@ Weitere Informationen finden Sie in der [Azure-Bereitstellungsdokumentation](htt
         <target state="translated">Wählen Sie Ihr Azure-Abonnement aus:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">Der Ressourcengruppenname muss ein gültiger Azure-Ressourcengruppenname sein.</target>
@@ -89,6 +114,11 @@ Weitere Informationen finden Sie in der [Azure-Bereitstellungsdokumentation](htt
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">Die Abonnement-ID muss eine gültige GUID sein.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.es.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.es.xlf
@@ -81,6 +81,31 @@ Para más información, consulte la [documentación de aprovisionamiento de Azur
         <target state="translated">Seleccione su suscripción de Azure:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">El nombre del grupo de recursos debe ser un nombre de grupo de recursos de Azure válido.</target>
@@ -89,6 +114,11 @@ Para más información, consulte la [documentación de aprovisionamiento de Azur
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">El identificador de suscripción debe ser un GUID válido.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.fr.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.fr.xlf
@@ -81,6 +81,31 @@ Pour en savoir plus, consultez la [documentation d’approvisionnement Azure](ht
         <target state="translated">Sélectionnez votre abonnement Azure :</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">Le nom du groupe de ressources doit être un nom de groupe de ressources Azure valide.</target>
@@ -89,6 +114,11 @@ Pour en savoir plus, consultez la [documentation d’approvisionnement Azure](ht
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">L’ID d’abonnement doit être un GUID valide.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.it.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.it.xlf
@@ -81,6 +81,31 @@ Per altre informazioni, vedere la [documentazione sul provisioning di Azure](htt
         <target state="translated">Selezionare la sottoscrizione di Azure:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">Il nome del gruppo di risorse deve essere un nome valido per un gruppo di risorse di Azure.</target>
@@ -89,6 +114,11 @@ Per altre informazioni, vedere la [documentazione sul provisioning di Azure](htt
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">L'ID sottoscrizione deve essere un GUID valido.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ja.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ja.xlf
@@ -81,6 +81,31 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">Azure サブスクリプションを選択してください:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">リソース グループ名は、有効な Azure リソース グループ名である必要があります。</target>
@@ -89,6 +114,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">サブスクリプション ID は有効な GUID である必要があります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ko.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ko.xlf
@@ -81,6 +81,31 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">Azure 구독 선택:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">리소스 그룹 이름은 유효한 Azure 리소스 그룹 이름이어야 합니다.</target>
@@ -89,6 +114,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">구독 ID는 유효한 GUID여야 합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pl.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pl.xlf
@@ -81,6 +81,31 @@ Aby dowiedzieć się więcej, zobacz [dokumentację aprowizacji platformy Azure]
         <target state="translated">Wybierz subskrypcję platformy Azure:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">Nazwa grupy zasobów musi być prawidłową nazwą grupy zasobów platformy Azure.</target>
@@ -89,6 +114,11 @@ Aby dowiedzieć się więcej, zobacz [dokumentację aprowizacji platformy Azure]
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">Identyfikator subskrypcji musi być prawidłowym identyfikatorem GUID.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pt-BR.xlf
@@ -81,6 +81,31 @@ Para saber mais, veja a [documentação de provisionamento do Azure](https://aka
         <target state="translated">Selecione sua assinatura do Azure:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">O nome do grupo de recursos deve ser um nome válido de grupo de recursos do Azure.</target>
@@ -89,6 +114,11 @@ Para saber mais, veja a [documentação de provisionamento do Azure](https://aka
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">A ID da assinatura deve ser um GUID válido.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ru.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ru.xlf
@@ -81,6 +81,31 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">Выберите свою подписку Azure:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">Имя группы ресурсов должно быть допустимым именем группы ресурсов Azure.</target>
@@ -89,6 +114,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">Идентификатор подписки должен быть допустимым GUID.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.tr.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.tr.xlf
@@ -81,6 +81,31 @@ Daha fazla bilgi için [Azure sağlama belgelerine](https://aka.ms/dotnet/aspire
         <target state="translated">Azure aboneliğinizi seçin:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">Kaynak grubu adı, geçerli bir Azure kaynak grubu adı olmalıdır.</target>
@@ -89,6 +114,11 @@ Daha fazla bilgi için [Azure sağlama belgelerine](https://aka.ms/dotnet/aspire
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">Abonelik kimliği geçerli bir GUID olmalıdır.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hans.xlf
@@ -81,6 +81,31 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">选择 Azure 订阅:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">资源组名称必须是有效的 Azure 资源组名称。</target>
@@ -89,6 +114,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">订阅 ID 必须是有效的 GUID。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hant.xlf
@@ -81,6 +81,31 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
         <target state="translated">選取您的 Azure 訂用帳戶:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TenantDialogTitle">
+        <source>Azure tenant</source>
+        <target state="new">Azure tenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantLabel">
+        <source>Tenant ID</source>
+        <target state="new">Tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantManualEntryMessage">
+        <source>Enter your Azure tenant ID:</source>
+        <target state="new">Enter your Azure tenant ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantPlaceholder">
+        <source>Select tenant ID</source>
+        <target state="new">Select tenant ID</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TenantSelectionMessage">
+        <source>Select your Azure tenant:</source>
+        <target state="new">Select your Azure tenant:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ValidationResourceGroupNameInvalid">
         <source>Resource group name must be a valid Azure resource group name.</source>
         <target state="translated">資源群組名稱必須是有效的 Azure 資源群組名稱。</target>
@@ -89,6 +114,11 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/dotnet/aspire/az
       <trans-unit id="ValidationSubscriptionIdInvalid">
         <source>Subscription ID must be a valid GUID.</source>
         <target state="translated">訂閱識別碼必須是有效的 GUID。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ValidationTenantIdInvalid">
+        <source>Tenant ID must be a valid GUID.</source>
+        <target state="new">Tenant ID must be a valid GUID.</target>
         <note />
       </trans-unit>
     </body>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -68,6 +68,22 @@ public class AzureDeployerTests(ITestOutputHelper output)
         var runTask = Task.Run(app.Run);
 
         // Wait for the first interaction (subscription selection)
+        var tenantInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        Assert.Equal("Azure tenant", tenantInteraction.Title);
+        Assert.False(tenantInteraction.Options!.EnableMessageMarkdown);
+
+        Assert.Collection(tenantInteraction.Inputs,
+            input =>
+            {
+                Assert.Equal("Tenant ID", input.Label);
+                Assert.Equal(InputType.Choice, input.InputType);
+                Assert.True(input.Required);
+            });
+
+        tenantInteraction.Inputs[0].Value = "87654321-4321-4321-4321-210987654321";
+        tenantInteraction.CompletionTcs.SetResult(InteractionResult.Ok(tenantInteraction.Inputs));
+
+        // Wait for the next interaction (subscription selection)
         var subscriptionInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
         Assert.Equal("Azure subscription", subscriptionInteraction.Title);
         Assert.False(subscriptionInteraction.Options!.EnableMessageMarkdown);

--- a/tests/Aspire.Hosting.Azure.Tests/DefaultTokenCredentialProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DefaultTokenCredentialProviderTests.cs
@@ -14,85 +14,60 @@ namespace Aspire.Hosting.Azure.Tests;
 public class DefaultTokenCredentialProviderTests
 {
     [Fact]
-    public void Constructor_PublishMode_NoCredentialSource_UsesAzureCli()
+    public void Constructor_NoCredentialSource_UsesDefaultAzureCredential()
     {
         // Arrange
         var azureOptions = CreateAzureOptions(credentialSource: null);
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
 
         // Act
         var provider = new DefaultTokenCredentialProvider(
             NullLogger<DefaultTokenCredentialProvider>.Instance,
-            azureOptions,
-            executionContext);
-
-        // Assert
-        Assert.IsType<AzureCliCredential>(provider.TokenCredential);
-    }
-
-    [Fact]
-    public void Constructor_PublishMode_ExplicitDefaultCredentialSource_UsesAzureCli()
-    {
-        // Arrange
-        var azureOptions = CreateAzureOptions(credentialSource: "Default");
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
-
-        // Act
-        var provider = new DefaultTokenCredentialProvider(
-            NullLogger<DefaultTokenCredentialProvider>.Instance,
-            azureOptions,
-            executionContext);
-
-        // Assert
-        Assert.IsType<AzureCliCredential>(provider.TokenCredential);
-    }
-
-    [Fact]
-    public void Constructor_PublishMode_ExplicitNonDefaultCredentialSource_RespectsSource()
-    {
-        // Arrange
-        var azureOptions = CreateAzureOptions(credentialSource: "AzurePowerShell");
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
-
-        // Act
-        var provider = new DefaultTokenCredentialProvider(
-            NullLogger<DefaultTokenCredentialProvider>.Instance,
-            azureOptions,
-            executionContext);
-
-        // Assert
-        Assert.IsType<AzurePowerShellCredential>(provider.TokenCredential);
-    }
-
-    [Fact]
-    public void Constructor_RunMode_NoCredentialSource_UsesDefaultAzureCredential()
-    {
-        // Arrange
-        var azureOptions = CreateAzureOptions(credentialSource: null);
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-
-        // Act
-        var provider = new DefaultTokenCredentialProvider(
-            NullLogger<DefaultTokenCredentialProvider>.Instance,
-            azureOptions,
-            executionContext);
+            azureOptions);
 
         // Assert
         Assert.IsType<DefaultAzureCredential>(provider.TokenCredential);
     }
 
     [Fact]
-    public void Constructor_RunMode_ExplicitCredentialSource_RespectsSource()
+    public void Constructor_ExplicitDefaultCredentialSource_UsesDefaultAzureCredential()
     {
         // Arrange
-        var azureOptions = CreateAzureOptions(credentialSource: "VisualStudio");
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var azureOptions = CreateAzureOptions(credentialSource: "Default");
 
         // Act
         var provider = new DefaultTokenCredentialProvider(
             NullLogger<DefaultTokenCredentialProvider>.Instance,
-            azureOptions,
-            executionContext);
+            azureOptions);
+
+        // Assert
+        Assert.IsType<DefaultAzureCredential>(provider.TokenCredential);
+    }
+
+    [Fact]
+    public void Constructor_ExplicitNonDefaultCredentialSource_RespectsSource()
+    {
+        // Arrange
+        var azureOptions = CreateAzureOptions(credentialSource: "AzurePowerShell");
+
+        // Act
+        var provider = new DefaultTokenCredentialProvider(
+            NullLogger<DefaultTokenCredentialProvider>.Instance,
+            azureOptions);
+
+        // Assert
+        Assert.IsType<AzurePowerShellCredential>(provider.TokenCredential);
+    }
+
+    [Fact]
+    public void Constructor_ExplicitCredentialSource_RespectsSource()
+    {
+        // Arrange
+        var azureOptions = CreateAzureOptions(credentialSource: "VisualStudio");
+
+        // Act
+        var provider = new DefaultTokenCredentialProvider(
+            NullLogger<DefaultTokenCredentialProvider>.Instance,
+            azureOptions);
 
         // Assert
         Assert.IsType<VisualStudioCredential>(provider.TokenCredential);
@@ -103,16 +78,59 @@ public class DefaultTokenCredentialProviderTests
     {
         // Arrange
         var azureOptions = CreateAzureOptions(credentialSource: "InvalidSource");
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
 
         // Act
         var provider = new DefaultTokenCredentialProvider(
             NullLogger<DefaultTokenCredentialProvider>.Instance,
-            azureOptions,
-            executionContext);
+            azureOptions);
 
         // Assert
         Assert.IsType<DefaultAzureCredential>(provider.TokenCredential);
+    }
+
+    [Fact]
+    public void Constructor_AzureCliCredentialSource_UsesAzureCliCredential()
+    {
+        // Arrange
+        var azureOptions = CreateAzureOptions(credentialSource: "AzureCli");
+
+        // Act
+        var provider = new DefaultTokenCredentialProvider(
+            NullLogger<DefaultTokenCredentialProvider>.Instance,
+            azureOptions);
+
+        // Assert
+        Assert.IsType<AzureCliCredential>(provider.TokenCredential);
+    }
+
+    [Fact]
+    public void Constructor_AzureDeveloperCliCredentialSource_UsesAzureDeveloperCliCredential()
+    {
+        // Arrange
+        var azureOptions = CreateAzureOptions(credentialSource: "AzureDeveloperCli");
+
+        // Act
+        var provider = new DefaultTokenCredentialProvider(
+            NullLogger<DefaultTokenCredentialProvider>.Instance,
+            azureOptions);
+
+        // Assert
+        Assert.IsType<AzureDeveloperCliCredential>(provider.TokenCredential);
+    }
+
+    [Fact]
+    public void Constructor_InteractiveBrowserCredentialSource_UsesInteractiveBrowserCredential()
+    {
+        // Arrange
+        var azureOptions = CreateAzureOptions(credentialSource: "InteractiveBrowser");
+
+        // Act
+        var provider = new DefaultTokenCredentialProvider(
+            NullLogger<DefaultTokenCredentialProvider>.Instance,
+            azureOptions);
+
+        // Assert
+        Assert.IsType<InteractiveBrowserCredential>(provider.TokenCredential);
     }
 
     private static IOptions<AzureProvisionerOptions> CreateAzureOptions(string? credentialSource)

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningContextProviderTests.cs
@@ -279,6 +279,13 @@ public class ProvisioningContextProviderTests
         Assert.Collection(inputsInteraction.Inputs,
             input =>
             {
+                Assert.Equal(BaseProvisioningContextProvider.TenantName, input.Name);
+                Assert.Equal("Tenant ID", input.Label);
+                Assert.Equal(InputType.Choice, input.InputType);
+                Assert.True(input.Required);
+            },
+            input =>
+            {
                 Assert.Equal(BaseProvisioningContextProvider.SubscriptionIdName, input.Name);
                 Assert.Equal("Subscription ID", input.Label);
                 Assert.Equal(InputType.Choice, input.InputType);

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
@@ -210,8 +210,29 @@ internal sealed class TestArmClient : IArmClient
         return Task.FromResult<(ISubscriptionResource, ITenantResource)>((subscription, tenant));
     }
 
+    public Task<IEnumerable<ITenantResource>> GetAvailableTenantsAsync(CancellationToken cancellationToken = default)
+    {
+        var tenants = new List<ITenantResource>
+        {
+            new TestTenantResource()
+        };
+        return Task.FromResult<IEnumerable<ITenantResource>>(tenants);
+    }
+
     public Task<IEnumerable<ISubscriptionResource>> GetAvailableSubscriptionsAsync(CancellationToken cancellationToken = default)
     {
+        var subscriptions = new List<ISubscriptionResource>
+        {
+            new TestSubscriptionResource()
+        };
+        return Task.FromResult<IEnumerable<ISubscriptionResource>>(subscriptions);
+    }
+
+    public Task<IEnumerable<ISubscriptionResource>> GetAvailableSubscriptionsAsync(string? tenantId, CancellationToken cancellationToken = default)
+    {
+        // For testing, return the same subscription regardless of tenant filtering
+        _ = tenantId; // Suppress unused parameter warning
+        _ = cancellationToken; // Suppress unused parameter warning
         var subscriptions = new List<ISubscriptionResource>
         {
             new TestSubscriptionResource()
@@ -414,6 +435,7 @@ internal sealed class TestArmDeploymentCollection : IArmDeploymentCollection
 internal sealed class TestTenantResource : ITenantResource
 {
     public Guid? TenantId { get; } = Guid.Parse("87654321-4321-4321-4321-210987654321");
+    public string? DisplayName { get; } = "Test Tenant";
     public string? DefaultDomain { get; } = "testdomain.onmicrosoft.com";
 }
 


### PR DESCRIPTION
## Description

When we create a provisioning context, we gather the subscription id using the default tenant based on the azure credential. This is problematic when users want to switch between work and personal accounts so ask the user which one they want to use and store that along with sub, location and rg.

Contributes to #10364

Fixes https://github.com/dotnet/aspire/issues/9782
Fixes https://github.com/dotnet/aspire/issues/3544
Fixes https://github.com/dotnet/aspire/issues/4872

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
