### PR TITLE
Cleanup logging when we don't apply certs

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -2130,7 +2130,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             {
                 if (resourceArguments.Contains(arg, StringComparer.Ordinal))
                 {
-                    resourceLogger.LogWarning("Resource '{ExecutableName}' has manually applied argument '{ArgumentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
+                    resourceLogger.LogWarning("Resource '{ExecutableName}' has manually applied argument '{ArgumentName}' that conflicts with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
 
                     // The user explicitly set an arg required to configure certificates, so we won't do automatic certificate configuration
                     return (new List<string>(), new List<EnvVar>(), false);
@@ -2143,7 +2143,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             {
                 if (resourceArguments.Contains(arg, StringComparer.Ordinal))
                 {
-                    resourceLogger.LogWarning("Resource '{ExecutableName}' has manually applied argument '{ArgumentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
+                    resourceLogger.LogWarning("Resource '{ExecutableName}' has manually applied argument '{ArgumentName}' that conflicts with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
 
                     // The user explicitly set an arg required to configure certificates, so we won't do automatic certificate configuration
                     return (new List<string>(), new List<EnvVar>(), false);
@@ -2158,7 +2158,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             {
                 if (resourceEnvironment.Any(e => string.Equals(e.Name, caFileEnv, StringComparison.OrdinalIgnoreCase)))
                 {
-                    resourceLogger.LogWarning("Resource '{ExecutableName}' has manually applied environment '{EnvironmentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, caFileEnv);
+                    resourceLogger.LogWarning("Resource '{ExecutableName}' has manually applied environment '{EnvironmentName}' that conflicts with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, caFileEnv);
 
                     // If any of the certificate environment variables are already present in the existing env list, then we
                     // assume the user has already done custom certificate configuration and we won't do automatic
@@ -2279,7 +2279,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             {
                 if (resourceArguments.Contains(arg, StringComparer.Ordinal))
                 {
-                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied argument '{ArgumentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
+                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied argument '{ArgumentName}' that conflicts with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
 
                     // The user explicitly set an arg required to configure certificates, so we won't do automatic certificate configuration
                     return (new List<string>(), new List<EnvVar>(), createFiles, false);
@@ -2292,7 +2292,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             {
                 if (resourceArguments.Contains(arg, StringComparer.Ordinal))
                 {
-                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied argument '{ArgumentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
+                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied argument '{ArgumentName}' that conflicts with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
 
                     // The user explicitly set an arg required to configure certificates, so we won't do automatic certificate configuration
                     return (new List<string>(), new List<EnvVar>(), createFiles, false);
@@ -2305,9 +2305,9 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             // Build the required environment variables to configure the resource to trust the custom certificates
             foreach (var caFileEnv in context.CertificateBundleEnvironment)
             {
-                if (resourceEnvironment.Any(e => string.Equals(e.Name, caFileEnv, StringComparison.Ordinal)))
+                if (resourceEnvironment.Any(e => string.Equals(e.Name, caFileEnv, StringComparison.OrdinalIgnoreCase)))
                 {
-                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied environment '{EnvironmentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, caFileEnv);
+                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied environment '{EnvironmentName}' that conflicts with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, caFileEnv);
 
                     // If any of the certificate environment variables are already present in the existing env list, then we
                     // assume the user has already done custom certificate configuration and we won't do automatic
@@ -2333,9 +2333,9 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             foreach (var caDirEnv in context.CertificatesDirectoryEnvironment)
             {
-                if (resourceEnvironment.Any(e => string.Equals(e.Name, caDirEnv, StringComparison.Ordinal)))
+                if (resourceEnvironment.Any(e => string.Equals(e.Name, caDirEnv, StringComparison.OrdinalIgnoreCase)))
                 {
-                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied environment '{EnvironmentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, caDirEnv);
+                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied environment '{EnvironmentName}' that conflicts with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, caDirEnv);
 
                     // If any of the certificate environment variables are already present in the existing env list, then we
                     // assume the user has already done custom certificate configuration and we won't do automatic

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1267,7 +1267,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             throw new FailedToApplyEnvironmentException();
         }
 
-        (var certificateArgs, var certificateEnv, var applyCustomCertificateConfig) = await BuildExecutableCertificateAuthorityTrustAsync(er.ModelResource, spec.Args ?? [], spec.Env, cancellationToken).ConfigureAwait(false);
+        (var certificateArgs, var certificateEnv, var applyCustomCertificateConfig) = await BuildExecutableCertificateAuthorityTrustAsync(resourceLogger, er.ModelResource, spec.Args ?? [], spec.Env, cancellationToken).ConfigureAwait(false);
         if (applyCustomCertificateConfig)
         {
             if (certificateArgs.Count > 0)
@@ -1280,10 +1280,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 spec.Env ??= [];
                 spec.Env.AddRange(certificateEnv);
             }
-        }
-        else
-        {
-            resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied arguments or environment that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", er.ModelResource.Name);
         }
 
         try
@@ -1542,7 +1538,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             throw new FailedToApplyEnvironmentException();
         }
 
-        (var certificateArgs, var certificateEnv, var certificateFiles, var applyCustomCertificateConfig) = await BuildContainerCertificateAuthorityTrustAsync(modelContainerResource, spec.Args ?? [], spec.Env ?? [], cancellationToken).ConfigureAwait(false);
+        (var certificateArgs, var certificateEnv, var certificateFiles, var applyCustomCertificateConfig) = await BuildContainerCertificateAuthorityTrustAsync(resourceLogger, modelContainerResource, spec.Args ?? [], spec.Env ?? [], cancellationToken).ConfigureAwait(false);
         if (applyCustomCertificateConfig)
         {
             if (certificateArgs.Count > 0)
@@ -1556,10 +1552,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 spec.Env.AddRange(certificateEnv);
             }
             spec.CreateFiles.AddRange(certificateFiles);
-        }
-        else
-        {
-            resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied arguments or environment that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelContainerResource.Name);
         }
 
         if (_dcpInfo is not null)
@@ -2071,12 +2063,13 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     /// <summary>
     /// Build up the certificate authority trust configuration for an executable.
     /// </summary>
+    /// <param name="resourceLogger">The logger for the resource.</param>
     /// <param name="modelResource">The executable IResource.</param>
     /// <param name="resourceArguments">The existing list of executable command line arguments.</param>
     /// <param name="resourceEnvironment">The existing list of executable environment variables.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>A tuple containing additional command line arguments and environment variables, as well as a boolean indicating whether the operation was successful.</returns>
-    private async Task<(List<string>, List<EnvVar>, bool)> BuildExecutableCertificateAuthorityTrustAsync(IResource modelResource, List<string> resourceArguments, List<EnvVar> resourceEnvironment, CancellationToken cancellationToken)
+    private async Task<(List<string>, List<EnvVar>, bool)> BuildExecutableCertificateAuthorityTrustAsync(ILogger resourceLogger, IResource modelResource, List<string> resourceArguments, List<EnvVar> resourceEnvironment, CancellationToken cancellationToken)
     {
         // Apply the default dev cert trust behavior from options
         bool trustDevCert = _developerCertificateService.TrustCertificate;
@@ -2135,8 +2128,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             foreach (var arg in context.CertificateTrustArguments)
             {
-                if (resourceArguments.Contains(arg))
+                if (resourceArguments.Contains(arg, StringComparer.Ordinal))
                 {
+                    resourceLogger.LogWarning("Resource '{ExecutableName}' has manually applied argument '{ArgumentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
+
                     // The user explicitly set an arg required to configure certificates, so we won't do automatic certificate configuration
                     return (new List<string>(), new List<EnvVar>(), false);
                 }
@@ -2146,8 +2141,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             foreach (var arg in context.CertificateBundleArguments)
             {
-                if (resourceArguments.Contains(arg))
+                if (resourceArguments.Contains(arg, StringComparer.Ordinal))
                 {
+                    resourceLogger.LogWarning("Resource '{ExecutableName}' has manually applied argument '{ArgumentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
+
                     // The user explicitly set an arg required to configure certificates, so we won't do automatic certificate configuration
                     return (new List<string>(), new List<EnvVar>(), false);
                 }
@@ -2159,8 +2156,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             // Build the required environment variables to configure the resource to trust the custom certificates
             foreach (var caFileEnv in context.CertificateBundleEnvironment)
             {
-                if (resourceEnvironment.Any(e => string.Equals(e.Name, caFileEnv, StringComparison.Ordinal)))
+                if (resourceEnvironment.Any(e => string.Equals(e.Name, caFileEnv, StringComparison.OrdinalIgnoreCase)))
                 {
+                    resourceLogger.LogWarning("Resource '{ExecutableName}' has manually applied environment '{EnvironmentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, caFileEnv);
+
                     // If any of the certificate environment variables are already present in the existing env list, then we
                     // assume the user has already done custom certificate configuration and we won't do automatic
                     // configuration.
@@ -2202,12 +2201,13 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     /// <summary>
     /// Build up the certificate authority trust configuration for a container.
     /// </summary>
+    /// <param name="resourceLogger">The logger for the resource.</param>
     /// <param name="modelResource">The container IResource.</param>
     /// <param name="resourceArguments">The existing list of container arguments.</param>
     /// <param name="resourceEnvironment">The existing list of container environment variables.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>A tuple containing additional command line arguments, environment variables, and container file entries required to configure certificate authority trust, as well as a boolean indicating whether the operation was successful.</returns>
-    private async Task<(List<string>, List<EnvVar>, List<ContainerCreateFileSystem>, bool)> BuildContainerCertificateAuthorityTrustAsync(IResource modelResource, List<string> resourceArguments, List<EnvVar> resourceEnvironment, CancellationToken cancellationToken)
+    private async Task<(List<string>, List<EnvVar>, List<ContainerCreateFileSystem>, bool)> BuildContainerCertificateAuthorityTrustAsync(ILogger resourceLogger, IResource modelResource, List<string> resourceArguments, List<EnvVar> resourceEnvironment, CancellationToken cancellationToken)
     {
         // Apply the default dev cert trust behavior from options
         bool trustDevCert = _developerCertificateService.TrustCertificate;
@@ -2277,8 +2277,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             foreach (var arg in context.CertificateTrustArguments)
             {
-                if (resourceArguments.Contains(arg))
+                if (resourceArguments.Contains(arg, StringComparer.Ordinal))
                 {
+                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied argument '{ArgumentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
+
                     // The user explicitly set an arg required to configure certificates, so we won't do automatic certificate configuration
                     return (new List<string>(), new List<EnvVar>(), createFiles, false);
                 }
@@ -2288,8 +2290,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             foreach (var arg in context.CertificateBundleArguments)
             {
-                if (resourceArguments.Contains(arg))
+                if (resourceArguments.Contains(arg, StringComparer.Ordinal))
                 {
+                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied argument '{ArgumentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, arg);
+
                     // The user explicitly set an arg required to configure certificates, so we won't do automatic certificate configuration
                     return (new List<string>(), new List<EnvVar>(), createFiles, false);
                 }
@@ -2303,6 +2307,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             {
                 if (resourceEnvironment.Any(e => string.Equals(e.Name, caFileEnv, StringComparison.Ordinal)))
                 {
+                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied environment '{EnvironmentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, caFileEnv);
+
                     // If any of the certificate environment variables are already present in the existing env list, then we
                     // assume the user has already done custom certificate configuration and we won't do automatic
                     // configuration.
@@ -2329,6 +2335,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             {
                 if (resourceEnvironment.Any(e => string.Equals(e.Name, caDirEnv, StringComparison.Ordinal)))
                 {
+                    resourceLogger.LogWarning("Resource '{ContainerName}' has manually applied environment '{EnvironmentName}' that conflict with Aspire's automatic certificate authority trust configuration. Automatic certificate trust configuration will not be applied.", modelResource.Name, caDirEnv);
+
                     // If any of the certificate environment variables are already present in the existing env list, then we
                     // assume the user has already done custom certificate configuration and we won't do automatic
                     // configuration.


### PR DESCRIPTION
## Description

I was over logging when custom certificates weren't being applied. This PR ensures we only log when we're explicitly skipping applying certificates due to conflicting configuration. Additionally, I'm logging the environment variable name or argument flag that caused us to skip the config to make it easier to troubleshoot.
