### PR TITLE
Implement logging functionality for publishing activities with log le…

### DIFF
--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -320,7 +320,7 @@ internal abstract class PublishCommandBase : BaseCommand
                 // Log activity - display the log message
                 var logLevel = activity.Data.LogLevel ?? "Information";
                 var message = MarkdownToSpectreConverter.ConvertToSpectre(activity.Data.StatusText);
-                var timestamp = activity.Data.Timestamp?.ToString("HH:mm:ss", CultureInfo.InvariantCulture) ?? DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
+                var timestamp = activity.Data.Timestamp?.ToString("HH:mm:ss", CultureInfo.InvariantCulture) ?? DateTimeOffset.UtcNow.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
                 
                 // Use 3-letter prefixes for log levels
                 var logPrefix = logLevel.ToUpperInvariant() switch

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -125,6 +125,16 @@ internal sealed class PublishingActivityData
     /// Gets the input information for prompt activities, if available.
     /// </summary>
     public IReadOnlyList<PublishingPromptInput>? Inputs { get; init; }
+
+    /// <summary>
+    /// Gets the log level for log activities, if available.
+    /// </summary>
+    public string? LogLevel { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp for log activities, if available.
+    /// </summary>
+    public DateTimeOffset? Timestamp { get; init; }
 }
 
 /// <summary>
@@ -192,6 +202,7 @@ internal static class PublishingActivityTypes
     public const string Task = "task";
     public const string PublishComplete = "publish-complete";
     public const string Prompt = "prompt";
+    public const string Log = "log";
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Pipelines/IReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/IReportingStep.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Pipelines;
 
@@ -18,6 +19,13 @@ public interface IReportingStep : IAsyncDisposable
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created task.</returns>
     Task<IReportingTask> CreateTaskAsync(string statusText, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Logs a message at the specified level within this step.
+    /// </summary>
+    /// <param name="logLevel">The log level for the message.</param>
+    /// <param name="message">The message to log.</param>
+    void Log(LogLevel logLevel, string message);
 
     /// <summary>
     /// Completes the step with the specified completion text and state.

--- a/src/Aspire.Hosting/Pipelines/NullPipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/NullPipelineActivityReporter.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREPUBLISHERS001
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Pipelines;
 
@@ -32,6 +33,11 @@ internal sealed class NullPublishingStep : IReportingStep
     public Task<IReportingTask> CreateTaskAsync(string statusText, CancellationToken cancellationToken = default)
     {
         return Task.FromResult<IReportingTask>(new NullPublishingTask());
+    }
+
+    public void Log(LogLevel logLevel, string message)
+    {
+        // No-op for null implementation
     }
 
     public Task CompleteAsync(string completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)

--- a/src/Aspire.Hosting/Pipelines/PipelineStepContext.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineStepContext.cs
@@ -46,9 +46,10 @@ public sealed class PipelineStepContext
     public IServiceProvider Services => PipelineContext.Services;
 
     /// <summary>
-    /// Gets the logger for pipeline operations.
+    /// Gets the logger for pipeline operations that writes to both the pipeline logger and the step logger.
     /// </summary>
-    public ILogger Logger => PipelineContext.Logger; // Review, this should be a step logger
+    public ILogger Logger => _logger ??= new StepLogger(PipelineContext.Logger, ReportingStep);
+    private ILogger? _logger;
 
     /// <summary>
     /// Gets the cancellation token for the pipeline operation.
@@ -59,4 +60,50 @@ public sealed class PipelineStepContext
     /// Gets the output path for deployment artifacts.
     /// </summary>
     public string? OutputPath => PipelineContext.OutputPath;
+}
+
+/// <summary>
+/// An ILogger implementation that writes to both the pipeline logger and the step logger.
+/// </summary>
+[Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+internal sealed class StepLogger : ILogger
+{
+    private readonly ILogger _pipelineLogger;
+    private readonly IReportingStep _step;
+
+    public StepLogger(ILogger pipelineLogger, IReportingStep step)
+    {
+        _pipelineLogger = pipelineLogger;
+        _step = step;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        return _pipelineLogger.BeginScope(state);
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return _pipelineLogger.IsEnabled(logLevel);
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        // Log to the pipeline logger first
+        _pipelineLogger.Log(logLevel, eventId, state, exception, formatter);
+
+        // Also log to the step logger (for publishing output display)
+        var message = formatter(state, exception);
+        if (exception != null)
+        {
+            message = $"{message} {exception}";
+        }
+        
+        _step.Log(logLevel, message);
+    }
 }

--- a/src/Aspire.Hosting/Pipelines/ReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/ReportingStep.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Pipelines;
 
@@ -103,6 +104,21 @@ internal sealed class ReportingStep : IReportingStep
         }
 
         return await Reporter.CreateTaskAsync(this, statusText, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Logs a message at the specified level within this step.
+    /// </summary>
+    /// <param name="logLevel">The log level for the message.</param>
+    /// <param name="message">The message to log.</param>
+    public void Log(LogLevel logLevel, string message)
+    {
+        if (Reporter is null)
+        {
+            return;
+        }
+
+        Reporter.Log(this, logLevel, message);
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -9,6 +9,7 @@
 using Aspire.Hosting.Utils;
 using Aspire.Hosting.Tests;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Aspire.Hosting.Azure.Provisioning.Internal;
 using Aspire.Hosting.Publishing.Internal;
 using Aspire.Hosting.Testing;
@@ -1241,6 +1242,13 @@ public class AzureDeployerTests(ITestOutputHelper output)
             {
                 _reporter.CreatedTasks.Add((_title, statusText));
                 return Task.FromResult<IReportingTask>(new TestReportingTask(_reporter, statusText));
+            }
+
+            public void Log(LogLevel logLevel, string message)
+            {
+                // For testing purposes, we just track that Log was called
+                _ = logLevel;
+                _ = message;
             }
         }
 


### PR DESCRIPTION
## Description

Make it possibe to log step specific information. Right now the level is controlled by the configuration of the logger (Aspire.Hosting.Publishing.Publisher) but we can change this an allow for more control via flags from the CLI. 

Fixes #12195

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No


```C#
builder.Pipeline.AddStep("Setup", (context) =>
{
    // Log 5 messages at different levels
    context.Logger.LogTrace("This is a TRACE level message.");
    context.Logger.LogDebug("This is a DEBUG level message.");
    context.Logger.LogInformation("This is an INFORMATION level message.");
    context.Logger.LogWarning("This is a WARNING level message.");
    context.Logger.LogError("This is an ERROR level message.");

    return Task.CompletedTask;
});
```

<img width="1644" height="392" alt="image" src="https://github.com/user-attachments/assets/a686297f-4f91-4673-a4e5-aedf3d4a6c54" />

