### PR TITLE
Allow configuring the dev cert trust via environment variable as well as DistributedApplicationOptions

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -2060,7 +2060,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     private async Task<(List<string>, List<EnvVar>, bool)> BuildExecutableCertificateAuthorityTrustAsync(IResource modelResource, List<string> resourceArguments, List<EnvVar> resourceEnvironment, CancellationToken cancellationToken)
     {
         // Apply the default dev cert trust behavior from options
-        bool trustDevCert = _distributedApplicationOptions.TrustDeveloperCertificate;
+        bool trustDevCert = _developerCertificateService.TrustCertificate;
 
         var certificates = new X509Certificate2Collection();
         var scope = CustomCertificateAuthoritiesScope.Append;
@@ -2169,7 +2169,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     private async Task<(List<string>, List<EnvVar>, List<ContainerCreateFileSystem>, bool)> BuildContainerCertificateAuthorityTrustAsync(IResource modelResource, List<string> resourceArguments, List<EnvVar> resourceEnvironment, CancellationToken cancellationToken)
     {
         // Apply the default dev cert trust behavior from options
-        bool trustDevCert = _distributedApplicationOptions.TrustDeveloperCertificate;
+        bool trustDevCert = _developerCertificateService.TrustCertificate;
 
         var certificates = new X509Certificate2Collection();
         var scope = CustomCertificateAuthoritiesScope.Append;

--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -11,8 +11,6 @@ namespace Aspire.Hosting;
 
 internal class DeveloperCertificateService : IDeveloperCertificateService
 {
-    internal const string DefaultConfigSectionName = "Aspire:DeveloperCertificate";
-
     private readonly Lazy<ImmutableList<X509Certificate2>> _certificates;
     private readonly Lazy<bool> _supportsContainerTrust;
 
@@ -60,17 +58,10 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
             return containerTrustAvailable;
         });
 
-        if (options.TrustDeveloperCertificate.HasValue)
-        {
-            // Configuration from DistributedApplicationOptions takes precedence.
-            TrustCertificate = options.TrustDeveloperCertificate.Value;
-        }
-        else
-        {
-            // Otherwise, attempt to read from configuration. Default is true.
-            var configSection = configuration.GetSection(DefaultConfigSectionName);
-            TrustCertificate = configSection.GetBool("TrustCertificate", true);
-        }
+        // Environment variable config > DistributedApplicationOptions > default true
+        TrustCertificate = configuration.GetBool(KnownConfigNames.TrustDeveloperCertificate) ??
+            options.TrustDeveloperCertificate ??
+            true;
     }
 
     /// <inheritdoc />

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -203,11 +203,11 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         ConfigurePublishingOptions(options);
         var isExecMode = ConfigureExecOptions(options);
-        
+
         // Compute the dashboard application name - use DashboardApplicationName if set for file-based apps,
         // otherwise fall back to the environment's ApplicationName
         var dashboardApplicationName = options.DashboardApplicationName ?? _innerBuilder.Environment.ApplicationName;
-        
+
         _innerBuilder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             // Make the app host directory available to the application via configuration

--- a/src/Aspire.Hosting/DistributedApplicationOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationOptions.cs
@@ -103,7 +103,7 @@ public sealed class DistributedApplicationOptions
     /// Whether to attempt to implicitly add trust for developer certificates (currently the ASP.NET developer certificate)
     /// by default at runtime.
     /// </summary>
-    public bool TrustDeveloperCertificate { get; set; } = true;
+    public bool? TrustDeveloperCertificate { get; set; }
 
     private string? ResolveProjectDirectory()
     {

--- a/src/Aspire.Hosting/IDeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/IDeveloperCertificateService.cs
@@ -22,4 +22,9 @@ public interface IDeveloperCertificateService
     /// for accessing host services such as "host.docker.internal" and "host.containers.internal".
     /// </summary>
     bool SupportsContainerTrust { get; }
+
+    /// <summary>
+    /// Indicates whether the default behavior is to attempt to trust the developer certificate(s) at runtime.
+    /// </summary>
+    bool TrustCertificate { get; }
 }

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -44,6 +44,8 @@ internal static class KnownConfigNames
     public const string ExtensionCert = "ASPIRE_EXTENSION_CERT";
     public const string ExtensionDebugSessionId = "ASPIRE_EXTENSION_DEBUG_SESSION_ID";
 
+    public const string TrustDeveloperCertificate = "ASPIRE_TRUST_DEVELOPER_CERTIFICATE";
+
     public const string DebugSessionInfo = "DEBUG_SESSION_INFO";
     public const string DebugSessionRunMode = "DEBUG_SESSION_RUN_MODE";
 

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -44,7 +44,7 @@ internal static class KnownConfigNames
     public const string ExtensionCert = "ASPIRE_EXTENSION_CERT";
     public const string ExtensionDebugSessionId = "ASPIRE_EXTENSION_DEBUG_SESSION_ID";
 
-    public const string TrustDeveloperCertificate = "ASPIRE_TRUST_DEVELOPER_CERTIFICATE";
+    public const string TrustDeveloperCertificate = "ASPIRE_DEVELOPER_CERTIFICATE_DEFAULT_TRUST";
 
     public const string DebugSessionInfo = "DEBUG_SESSION_INFO";
     public const string DebugSessionRunMode = "DEBUG_SESSION_RUN_MODE";

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -2015,6 +2015,8 @@ public class DcpExecutorTests
         resourceLoggerService ??= new ResourceLoggerService();
         dcpOptions ??= new DcpOptions { DashboardPath = "./dashboard" };
 
+        var options = new DistributedApplicationOptions();
+
         return new DcpExecutor(
             NullLogger<DcpExecutor>.Instance,
             NullLogger<DistributedApplication>.Instance,
@@ -2023,7 +2025,7 @@ public class DcpExecutorTests
             kubernetesService ?? new TestKubernetesService(),
             configuration,
             new Hosting.Eventing.DistributedApplicationEventing(),
-            new DistributedApplicationOptions(),
+            options,
             Options.Create(dcpOptions),
             new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
             {
@@ -2034,7 +2036,7 @@ public class DcpExecutorTests
             new DcpNameGenerator(configuration, Options.Create(dcpOptions)),
             events ?? new DcpExecutorEvents(),
             new Locations(),
-            new DeveloperCertificateService(NullLogger<DeveloperCertificateService>.Instance));
+            new DeveloperCertificateService(NullLogger<DeveloperCertificateService>.Instance, configuration, options));
     }
 
     private sealed class TestExecutableResource(string directory) : ExecutableResource("TestExecutable", "test", directory);

--- a/tests/Aspire.Hosting.Tests/Utils/TestDeveloperCertificateService.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDeveloperCertificateService.cs
@@ -6,9 +6,14 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Aspire.Hosting.Tests.Utils;
 
-public sealed class TestDeveloperCertificateService(List<X509Certificate2> certificates, bool supportsContainerTrust) : IDeveloperCertificateService
+public sealed class TestDeveloperCertificateService(List<X509Certificate2> certificates, bool supportsContainerTrust, bool trustCertificate) : IDeveloperCertificateService
 {
+    /// <inheritdoc />
     public ImmutableList<X509Certificate2> Certificates { get; } = certificates.ToImmutableList();
 
+    /// <inheritdoc />
     public bool SupportsContainerTrust => supportsContainerTrust;
+
+    /// <inheritdoc />
+    public bool TrustCertificate => trustCertificate;
 }


### PR DESCRIPTION
## Description

Implements a new `ASPIRE_TRUST_DEVELOPER_CERTIFICATE` environment variable that can be used to override the default behavior for trusting the developer certificate in services.

Fixes #12016 