### PR TITLE
Add cancellation token to `aspire add` command

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -97,7 +97,7 @@ internal sealed class AddCommand : BaseCommand
                     var packages = new List<(NuGetPackage Package, PackageChannel Channel)>();
                     var packagesLock = new object();
 
-                    await Parallel.ForEachAsync(channels, async (channel, ct) =>
+                    await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
                     {
                         var integrationPackages = await channel.GetIntegrationPackagesAsync(
                             workingDirectory: effectiveAppHostProjectFile.Directory!,


### PR DESCRIPTION
Include a cancellation token in the `aspire add` command to properly handle CTRL-C interruptions and display an error message during package searches.

Fixes #11296