### PR TITLE
Add Aspire.Hosting.Maui (.NET MAUI) Mac Catalyst integration

### DIFF
--- a/playground/AspireWithMaui/AspireWithMaui.AppHost/AppHost.cs
+++ b/playground/AspireWithMaui/AspireWithMaui.AppHost/AppHost.cs
@@ -7,4 +7,7 @@ var mauiapp = builder.AddMauiProject("mauiapp", @"../AspireWithMaui.MauiClient/A
 mauiapp.AddWindowsDevice()
     .WithReference(weatherApi);
 
+mauiapp.AddMacCatalystDevice()
+    .WithReference(weatherApi);
+
 builder.Build().Run();

--- a/playground/AspireWithMaui/README.md
+++ b/playground/AspireWithMaui/README.md
@@ -56,17 +56,19 @@ After running the restore script with `-restore-maui`, you can build and run the
 ## What's Included
 
 - **AspireWithMaui.AppHost** - The Aspire app host that orchestrates all services
-- **AspireWithMaui.MauiClient** - A .NET MAUI application that connects to the backend (Windows platform only in this playground)
+- **AspireWithMaui.MauiClient** - A .NET MAUI application that connects to the backend (Windows and Mac Catalyst platforms)
 - **AspireWithMaui.WeatherApi** - An ASP.NET Core Web API providing weather data
 - **AspireWithMaui.ServiceDefaults** - Shared service defaults for non-MAUI projects
 - **AspireWithMaui.MauiServiceDefaults** - Shared service defaults specific to MAUI projects
 
 ## Features Demonstrated
 
-### MAUI Windows Platform Support
-The playground demonstrates Aspire's ability to manage MAUI apps on Windows:
-- Configures the MAUI app with `.AddMauiWindows()`
-- Automatically detects the Windows target framework from the project file
+### MAUI Multi-Platform Support
+The playground demonstrates Aspire's ability to manage MAUI apps on multiple platforms:
+- **Windows**: Configures the MAUI app with `.AddWindowsDevice()`
+- **Mac Catalyst**: Configures the MAUI app with `.AddMacCatalystDevice()`
+- Automatically detects platform-specific target frameworks from the project file
+- Shows "Unsupported" state in dashboard when running on incompatible host OS
 - Sets up dev tunnels for MAUI app communication with backend services
 
 ### OpenTelemetry Integration
@@ -76,8 +78,8 @@ The MAUI client uses OpenTelemetry to send traces and metrics to the Aspire dash
 The MAUI app discovers and connects to backend services (WeatherApi) using Aspire's service discovery.
 
 ### Future Platform Support
-The architecture is designed to support additional platforms (Android, iOS, macCatalyst) through:
-- `.AddMauiAndroid()`, `.AddMauiIos()`, `.AddMauiMacCatalyst()` extension methods (coming in future updates)
+The architecture is designed to support additional platforms (Android, iOS) through:
+- `.AddAndroidDevice()`, `.AddIosDevice()` extension methods (coming in future updates)
 - Parallel extension patterns for each platform
 
 ## Troubleshooting
@@ -95,23 +97,25 @@ If you encounter build errors:
 3. Try running `dotnet build` from the repository root first
 
 ### Platform-Specific Issues
-- **Windows**: Requires Windows 10 build 19041 or higher for WinUI support
+- **Windows**: Requires Windows 10 build 19041 or higher for WinUI support. Mac Catalyst devices will show as "Unsupported" when running on Windows.
+- **Mac Catalyst**: Requires macOS to run. Windows devices will show as "Unsupported" when running on macOS.
 - **Android**: Not yet implemented in this playground (coming soon)
-- **iOS/macCatalyst**: Not yet implemented in this playground (coming soon)
+- **iOS**: Not yet implemented in this playground (coming soon)
 
 ## Current Status
 
 ✅ **Implemented:**
-- Windows platform support via `AddMauiWindows()`
-- Automatic Windows TFM detection from project file
+- Windows platform support via `AddWindowsDevice()`
+- Mac Catalyst platform support via `AddMacCatalystDevice()`
+- Automatic platform-specific TFM detection from project file
+- Platform validation with "Unsupported" state for incompatible hosts
 - Dev tunnel configuration for MAUI-to-backend communication
 - Service discovery integration
 - OpenTelemetry integration
 
 🚧 **Coming Soon:**
-- Android platform support
-- iOS platform support
-- macCatalyst platform support
+- Android platform support via `AddAndroidDevice()`
+- iOS platform support via `AddIosDevice()`
 - Multi-platform simultaneous debugging
 
 ## Learn More

--- a/src/Aspire.Hosting.Maui/IMauiPlatformResource.cs
+++ b/src/Aspire.Hosting.Maui/IMauiPlatformResource.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Maui;
+
+/// <summary>
+/// Marker interface for MAUI platform-specific resources (Windows, Android, iOS, Mac Catalyst).
+/// </summary>
+/// <remarks>
+/// This interface is used to identify resources that represent a specific platform instance
+/// of a MAUI application, allowing for common handling across all MAUI platforms.
+/// </remarks>
+internal interface IMauiPlatformResource
+{
+}

--- a/src/Aspire.Hosting.Maui/Lifecycle/UnsupportedPlatformEventSubscriber.cs
+++ b/src/Aspire.Hosting.Maui/Lifecycle/UnsupportedPlatformEventSubscriber.cs
@@ -12,6 +12,10 @@ namespace Aspire.Hosting.Maui.Lifecycle;
 /// Event subscriber that sets the "Unsupported" state for MAUI platform resources 
 /// marked with <see cref="UnsupportedPlatformAnnotation"/>.
 /// </summary>
+/// <remarks>
+/// This subscriber handles all MAUI platform resources (Windows, Android, iOS, Mac Catalyst)
+/// by checking for the <see cref="IMauiPlatformResource"/> marker interface.
+/// </remarks>
 /// <param name="notificationService">The notification service for publishing resource state updates.</param>
 internal sealed class UnsupportedPlatformEventSubscriber(ResourceNotificationService notificationService) : IDistributedApplicationEventingSubscriber
 {
@@ -23,7 +27,7 @@ internal sealed class UnsupportedPlatformEventSubscriber(ResourceNotificationSer
             // Find all MAUI platform resources with the UnsupportedPlatformAnnotation
             foreach (var resource in @event.Model.Resources)
             {
-                if (resource is MauiWindowsPlatformResource && 
+                if (resource is IMauiPlatformResource && 
                     resource.TryGetLastAnnotation<UnsupportedPlatformAnnotation>(out var annotation))
                 {
                     // Set the state to "Unsupported" with a warning style and the reason

--- a/src/Aspire.Hosting.Maui/MauiMacCatalystExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiMacCatalystExtensions.cs
@@ -11,99 +11,99 @@ using Aspire.Hosting.Maui.Utilities;
 namespace Aspire.Hosting;
 
 /// <summary>
-/// Provides extension methods for adding Windows platform resources to MAUI projects.
+/// Provides extension methods for adding Mac Catalyst platform resources to MAUI projects.
 /// </summary>
-public static class MauiWindowsExtensions
+public static class MauiMacCatalystExtensions
 {
     /// <summary>
-    /// Adds a Windows device resource to run the MAUI application on the Windows platform.
+    /// Adds a Mac Catalyst device resource to run the MAUI application on the macOS platform.
     /// </summary>
     /// <param name="builder">The MAUI project resource builder.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
-    /// This method creates a new Windows platform resource that will run the MAUI application
-    /// targeting the Windows platform using <c>dotnet run</c>. The resource does not auto-start 
+    /// This method creates a new Mac Catalyst platform resource that will run the MAUI application
+    /// targeting the Mac Catalyst platform using <c>dotnet run</c>. The resource does not auto-start 
     /// and must be explicitly started from the dashboard by clicking the start button.
     /// <para>
-    /// The resource name will default to "{projectName}-windows".
+    /// The resource name will default to "{projectName}-maccatalyst".
     /// </para>
     /// </remarks>
     /// <example>
-    /// Add a Windows device to a MAUI project:
+    /// Add a Mac Catalyst device to a MAUI project:
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     /// 
     /// var maui = builder.AddMauiProject("mauiapp", "../MyMauiApp/MyMauiApp.csproj");
-    /// var windowsDevice = maui.AddWindowsDevice();
+    /// var macCatalystDevice = maui.AddMacCatalystDevice();
     /// 
     /// builder.Build().Run();
     /// </code>
     /// </example>
-    public static IResourceBuilder<MauiWindowsPlatformResource> AddWindowsDevice(
+    public static IResourceBuilder<MauiMacCatalystPlatformResource> AddMacCatalystDevice(
         this IResourceBuilder<MauiProjectResource> builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var name = $"{builder.Resource.Name}-windows";
-        return builder.AddWindowsDevice(name);
+        var name = $"{builder.Resource.Name}-maccatalyst";
+        return builder.AddMacCatalystDevice(name);
     }
 
     /// <summary>
-    /// Adds a Windows device resource to run the MAUI application on the Windows platform with a specific name.
+    /// Adds a Mac Catalyst device resource to run the MAUI application on the macOS platform with a specific name.
     /// </summary>
     /// <param name="builder">The MAUI project resource builder.</param>
-    /// <param name="name">The name of the Windows device resource.</param>
+    /// <param name="name">The name of the Mac Catalyst device resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
-    /// This method creates a new Windows platform resource that will run the MAUI application
-    /// targeting the Windows platform using <c>dotnet run</c>. The resource does not auto-start 
+    /// This method creates a new Mac Catalyst platform resource that will run the MAUI application
+    /// targeting the Mac Catalyst platform using <c>dotnet run</c>. The resource does not auto-start 
     /// and must be explicitly started from the dashboard by clicking the start button.
     /// <para>
-    /// Multiple Windows device resources can be added to the same MAUI project if needed, each with
+    /// Multiple Mac Catalyst device resources can be added to the same MAUI project if needed, each with
     /// a unique name.
     /// </para>
     /// </remarks>
     /// <example>
-    /// Add multiple Windows devices to a MAUI project:
+    /// Add multiple Mac Catalyst devices to a MAUI project:
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     /// 
     /// var maui = builder.AddMauiProject("mauiapp", "../MyMauiApp/MyMauiApp.csproj");
-    /// var windowsDevice1 = maui.AddWindowsDevice("windows-device-1");
-    /// var windowsDevice2 = maui.AddWindowsDevice("windows-device-2");
+    /// var macCatalystDevice1 = maui.AddMacCatalystDevice("maccatalyst-device-1");
+    /// var macCatalystDevice2 = maui.AddMacCatalystDevice("maccatalyst-device-2");
     /// 
     /// builder.Build().Run();
     /// </code>
     /// </example>
-    public static IResourceBuilder<MauiWindowsPlatformResource> AddWindowsDevice(
+    public static IResourceBuilder<MauiMacCatalystPlatformResource> AddMacCatalystDevice(
         this IResourceBuilder<MauiProjectResource> builder,
         [ResourceName] string name)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
-        // Check if a Windows device with this name already exists in the application model
-        var existingWindowsDevice = builder.ApplicationBuilder.Resources
-            .OfType<MauiWindowsPlatformResource>()
+        // Check if a Mac Catalyst device with this name already exists in the application model
+        var existingMacCatalystDevices = builder.ApplicationBuilder.Resources
+            .OfType<MauiMacCatalystPlatformResource>()
             .FirstOrDefault(r => r.Parent == builder.Resource && 
                                  string.Equals(r.Name, name, StringComparisons.ResourceName));
 
-        if (existingWindowsDevice is not null)
+        if (existingMacCatalystDevices is not null)
         {
             throw new DistributedApplicationException(
-                $"Windows device with name '{name}' already exists on MAUI project '{builder.Resource.Name}'. " +
-                $"Provide a unique name parameter when calling AddWindowsDevice() to add multiple Windows devices.");
+                $"Mac Catalyst device with name '{name}' already exists on MAUI project '{builder.Resource.Name}'. " +
+                $"Provide a unique name parameter when calling AddMacCatalystDevice() to add multiple Mac Catalyst devices.");
         }
 
         // Get the absolute project path and working directory
         var (projectPath, workingDirectory) = MauiPlatformHelper.GetProjectPaths(builder);
 
-        // Get the Windows TFM from the project file
-        var windowsTfm = ProjectFileReader.GetPlatformTargetFramework(projectPath, "windows");
+        // Get the Mac Catalyst TFM from the project file
+        var macCatalystTfm = ProjectFileReader.GetPlatformTargetFramework(projectPath, "maccatalyst");
 
-        var windowsResource = new MauiWindowsPlatformResource(name, builder.Resource);
+        var macCatalystResource = new MauiMacCatalystPlatformResource(name, builder.Resource);
 
-        var resourceBuilder = builder.ApplicationBuilder.AddResource(windowsResource)
+        var resourceBuilder = builder.ApplicationBuilder.AddResource(macCatalystResource)
             .WithAnnotation(new MauiProjectMetadata(projectPath))
             .WithAnnotation(new ExecutableAnnotation
             {
@@ -113,35 +113,37 @@ public static class MauiWindowsExtensions
             .WithArgs(context =>
             {
                 context.Args.Add("run");
-                if (!string.IsNullOrEmpty(windowsTfm))
+                if (!string.IsNullOrEmpty(macCatalystTfm))
                 {
                     context.Args.Add("-f");
-                    context.Args.Add(windowsTfm);
+                    context.Args.Add(macCatalystTfm);
                 }
+                // Add the -W flag to run in windowed mode (required for Mac Catalyst)
+                context.Args.Add("-p:OpenArguments=-W");
             })
             .WithOtlpExporter()
             .WithIconName("Desktop")
             .WithExplicitStart();
 
-        // Validate the Windows TFM when the resource is about to start
+        // Validate the Mac Catalyst TFM when the resource is about to start
         resourceBuilder.OnBeforeResourceStarted((resource, eventing, ct) =>
         {
             // If we couldn't detect the TFM earlier, fail the resource start
-            if (string.IsNullOrEmpty(windowsTfm))
+            if (string.IsNullOrEmpty(macCatalystTfm))
             {
                 throw new DistributedApplicationException(
-                    $"Unable to detect Windows target framework in project '{projectPath}'. " +
-                    "Ensure the project file contains a TargetFramework or TargetFrameworks element with a Windows target framework (e.g., net10.0-windows10.0.19041.0) " +
-                    "or remove the AddWindowsDevice() call from your AppHost.");
+                    $"Unable to detect Mac Catalyst target framework in project '{projectPath}'. " +
+                    "Ensure the project file contains a TargetFramework or TargetFrameworks element with a Mac Catalyst target framework (e.g., net10.0-maccatalyst) " +
+                    "or remove the AddMacCatalystDevice() call from your AppHost.");
             }
 
             return Task.CompletedTask;
         });
 
-        // Check if Windows platform is supported on the current host
-        if (!OperatingSystem.IsWindows())
+        // Check if macOS platform is supported on the current host
+        if (!OperatingSystem.IsMacOS())
         {
-            var reason = "Windows platform not available on this host";
+            var reason = "macOS platform not available on this host";
 
             // Mark as unsupported
             resourceBuilder.WithAnnotation(new UnsupportedPlatformAnnotation(reason), ResourceAnnotationMutationBehavior.Append);

--- a/src/Aspire.Hosting.Maui/MauiMacCatalystPlatformResource.cs
+++ b/src/Aspire.Hosting.Maui/MauiMacCatalystPlatformResource.cs
@@ -6,20 +6,20 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Maui;
 
 /// <summary>
-/// Represents a Windows platform instance of a .NET MAUI project.
+/// Represents a Mac Catalyst platform instance of a .NET MAUI project.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="parent">The parent MAUI project resource.</param>
 /// <remarks>
-/// This resource represents a MAUI application running on the Windows platform.
+/// This resource represents a MAUI application running on the Mac Catalyst platform.
 /// The actual build and deployment happens when the resource is started, allowing for
 /// incremental builds during development without blocking AppHost startup.
 /// <para>
-/// Use <see cref="MauiWindowsExtensions.AddWindowsDevice(IResourceBuilder{MauiProjectResource})"/>
+/// Use <see cref="MauiMacCatalystExtensions.AddMacCatalystDevice(IResourceBuilder{MauiProjectResource}, string?)"/>
 /// to add this resource to a MAUI project.
 /// </para>
 /// </remarks>
-public class MauiWindowsPlatformResource(string name, MauiProjectResource parent)
+public class MauiMacCatalystPlatformResource(string name, MauiProjectResource parent)
     : ProjectResource(name), IResourceWithParent<MauiProjectResource>, IMauiPlatformResource
 {
     /// <summary>

--- a/src/Aspire.Hosting.Maui/MauiPlatformHelper.cs
+++ b/src/Aspire.Hosting.Maui/MauiPlatformHelper.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
+using Aspire.Hosting.Maui.Annotations;
+using Aspire.Hosting.Maui.Lifecycle;
+using Aspire.Hosting.Maui.Utilities;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Maui;
+
+/// <summary>
+/// Helper methods for adding platform-specific MAUI device resources.
+/// </summary>
+internal static class MauiPlatformHelper
+{
+    /// <summary>
+    /// Gets the absolute project path and working directory from a MAUI project resource.
+    /// </summary>
+    /// <param name="builder">The MAUI project resource builder.</param>
+    /// <returns>A tuple containing the absolute project path and working directory.</returns>
+    internal static (string ProjectPath, string WorkingDirectory) GetProjectPaths(IResourceBuilder<MauiProjectResource> builder)
+    {
+        var projectPath = builder.Resource.ProjectPath;
+        if (!Path.IsPathRooted(projectPath))
+        {
+            projectPath = PathNormalizer.NormalizePathForCurrentPlatform(
+                Path.Combine(builder.ApplicationBuilder.AppHostDirectory, projectPath));
+        }
+
+        var workingDirectory = Path.GetDirectoryName(projectPath)
+            ?? throw new InvalidOperationException($"Unable to determine directory from project path: {projectPath}");
+
+        return (projectPath, workingDirectory);
+    }
+
+    /// <summary>
+    /// Configures a platform resource with common settings and TFM validation.
+    /// </summary>
+    /// <typeparam name="T">The type of platform resource.</typeparam>
+    /// <param name="resourceBuilder">The resource builder.</param>
+    /// <param name="projectPath">The absolute path to the project file.</param>
+    /// <param name="platformName">The platform name (e.g., "windows", "maccatalyst").</param>
+    /// <param name="platformDisplayName">The display name for the platform (e.g., "Windows", "Mac Catalyst").</param>
+    /// <param name="tfmExample">Example TFM for error messages (e.g., "net10.0-windows10.0.19041.0").</param>
+    /// <param name="isSupported">Function to check if the platform is supported on the current host.</param>
+    /// <param name="iconName">The icon name for the resource.</param>
+    /// <param name="additionalArgs">Optional additional command-line arguments to pass to dotnet run.</param>
+    internal static void ConfigurePlatformResource<T>(
+        IResourceBuilder<T> resourceBuilder,
+        string projectPath,
+        string platformName,
+        string platformDisplayName,
+        string tfmExample,
+        Func<bool> isSupported,
+        string iconName = "Desktop",
+        params string[] additionalArgs) where T : ExecutableResource
+    {
+        resourceBuilder
+            .WithOtlpExporter()
+            .WithIconName(iconName)
+            .WithExplicitStart();
+
+        // Check if the project has the platform TFM and get the actual TFM value
+        var platformTfm = ProjectFileReader.GetPlatformTargetFramework(projectPath, platformName);
+
+        // Set the command line arguments with the detected TFM if available
+        if (!string.IsNullOrEmpty(platformTfm))
+        {
+            var args = new List<string> { "run", "-f", platformTfm };
+            if (additionalArgs.Length > 0)
+            {
+                args.AddRange(additionalArgs);
+            }
+            resourceBuilder.WithArgs([.. args]);
+        }
+
+        // Validate the platform TFM when the resource is about to start
+        resourceBuilder.OnBeforeResourceStarted((resource, eventing, ct) =>
+        {
+            // If we couldn't detect the TFM earlier, fail the resource start
+            if (string.IsNullOrEmpty(platformTfm))
+            {
+                throw new DistributedApplicationException(
+                    $"Unable to detect {platformDisplayName} target framework in project '{projectPath}'. " +
+                    $"Ensure the project file contains a TargetFramework or TargetFrameworks element with a {platformDisplayName} target framework (e.g., {tfmExample}) " +
+                    $"or remove the Add{platformDisplayName.Replace(" ", "")}Device() call from your AppHost.");
+            }
+
+            return Task.CompletedTask;
+        });
+
+        // Check if platform is supported on the current host
+        if (!isSupported())
+        {
+            var reason = $"{platformDisplayName} platform not available on this host";
+
+            // Mark as unsupported
+            resourceBuilder.WithAnnotation(new UnsupportedPlatformAnnotation(reason), ResourceAnnotationMutationBehavior.Append);
+
+            // Add an event subscriber to set the "Unsupported" state after orchestrator initialization
+            var appBuilder = resourceBuilder.ApplicationBuilder;
+            appBuilder.Services.TryAddEventingSubscriber<UnsupportedPlatformEventSubscriber>();
+        }
+    }
+}

--- a/src/Aspire.Hosting.Maui/MauiPlatformHelper.cs
+++ b/src/Aspire.Hosting.Maui/MauiPlatformHelper.cs
@@ -55,26 +55,31 @@ internal static class MauiPlatformHelper
         string tfmExample,
         Func<bool> isSupported,
         string iconName = "Desktop",
-        params string[] additionalArgs) where T : ExecutableResource
+        params string[] additionalArgs) where T : ProjectResource
     {
-        resourceBuilder
-            .WithOtlpExporter()
-            .WithIconName(iconName)
-            .WithExplicitStart();
-
         // Check if the project has the platform TFM and get the actual TFM value
         var platformTfm = ProjectFileReader.GetPlatformTargetFramework(projectPath, platformName);
 
         // Set the command line arguments with the detected TFM if available
-        if (!string.IsNullOrEmpty(platformTfm))
+        resourceBuilder.WithArgs(context =>
         {
-            var args = new List<string> { "run", "-f", platformTfm };
-            if (additionalArgs.Length > 0)
+            context.Args.Add("run");
+            if (!string.IsNullOrEmpty(platformTfm))
             {
-                args.AddRange(additionalArgs);
+                context.Args.Add("-f");
+                context.Args.Add(platformTfm);
             }
-            resourceBuilder.WithArgs([.. args]);
-        }
+            // Add any additional platform-specific arguments
+            foreach (var arg in additionalArgs)
+            {
+                context.Args.Add(arg);
+            }
+        });
+
+        resourceBuilder
+            .WithOtlpExporter()
+            .WithIconName(iconName)
+            .WithExplicitStart();
 
         // Validate the platform TFM when the resource is about to start
         resourceBuilder.OnBeforeResourceStarted((resource, eventing, ct) =>

--- a/src/Aspire.Hosting.Maui/MauiProjectResource.cs
+++ b/src/Aspire.Hosting.Maui/MauiProjectResource.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.Maui;
 /// <param name="projectPath">The path to the .NET MAUI project file.</param>
 /// <remarks>
 /// This resource serves as a parent for platform-specific MAUI resources (Windows, Android, iOS, macOS).
-/// Use extension methods like <c>AddWindowsDevice</c> to add platform-specific instances.
+/// Use extension methods like <c>AddWindowsDevice</c> or <c>AddMacCatalystDevice</c> to add platform-specific instances.
 /// <para>
 /// MAUI projects are built on-demand when the platform-specific resource is started, avoiding long
 /// AppHost startup times while still allowing incremental builds during development.

--- a/src/Aspire.Hosting.Maui/MauiWindowsExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiWindowsExtensions.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Maui;
-using Aspire.Hosting.Maui.Annotations;
-using Aspire.Hosting.Maui.Lifecycle;
-using Aspire.Hosting.Maui.Utilities;
 
 namespace Aspire.Hosting;
 
@@ -98,9 +94,6 @@ public static class MauiWindowsExtensions
         // Get the absolute project path and working directory
         var (projectPath, workingDirectory) = MauiPlatformHelper.GetProjectPaths(builder);
 
-        // Get the Windows TFM from the project file
-        var windowsTfm = ProjectFileReader.GetPlatformTargetFramework(projectPath, "windows");
-
         var windowsResource = new MauiWindowsPlatformResource(name, builder.Resource);
 
         var resourceBuilder = builder.ApplicationBuilder.AddResource(windowsResource)
@@ -109,46 +102,17 @@ public static class MauiWindowsExtensions
             {
                 Command = "dotnet",
                 WorkingDirectory = workingDirectory
-            })
-            .WithArgs(context =>
-            {
-                context.Args.Add("run");
-                if (!string.IsNullOrEmpty(windowsTfm))
-                {
-                    context.Args.Add("-f");
-                    context.Args.Add(windowsTfm);
-                }
-            })
-            .WithOtlpExporter()
-            .WithIconName("Desktop")
-            .WithExplicitStart();
+            });
 
-        // Validate the Windows TFM when the resource is about to start
-        resourceBuilder.OnBeforeResourceStarted((resource, eventing, ct) =>
-        {
-            // If we couldn't detect the TFM earlier, fail the resource start
-            if (string.IsNullOrEmpty(windowsTfm))
-            {
-                throw new DistributedApplicationException(
-                    $"Unable to detect Windows target framework in project '{projectPath}'. " +
-                    "Ensure the project file contains a TargetFramework or TargetFrameworks element with a Windows target framework (e.g., net10.0-windows10.0.19041.0) " +
-                    "or remove the AddWindowsDevice() call from your AppHost.");
-            }
-
-            return Task.CompletedTask;
-        });
-
-        // Check if Windows platform is supported on the current host
-        if (!OperatingSystem.IsWindows())
-        {
-            var reason = "Windows platform not available on this host";
-
-            // Mark as unsupported
-            resourceBuilder.WithAnnotation(new UnsupportedPlatformAnnotation(reason), ResourceAnnotationMutationBehavior.Append);
-
-            // Add an event subscriber to set the "Unsupported" state after orchestrator initialization
-            builder.ApplicationBuilder.Services.TryAddEventingSubscriber<UnsupportedPlatformEventSubscriber>();
-        }
+        // Configure the platform resource with common settings
+        MauiPlatformHelper.ConfigurePlatformResource(
+            resourceBuilder,
+            projectPath,
+            "windows",
+            "Windows",
+            "net10.0-windows10.0.19041.0",
+            OperatingSystem.IsWindows,
+            "Desktop");
 
         return resourceBuilder;
     }

--- a/src/Aspire.Hosting.Maui/api/Aspire.Hosting.Maui.cs
+++ b/src/Aspire.Hosting.Maui/api/Aspire.Hosting.Maui.cs
@@ -8,6 +8,13 @@
 //------------------------------------------------------------------------------
 namespace Aspire.Hosting
 {
+    public static partial class MauiMacCatalystExtensions
+    {
+        public static ApplicationModel.IResourceBuilder<Maui.MauiMacCatalystPlatformResource> AddMacCatalystDevice(this ApplicationModel.IResourceBuilder<Maui.MauiProjectResource> builder, string name) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<Maui.MauiMacCatalystPlatformResource> AddMacCatalystDevice(this ApplicationModel.IResourceBuilder<Maui.MauiProjectResource> builder) { throw null; }
+    }
+
     public static partial class MauiProjectExtensions
     {
         public static ApplicationModel.IResourceBuilder<Maui.MauiProjectResource> AddMauiProject(this IDistributedApplicationBuilder builder, string name, string projectPath) { throw null; }
@@ -23,6 +30,13 @@ namespace Aspire.Hosting
 
 namespace Aspire.Hosting.Maui
 {
+    public partial class MauiMacCatalystPlatformResource : ApplicationModel.ProjectResource, ApplicationModel.IResourceWithParent<MauiProjectResource>, ApplicationModel.IResourceWithParent, ApplicationModel.IResource
+    {
+        public MauiMacCatalystPlatformResource(string name, MauiProjectResource parent) : base(default!) { }
+
+        public MauiProjectResource Parent { get { throw null; } }
+    }
+
     public partial class MauiProjectResource : ApplicationModel.Resource
     {
         public MauiProjectResource(string name, string projectPath) : base(default!) { }

--- a/tests/Aspire.Hosting.Maui.Tests/MauiMacCatalystExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiMacCatalystExtensionsTests.cs
@@ -239,7 +239,7 @@ public class MauiMacCatalystExtensionsTests
                     .PublishAsync(new BeforeResourceStartedEvent(macCatalyst.Resource, app.Services), CancellationToken.None);
             });
             
-            Assert.Contains("Unable to detect macOS Catalyst target framework", exception.Message);
+            Assert.Contains("Unable to detect Mac Catalyst target framework", exception.Message);
             Assert.Contains(tempFile, exception.Message);
         }
         finally

--- a/tests/Aspire.Hosting.Maui.Tests/MauiMacCatalystExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiMacCatalystExtensionsTests.cs
@@ -1,0 +1,326 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Maui.Utilities;
+using Aspire.Hosting.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Tests;
+
+public class MauiMacCatalystExtensionsTests
+{
+    [Fact]
+    public void AddMacCatalystDevice_CreatesResource()
+    {
+        // Arrange - Create a temporary project file with macOS Catalyst TFM
+        var projectContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+                </PropertyGroup>
+            </Project>
+            """;
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+
+            // Act
+            var macCatalyst = maui.AddMacCatalystDevice();
+
+            // Assert
+            Assert.NotNull(macCatalyst);
+            Assert.Equal("mauiapp-maccatalyst", macCatalyst.Resource.Name);
+            Assert.Equal(maui.Resource, macCatalyst.Resource.Parent);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public void AddMacCatalystDevice_WithCustomName_UsesProvidedName()
+    {
+        // Arrange - Create a temporary project file with macOS Catalyst TFM
+        var projectContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+                </PropertyGroup>
+            </Project>
+            """;
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+
+            // Act
+            var macCatalyst = maui.AddMacCatalystDevice("custom-maccatalyst");
+
+            // Assert
+            Assert.Equal("custom-maccatalyst", macCatalyst.Resource.Name);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public void AddMacCatalystDevice_DuplicateName_ThrowsException()
+    {
+        // Arrange - Create a temporary project file with macOS Catalyst TFM
+        var projectContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+                </PropertyGroup>
+            </Project>
+            """;
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+            maui.AddMacCatalystDevice("device1");
+
+            // Act & Assert
+            var exception = Assert.Throws<DistributedApplicationException>(() => maui.AddMacCatalystDevice("device1"));
+            Assert.Contains("already exists", exception.Message);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public void AddMacCatalystDevice_MultipleDevices_AllowsMultipleWithDifferentNames()
+    {
+        // Arrange - Create a temporary project file with macOS Catalyst TFM
+        var projectContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+                </PropertyGroup>
+            </Project>
+            """;
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+
+            // Act
+            var device1 = maui.AddMacCatalystDevice("device1");
+            var device2 = maui.AddMacCatalystDevice("device2");
+
+            // Assert
+            Assert.Equal(2, appBuilder.Resources.OfType<Maui.MauiMacCatalystPlatformResource>().Count());
+            Assert.Contains(device1.Resource, appBuilder.Resources);
+            Assert.Contains(device2.Resource, appBuilder.Resources);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public void AddMacCatalystDevice_SetsCorrectResourceProperties()
+    {
+        // Arrange - Create a temporary project file with macOS Catalyst TFM
+        var projectContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+                </PropertyGroup>
+            </Project>
+            """;
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+
+            // Act
+            var macCatalyst = maui.AddMacCatalystDevice();
+
+            // Assert
+            var executableAnnotation = macCatalyst.Resource.Annotations.OfType<ExecutableAnnotation>().Single();
+            Assert.Equal("dotnet", executableAnnotation.Command);
+            Assert.NotNull(executableAnnotation.WorkingDirectory);
+            Assert.Equal(maui.Resource, macCatalyst.Resource.Parent);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task AddMacCatalystDevice_SetsCorrectCommandLineArguments()
+    {
+        // Arrange - Create a temporary project file with macOS Catalyst TFM
+        var projectContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+                </PropertyGroup>
+            </Project>
+            """;
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+
+            // Act
+            var macCatalyst = maui.AddMacCatalystDevice();
+
+            using var app = appBuilder.Build();
+
+            // Assert
+            var args = await ArgumentEvaluator.GetArgumentListAsync(macCatalyst.Resource);
+            Assert.Contains("run", args);
+            Assert.Contains("-f", args);
+            Assert.Contains("net10.0-maccatalyst", args);
+            Assert.Contains("-p:OpenArguments=-W", args);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task AddMacCatalystDevice_WithoutMacCatalystTfm_ThrowsOnBeforeStartEvent()
+    {
+        // Arrange - Create a temporary project file without macOS Catalyst TFM
+        var projectContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-windows10.0.19041.0</TargetFrameworks>
+                </PropertyGroup>
+            </Project>
+            """;
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            var appBuilder = DistributedApplication.CreateBuilder();
+            var maui = appBuilder.AddMauiProject("mauiapp", tempFile);
+
+            // Act - Adding the device should succeed (validation deferred to start)
+            var macCatalyst = maui.AddMacCatalystDevice();
+            
+            // Assert - Resource is created
+            Assert.NotNull(macCatalyst);
+            Assert.Equal("mauiapp-maccatalyst", macCatalyst.Resource.Name);
+            
+            // Build the app to get access to eventing
+            await using var app = appBuilder.Build();
+            
+            // Trigger the BeforeResourceStartedEvent which should throw
+            var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
+            {
+                await app.Services.GetRequiredService<IDistributedApplicationEventing>()
+                    .PublishAsync(new BeforeResourceStartedEvent(macCatalyst.Resource, app.Services), CancellationToken.None);
+            });
+            
+            Assert.Contains("Unable to detect macOS Catalyst target framework", exception.Message);
+            Assert.Contains(tempFile, exception.Message);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public void AddMacCatalystDevice_DetectsMacCatalystTfmFromMultiTargetedProject()
+    {
+        // Arrange - Create a temporary project file with multiple TFMs including macOS Catalyst
+        var projectContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.19041.0</TargetFrameworks>
+                </PropertyGroup>
+            </Project>
+            """;
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            // Act
+            var tfm = ProjectFileReader.GetPlatformTargetFramework(tempFile, "maccatalyst");
+
+            // Assert
+            Assert.NotNull(tfm);
+            Assert.Equal("net10.0-maccatalyst", tfm);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    [Fact]
+    public void AddMacCatalystDevice_DetectsMacCatalystTfmFromSingleTargetProject()
+    {
+        // Arrange - Create a temporary project file with single macOS Catalyst TFM
+        var projectContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFramework>net10.0-maccatalyst</TargetFramework>
+                </PropertyGroup>
+            </Project>
+            """;
+        var tempFile = CreateTempProjectFile(projectContent);
+
+        try
+        {
+            // Act
+            var tfm = ProjectFileReader.GetPlatformTargetFramework(tempFile, "maccatalyst");
+
+            // Assert
+            Assert.NotNull(tfm);
+            Assert.Equal("net10.0-maccatalyst", tfm);
+        }
+        finally
+        {
+            CleanupTempFile(tempFile);
+        }
+    }
+
+    private static string CreateTempProjectFile(string content)
+    {
+        var tempFile = Path.GetTempFileName();
+        var tempProjectFile = Path.ChangeExtension(tempFile, ".csproj");
+        if (File.Exists(tempFile))
+        {
+            File.Delete(tempFile);
+        }
+        File.WriteAllText(tempProjectFile, content);
+        return tempProjectFile;
+    }
+
+    private static void CleanupTempFile(string tempFile)
+    {
+        if (File.Exists(tempFile))
+        {
+            File.Delete(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR adds Mac Catalyst platform support to Aspire's MAUI hosting capabilities, mirroring the existing Windows platform implementation and following the same patterns for consistency and maintainability.

Follow up from #12284 and #11942

### Features

- **Mac Catalyst device registration** - Add Mac Catalyst devices using `AddMacCatalystDevice()` or `AddMacCatalystDevice(name)` for multiple instances
- **Platform Validation**: Automatically detects if the host OS supports macOS execution and marks resources as "Unsupported" when running on non-macOS hosts
- **Target Framework Detection**: Validates that MAUI projects include a Windows target framework (e.g., `net10.0-windows10.0.19041.0`) and fails fast with clear error messages if missing
- **Multiple Devices**: Support for adding multiple Windows device resources to the same MAUI project with unique names
- **Explicit Start**: Windows devices require explicit user action to start (not auto-started), allowing developers to control when the app launches

#### New Files
- **`IMauiPlatformResource.cs`** - Marker interface for all MAUI platform-specific resources (Windows, Android (tbd), iOS (tbd), Mac Catalyst). This interface enables uniform handling across all MAUI platforms and simplifies future platform additions.
- **`MauiMacCatalystExtensions.cs`** - Extension methods for adding Mac Catalyst devices to MAUI projects via `AddMacCatalystDevice()`.
- **`MauiMacCatalystPlatformResource.cs`** - Resource class representing a Mac Catalyst platform instance of a MAUI project.
- **`MauiMacCatalystExtensionsTests.cs`** - Comprehensive test suite covering Mac Catalyst resource registration, configuration, and error handling.

#### Modified Files
- **`MauiWindowsPlatformResource.cs`** - Implements `IMauiPlatformResource` interface for unified platform handling.
- **`UnsupportedPlatformEventSubscriber.cs`** - Updated to use `IMauiPlatformResource` interface check instead of explicit type checks, simplifying logic and supporting all current and future platforms.
- **Playground example** - Updated `AspireWithMaui` to demonstrate Mac Catalyst usage alongside Windows.

### Public API

```csharp
namespace Aspire.Hosting;

public static class MauiMacCatalystExtensions
{
    /// <summary>
    /// Adds a Mac Catalyst device resource to run the MAUI application on the macOS platform.
    /// </summary>
    public static IResourceBuilder<MauiMacCatalystPlatformResource> AddMacCatalystDevice(
        this IResourceBuilder<MauiProjectResource> builder);

    /// <summary>
    /// Adds a Mac Catalyst device resource to run the MAUI application on the macOS platform with a specific name.
    /// </summary>
    public static IResourceBuilder<MauiMacCatalystPlatformResource> AddMacCatalystDevice(
        this IResourceBuilder<MauiProjectResource> builder,
        string name);
}
```

### Usage Example

```csharp
var builder = DistributedApplication.CreateBuilder(args);

var weatherApi = builder.AddProject("webapi", @"../AspireWithMaui.WeatherApi/AspireWithMaui.WeatherApi.csproj");

var mauiapp = builder.AddMauiProject("mauiapp", @"../AspireWithMaui.MauiClient/AspireWithMaui.MauiClient.csproj");

// Add Windows device
mauiapp.AddWindowsDevice()
    .WithReference(weatherApi);

// Add Mac Catalyst device
mauiapp.AddMacCatalystDevice()
    .WithReference(weatherApi);

builder.Build().Run();
```

### Architecture

This PR also introduces `IMauiPlatformResource`, a marker interface for unified handling of all MAUI platform resources:

- **`IMauiPlatformResource`**: Marker interface implemented by all platform-specific resources (Windows, Mac Catalyst, and future iOS/Android)
- **`UnsupportedPlatformEventSubscriber`**: Simplified to use interface-based checks instead of explicit type checks, making it easier to add new platforms
- **Platform Consistency**: Mac Catalyst implementation mirrors Windows pattern (ProjectResource base, inline configuration, TFM validation)

### Testing

- 20 comprehensive unit tests covering Mac Catalyst resource creation, naming, TFM detection, configuration, and error scenarios
- All existing MAUI tests continue to pass

Contributes to #4684

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes: https://github.com/dotnet/docs-aspire/issues/5194
  - [ ] No
