### PR TITLE
Change KnownResourceStateStyle.Warn state string from 'warn' to 'warning'

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -353,7 +353,7 @@ public static class KnownResourceStateStyles
     /// <summary>
     /// The warn state. Useful for showing warnings.
     /// </summary>
-    public static readonly string Warn = "warn";
+    public static readonly string Warn = "warning";
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -351,7 +351,7 @@ public static class KnownResourceStateStyles
     public static readonly string Info = "info";
 
     /// <summary>
-    /// The warn state. Useful for showing warnings.
+    /// The warning state. Useful for showing warnings.
     /// </summary>
     public static readonly string Warn = "warning";
 }


### PR DESCRIPTION
## Description

The `KnownResourceStateStyle` has a wrong value of `warn`, where the dashboard is expecting `warning`. I guess we might want to change `KnownResourceStateStyle.Warn` then also to `Warning`? Or the other way around and make the dashboard look for `"warn"` instead of `"warning"` let me know if you want to change it the other way around.

https://github.com/dotnet/aspire/blob/main/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs#L77
