### PR TITLE
Add more logging and support custom certificate trust for .NET projects on Mac/Linux

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionAnnotation.cs
@@ -16,7 +16,8 @@ public enum CertificateTrustScope
     /// </summary>
     Append,
     /// <summary>
-    /// Replace the default set of trusted CAs for a resource with the specified certificate authorities.
+    /// Replace the default set of trusted CAs for a resource with the specified certificate authorities. This mode
+    /// indicates that only the provided custom certificate authorities should be considered trusted by the resource.
     /// </summary>
     Override,
     /// <summary>
@@ -27,7 +28,8 @@ public enum CertificateTrustScope
     /// </summary>
     System,
     /// <summary>
-    /// Disable all custom certificate authority configuration for a resource.
+    /// Disable all custom certificate authority configuration for a resource. This indicates that the resource
+    /// should use its default certificate authority trust behavior without modification.
     /// </summary>
     None,
 }

--- a/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionResourceExtensions.cs
@@ -11,7 +11,8 @@ namespace Aspire.Hosting.ApplicationModel;
 public static class CertificateAuthorityCollectionResourceExtensions
 {
     /// <summary>
-    /// Adds a new <see cref="CertificateAuthorityCollection"/> to the application model.
+    /// Adds a new <see cref="CertificateAuthorityCollection"/> to the application model. This resource is
+    /// intended for local development run time configuration and is excluded from published artifacts.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the certificate authority collection resource.</param>

--- a/src/Aspire.Hosting/ApplicationModel/ContainerCertificateTrustCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerCertificateTrustCallbackAnnotation.cs
@@ -23,6 +23,11 @@ public sealed class ContainerCertificateTrustCallbackAnnotation(Func<ContainerCe
 public sealed class ContainerCertificateTrustCallbackAnnotationContext
 {
     /// <summary>
+    /// Gets the <see cref="DistributedApplicationExecutionContext"/> for this session.
+    /// </summary>
+    public required DistributedApplicationExecutionContext ExecutionContext { get; init; }
+
+    /// <summary>
     /// Gets the resource to which the annotation is applied.
     /// </summary>
     public required IResource Resource { get; init; }

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableCertificateTrustCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableCertificateTrustCallbackAnnotation.cs
@@ -23,6 +23,11 @@ public sealed class ExecutableCertificateTrustCallbackAnnotation(Func<Executable
 public sealed class ExecutableCertificateTrustCallbackAnnotationContext
 {
     /// <summary>
+    /// Gets the <see cref="DistributedApplicationExecutionContext"/> for this session.
+    /// </summary>
+    public required DistributedApplicationExecutionContext ExecutionContext { get; init; }
+
+    /// <summary>
     /// Gets the resource to which the annotation is applied.
     /// </summary>
     public required IResource Resource { get; init; }

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -551,7 +551,7 @@ public static class ContainerResourceBuilderExtensions
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// builder.AddContainer("mycontainer", "myimage")
-    ///        .WithDockerfileFactory("path/to/context", context => 
+    ///        .WithDockerfileFactory("path/to/context", context =>
     ///        {
     ///            return "FROM alpine:latest\nRUN echo 'Hello World'";
     ///        });
@@ -596,7 +596,7 @@ public static class ContainerResourceBuilderExtensions
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// builder.AddContainer("mycontainer", "myimage")
-    ///        .WithDockerfileFactory("path/to/context", async context => 
+    ///        .WithDockerfileFactory("path/to/context", async context =>
     ///        {
     ///            var template = await File.ReadAllTextAsync("template.dockerfile", context.CancellationToken);
     ///            return template.Replace("{{VERSION}}", "1.0");
@@ -762,7 +762,7 @@ public static class ContainerResourceBuilderExtensions
     /// <code language="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
-    /// builder.AddDockerfileBuilder("mycontainer", "path/to/context", context => 
+    /// builder.AddDockerfileBuilder("mycontainer", "path/to/context", context =>
     /// {
     ///     context.Builder.From("alpine:latest")
     ///         .WorkDir("/app")
@@ -809,7 +809,7 @@ public static class ContainerResourceBuilderExtensions
     /// <code language="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
-    /// builder.AddDockerfileBuilder("mycontainer", "path/to/context", context => 
+    /// builder.AddDockerfileBuilder("mycontainer", "path/to/context", context =>
     /// {
     ///     context.Builder.From("node:18")
     ///         .WorkDir("/app")
@@ -1001,8 +1001,9 @@ public static class ContainerResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a <see cref="ContainerCertificateTrustCallbackAnnotation"/> to the resource annotations to associate a callback that is invoked when a certificate needs to
-    /// configure itself for custom certificate trust.
+    /// Adds a <see cref="ExecutableCertificateTrustCallbackAnnotation"/> to the resource annotations to associate a callback that is
+    /// invoked when a container resource needs to configure itself for custom certificate trust. This is only supported in run mode;
+    /// certificate trust customization is not supported in publish or deploy.
     /// </summary>
     /// <typeparam name="TResource">The type of the resource.</typeparam>
     /// <param name="builder">The resource builder.</param>
@@ -1244,7 +1245,7 @@ public static class ContainerResourceBuilderExtensions
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// builder.AddContainer("mycontainer", "myimage")
-    ///        .WithDockerfileBuilder("path/to/context", context => 
+    ///        .WithDockerfileBuilder("path/to/context", context =>
     ///        {
     ///            context.Builder.From("alpine:latest")
     ///                .WorkDir("/app")
@@ -1349,7 +1350,7 @@ public static class ContainerResourceBuilderExtensions
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// builder.AddContainer("mycontainer", "myimage")
-    ///        .WithDockerfileBuilder("path/to/context", context => 
+    ///        .WithDockerfileBuilder("path/to/context", context =>
     ///        {
     ///            context.Builder.From("node:18")
     ///                .WorkDir("/app")

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1270,8 +1270,16 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         (var certificateArgs, var certificateEnv, var applyCustomCertificateConfig) = await BuildExecutableCertificateAuthorityTrustAsync(er.ModelResource, spec.Args ?? [], spec.Env, cancellationToken).ConfigureAwait(false);
         if (applyCustomCertificateConfig)
         {
-            spec.Args = (spec.Args ?? []).Concat(certificateArgs).ToList();
-            spec.Env.AddRange(certificateEnv);
+            if (certificateArgs.Count > 0)
+            {
+                spec.Args ??= [];
+                spec.Args.AddRange(certificateArgs);
+            }
+            if (certificateEnv.Count > 0)
+            {
+                spec.Env ??= [];
+                spec.Env.AddRange(certificateEnv);
+            }
         }
         else
         {
@@ -1537,8 +1545,16 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         (var certificateArgs, var certificateEnv, var certificateFiles, var applyCustomCertificateConfig) = await BuildContainerCertificateAuthorityTrustAsync(modelContainerResource, spec.Args ?? [], spec.Env ?? [], cancellationToken).ConfigureAwait(false);
         if (applyCustomCertificateConfig)
         {
-            spec.Args = (spec.Args ?? []).Concat(certificateArgs).ToList();
-            spec.Env = (spec.Env ?? []).Concat(certificateEnv).ToList();
+            if (certificateArgs.Count > 0)
+            {
+                spec.Args ??= [];
+                spec.Args.AddRange(certificateArgs);
+            }
+            if (certificateEnv.Count > 0)
+            {
+                spec.Env ??= [];
+                spec.Env.AddRange(certificateEnv);
+            }
             spec.CreateFiles.AddRange(certificateFiles);
         }
         else

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1117,7 +1117,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         CancellationToken cancellationToken)
     {
         var executablesList = executables.ToList();
-        
+
         async Task CreateResourceExecutablesAsyncCore(IResource resource, IEnumerable<AppResource> executables, CancellationToken cancellationToken)
         {
             var resourceLogger = _loggerService.GetLogger(resource);
@@ -1187,7 +1187,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
         var tasks = new List<Task>();
         var groups = executablesList.GroupBy(e => e.ModelResource).ToList();
-        
+
         foreach (var group in groups)
         {
             var groupList = group.ToList();
@@ -2100,6 +2100,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
         var context = new ExecutableCertificateTrustCallbackAnnotationContext
         {
+            ExecutionContext = _executionContext,
             Resource = modelResource,
             Scope = scope,
             Certificates = certificates,
@@ -2231,6 +2232,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
         var context = new ContainerCertificateTrustCallbackAnnotationContext
         {
+            ExecutionContext = _executionContext,
             Resource = modelResource,
             Scope = scope,
             Certificates = certificates,

--- a/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class ExecutableResourceBuilderExtensions
     /// <remarks>
     /// You can run any executable command using its full path.
     /// As a security feature, Aspire doesn't run executable unless the command is located in a path listed in the PATH environment variable.
-    /// <para/> 
+    /// <para/>
     /// To run an executable file that's in the current directory, specify the full path or use the relative path <c>./</c> to represent the current directory.
     /// </remarks>
     public static IResourceBuilder<ExecutableResource> AddExecutable(this IDistributedApplicationBuilder builder, [ResourceName] string name, string command, string workingDirectory, params string[]? args)
@@ -180,7 +180,7 @@ public static class ExecutableResourceBuilderExtensions
                 Command = command,
                 WorkingDirectory = string.Empty
             };
-            builder.Resource.Annotations.Add(executableAnnotation);            
+            builder.Resource.Annotations.Add(executableAnnotation);
         }
 
         return builder;
@@ -205,6 +205,23 @@ public static class ExecutableResourceBuilderExtensions
         }
 
         throw new InvalidOperationException($"The resource '{builder.Resource.Name}' is missing the ExecutableAnnotation");
+    }
+
+    /// <summary>
+    /// Adds a <see cref="ExecutableCertificateTrustCallbackAnnotation"/> to the resource annotations to associate a callback that is invoked when a resource needs to
+    /// configure itself for custom certificate trust.
+    /// </summary>
+    /// <typeparam name="TResource">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="callback">The callback to invoke when a resource needs to configure itself for custom certificate trust.</param>
+    /// <returns>The updated resource builder.</returns>
+    public static IResourceBuilder<TResource> WithExecutableCertificateTrustCallback<TResource>(this IResourceBuilder<TResource> builder, Func<ExecutableCertificateTrustCallbackAnnotationContext, Task> callback)
+        where TResource : ExecutableResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        return builder.WithAnnotation(new ExecutableCertificateTrustCallbackAnnotation(callback), ResourceAnnotationMutationBehavior.Replace);
     }
 
     // Allows us to mirror annotations from ExecutableResource to ContainerResource

--- a/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
@@ -208,8 +208,9 @@ public static class ExecutableResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a <see cref="ExecutableCertificateTrustCallbackAnnotation"/> to the resource annotations to associate a callback that is invoked when a resource needs to
-    /// configure itself for custom certificate trust.
+    /// Adds a <see cref="ExecutableCertificateTrustCallbackAnnotation"/> to the resource annotations to associate a callback that
+    /// is invoked when an executable resource needs to configure itself for custom certificate trust. This is only supported in run mode;
+    /// certificate trust customization is not supported in publish or deploy.
     /// </summary>
     /// <typeparam name="TResource">The type of the resource.</typeparam>
     /// <param name="builder">The resource builder.</param>

--- a/src/Aspire.Hosting/ExecutableResourceExtensions.cs
+++ b/src/Aspire.Hosting/ExecutableResourceExtensions.cs
@@ -21,21 +21,4 @@ public static class ExecutableResourceExtensions
 
         return model.Resources.OfType<ExecutableResource>();
     }
-
-    /// <summary>
-    /// Adds a <see cref="ExecutableCertificateTrustCallbackAnnotation"/> to the resource annotations to associate a callback that is invoked when a certificate needs to
-    /// configure itself for custom certificate trust.
-    /// </summary>
-    /// <typeparam name="TResource">The type of the resource.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="callback">The callback to invoke when a resource needs to configure itself for custom certificate trust.</param>
-    /// <returns>The updated resource builder.</returns>
-    public static IResourceBuilder<TResource> WithExecutableCertificateTrustCallback<TResource>(this IResourceBuilder<TResource> builder, Func<ExecutableCertificateTrustCallbackAnnotationContext, Task> callback)
-        where TResource : ExecutableResource
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(callback);
-
-        return builder.WithAnnotation(new ExecutableCertificateTrustCallbackAnnotation(callback), ResourceAnnotationMutationBehavior.Replace);
-    }
 }

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -865,8 +865,9 @@ public static class ProjectResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a <see cref="ExecutableCertificateTrustCallbackAnnotation"/> to the resource annotations to associate a callback that is invoked when a resource needs to
-    /// configure itself for custom certificate trust.
+    /// Adds a <see cref="ExecutableCertificateTrustCallbackAnnotation"/> to the resource annotations to associate a callback that
+    /// is invoked when a project resource needs to configure itself for custom certificate trust. This is only supported in run mode;
+    /// certificate trust customization is not supported in publish or deploy.
     /// </summary>
     /// <typeparam name="TResource">The type of the resource.</typeparam>
     /// <param name="builder">The resource builder.</param>

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -2148,6 +2148,7 @@ public static class ResourceBuilderExtensions
 
     /// <summary>
     /// Adds a <see cref="CertificateAuthorityCollectionAnnotation"/> to the resource annotations to associate a certificate authority collection with the resource.
+    /// This is used to configure additional trusted certificate authorities for the resource at run time.
     /// </summary>
     /// <typeparam name="TResource">The type of the resource.</typeparam>
     /// <param name="builder">The resource builder.</param>
@@ -2240,7 +2241,8 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Sets the <see cref="CertificateTrustScope"/> for custom certificate authorities associated with the resource.
+    /// Sets the <see cref="CertificateTrustScope"/> for custom certificate authorities associated with the resource. The scope
+    /// specifies how custom certificate authorities should be applied to a resource at run time in local development scenarios.
     /// </summary>
     /// <typeparam name="TResource">The type of the resource.</typeparam>
     /// <param name="builder">The resource builder.</param>

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -108,7 +108,7 @@ public class DcpExecutorTests
     }
 
     [Theory]
-    [InlineData(ExecutionType.IDE, false, new string[] { }, new string[] { "--test1", "--test2" })]
+    [InlineData(ExecutionType.IDE, false, null, new string[] { "--test1", "--test2" })]
     [InlineData(ExecutionType.IDE, true, new string[] { "--withargs-test" }, new string[] { "--withargs-test" })]
     [InlineData(ExecutionType.Process, false, new string[] { "--test1", "--test2" }, new string[] { "--test1", "--test2" })]
     [InlineData(ExecutionType.Process, true, new string[] { "--", "--test1", "--test2", "--withargs-test" }, new string[] { "--", "--test1", "--test2", "--withargs-test" })]


### PR DESCRIPTION
## Description

On Mac and Linux it's possible to apply custom certificate trust configuration to .NET projects, so this PR adds the required configuration. The functionality doesn't work on Windows, so in that case it's disabled by default by setting `CertificateTrustScope` to `None`.

Added logging in cases where the certificate trust settings can't be fully applied as configured for a given resource.