### PR TITLE
Set default target port for app service endpoints if not specified

### DIFF
--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -99,7 +99,9 @@ internal sealed class AzureAppServiceWebsiteContext(
             throw new NotSupportedException("App Service does not support resources with multiple external endpoints.");
         }
 
-        _targetPort = targetPortEndpoints.FirstOrDefault();
+        // If the target port is specified, use it; otherwise, allocate a default port
+        // There can only be a single target port with an HTTP binding in app service
+        _targetPort = targetPortEndpoints.FirstOrDefault() ?? 8000;
 
         foreach (var endpoint in endpoints)
         {
@@ -113,7 +115,7 @@ internal sealed class AzureAppServiceWebsiteContext(
                 Scheme: endpoint.UriScheme,
                 Host: HostName,
                 Port: endpoint.UriScheme == "https" ? 443 : 80,
-                TargetPort: endpoint.TargetPort,
+                TargetPort: endpoint.TargetPort ?? _targetPort,
                 IsHttpIngress: true,
                 External: true); // All App Service endpoints are external
         }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -585,7 +585,7 @@ public class AzureAppServiceTests
     }
 
     [Fact]
-    public async Task AddAppServiceWithoutTargetPortUsesDefaultPort()
+    public async Task AddAppServiceProjectWithoutTargetPortUsesContainerPort()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
@@ -610,6 +610,38 @@ public class AzureAppServiceTests
 
         var (manifest, bicep) = await GetManifestWithBicep(resource);
 
+        // For project resources without explicit target port, should use container port reference
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AddAppServiceContainerWithoutTargetPortUsesDefaultPort()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureAppServiceEnvironment("env");
+
+        // Add container with endpoints but no target port specified
+        var container = builder.AddDockerfile("container1", "./myimage")
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        container.Resource.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        // For non-project resources without explicit target port, should default to 8000
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep");
     }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceContainerWithoutTargetPortUsesDefaultPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceContainerWithoutTargetPortUsesDefaultPort.verified.bicep
@@ -1,0 +1,94 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_planid string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param env_outputs_azure_container_registry_managed_identity_client_id string
+
+param container1_containerimage string
+
+param env_outputs_azure_app_service_dashboard_uri string
+
+param env_outputs_azure_website_contributor_managed_identity_id string
+
+param env_outputs_azure_website_contributor_managed_identity_principal_id string
+
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: container1_containerimage
+    isMain: true
+    targetPort: '8000'
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+resource webapp 'Microsoft.Web/sites@2024-11-01' = {
+  name: take('${toLower('container1')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: '8000'
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'container1'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}
+
+resource container1_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceContainerWithoutTargetPortUsesDefaultPort.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceContainerWithoutTargetPortUsesDefaultPort.verified.json
@@ -1,0 +1,14 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "container1.module.bicep",
+  "params": {
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "container1_containerimage": "{container1.containerImage}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithoutTargetPortUsesContainerPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithoutTargetPortUsesContainerPort.verified.bicep
@@ -1,0 +1,116 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_planid string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param env_outputs_azure_container_registry_managed_identity_client_id string
+
+param project1_containerimage string
+
+param project1_containerport string
+
+param env_outputs_azure_app_service_dashboard_uri string
+
+param env_outputs_azure_website_contributor_managed_identity_id string
+
+param env_outputs_azure_website_contributor_managed_identity_principal_id string
+
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: project1_containerimage
+    isMain: true
+    targetPort: project1_containerport
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+resource webapp 'Microsoft.Web/sites@2024-11-01' = {
+  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: project1_containerport
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: project1_containerport
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'project1'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}
+
+resource project1_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithoutTargetPortUsesContainerPort.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithoutTargetPortUsesContainerPort.verified.json
@@ -1,0 +1,15 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "project1.module.bicep",
+  "params": {
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "project1_containerimage": "{project1.containerImage}",
+    "project1_containerport": "{project1.containerPort}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -19,6 +19,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
     authType: 'UserAssigned'
     image: project2_containerimage
     isMain: true
+    targetPort: project2_containerport
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -35,6 +36,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: project2_containerport
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -29,6 +29,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
       '--myarg'
       'myvalue'
     ], ' ')
+    targetPort: project2_containerport
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -45,6 +46,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: project2_containerport
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithoutTargetPortUsesDefaultPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithoutTargetPortUsesDefaultPort.verified.bicep
@@ -1,0 +1,114 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_planid string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param env_outputs_azure_container_registry_managed_identity_client_id string
+
+param project1_containerimage string
+
+param env_outputs_azure_app_service_dashboard_uri string
+
+param env_outputs_azure_website_contributor_managed_identity_id string
+
+param env_outputs_azure_website_contributor_managed_identity_principal_id string
+
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: project1_containerimage
+    isMain: true
+    targetPort: '8000'
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+resource webapp 'Microsoft.Web/sites@2024-11-01' = {
+  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: '8000'
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: '8000'
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'project1'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}
+
+resource project1_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithoutTargetPortUsesDefaultPort.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithoutTargetPortUsesDefaultPort.verified.json
@@ -1,0 +1,14 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "project1.module.bicep",
+  "params": {
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "project1_containerimage": "{project1.containerImage}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -25,6 +25,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
     authType: 'UserAssigned'
     image: api_containerimage
     isMain: true
+    targetPort: api_containerport
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -41,6 +42,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: api_containerport
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferencesAreResolvedAcrossProjects.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferencesAreResolvedAcrossProjects.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -25,6 +25,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
     authType: 'UserAssigned'
     image: project2_containerimage
     isMain: true
+    targetPort: project2_containerport
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -41,6 +42,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: project2_containerport
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -10,6 +10,8 @@ param env_outputs_azure_container_registry_managed_identity_id string
 param env_outputs_azure_container_registry_managed_identity_client_id string
 
 param api_containerimage string
+
+param api_containerport string
 
 param mydb_kv_outputs_name string
 
@@ -52,6 +54,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
     authType: 'UserAssigned'
     image: api_containerimage
     isMain: true
+    targetPort: api_containerport
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -69,6 +72,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: api_containerport
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "type": "azure.bicep.v0",
   "path": "api.module.bicep",
   "params": {
@@ -7,6 +7,7 @@
     "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
     "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
     "api_containerimage": "{api.containerImage}",
+    "api_containerport": "{api.containerPort}",
     "mydb_kv_outputs_name": "{mydb-kv.outputs.name}",
     "kvName": "{kvName.value}",
     "sharedRg": "{sharedRg.value}",

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.ResourceWithProbes.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.ResourceWithProbes.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -25,6 +25,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
     authType: 'UserAssigned'
     image: project1_containerimage
     isMain: true
+    targetPort: project1_containerport
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -41,6 +42,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: project1_containerport
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.UnknownManifestExpressionProviderIsHandledWithAllocateParameter.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.UnknownManifestExpressionProviderIsHandledWithAllocateParameter.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -27,6 +27,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
     authType: 'UserAssigned'
     image: api_containerimage
     isMain: true
+    targetPort: api_containerport
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -43,6 +44,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: api_containerport
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#00.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param appservice_outputs_azure_container_registry_endpoint string
@@ -10,6 +10,8 @@ param appservice_outputs_azure_container_registry_managed_identity_id string
 param appservice_outputs_azure_container_registry_managed_identity_client_id string
 
 param myapp_containerimage string
+
+param myapp_containerport string
 
 param myidentity_outputs_id string
 
@@ -27,6 +29,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2024-11-01' = {
     authType: 'UserAssigned'
     image: myapp_containerimage
     isMain: true
+    targetPort: myapp_containerport
     userManagedIdentityClientId: appservice_outputs_azure_container_registry_managed_identity_client_id
   }
   parent: webapp
@@ -44,6 +47,10 @@ resource webapp 'Microsoft.Web/sites@2024-11-01' = {
       acrUseManagedIdentityCreds: true
       acrUserManagedIdentityID: appservice_outputs_azure_container_registry_managed_identity_client_id
       appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: myapp_containerport
+        }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
           value: 'true'


### PR DESCRIPTION
## Description

Fallback to port 8000 or project port if there's no target port set.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
