### PR TITLE
fade apphost logs, put dashboard/codespaces in green in console

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -37,6 +37,9 @@
     <trans-unit id="aspire-vscode.strings.csharpSupportNotEnabled">
       <source xml:lang="en">C# support is not enabled in this workspace. This project should have started through the Aspire CLI.</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.codespaces">
+      <source xml:lang="en">Codespaces</source>
+    </trans-unit>
     <trans-unit id="aspire-vscode.strings.codespacesUrl">
       <source xml:lang="en">Codespaces: {0}</source>
     </trans-unit>
@@ -48,6 +51,9 @@
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.dcpServerNotInitialized">
       <source xml:lang="en">DCP server not initialized - cannot forward debug output.</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.dashboard">
+      <source xml:lang="en">Dashboard</source>
     </trans-unit>
     <trans-unit id="command.debugAppHost">
       <source xml:lang="en">Debug Aspire apphost</source>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -64,5 +64,7 @@
   "aspire-vscode.strings.processExceptionOccurred": "Encountered an exception ({0}) while running the following command: {1}.",
   "aspire-vscode.strings.failedToStartDebugSession": "Failed to start debug session.",
   "aspire-vscode.strings.invalidLaunchConfiguration": "Invalid launch configuration for {0}.",
-  "aspire-vscode.strings.noAppHostInWorkspace": "No apphost found in the Aspire settings file."
+  "aspire-vscode.strings.noAppHostInWorkspace": "No apphost found in the Aspire settings file.",
+  "aspire-vscode.strings.dashboard": "Dashboard",
+  "aspire-vscode.strings.codespaces": "Codespaces"
 }

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -51,3 +51,5 @@ export const processExceptionOccurred = (error: string, command: string) => vsco
 export const failedToStartDebugSession = vscode.l10n.t('Failed to start debug session.');
 export const invalidLaunchConfiguration = (projectPath: string) => vscode.l10n.t('Invalid launch configuration for {0}.', projectPath);
 export const noAppHostInWorkspace = vscode.l10n.t('No apphost found in the Aspire settings file.');
+export const dashboard = vscode.l10n.t('Dashboard');
+export const codespaces = vscode.l10n.t('Codespaces');

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -2,10 +2,10 @@ import { MessageConnection } from 'vscode-jsonrpc';
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import { getRelativePathToWorkspace, isFolderOpenInWorkspace } from '../utils/workspace';
-import { yesLabel, noLabel, directLink, codespacesLink, openAspireDashboard, failedToShowPromptEmpty, incompatibleAppHostError, aspireHostingSdkVersion, aspireCliVersion, requiredCapability, fieldRequired, aspireDebugSessionNotInitialized, errorMessage, failedToStartDebugSession } from '../loc/strings';
+import { yesLabel, noLabel, directLink, codespacesLink, openAspireDashboard, failedToShowPromptEmpty, incompatibleAppHostError, aspireHostingSdkVersion, aspireCliVersion, requiredCapability, fieldRequired, aspireDebugSessionNotInitialized, errorMessage, failedToStartDebugSession, dashboard, codespaces } from '../loc/strings';
 import { ICliRpcClient } from './rpcClient';
 import { ProgressNotifier } from './progressNotifier';
-import { formatText } from '../utils/strings';
+import { applyTextStyle, formatText } from '../utils/strings';
 import { extensionLogOutputChannel } from '../utils/logging';
 import { AspireExtendedDebugConfiguration, EnvVar } from '../dcp/types';
 import { AspireDebugSession } from '../debugger/AspireDebugSession';
@@ -33,7 +33,7 @@ export interface IInteractionService {
     stopDebugging: () => void;
     notifyAppHostStartupCompleted: () => void;
     startDebugSession: (workingDirectory: string, projectFile: string | null, debug: boolean) => Promise<void>;
-    writeDebugSessionMessage: (message: string, stdout: boolean) => void;
+    writeDebugSessionMessage: (message: string, stdout: boolean, textStyle?: string) => void;
 }
 
 type CSLogLevel = 'Trace' | 'Debug' | 'Information' | 'Warn' | 'Error' | 'Critical';
@@ -248,6 +248,12 @@ export class InteractionService implements IInteractionService {
     async displayDashboardUrls(dashboardUrls: DashboardUrls) {
         extensionLogOutputChannel.info(`Displaying dashboard URLs: ${JSON.stringify(dashboardUrls)}`);
 
+        this.writeDebugSessionMessage(dashboard + ': ' + dashboardUrls.BaseUrlWithLoginToken, true, '\x1b[32m');
+
+        if (dashboardUrls.CodespacesUrlWithLoginToken) {
+            this.writeDebugSessionMessage(codespaces + ': ' + dashboardUrls.CodespacesUrlWithLoginToken, true, '\x1b[32m');
+        }
+
         const actions: vscode.MessageItem[] = [
             { title: directLink }
         ];
@@ -340,14 +346,14 @@ export class InteractionService implements IInteractionService {
         }
     }
 
-    writeDebugSessionMessage(message: string, stdout: boolean) {
+    writeDebugSessionMessage(message: string, stdout: boolean, textStyle: string | null | undefined) {
         const debugSession = this._getAspireDebugSession();
         if (!debugSession) {
             extensionLogOutputChannel.warn('Attempted to write to debug session, but no active debug session exists.');
             return;
         }
 
-        debugSession.sendMessage(message, true, stdout ? 'stdout' : 'stderr');
+        debugSession.sendMessage(applyTextStyle(message, textStyle), true, stdout ? 'stdout' : 'stderr');
     }
 
     async launchAppHost(projectFile: string, args: string[], environment: EnvVar[], debug: boolean): Promise<void> {

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -9,6 +9,7 @@ import { applyTextStyle, formatText } from '../utils/strings';
 import { extensionLogOutputChannel } from '../utils/logging';
 import { AspireExtendedDebugConfiguration, EnvVar } from '../dcp/types';
 import { AspireDebugSession } from '../debugger/AspireDebugSession';
+import { AnsiColors } from '../utils/AspireTerminalProvider';
 
 export interface IInteractionService {
     showStatus: (statusText: string | null) => void;
@@ -248,10 +249,10 @@ export class InteractionService implements IInteractionService {
     async displayDashboardUrls(dashboardUrls: DashboardUrls) {
         extensionLogOutputChannel.info(`Displaying dashboard URLs: ${JSON.stringify(dashboardUrls)}`);
 
-        this.writeDebugSessionMessage(dashboard + ': ' + dashboardUrls.BaseUrlWithLoginToken, true, '\x1b[32m');
+        this.writeDebugSessionMessage(dashboard + ': ' + dashboardUrls.BaseUrlWithLoginToken, true, AnsiColors.Green);
 
         if (dashboardUrls.CodespacesUrlWithLoginToken) {
-            this.writeDebugSessionMessage(codespaces + ': ' + dashboardUrls.CodespacesUrlWithLoginToken, true, '\x1b[32m');
+            this.writeDebugSessionMessage(codespaces + ': ' + dashboardUrls.CodespacesUrlWithLoginToken, true, AnsiColors.Green);
         }
 
         const actions: vscode.MessageItem[] = [

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -5,6 +5,10 @@ import { RpcServerConnectionInfo } from '../server/AspireRpcServer';
 import { DcpServerConnectionInfo } from '../dcp/types';
 import { getRunSessionInfo, getSupportedCapabilities } from '../capabilities';
 
+export const enum AnsiColors {
+    Green = '\x1b[32m'
+}
+
 export interface AspireTerminal {
     terminal: vscode.Terminal;
     dispose: () => void;

--- a/extension/src/utils/strings.ts
+++ b/extension/src/utils/strings.ts
@@ -23,3 +23,11 @@ export function formatText(str: string): string {
 export function removeTrailingNewline(str: string): string {
   return str.replace(/(\r\n|\n)$/, '');
 }
+
+export function applyTextStyle(text: string, style: string | null | undefined): string {
+  if (!style) {
+    return text;
+  }
+
+  return `${style}${text}\x1b[0m`;
+}

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -44,7 +44,7 @@ internal interface IExtensionBackchannel
     Task NotifyAppHostStartupCompletedAsync(CancellationToken cancellationToken);
     Task StartDebugSessionAsync(string workingDirectory, string? projectFile, bool debug, CancellationToken cancellationToken);
     Task DisplayPlainTextAsync(string text, CancellationToken cancellationToken);
-    Task WriteDebugSessionMessageAsync(string message, bool stdout, CancellationToken cancellationToken);
+    Task WriteDebugSessionMessageAsync(string message, bool stdout, string? textStyle, CancellationToken cancellationToken);
 }
 
 internal sealed class ExtensionBackchannel : IExtensionBackchannel
@@ -596,7 +596,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
             cancellationToken);
     }
 
-    public async Task WriteDebugSessionMessageAsync(string message, bool stdout, CancellationToken cancellationToken)
+    public async Task WriteDebugSessionMessageAsync(string message, bool stdout, string? textStyle, CancellationToken cancellationToken)
     {
         await ConnectAsync(cancellationToken);
 
@@ -608,7 +608,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
         await rpc.InvokeWithCancellationAsync(
             "writeDebugSessionMessage",
-            [_token, message, stdout],
+            [_token, message, stdout, textStyle],
             cancellationToken);
     }
 

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -20,7 +20,7 @@ internal interface IExtensionInteractionService : IInteractionService
     void NotifyAppHostStartupCompleted();
     void DisplayConsolePlainText(string message);
     Task StartDebugSessionAsync(string workingDirectory, string? projectFile, bool debug);
-    void WriteDebugSessionMessage(string message, bool stdout);
+    void WriteDebugSessionMessage(string message, bool stdout, string? textStyle);
 }
 
 internal class ExtensionInteractionService : IExtensionInteractionService
@@ -339,9 +339,9 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         return Backchannel.StartDebugSessionAsync(workingDirectory, projectFile, debug, _cancellationToken);
     }
 
-    public void WriteDebugSessionMessage(string message, bool stdout)
+    public void WriteDebugSessionMessage(string message, bool stdout, string? textStyle)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(message.RemoveSpectreFormatting(), stdout, _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.WriteDebugSessionMessageAsync(message.RemoveSpectreFormatting(), stdout, textStyle, _cancellationToken));
         Debug.Assert(result);
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionBackchannel.cs
@@ -79,7 +79,7 @@ internal sealed class TestExtensionBackchannel : IExtensionBackchannel
     public Func<string, Task>? DisplayPlainTextAsyncCallback { get; set; }
 
     public TaskCompletionSource? WriteDebugSessionMessageAsyncCalled { get; set; }
-    public Func<string, bool, Task>? WriteDebugSessionMessageAsyncCallback { get; set; }
+    public Func<string, bool, string?, Task>? WriteDebugSessionMessageAsyncCallback { get; set; }
 
     public Task ConnectAsync(CancellationToken cancellationToken)
     {
@@ -259,11 +259,11 @@ internal sealed class TestExtensionBackchannel : IExtensionBackchannel
             : Task.CompletedTask;
     }
 
-    public Task WriteDebugSessionMessageAsync(string message, bool stdout, CancellationToken cancellationToken)
+    public Task WriteDebugSessionMessageAsync(string message, bool stdout, string? textStyle, CancellationToken cancellationToken)
     {
         WriteDebugSessionMessageAsyncCalled?.SetResult();
         return WriteDebugSessionMessageAsyncCallback != null
-            ? WriteDebugSessionMessageAsyncCallback.Invoke(message, stdout)
+            ? WriteDebugSessionMessageAsyncCallback.Invoke(message, stdout, textStyle)
             : Task.CompletedTask;
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -95,7 +95,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         return Task.CompletedTask;
     }
 
-    public void WriteDebugSessionMessage(string message, bool stdout)
+    public void WriteDebugSessionMessage(string message, bool stdout, string? textStyle)
     {
     }
 


### PR DESCRIPTION
## Description

Fixes #12255

<img width="805" height="251" alt="image" src="https://github.com/user-attachments/assets/695f29a7-16a1-43c6-bd03-637fb62974b9" />

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
