### PR TITLE
Add logging capabilities to the publishing pipeline

### DIFF
--- a/src/Aspire.Cli/Commands/DeployCommand.cs
+++ b/src/Aspire.Cli/Commands/DeployCommand.cs
@@ -47,6 +47,20 @@ internal sealed class DeployCommand : PublishCommandBase
             baseArgs.AddRange(["--clear-cache", "true"]);
         }
 
+        // Add --log-level and --envionment flags if specified
+        var logLevel = parseResult.GetValue(_logLevelOption);
+
+        if (!string.IsNullOrEmpty(logLevel))
+        {
+            baseArgs.AddRange(["--log-level", logLevel!]);
+        }
+
+        var environment = parseResult.GetValue(_environmentOption);
+        if (!string.IsNullOrEmpty(environment))
+        {
+            baseArgs.AddRange(["--environment", environment!]);
+        }
+
         baseArgs.AddRange(unmatchedTokens);
 
         return [.. baseArgs];

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -55,6 +55,20 @@ internal sealed class PublishCommand : PublishCommandBase
 
         baseArgs.AddRange(["--output-path", targetPath]);
 
+        // Add --log-level and --envionment flags if specified
+        var logLevel = parseResult.GetValue(_logLevelOption);
+
+        if (!string.IsNullOrEmpty(logLevel))
+        {
+            baseArgs.AddRange(["--log-level", logLevel!]);
+        }
+
+        var environment = parseResult.GetValue(_environmentOption);
+        if (!string.IsNullOrEmpty(environment))
+        {
+            baseArgs.AddRange(["--environment", environment!]);
+        }
+
         baseArgs.AddRange(unmatchedTokens);
 
         return [.. baseArgs];

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -149,8 +149,6 @@ internal abstract class PublishCommandBase : BaseCommand
                 env[KnownConfigNames.WaitForDebugger] = "true";
             }
 
-
-
             if (isSingleFileAppHost)
             {
                 // TODO: Add logic to read SDK version from *.cs file.

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -70,6 +70,18 @@ internal abstract class PublishCommandBase : BaseCommand
         };
         Options.Add(outputPath);
 
+        var logLevel = new Option<string?>("--log-level")
+        {
+            Description = "Set the minimum log level for pipeline logging (trace, debug, information, warning, error, critical)"
+        };
+        Options.Add(logLevel);
+
+        var environment = new Option<string?>("--environment", "-e")
+        {
+            Description = "The environment to use for the operation. The default is 'Production'."
+        };
+        Options.Add(environment);
+
         // In the publish and deploy commands we forward all unrecognized tokens
         // through to the underlying tooling when we launch the app host.
         TreatUnmatchedTokensAsErrors = false;
@@ -135,6 +147,18 @@ internal abstract class PublishCommandBase : BaseCommand
             if (waitForDebugger)
             {
                 env[KnownConfigNames.WaitForDebugger] = "true";
+            }
+
+            var logLevel = parseResult.GetValue<string?>("--log-level");
+            if (!string.IsNullOrEmpty(logLevel))
+            {
+                env["Publishing:LogLevel"] = logLevel;
+            }
+
+            var environment = parseResult.GetValue<string?>("--environment");
+            if (!string.IsNullOrEmpty(environment))
+            {
+                env["ASPNETCORE_ENVIRONMENT"] = environment;
             }
 
             if (isSingleFileAppHost)

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -72,7 +72,7 @@ internal abstract class PublishCommandBase : BaseCommand
 
         var logLevel = new Option<string?>("--log-level")
         {
-            Description = "Set the minimum log level for pipeline logging (trace, debug, information, warning, error, critical)"
+            Description = "Set the minimum log level for pipeline logging (trace, debug, information, warning, error, critical). The default is 'information'."
         };
         Options.Add(logLevel);
 

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -29,6 +29,16 @@ internal abstract class PublishCommandBase : BaseCommand
     private readonly IFeatures _features;
     private readonly ICliHostEnvironment _hostEnvironment;
 
+    protected readonly Option<string?> _logLevelOption = new("--log-level")
+    {
+        Description = "Set the minimum log level for pipeline logging (trace, debug, information, warning, error, critical). The default is 'information'."
+    };
+
+    protected readonly Option<string?> _environmentOption = new("--environment", "-e")
+    {
+        Description = "The environment to use for the operation. The default is 'Production'."
+    };
+
     protected abstract string OperationCompletedPrefix { get; }
     protected abstract string OperationFailedPrefix { get; }
 
@@ -70,17 +80,8 @@ internal abstract class PublishCommandBase : BaseCommand
         };
         Options.Add(outputPath);
 
-        var logLevel = new Option<string?>("--log-level")
-        {
-            Description = "Set the minimum log level for pipeline logging (trace, debug, information, warning, error, critical). The default is 'information'."
-        };
-        Options.Add(logLevel);
-
-        var environment = new Option<string?>("--environment", "-e")
-        {
-            Description = "The environment to use for the operation. The default is 'Production'."
-        };
-        Options.Add(environment);
+        Options.Add(_logLevelOption);
+        Options.Add(_environmentOption);
 
         // In the publish and deploy commands we forward all unrecognized tokens
         // through to the underlying tooling when we launch the app host.
@@ -360,9 +361,9 @@ internal abstract class PublishCommandBase : BaseCommand
                 // Make debug and trace logs more subtle
                 var formattedMessage = logLevel.ToUpperInvariant() switch
                 {
-                    "DEBUG" => $"[{timestamp}] [dim][[{logPrefix}]] {message}[/]",
-                    "TRACE" => $"[{timestamp}] [dim][[{logPrefix}]] {message}[/]",
-                    _ => $"[{timestamp}] [[{logPrefix}]] {message}"
+                    "DEBUG" => $"[[{timestamp}]] [dim][[{logPrefix}]] {message}[/]",
+                    "TRACE" => $"[[{timestamp}]] [dim][[{logPrefix}]] {message}[/]",
+                    _ => $"[[{timestamp}]] [[{logPrefix}]] {message}"
                 };
                 
                 InteractionService.DisplaySubtleMessage(formattedMessage, escapeMarkup: false);

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -298,7 +298,7 @@ internal abstract class PublishCommandBase : BaseCommand
     /// <returns>The converted text if markdown is enabled, otherwise the original text.</returns>
     private static string ConvertTextWithMarkdownFlag(string text, PublishingActivityData activityData)
     {
-        return activityData.EnableMarkdown ? MarkdownToSpectreConverter.ConvertToSpectre(text) : text;
+        return activityData.EnableMarkdown ? MarkdownToSpectreConverter.ConvertToSpectre(text) : text.EscapeMarkup();
     }
 
     public async Task<bool> ProcessPublishingActivitiesDebugAsync(IAsyncEnumerable<PublishingActivity> publishingActivities, IAppHostBackchannel backchannel, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/PublishCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PublishCommandBase.cs
@@ -149,17 +149,7 @@ internal abstract class PublishCommandBase : BaseCommand
                 env[KnownConfigNames.WaitForDebugger] = "true";
             }
 
-            var logLevel = parseResult.GetValue<string?>("--log-level");
-            if (!string.IsNullOrEmpty(logLevel))
-            {
-                env["Publishing:LogLevel"] = logLevel;
-            }
 
-            var environment = parseResult.GetValue<string?>("--environment");
-            if (!string.IsNullOrEmpty(environment))
-            {
-                env["ASPNETCORE_ENVIRONMENT"] = environment;
-            }
 
             if (isSingleFileAppHost)
             {

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/PublishModeProvisioningContextProvider.cs
@@ -65,6 +65,10 @@ internal sealed class PublishModeProvisioningContextProvider(
             await RetrieveAzureProvisioningOptions(cancellationToken).ConfigureAwait(false);
             _logger.LogDebug("Azure provisioning options have been handled successfully.");
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to retrieve Azure provisioning options.");

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -135,6 +135,11 @@ internal sealed class PublishingActivityData
     /// Gets the timestamp for log activities, if available.
     /// </summary>
     public DateTimeOffset? Timestamp { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether markdown formatting is enabled for the publishing activity.
+    /// </summary>
+    public bool EnableMarkdown { get; init; } = true;
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -446,6 +446,25 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddSingleton<PipelineActivityReporter>();
         _innerBuilder.Services.AddSingleton<IPipelineActivityReporter, PipelineActivityReporter>(sp => sp.GetRequiredService<PipelineActivityReporter>());
         _innerBuilder.Services.AddSingleton(Pipeline);
+        _innerBuilder.Services.AddSingleton<ILoggerProvider, PipelineLoggerProvider>();
+
+        // Read this once from configuration and use it to filter logs from the pipeline
+        LogLevel? minLevel = null;
+        _innerBuilder.Logging.AddFilter<PipelineLoggerProvider>((level) =>
+        {
+            minLevel ??= _innerBuilder.Configuration["Publishing:LogLevel"]?.ToLowerInvariant() switch
+            {
+                "trace" => LogLevel.Trace,
+                "debug" => LogLevel.Debug,
+                "info" or "information" => LogLevel.Information,
+                "warn" or "warning" => LogLevel.Warning,
+                "error" => LogLevel.Error,
+                "crit" or "critical" => LogLevel.Critical,
+                _ => LogLevel.Information
+            };
+
+            return level >= minLevel;
+        });
 
         // Register IDeploymentStateManager based on execution context
         if (ExecutionContext.IsPublishMode)
@@ -540,6 +559,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             { "--publisher", "Publishing:Publisher" },
             { "--output-path", "Publishing:OutputPath" },
             { "--deploy", "Publishing:Deploy" },
+            { "--log-level", "Publishing:LogLevel" },
             { "--clear-cache", "Publishing:ClearCache" },
             { "--dcp-cli-path", "DcpPublisher:CliPath" },
             { "--dcp-container-runtime", "DcpPublisher:ContainerRuntime" },

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Pipelines;
 
@@ -254,6 +255,9 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
                                 PipelineContext = context,
                                 ReportingStep = publishingStep
                             };
+
+                            PipelineLoggerProvider.CurrentLogger = stepContext.Logger;
+
                             await ExecuteStepAsync(step, stepContext).ConfigureAwait(false);
                         }
                         catch (Exception ex)
@@ -261,6 +265,10 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
                             // Report the failure to the activity reporter before disposing
                             await publishingStep.FailAsync(ex.Message, CancellationToken.None).ConfigureAwait(false);
                             throw;
+                        }
+                        finally
+                        {
+                            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
                         }
                     }
 

--- a/src/Aspire.Hosting/Pipelines/IReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/IReportingStep.cs
@@ -25,7 +25,8 @@ public interface IReportingStep : IAsyncDisposable
     /// </summary>
     /// <param name="logLevel">The log level for the message.</param>
     /// <param name="message">The message to log.</param>
-    void Log(LogLevel logLevel, string message);
+    /// <param name="enableMarkdown">Whether to enable Markdown formatting for the message.</param>
+    void Log(LogLevel logLevel, string message, bool enableMarkdown);
 
     /// <summary>
     /// Completes the step with the specified completion text and state.

--- a/src/Aspire.Hosting/Pipelines/NullPipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/NullPipelineActivityReporter.cs
@@ -35,7 +35,7 @@ internal sealed class NullPublishingStep : IReportingStep
         return Task.FromResult<IReportingTask>(new NullPublishingTask());
     }
 
-    public void Log(LogLevel logLevel, string message)
+    public void Log(LogLevel logLevel, string message, bool enableMarkdown)
     {
         // No-op for null implementation
     }

--- a/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
@@ -182,7 +182,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                 StepId = step.Id,
                 LogLevel = logLevel.ToString(),
                 Timestamp = DateTimeOffset.UtcNow,
-                EnableMarkdown =enableMarkdown
+                EnableMarkdown = enableMarkdown
             }
         };
 

--- a/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
@@ -156,7 +156,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
         await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
     }
 
-    internal void Log(ReportingStep step, LogLevel logLevel, string message)
+    internal void Log(ReportingStep step, LogLevel logLevel, string message, bool enableMarkdown)
     {
         if (!_steps.TryGetValue(step.Id, out var parentStep))
         {
@@ -181,7 +181,8 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                 CompletionState = ToBackchannelCompletionState(CompletionState.Completed),
                 StepId = step.Id,
                 LogLevel = logLevel.ToString(),
-                Timestamp = DateTimeOffset.UtcNow
+                Timestamp = DateTimeOffset.UtcNow,
+                EnableMarkdown =enableMarkdown
             }
         };
 

--- a/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Hosting.Pipelines;
+
+/// <summary>
+/// A logger provider that forwards logging calls to a logger stored in AsyncLocal context.
+/// This enables pipeline steps to log through a contextual logger that can be set per execution.
+/// </summary>
+internal sealed class PipelineLoggerProvider : ILoggerProvider
+{
+    private static readonly AsyncLocal<StepLoggerHolder?> s_currentLogger = new();
+
+    /// <summary>
+    /// Gets or sets the current logger for the executing pipeline step.
+    /// </summary>
+    public static ILogger CurrentLogger
+    {
+        get => s_currentLogger.Value?.Logger ?? NullLogger.Instance;
+        set
+        {
+            // Clear the current logger from AsyncLocal context
+            s_currentLogger.Value = null;
+
+            if (value is not null && value != NullLogger.Instance)
+            {
+                // Use an object indirection to hold the logger in the AsyncLocal,
+                // so it can be cleared in all ExecutionContexts when cleared.
+                s_currentLogger.Value = new StepLoggerHolder { Logger = value };
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public ILogger CreateLogger(string categoryName) =>
+        new PipelineLogger(() => CurrentLogger);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // No resources to dispose
+    }
+
+    /// <summary>
+    /// Holds the logger instance in AsyncLocal storage.
+    /// </summary>
+    private sealed class StepLoggerHolder
+    {
+        public ILogger? Logger;
+    }
+
+    /// <summary>
+    /// A logger implementation that forwards all calls to the current contextual logger.
+    /// </summary>
+    private sealed class PipelineLogger(Func<ILogger> currentLoggerAccessor) : ILogger
+    {
+        /// <inheritdoc/>
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull =>
+            currentLoggerAccessor().BeginScope(state);
+
+        /// <inheritdoc/>
+        public bool IsEnabled(LogLevel logLevel) =>
+            currentLoggerAccessor().IsEnabled(logLevel);
+
+        /// <inheritdoc/>
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            currentLoggerAccessor().Log(logLevel, eventId, state, exception, formatter);
+    }
+}

--- a/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
@@ -7,9 +7,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Aspire.Hosting.Pipelines;
 
 /// <summary>
-/// A logger provider that forwards logging calls to a logger stored in AsyncLocal context.
-/// This enables pipeline steps to log through a contextual logger that can be set per execution.
+/// Provides loggers that forward calls to a contextual logger associated with the current pipeline step.
 /// </summary>
+/// <remarks>
+/// This logger provider uses AsyncLocal storage to maintain the current logger context across async operations.
+/// This enables pipeline steps to log through a contextual logger that can be set per execution.
+/// </remarks>
 internal sealed class PipelineLoggerProvider : ILoggerProvider
 {
     private static readonly AsyncLocal<StepLoggerHolder?> s_currentLogger = new();
@@ -55,6 +58,10 @@ internal sealed class PipelineLoggerProvider : ILoggerProvider
     /// <summary>
     /// A logger implementation that forwards all calls to the current contextual logger.
     /// </summary>
+    /// <remarks>
+    /// This logger acts as a proxy and dynamically resolves the current logger on each operation,
+    /// allowing the target logger to change between calls.
+    /// </remarks>
     private sealed class PipelineLogger(Func<ILogger> currentLoggerAccessor) : ILogger
     {
         /// <inheritdoc/>

--- a/src/Aspire.Hosting/Pipelines/PipelineStepContext.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineStepContext.cs
@@ -48,8 +48,7 @@ public sealed class PipelineStepContext
     /// <summary>
     /// Gets the logger for pipeline operations that writes to both the pipeline logger and the step logger.
     /// </summary>
-    public ILogger Logger => _logger ??= new StepLogger(PipelineContext.Logger, ReportingStep);
-    private ILogger? _logger;
+    public ILogger Logger => field ??= new StepLogger(ReportingStep);
 
     /// <summary>
     /// Gets the cancellation token for the pipeline operation.
@@ -63,47 +62,32 @@ public sealed class PipelineStepContext
 }
 
 /// <summary>
-/// An ILogger implementation that writes to both the pipeline logger and the step logger.
+/// A logger that writes to the step logger.
 /// </summary>
 [Experimental("ASPIREPUBLISHERS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-internal sealed class StepLogger : ILogger
+internal sealed class StepLogger(IReportingStep step) : ILogger
 {
-    private readonly ILogger _pipelineLogger;
-    private readonly IReportingStep _step;
-
-    public StepLogger(ILogger pipelineLogger, IReportingStep step)
-    {
-        _pipelineLogger = pipelineLogger;
-        _step = step;
-    }
+    private readonly IReportingStep _step = step;
 
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
-        return _pipelineLogger.BeginScope(state);
+        return null;
     }
 
     public bool IsEnabled(LogLevel logLevel)
     {
-        return _pipelineLogger.IsEnabled(logLevel);
+        return true;
     }
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        if (!IsEnabled(logLevel))
-        {
-            return;
-        }
-
-        // Log to the pipeline logger first
-        _pipelineLogger.Log(logLevel, eventId, state, exception, formatter);
-
         // Also log to the step logger (for publishing output display)
         var message = formatter(state, exception);
         if (exception != null)
         {
             message = $"{message} {exception}";
         }
-        
+
         _step.Log(logLevel, message);
     }
 }

--- a/src/Aspire.Hosting/Pipelines/PipelineStepContext.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineStepContext.cs
@@ -88,6 +88,6 @@ internal sealed class StepLogger(IReportingStep step) : ILogger
             message = $"{message} {exception}";
         }
 
-        _step.Log(logLevel, message);
+        _step.Log(logLevel, message, enableMarkdown: false);
     }
 }

--- a/src/Aspire.Hosting/Pipelines/ReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/ReportingStep.cs
@@ -111,14 +111,15 @@ internal sealed class ReportingStep : IReportingStep
     /// </summary>
     /// <param name="logLevel">The log level for the message.</param>
     /// <param name="message">The message to log.</param>
-    public void Log(LogLevel logLevel, string message)
+    /// <param name="enableMarkdown">The enableMarkdown</param>
+    public void Log(LogLevel logLevel, string message, bool enableMarkdown = true)
     {
         if (Reporter is null)
         {
             return;
         }
 
-        Reporter.Log(this, logLevel, message);
+        Reporter.Log(this, logLevel, message, enableMarkdown);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
@@ -214,11 +214,11 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
             Arguments = arguments,
             OnOutputData = output =>
             {
-                _logger.LogInformation("{RuntimeName} (stdout): {Output}", RuntimeExecutable, output);
+                _logger.LogDebug("{RuntimeName} (stdout): {Output}", RuntimeExecutable, output);
             },
             OnErrorData = error =>
             {
-                _logger.LogInformation("{RuntimeName} (stderr): {Error}", RuntimeExecutable, error);
+                _logger.LogDebug("{RuntimeName} (stderr): {Error}", RuntimeExecutable, error);
             },
             ThrowOnNonZeroReturnCode = false,
             InheritEnv = true

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -91,11 +91,11 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
                 Arguments = arguments,
                 OnOutputData = output =>
                 {
-                    Logger.LogInformation("docker buildx (stdout): {Output}", output);
+                    Logger.LogDebug("docker buildx (stdout): {Output}", output);
                 },
                 OnErrorData = error =>
                 {
-                    Logger.LogInformation("docker buildx (stderr): {Error}", error);
+                    Logger.LogDebug("docker buildx (stderr): {Error}", error);
                 },
                 ThrowOnNonZeroReturnCode = false,
                 InheritEnv = true,

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -310,11 +310,11 @@ internal sealed class ResourceContainerImageBuilder(
             Arguments = arguments,
             OnOutputData = output =>
             {
-                logger.LogInformation("dotnet publish {ProjectPath} (stdout): {Output}", projectMetadata.ProjectPath, output);
+                logger.LogDebug("dotnet publish {ProjectPath} (stdout): {Output}", projectMetadata.ProjectPath, output);
             },
             OnErrorData = error =>
             {
-                logger.LogError("dotnet publish {ProjectPath} (stderr): {Error}", projectMetadata.ProjectPath, error);
+                logger.LogDebug("dotnet publish {ProjectPath} (stderr): {Error}", projectMetadata.ProjectPath, error);
             }
         };
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1244,7 +1244,7 @@ public class AzureDeployerTests(ITestOutputHelper output)
                 return Task.FromResult<IReportingTask>(new TestReportingTask(_reporter, statusText));
             }
 
-            public void Log(LogLevel logLevel, string message)
+            public void Log(LogLevel logLevel, string message, bool enableMarkdown)
             {
                 // For testing purposes, we just track that Log was called
                 _ = logLevel;

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -1354,6 +1354,7 @@ public class DistributedApplicationPipelineTests
         Assert.Equal("Test log message from pipeline step", logActivity.Data.StatusText);
         Assert.Equal("Information", logActivity.Data.LogLevel);
         Assert.Equal(stepActivities[0].First().Data.Id, logActivity.Data.StepId);
+        Assert.False(logActivity.Data.EnableMarkdown);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -13,6 +13,7 @@ using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Publishing;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Tests.Pipelines;
@@ -1022,12 +1023,12 @@ public class DistributedApplicationPipelineTests
     {
         // Arrange
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
-        
+
         var interactionService = PublishingActivityReporterTests.CreateInteractionService();
         var reporter = new PipelineActivityReporter(interactionService, NullLogger<PipelineActivityReporter>.Instance);
-        
+
         builder.Services.AddSingleton<IPipelineActivityReporter>(reporter);
-        
+
         var pipeline = new DistributedApplicationPipeline();
         var exceptionMessage = "Test exception for reporting";
         pipeline.AddStep("failing-step", async (context) =>
@@ -1295,6 +1296,404 @@ public class DistributedApplicationPipelineTests
 
         Assert.Contains("async-step-1", executedSteps);
         Assert.Contains("async-step-2", executedSteps);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPipelineLoggerProvider_LogsToStepLogger()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
+
+        var interactionService = PublishingActivityReporterTests.CreateInteractionService();
+        var reporter = new PipelineActivityReporter(interactionService, NullLogger<PipelineActivityReporter>.Instance);
+
+        builder.Services.AddSingleton<IPipelineActivityReporter>(reporter);
+
+        var pipeline = new DistributedApplicationPipeline();
+        var loggedMessages = new List<string>();
+
+        pipeline.AddStep("logging-step", async (context) =>
+        {
+            // Get a logger from DI which should be the PipelineLogger
+            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("TestCategory");
+
+            logger.LogInformation("Test log message from pipeline step");
+            await Task.CompletedTask;
+        });
+
+        var context = CreateDeployingContext(builder.Build());
+
+        // Act
+        await pipeline.ExecuteAsync(context);
+
+        // Assert
+
+        // Collect all activities for easier assertion
+        var activities = new List<PublishingActivity>();
+        while (reporter.ActivityItemUpdated.Reader.TryRead(out var activity))
+        {
+            activities.Add(activity);
+        }
+
+        var stepActivities = activities.Where(a => a.Type == PublishingActivityTypes.Step).GroupBy(a => a.Data.Id).ToList();
+        var logActivities = activities.Where(a => a.Type == PublishingActivityTypes.Log).ToList();
+
+        var stepActivity = Assert.Single(stepActivities);
+        Assert.Collection(stepActivity,
+            step =>
+            {
+                Assert.Equal("logging-step", step.Data.StatusText);
+                Assert.False(step.Data.IsComplete);
+            },
+            step =>
+            {
+                Assert.True(step.Data.IsComplete);
+            });
+        var logActivity = Assert.Single(logActivities);
+        Assert.Equal("Test log message from pipeline step", logActivity.Data.StatusText);
+        Assert.Equal("Information", logActivity.Data.LogLevel);
+        Assert.Equal(stepActivities[0].First().Data.Id, logActivity.Data.StepId);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PipelineLoggerProvider_IsolatesLoggingBetweenSteps()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
+
+        var interactionService = PublishingActivityReporterTests.CreateInteractionService();
+        var reporter = new PipelineActivityReporter(interactionService, NullLogger<PipelineActivityReporter>.Instance);
+
+        builder.Services.AddSingleton<IPipelineActivityReporter>(reporter);
+
+        var pipeline = new DistributedApplicationPipeline();
+        var step1Logger = (ILogger?)null;
+        var step2Logger = (ILogger?)null;
+
+        pipeline.AddStep("step1", async (context) =>
+        {
+            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+            step1Logger = loggerFactory.CreateLogger("Step1Category");
+
+            // Verify this step has its own contextual logger
+            Assert.Same(context.Logger, PipelineLoggerProvider.CurrentLogger);
+
+            step1Logger.LogInformation("Message from step 1");
+            await Task.CompletedTask;
+        });
+
+        pipeline.AddStep("step2", async (context) =>
+        {
+            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+            step2Logger = loggerFactory.CreateLogger("Step2Category");
+
+            // Verify this step has its own contextual logger (different from step1)
+            Assert.Same(context.Logger, PipelineLoggerProvider.CurrentLogger);
+
+            step2Logger.LogInformation("Message from step 2");
+            await Task.CompletedTask;
+        });
+
+        var context = CreateDeployingContext(builder.Build());
+
+        // Act
+        await pipeline.ExecuteAsync(context);
+
+        // Assert
+        Assert.NotNull(step1Logger);
+        Assert.NotNull(step2Logger);
+
+        // Collect all activities for easier assertion
+        var activities = new List<PublishingActivity>();
+        while (reporter.ActivityItemUpdated.Reader.TryRead(out var activity))
+        {
+            activities.Add(activity);
+        }
+
+        var stepOrder = new[] { "step1", "step2" };
+        var logOrder = new[] { "Message from step 1", "Message from step 2" };
+
+        var stepActivities = activities.Where(a => a.Type == PublishingActivityTypes.Step)
+            .GroupBy(a => a.Data.Id)
+            .OrderBy(g => Array.IndexOf(stepOrder, g.First().Data.StatusText))
+            .ToList();
+        var logActivities = activities.Where(a => a.Type == PublishingActivityTypes.Log)
+            .OrderBy(a => Array.IndexOf(logOrder, a.Data.StatusText))
+            .ToList();
+
+        Assert.Collection(stepActivities,
+            step1Activity =>
+            {
+                Assert.Collection(step1Activity,
+                    step =>
+                    {
+                        Assert.Equal("step1", step.Data.StatusText);
+                        Assert.False(step.Data.IsComplete);
+                    },
+                    step =>
+                    {
+                        Assert.True(step.Data.IsComplete);
+                    });
+            },
+            step2Activity =>
+            {
+                Assert.Collection(step2Activity,
+                    step =>
+                    {
+                        Assert.Equal("step2", step.Data.StatusText);
+                        Assert.False(step.Data.IsComplete);
+                    },
+                    step =>
+                    {
+                        Assert.True(step.Data.IsComplete);
+                    });
+            });
+
+        Assert.Collection(logActivities,
+            logActivity =>
+            {
+                Assert.Equal("Message from step 1", logActivity.Data.StatusText);
+                Assert.Equal("Information", logActivity.Data.LogLevel);
+                var step1ActivityGroup = stepActivities.First(g => g.First().Data.StatusText == "step1");
+                Assert.Equal(step1ActivityGroup.First().Data.Id, logActivity.Data.StepId);
+            },
+            logActivity =>
+            {
+                Assert.Equal("Message from step 2", logActivity.Data.StatusText);
+                Assert.Equal("Information", logActivity.Data.LogLevel);
+                var step2ActivityGroup = stepActivities.First(g => g.First().Data.StatusText == "step2");
+                Assert.Equal(step2ActivityGroup.First().Data.Id, logActivity.Data.StepId);
+            });
+
+        // After execution, current logger should be NullLogger
+        Assert.Same(NullLogger.Instance, PipelineLoggerProvider.CurrentLogger);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenStepFails_PipelineLoggerIsCleanedUp()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
+
+        var interactionService = PublishingActivityReporterTests.CreateInteractionService();
+        var reporter = new PipelineActivityReporter(interactionService, NullLogger<PipelineActivityReporter>.Instance);
+
+        builder.Services.AddSingleton<IPipelineActivityReporter>(reporter);
+
+        var pipeline = new DistributedApplicationPipeline();
+
+        pipeline.AddStep("failing-step", async (context) =>
+        {
+            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("FailingCategory");
+
+            logger.LogInformation("About to fail");
+            await Task.CompletedTask;
+
+            throw new InvalidOperationException("Test failure");
+        });
+
+        var context = CreateDeployingContext(builder.Build());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => pipeline.ExecuteAsync(context));
+
+        // Collect all activities for easier assertion
+        var activities = new List<PublishingActivity>();
+        while (reporter.ActivityItemUpdated.Reader.TryRead(out var activity))
+        {
+            activities.Add(activity);
+        }
+
+        var stepActivities = activities.Where(a => a.Type == PublishingActivityTypes.Step).GroupBy(a => a.Data.Id).ToList();
+        var logActivities = activities.Where(a => a.Type == PublishingActivityTypes.Log).ToList();
+
+        Assert.Collection(stepActivities,
+            stepActivity =>
+            {
+                Assert.Collection(stepActivity,
+                    step =>
+                    {
+                        Assert.Equal("failing-step", step.Data.StatusText);
+                        Assert.False(step.Data.IsComplete);
+                    },
+                    step =>
+                    {
+                        Assert.True(step.Data.IsError);
+                    });
+            });
+
+        var logActivity = Assert.Single(logActivities);
+        Assert.Equal("About to fail", logActivity.Data.StatusText);
+        Assert.Equal("Information", logActivity.Data.LogLevel);
+        Assert.Equal(stepActivities[0].First().Data.Id, logActivity.Data.StepId);
+
+        // Verify logger is cleaned up even after failure
+        Assert.Same(NullLogger.Instance, PipelineLoggerProvider.CurrentLogger);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PipelineLoggerProvider_PreservesLoggerAfterStepCompletion()
+    {
+        // This test verifies that each step gets a clean logger context
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true);
+
+        var interactionService = PublishingActivityReporterTests.CreateInteractionService();
+        var reporter = new PipelineActivityReporter(interactionService, NullLogger<PipelineActivityReporter>.Instance);
+
+        builder.Services.AddSingleton<IPipelineActivityReporter>(reporter);
+
+        var pipeline = new DistributedApplicationPipeline();
+        var capturedLoggers = new List<ILogger>();
+
+        for (var i = 1; i <= 3; i++)
+        {
+            var stepNumber = i; // Capture for closure
+            pipeline.AddStep($"step{stepNumber}", async (context) =>
+            {
+                // Capture the current logger for this step
+                capturedLoggers.Add(PipelineLoggerProvider.CurrentLogger);
+
+                var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+                var logger = loggerFactory.CreateLogger($"Step{stepNumber}");
+
+                logger.LogInformation("Executing step {stepNumber}", stepNumber);
+                await Task.CompletedTask;
+            });
+        }
+
+        var context = CreateDeployingContext(builder.Build());
+
+        // Act
+        await pipeline.ExecuteAsync(context);
+
+        // Assert
+        Assert.Equal(3, capturedLoggers.Count);
+
+        // Each step should have had a different logger context
+        // (We can't easily verify they're different instances since they're created per step,
+        // but we can verify none of them are NullLogger during execution)
+        foreach (var logger in capturedLoggers)
+        {
+            Assert.NotSame(NullLogger.Instance, logger);
+        }
+
+        // Collect all activities for easier assertion
+        var activities = new List<PublishingActivity>();
+        while (reporter.ActivityItemUpdated.Reader.TryRead(out var activity))
+        {
+            activities.Add(activity);
+        }
+
+        var stepOrder = new[] { "step1", "step2", "step3" };
+        var logOrder = new[] { "Executing step 1", "Executing step 2", "Executing step 3" };
+
+        var stepActivities = activities.Where(a => a.Type == PublishingActivityTypes.Step)
+            .GroupBy(a => a.Data.Id)
+            .OrderBy(g => Array.IndexOf(stepOrder, g.First().Data.StatusText))
+            .ToList();
+        var logActivities = activities.Where(a => a.Type == PublishingActivityTypes.Log)
+            .OrderBy(a => Array.IndexOf(logOrder, a.Data.StatusText))
+            .ToList();
+
+        Assert.Equal(3, stepActivities.Count);
+        Assert.Collection(logActivities,
+            logActivity =>
+            {
+                Assert.Equal("Executing step 1", logActivity.Data.StatusText);
+                Assert.Equal("Information", logActivity.Data.LogLevel);
+            },
+            logActivity =>
+            {
+                Assert.Equal("Executing step 2", logActivity.Data.StatusText);
+                Assert.Equal("Information", logActivity.Data.LogLevel);
+            },
+            logActivity =>
+            {
+                Assert.Equal("Executing step 3", logActivity.Data.StatusText);
+                Assert.Equal("Information", logActivity.Data.LogLevel);
+            });
+
+        // Verify each log activity is associated with the correct step
+        foreach (var logActivity in logActivities)
+        {
+            Assert.Contains(stepActivities, stepGroup => stepGroup.First().Data.Id == logActivity.Data.StepId);
+        }
+
+        // After all steps complete, should be back to NullLogger
+        Assert.Same(NullLogger.Instance, PipelineLoggerProvider.CurrentLogger);
+    }
+
+    [Theory]
+    [InlineData("Debug", new[] { "Debug", "Information", "Warning" }, new[] { "Debug", "Information", "Warning" })]
+    [InlineData("Information", new[] { "Debug", "Information", "Warning" }, new[] { "Information", "Warning" })]
+    [InlineData("Warning", new[] { "Debug", "Information", "Warning" }, new[] { "Warning" })]
+    [InlineData("Error", new[] { "Debug", "Information", "Warning" }, new string[0])]
+    public async Task ExecuteAsync_PipelineLoggerProvider_RespectsPublishingLogLevelConfiguration(
+        string configuredLogLevel,
+        string[] loggedLevels,
+        string[] expectedFilteredLevels)
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, publisher: "default", isDeploy: true, logLevel: configuredLogLevel);
+
+        var interactionService = PublishingActivityReporterTests.CreateInteractionService();
+        var reporter = new PipelineActivityReporter(interactionService, NullLogger<PipelineActivityReporter>.Instance);
+
+        builder.Services.AddSingleton<IPipelineActivityReporter>(reporter);
+
+        var pipeline = new DistributedApplicationPipeline();
+
+        pipeline.AddStep("logging-step", (context) =>
+        {
+            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("TestCategory");
+
+            // Log messages at different levels
+            foreach (var level in loggedLevels)
+            {
+                switch (level)
+                {
+                    case "Debug":
+                        logger.LogDebug($"Debug message");
+                        break;
+                    case "Information":
+                        logger.LogInformation($"Information message");
+                        break;
+                    case "Warning":
+                        logger.LogWarning($"Warning message");
+                        break;
+                }
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var context = CreateDeployingContext(builder.Build());
+
+        // Act
+        await pipeline.ExecuteAsync(context);
+
+        // Assert
+        var activities = new List<PublishingActivity>();
+        while (reporter.ActivityItemUpdated.Reader.TryRead(out var activity))
+        {
+            activities.Add(activity);
+        }
+
+        var logActivities = activities.Where(a => a.Type == PublishingActivityTypes.Log).ToList();
+
+        // Verify that only the expected log levels are present
+        Assert.Equal(expectedFilteredLevels.Length, logActivities.Count);
+        
+        // Verify each expected log level appears exactly once
+        foreach (var expectedLevel in expectedFilteredLevels)
+        {
+            Assert.Contains(logActivities, activity => 
+                activity.Data.LogLevel == expectedLevel && 
+                activity.Data.StatusText == $"{expectedLevel} message");
+        }
     }
 
     private sealed class CustomResource(string name) : Resource(name)

--- a/tests/Aspire.Hosting.Tests/Pipelines/PipelineLoggerProviderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/PipelineLoggerProviderTests.cs
@@ -7,6 +7,7 @@
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Hosting.Tests.Pipelines;
 
@@ -26,7 +27,7 @@ public class PipelineLoggerProviderTests
     public void CurrentLogger_WhenSetToValidLogger_ReturnsSetLogger()
     {
         // Arrange
-        var testLogger = new TestLogger();
+        var testLogger = new FakeLogger();
 
         try
         {
@@ -48,7 +49,7 @@ public class PipelineLoggerProviderTests
     public void CurrentLogger_WhenSetToNull_ReturnsNullLogger()
     {
         // Arrange
-        var testLogger = new TestLogger();
+        var testLogger = new FakeLogger();
         PipelineLoggerProvider.CurrentLogger = testLogger;
 
         try
@@ -68,17 +69,6 @@ public class PipelineLoggerProviderTests
     }
 
     [Fact]
-    public void CurrentLogger_WhenSetToNullLogger_ReturnsNullLogger()
-    {
-        // Arrange & Act
-        PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
-        var retrievedLogger = PipelineLoggerProvider.CurrentLogger;
-
-        // Assert
-        Assert.Same(NullLogger.Instance, retrievedLogger);
-    }
-
-    [Fact]
     public void CreateLogger_ReturnsValidLogger()
     {
         // Arrange
@@ -92,295 +82,41 @@ public class PipelineLoggerProviderTests
     }
 
     [Fact]
-    public void CreatedLogger_WhenNoCurrentLogger_ForwardsToNullLogger()
-    {
-        // Arrange
-        var provider = new PipelineLoggerProvider();
-        var logger = provider.CreateLogger("TestCategory");
-
-        // Act & Assert
-        Assert.False(logger.IsEnabled(LogLevel.Information));
-        
-        // Should not throw when logging with no current logger
-        logger.LogInformation("Test message");
-    }
-
-    [Fact]
-    public void CreatedLogger_WhenCurrentLoggerSet_ForwardsToCurrentLogger()
-    {
-        // Arrange
-        var testLogger = new TestLogger();
-        var provider = new PipelineLoggerProvider();
-        var logger = provider.CreateLogger("TestCategory");
-
-        try
-        {
-            // Act
-            PipelineLoggerProvider.CurrentLogger = testLogger;
-            
-            logger.LogInformation("Test message");
-
-            // Assert
-            var logEntry = Assert.Single(testLogger.LogEntries);
-            Assert.Equal(LogLevel.Information, logEntry.LogLevel);
-            Assert.Equal("Test message", logEntry.Message);
-        }
-        finally
-        {
-            // Cleanup
-            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
-        }
-    }
-
-    [Fact]
-    public void CreatedLogger_IsEnabled_ForwardsToCurrentLogger()
-    {
-        // Arrange
-        var testLogger = new TestLogger { EnabledLogLevel = LogLevel.Warning };
-        var provider = new PipelineLoggerProvider();
-        var logger = provider.CreateLogger("TestCategory");
-
-        try
-        {
-            // Act
-            PipelineLoggerProvider.CurrentLogger = testLogger;
-
-            // Assert
-            Assert.False(logger.IsEnabled(LogLevel.Information));
-            Assert.True(logger.IsEnabled(LogLevel.Warning));
-            Assert.True(logger.IsEnabled(LogLevel.Error));
-        }
-        finally
-        {
-            // Cleanup
-            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
-        }
-    }
-
-    [Fact]
-    public void CreatedLogger_BeginScope_ForwardsToCurrentLogger()
-    {
-        // Arrange
-        var testLogger = new TestLogger();
-        var provider = new PipelineLoggerProvider();
-        var logger = provider.CreateLogger("TestCategory");
-
-        try
-        {
-            // Act
-            PipelineLoggerProvider.CurrentLogger = testLogger;
-            
-            using var scope = logger.BeginScope("Test scope");
-
-            // Assert
-            Assert.Single(testLogger.Scopes);
-            Assert.Equal("Test scope", testLogger.Scopes[0]);
-        }
-        finally
-        {
-            // Cleanup
-            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
-        }
-    }
-
-    [Fact]
-    public void CreatedLogger_WhenCurrentLoggerChanges_UsesNewLogger()
-    {
-        // Arrange
-        var testLogger1 = new TestLogger();
-        var testLogger2 = new TestLogger();
-        var provider = new PipelineLoggerProvider();
-        var logger = provider.CreateLogger("TestCategory");
-
-        try
-        {
-            // Act
-            PipelineLoggerProvider.CurrentLogger = testLogger1;
-            logger.LogInformation("Message 1");
-
-            PipelineLoggerProvider.CurrentLogger = testLogger2;
-            logger.LogInformation("Message 2");
-
-            // Assert
-            var logEntry1 = Assert.Single(testLogger1.LogEntries);
-            Assert.Equal("Message 1", logEntry1.Message);
-
-            var logEntry2 = Assert.Single(testLogger2.LogEntries);
-            Assert.Equal("Message 2", logEntry2.Message);
-        }
-        finally
-        {
-            // Cleanup
-            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
-        }
-    }
-
-    [Fact]
     public async Task CurrentLogger_IsAsyncLocal_IsolatedBetweenTasks()
     {
         // Arrange
-        var testLogger1 = new TestLogger();
-        var testLogger2 = new TestLogger();
+        var fakeLogger1 = new FakeLogger();
+        var fakeLogger2 = new FakeLogger();
         var provider = new PipelineLoggerProvider();
-
-        var task1Complete = new TaskCompletionSource<bool>();
-        var task2Complete = new TaskCompletionSource<bool>();
-        var bothTasksStarted = new TaskCompletionSource<bool>();
-        var startedCount = 0;
 
         // Act
         var task1 = Task.Run(async () =>
         {
-            PipelineLoggerProvider.CurrentLogger = testLogger1;
+            PipelineLoggerProvider.CurrentLogger = fakeLogger1;
             var logger = provider.CreateLogger("Task1");
 
-            if (Interlocked.Increment(ref startedCount) == 2)
-            {
-                bothTasksStarted.SetResult(true);
-            }
-
-            await bothTasksStarted.Task;
-            await Task.Delay(10); // Allow other task to potentially interfere
-
             logger.LogInformation("Task 1 message");
-            task1Complete.SetResult(true);
         });
 
         var task2 = Task.Run(async () =>
         {
-            PipelineLoggerProvider.CurrentLogger = testLogger2;
+            PipelineLoggerProvider.CurrentLogger = fakeLogger2;
             var logger = provider.CreateLogger("Task2");
 
-            if (Interlocked.Increment(ref startedCount) == 2)
-            {
-                bothTasksStarted.SetResult(true);
-            }
-
-            await bothTasksStarted.Task;
-            await Task.Delay(10); // Allow other task to potentially interfere
-
             logger.LogInformation("Task 2 message");
-            task2Complete.SetResult(true);
         });
 
         await Task.WhenAll(task1, task2);
-        await Task.WhenAll(task1Complete.Task, task2Complete.Task);
 
         // Assert
-        var logEntry1 = Assert.Single(testLogger1.LogEntries);
+        var logs1 = fakeLogger1.Collector.GetSnapshot();
+        var logEntry1 = Assert.Single(logs1);
+        Assert.Equal(LogLevel.Information, logEntry1.Level);
         Assert.Equal("Task 1 message", logEntry1.Message);
 
-        var logEntry2 = Assert.Single(testLogger2.LogEntries);
+        var logs2 = fakeLogger2.Collector.GetSnapshot();
+        var logEntry2 = Assert.Single(logs2);
+        Assert.Equal(LogLevel.Information, logEntry2.Level);
         Assert.Equal("Task 2 message", logEntry2.Message);
-    }
-
-    [Fact]
-    public void Dispose_DoesNotThrow()
-    {
-        // Arrange
-        var provider = new PipelineLoggerProvider();
-
-        // Act & Assert
-        provider.Dispose(); // Should not throw
-    }
-
-    [Fact]
-    public void CreatedLogger_LogWithException_ForwardsToCurrentLogger()
-    {
-        // Arrange
-        var testLogger = new TestLogger();
-        var provider = new PipelineLoggerProvider();
-        var logger = provider.CreateLogger("TestCategory");
-        var exception = new InvalidOperationException("Test exception");
-
-        try
-        {
-            // Act
-            PipelineLoggerProvider.CurrentLogger = testLogger;
-            logger.LogError(exception, "Error occurred");
-
-            // Assert
-            var logEntry = Assert.Single(testLogger.LogEntries);
-            Assert.Equal(LogLevel.Error, logEntry.LogLevel);
-            Assert.Equal("Error occurred", logEntry.Message);
-            Assert.Same(exception, logEntry.Exception);
-        }
-        finally
-        {
-            // Cleanup
-            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
-        }
-    }
-
-    [Fact]
-    public void CreatedLogger_LogWithEventId_ForwardsToCurrentLogger()
-    {
-        // Arrange
-        var testLogger = new TestLogger();
-        var provider = new PipelineLoggerProvider();
-        var logger = provider.CreateLogger("TestCategory");
-        var eventId = new EventId(42, "TestEvent");
-
-        try
-        {
-            // Act
-            PipelineLoggerProvider.CurrentLogger = testLogger;
-            logger.Log(LogLevel.Information, eventId, "Test message", null, (state, ex) => state);
-
-            // Assert
-            var logEntry = Assert.Single(testLogger.LogEntries);
-            Assert.Equal(LogLevel.Information, logEntry.LogLevel);
-            Assert.Equal(eventId, logEntry.EventId);
-            Assert.Equal("Test message", logEntry.Message);
-        }
-        finally
-        {
-            // Cleanup
-            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
-        }
-    }
-
-    private sealed class TestLogger : ILogger
-    {
-        public List<LogEntry> LogEntries { get; } = [];
-        public List<object> Scopes { get; } = [];
-        public LogLevel EnabledLogLevel { get; set; } = LogLevel.Trace;
-
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
-        {
-            Scopes.Add(state);
-            return new TestScope(() => Scopes.Remove(state));
-        }
-
-        public bool IsEnabled(LogLevel logLevel) => logLevel >= EnabledLogLevel;
-
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-        {
-            if (!IsEnabled(logLevel))
-            {
-                return;
-            }
-
-            LogEntries.Add(new LogEntry
-            {
-                LogLevel = logLevel,
-                EventId = eventId,
-                Message = formatter(state, exception),
-                Exception = exception
-            });
-        }
-
-        public sealed class LogEntry
-        {
-            public LogLevel LogLevel { get; init; }
-            public EventId EventId { get; init; }
-            public string Message { get; init; } = string.Empty;
-            public Exception? Exception { get; init; }
-        }
-
-        private sealed class TestScope(Action onDispose) : IDisposable
-        {
-            public void Dispose() => onDispose();
-        }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Pipelines/PipelineLoggerProviderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/PipelineLoggerProviderTests.cs
@@ -1,0 +1,386 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPUBLISHERS001
+#pragma warning disable ASPIREPIPELINES001
+
+using Aspire.Hosting.Pipelines;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Hosting.Tests.Pipelines;
+
+public class PipelineLoggerProviderTests
+{
+    [Fact]
+    public void CurrentLogger_WhenNotSet_ReturnsNullLogger()
+    {
+        // Arrange & Act
+        var currentLogger = PipelineLoggerProvider.CurrentLogger;
+
+        // Assert
+        Assert.Same(NullLogger.Instance, currentLogger);
+    }
+
+    [Fact]
+    public void CurrentLogger_WhenSetToValidLogger_ReturnsSetLogger()
+    {
+        // Arrange
+        var testLogger = new TestLogger();
+
+        try
+        {
+            // Act
+            PipelineLoggerProvider.CurrentLogger = testLogger;
+            var retrievedLogger = PipelineLoggerProvider.CurrentLogger;
+
+            // Assert
+            Assert.Same(testLogger, retrievedLogger);
+        }
+        finally
+        {
+            // Cleanup
+            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+        }
+    }
+
+    [Fact]
+    public void CurrentLogger_WhenSetToNull_ReturnsNullLogger()
+    {
+        // Arrange
+        var testLogger = new TestLogger();
+        PipelineLoggerProvider.CurrentLogger = testLogger;
+
+        try
+        {
+            // Act
+            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+            var retrievedLogger = PipelineLoggerProvider.CurrentLogger;
+
+            // Assert
+            Assert.Same(NullLogger.Instance, retrievedLogger);
+        }
+        finally
+        {
+            // Cleanup
+            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+        }
+    }
+
+    [Fact]
+    public void CurrentLogger_WhenSetToNullLogger_ReturnsNullLogger()
+    {
+        // Arrange & Act
+        PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+        var retrievedLogger = PipelineLoggerProvider.CurrentLogger;
+
+        // Assert
+        Assert.Same(NullLogger.Instance, retrievedLogger);
+    }
+
+    [Fact]
+    public void CreateLogger_ReturnsValidLogger()
+    {
+        // Arrange
+        var provider = new PipelineLoggerProvider();
+
+        // Act
+        var logger = provider.CreateLogger("TestCategory");
+
+        // Assert
+        Assert.NotNull(logger);
+    }
+
+    [Fact]
+    public void CreatedLogger_WhenNoCurrentLogger_ForwardsToNullLogger()
+    {
+        // Arrange
+        var provider = new PipelineLoggerProvider();
+        var logger = provider.CreateLogger("TestCategory");
+
+        // Act & Assert
+        Assert.False(logger.IsEnabled(LogLevel.Information));
+        
+        // Should not throw when logging with no current logger
+        logger.LogInformation("Test message");
+    }
+
+    [Fact]
+    public void CreatedLogger_WhenCurrentLoggerSet_ForwardsToCurrentLogger()
+    {
+        // Arrange
+        var testLogger = new TestLogger();
+        var provider = new PipelineLoggerProvider();
+        var logger = provider.CreateLogger("TestCategory");
+
+        try
+        {
+            // Act
+            PipelineLoggerProvider.CurrentLogger = testLogger;
+            
+            logger.LogInformation("Test message");
+
+            // Assert
+            var logEntry = Assert.Single(testLogger.LogEntries);
+            Assert.Equal(LogLevel.Information, logEntry.LogLevel);
+            Assert.Equal("Test message", logEntry.Message);
+        }
+        finally
+        {
+            // Cleanup
+            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+        }
+    }
+
+    [Fact]
+    public void CreatedLogger_IsEnabled_ForwardsToCurrentLogger()
+    {
+        // Arrange
+        var testLogger = new TestLogger { EnabledLogLevel = LogLevel.Warning };
+        var provider = new PipelineLoggerProvider();
+        var logger = provider.CreateLogger("TestCategory");
+
+        try
+        {
+            // Act
+            PipelineLoggerProvider.CurrentLogger = testLogger;
+
+            // Assert
+            Assert.False(logger.IsEnabled(LogLevel.Information));
+            Assert.True(logger.IsEnabled(LogLevel.Warning));
+            Assert.True(logger.IsEnabled(LogLevel.Error));
+        }
+        finally
+        {
+            // Cleanup
+            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+        }
+    }
+
+    [Fact]
+    public void CreatedLogger_BeginScope_ForwardsToCurrentLogger()
+    {
+        // Arrange
+        var testLogger = new TestLogger();
+        var provider = new PipelineLoggerProvider();
+        var logger = provider.CreateLogger("TestCategory");
+
+        try
+        {
+            // Act
+            PipelineLoggerProvider.CurrentLogger = testLogger;
+            
+            using var scope = logger.BeginScope("Test scope");
+
+            // Assert
+            Assert.Single(testLogger.Scopes);
+            Assert.Equal("Test scope", testLogger.Scopes[0]);
+        }
+        finally
+        {
+            // Cleanup
+            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+        }
+    }
+
+    [Fact]
+    public void CreatedLogger_WhenCurrentLoggerChanges_UsesNewLogger()
+    {
+        // Arrange
+        var testLogger1 = new TestLogger();
+        var testLogger2 = new TestLogger();
+        var provider = new PipelineLoggerProvider();
+        var logger = provider.CreateLogger("TestCategory");
+
+        try
+        {
+            // Act
+            PipelineLoggerProvider.CurrentLogger = testLogger1;
+            logger.LogInformation("Message 1");
+
+            PipelineLoggerProvider.CurrentLogger = testLogger2;
+            logger.LogInformation("Message 2");
+
+            // Assert
+            var logEntry1 = Assert.Single(testLogger1.LogEntries);
+            Assert.Equal("Message 1", logEntry1.Message);
+
+            var logEntry2 = Assert.Single(testLogger2.LogEntries);
+            Assert.Equal("Message 2", logEntry2.Message);
+        }
+        finally
+        {
+            // Cleanup
+            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+        }
+    }
+
+    [Fact]
+    public async Task CurrentLogger_IsAsyncLocal_IsolatedBetweenTasks()
+    {
+        // Arrange
+        var testLogger1 = new TestLogger();
+        var testLogger2 = new TestLogger();
+        var provider = new PipelineLoggerProvider();
+
+        var task1Complete = new TaskCompletionSource<bool>();
+        var task2Complete = new TaskCompletionSource<bool>();
+        var bothTasksStarted = new TaskCompletionSource<bool>();
+        var startedCount = 0;
+
+        // Act
+        var task1 = Task.Run(async () =>
+        {
+            PipelineLoggerProvider.CurrentLogger = testLogger1;
+            var logger = provider.CreateLogger("Task1");
+
+            if (Interlocked.Increment(ref startedCount) == 2)
+            {
+                bothTasksStarted.SetResult(true);
+            }
+
+            await bothTasksStarted.Task;
+            await Task.Delay(10); // Allow other task to potentially interfere
+
+            logger.LogInformation("Task 1 message");
+            task1Complete.SetResult(true);
+        });
+
+        var task2 = Task.Run(async () =>
+        {
+            PipelineLoggerProvider.CurrentLogger = testLogger2;
+            var logger = provider.CreateLogger("Task2");
+
+            if (Interlocked.Increment(ref startedCount) == 2)
+            {
+                bothTasksStarted.SetResult(true);
+            }
+
+            await bothTasksStarted.Task;
+            await Task.Delay(10); // Allow other task to potentially interfere
+
+            logger.LogInformation("Task 2 message");
+            task2Complete.SetResult(true);
+        });
+
+        await Task.WhenAll(task1, task2);
+        await Task.WhenAll(task1Complete.Task, task2Complete.Task);
+
+        // Assert
+        var logEntry1 = Assert.Single(testLogger1.LogEntries);
+        Assert.Equal("Task 1 message", logEntry1.Message);
+
+        var logEntry2 = Assert.Single(testLogger2.LogEntries);
+        Assert.Equal("Task 2 message", logEntry2.Message);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        // Arrange
+        var provider = new PipelineLoggerProvider();
+
+        // Act & Assert
+        provider.Dispose(); // Should not throw
+    }
+
+    [Fact]
+    public void CreatedLogger_LogWithException_ForwardsToCurrentLogger()
+    {
+        // Arrange
+        var testLogger = new TestLogger();
+        var provider = new PipelineLoggerProvider();
+        var logger = provider.CreateLogger("TestCategory");
+        var exception = new InvalidOperationException("Test exception");
+
+        try
+        {
+            // Act
+            PipelineLoggerProvider.CurrentLogger = testLogger;
+            logger.LogError(exception, "Error occurred");
+
+            // Assert
+            var logEntry = Assert.Single(testLogger.LogEntries);
+            Assert.Equal(LogLevel.Error, logEntry.LogLevel);
+            Assert.Equal("Error occurred", logEntry.Message);
+            Assert.Same(exception, logEntry.Exception);
+        }
+        finally
+        {
+            // Cleanup
+            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+        }
+    }
+
+    [Fact]
+    public void CreatedLogger_LogWithEventId_ForwardsToCurrentLogger()
+    {
+        // Arrange
+        var testLogger = new TestLogger();
+        var provider = new PipelineLoggerProvider();
+        var logger = provider.CreateLogger("TestCategory");
+        var eventId = new EventId(42, "TestEvent");
+
+        try
+        {
+            // Act
+            PipelineLoggerProvider.CurrentLogger = testLogger;
+            logger.Log(LogLevel.Information, eventId, "Test message", null, (state, ex) => state);
+
+            // Assert
+            var logEntry = Assert.Single(testLogger.LogEntries);
+            Assert.Equal(LogLevel.Information, logEntry.LogLevel);
+            Assert.Equal(eventId, logEntry.EventId);
+            Assert.Equal("Test message", logEntry.Message);
+        }
+        finally
+        {
+            // Cleanup
+            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+        }
+    }
+
+    private sealed class TestLogger : ILogger
+    {
+        public List<LogEntry> LogEntries { get; } = [];
+        public List<object> Scopes { get; } = [];
+        public LogLevel EnabledLogLevel { get; set; } = LogLevel.Trace;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            Scopes.Add(state);
+            return new TestScope(() => Scopes.Remove(state));
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= EnabledLogLevel;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            LogEntries.Add(new LogEntry
+            {
+                LogLevel = logLevel,
+                EventId = eventId,
+                Message = formatter(state, exception),
+                Exception = exception
+            });
+        }
+
+        public sealed class LogEntry
+        {
+            public LogLevel LogLevel { get; init; }
+            public EventId EventId { get; init; }
+            public string Message { get; init; } = string.Empty;
+            public Exception? Exception { get; init; }
+        }
+
+        private sealed class TestScope(Action onDispose) : IDisposable
+        {
+            public void Dispose() => onDispose();
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
@@ -848,7 +848,7 @@ public class PublishingActivityReporterTests
         reporter.ActivityItemUpdated.Reader.TryRead(out _);
 
         // Act
-        step.Log(logLevel, logMessage);
+        step.Log(logLevel, logMessage, enableMarkdown: true);
 
         // Assert
         // Verify activity was emitted
@@ -862,6 +862,7 @@ public class PublishingActivityReporterTests
         Assert.True(activity.Data.IsComplete);
         Assert.False(activity.Data.IsError);
         Assert.False(activity.Data.IsWarning);
+        Assert.True(activity.Data.EnableMarkdown);
     }
 
     [Fact]
@@ -878,7 +879,7 @@ public class PublishingActivityReporterTests
         while (reporter.ActivityItemUpdated.Reader.TryRead(out _)) { }
 
         // Act - Step is completed, so logging should be a no-op
-        step.Log(LogLevel.Information, "Test log");
+        step.Log(LogLevel.Information, "Test log", enableMarkdown: false);
 
         // Assert - No new activity should be emitted
         Assert.False(reporter.ActivityItemUpdated.Reader.TryRead(out _));

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -17,12 +17,12 @@ namespace Aspire.Hosting.Utils;
 /// </summary>
 public static class TestDistributedApplicationBuilder
 {
-    public static IDistributedApplicationTestingBuilder Create(DistributedApplicationOperation operation, string publisher = "manifest", string outputPath = "./", bool isDeploy = false)
+    public static IDistributedApplicationTestingBuilder Create(DistributedApplicationOperation operation, string publisher = "manifest", string outputPath = "./", bool isDeploy = false, string? logLevel = "information")
     {
         var args = operation switch
         {
             DistributedApplicationOperation.Run => (string[])[],
-            DistributedApplicationOperation.Publish => [$"Publishing:Publisher={publisher}", $"Publishing:OutputPath={outputPath}", $"Publishing:Deploy={isDeploy}"],
+            DistributedApplicationOperation.Publish => [$"Publishing:Publisher={publisher}", $"Publishing:OutputPath={outputPath}", $"Publishing:Deploy={isDeploy}", $"Publishing:LogLevel={logLevel}"],
             _ => throw new ArgumentOutOfRangeException(nameof(operation))
         };
 


### PR DESCRIPTION
## Description

Follow up to https://github.com/dotnet/aspire/pull/12243

- Introduced `--log-level` and `--environment` options for the publish command to configure logging and environment settings.
- Implemented `PipelineLoggerProvider` to manage logging context across pipeline steps.
- Enhanced `DistributedApplicationPipeline` to utilize the new logging provider.
- Updated tests to verify logging behavior and configuration.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No

