### PR TITLE
Enable Urls to display using FluentIcon

### DIFF
--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -8,7 +8,12 @@ var catalogDb = builder.AddPostgres("postgres")
                        .WithDataVolume()
                        .WithPgAdmin(resource =>
                        {
-                           resource.WithUrlForEndpoint("http", u => u.DisplayText = "PG Admin");
+                           resource.WithUrlForEndpoint("http", u =>
+                           {
+                               u.DisplayText = "PG Admin";
+                               u.IconName = "DatabaseStack";
+                               u.IconVariant = IconVariant.Filled;
+                           });
                        })
                        .AddDatabase("catalogdb");
 

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
@@ -45,7 +45,7 @@ else if (DisplayedUrls.Count > 1)
                             {
                                 var d = (DisplayedUrl)item.Data!;
                                 <div class="url-link">
-                                    @WriteUrl(d)
+                                    @WriteUrl(d, displayLabel: true)
                                 </div>
                             }
                         </div>
@@ -62,10 +62,18 @@ else if (DisplayedUrls.Count > 1)
 }
 
 @code {
-    RenderFragment WriteUrl(DisplayedUrl displayedUrl)
+    RenderFragment WriteUrl(DisplayedUrl displayedUrl, bool displayLabel = false)
     {
         if (displayedUrl.Url != null)
         {
+            if (string.IsNullOrWhiteSpace(displayedUrl.IconName) == false && IconResolver.ResolveIconName(displayedUrl.IconName, IconSize.Size16, iconVariant: displayedUrl.IconVariant) is { } icon)
+            {
+                return @<FluentButton Appearance="Appearance.Lightweight" Title="@displayedUrl.Text" StopPropagation="true" OnClick="@(() => JSRuntime.InvokeAsync<object>("open", displayedUrl.Url, "_blank"))" >
+                            <FluentIcon Value="@icon" Width="16px" Title="@displayedUrl.Text" />
+                        </FluentButton>;
+            }
+            //<a href="@displayedUrl.Url" target="_blank" @onclick:stopPropagation="true">
+
             return @<a href="@displayedUrl.Url" target="_blank" @onclick:stopPropagation="true">@displayedUrl.Text</a>;
         }
         else

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor
@@ -68,11 +68,11 @@ else if (DisplayedUrls.Count > 1)
         {
             if (string.IsNullOrWhiteSpace(displayedUrl.IconName) == false && IconResolver.ResolveIconName(displayedUrl.IconName, IconSize.Size16, iconVariant: displayedUrl.IconVariant) is { } icon)
             {
-                return @<FluentButton Appearance="Appearance.Lightweight" Title="@displayedUrl.Text" StopPropagation="true" OnClick="@(() => JSRuntime.InvokeAsync<object>("open", displayedUrl.Url, "_blank"))" >
+                return @<FluentButton Appearance="Appearance.Lightweight" Title="@displayedUrl.Text" AriaLabel="@displayedUrl.Text" StopPropagation="true" OnClick="@(() => JSRuntime.InvokeAsync<object>("open", displayedUrl.Url, "_blank"))" >
                             <FluentIcon Value="@icon" Width="16px" Title="@displayedUrl.Text" />
                         </FluentButton>;
             }
-            //<a href="@displayedUrl.Url" target="_blank" @onclick:stopPropagation="true">
+
 
             return @<a href="@displayedUrl.Url" target="_blank" @onclick:stopPropagation="true">@displayedUrl.Text</a>;
         }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.cs
@@ -5,6 +5,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components;
 
@@ -25,5 +26,14 @@ public partial class UrlsColumnDisplay
     [Inject]
     public required IStringLocalizer<Columns> Loc { get; init; }
 
+    [Inject]
+    public required IconResolver IconResolver { get; init; }
+
+    [Inject]
+    public required NavigationManager NavigationManager { get; init; }
+
+    [Inject]
+    public required IJSRuntime JSRuntime { get; init; }
+    
     private bool _popoverVisible;
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UrlsColumnDisplay.razor.cs
@@ -34,6 +34,6 @@ public partial class UrlsColumnDisplay
 
     [Inject]
     public required IJSRuntime JSRuntime { get; init; }
-    
+
     private bool _popoverVisible;
 }

--- a/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Dashboard.Components.Controls;
+using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Model;
 
@@ -51,7 +52,9 @@ internal static class ResourceUrlHelpers
                     SortOrder = url.DisplayProperties.SortOrder,
                     DisplayName = string.IsNullOrEmpty(url.DisplayProperties.DisplayName) ? null : url.DisplayProperties.DisplayName,
                     OriginalUrlString = url.Url.OriginalString,
-                    Text = string.IsNullOrEmpty(url.DisplayProperties.DisplayName) ? url.Url.OriginalString : url.DisplayProperties.DisplayName
+                    Text = string.IsNullOrEmpty(url.DisplayProperties.DisplayName) ? url.Url.OriginalString : url.DisplayProperties.DisplayName,
+                    IconName = url.DisplayProperties.IconName,
+                    IconVariant = url.DisplayProperties.IconVariant,
                 });
                 index++;
             }
@@ -85,6 +88,9 @@ public sealed class DisplayedUrl : IPropertyGridItem
     public int SortOrder { get; set; }
     public string? DisplayName { get; set; }
     public required string OriginalUrlString { get; set; }
+
+    public string? IconName { get; set; }
+    public IconVariant? IconVariant { get; set; }
 
     /// <summary>
     /// Don't display a plain string value here. The URL will be displayed as a hyperlink

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -428,9 +428,9 @@ public sealed class UrlViewModel
     }
 }
 
-public record UrlDisplayPropertiesViewModel(string DisplayName, int SortOrder)
+public record UrlDisplayPropertiesViewModel(string DisplayName, int SortOrder, string? IconName, IconVariant? IconVariant)
 {
-    public static readonly UrlDisplayPropertiesViewModel Empty = new(string.Empty, 0);
+    public static readonly UrlDisplayPropertiesViewModel Empty = new(string.Empty, 0, string.Empty, (IconVariant)(-1));
 }
 
 public sealed record class VolumeViewModel(int index, string Source, string Target, string MountType, bool IsReadOnly) : IPropertyGridItem

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -430,7 +430,7 @@ public sealed class UrlViewModel
 
 public record UrlDisplayPropertiesViewModel(string DisplayName, int SortOrder, string? IconName, IconVariant? IconVariant)
 {
-    public static readonly UrlDisplayPropertiesViewModel Empty = new(string.Empty, 0, string.Empty, (IconVariant)(-1));
+    public static readonly UrlDisplayPropertiesViewModel Empty = new(string.Empty, 0, string.Empty, null);
 }
 
 public sealed record class VolumeViewModel(int index, string Source, string Target, string MountType, bool IsReadOnly) : IPropertyGridItem

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -98,11 +98,21 @@ partial class Resource
                 };
             }
 
+            static FluentUIIconVariant MapIconVariant(IconVariant iconVariant)
+            {
+                return iconVariant switch
+                {
+                    IconVariant.Regular => FluentUIIconVariant.Regular,
+                    IconVariant.Filled => FluentUIIconVariant.Filled,
+                    _ => throw new InvalidOperationException("Unknown icon variant: " + iconVariant),
+                };
+            }
+
             // Filter out bad urls
             return (from u in Urls
                     let parsedUri = Uri.TryCreate(u.FullUrl, UriKind.Absolute, out var uri) ? uri : null
                     where parsedUri != null
-                    select new UrlViewModel(u.EndpointName, parsedUri, u.IsInternal, u.IsInactive, new UrlDisplayPropertiesViewModel(TranslateKnownUrlName(u), u.DisplayProperties.SortOrder)))
+                    select new UrlViewModel(u.EndpointName, parsedUri, u.IsInternal, u.IsInactive, new UrlDisplayPropertiesViewModel(TranslateKnownUrlName(u), u.DisplayProperties.SortOrder, u.DisplayProperties.IconName, MapIconVariant(u.DisplayProperties.IconVariant))))
                 .ToImmutableArray();
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -230,7 +230,7 @@ public sealed record UrlSnapshot(string? Name, string Url, bool IsInternal)
 /// <param name="SortOrder">The order of the url in UI. Higher numbers are displayed first in the UI.</param>
 /// <param name="IconName">The icon name for the Url. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons</param>
 /// <param name="IconVariant">The icon variant.</param>
-/// 
+
 public sealed record UrlDisplayPropertiesSnapshot(string DisplayName = "", int SortOrder = 0, string? IconName = null, IconVariant? IconVariant = null);
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -228,7 +228,10 @@ public sealed record UrlSnapshot(string? Name, string Url, bool IsInternal)
 /// </summary>
 /// <param name="DisplayName">The display name of the url.</param>
 /// <param name="SortOrder">The order of the url in UI. Higher numbers are displayed first in the UI.</param>
-public sealed record UrlDisplayPropertiesSnapshot(string DisplayName = "", int SortOrder = 0);
+/// <param name="IconName">The icon name for the Url. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons</param>
+/// <param name="IconVariant">The icon variant.</param>
+/// 
+public sealed record UrlDisplayPropertiesSnapshot(string DisplayName = "", int SortOrder = 0, string? IconName = null, IconVariant? IconVariant = null);
 
 /// <summary>
 /// A snapshot of a volume, mounted to a container.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
@@ -39,12 +39,12 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
     /// <summary>
     /// The name of the icon to display with this URL.
     /// </summary>
-    public string IconName { get; set; } = string.Empty;
-    
+    public string? IconName { get; set; }
+
     /// <summary>
     /// The variant of the icon to display with this URL.
     /// </summary>
-    public IconVariant IconVariant { get; set; } = IconVariant.Regular;
+    public IconVariant? IconVariant { get; set; }
 
     internal bool IsInternal => DisplayLocation == UrlDisplayLocation.DetailsOnly;
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
@@ -36,6 +36,16 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
     /// </summary>
     public UrlDisplayLocation DisplayLocation { get; set; } = UrlDisplayLocation.SummaryAndDetails;
 
+    /// <summary>
+    /// The name of the icon to display with this URL.
+    /// </summary>
+    public string IconName { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// The variant of the icon to display with this URL.
+    /// </summary>
+    public IconVariant IconVariant { get; set; } = IconVariant.Regular;
+
     internal bool IsInternal => DisplayLocation == UrlDisplayLocation.DetailsOnly;
 
     internal ResourceUrlAnnotation WithEndpoint(EndpointReference endpoint)
@@ -46,7 +56,7 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
             DisplayText = DisplayText,
             Endpoint = endpoint,
             DisplayOrder = DisplayOrder,
-            DisplayLocation = DisplayLocation
+            DisplayLocation = DisplayLocation,
         };
     }
 }

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -66,6 +66,16 @@ partial class Resource
                 displayProperties.SortOrder = urlSnapshot.DisplayProperties.SortOrder;
             }
 
+            if (urlSnapshot.DisplayProperties?.IconName is not null)
+            {
+                displayProperties.IconName = urlSnapshot.DisplayProperties.IconName;
+            }
+
+            if (urlSnapshot.DisplayProperties?.IconVariant is not null)
+            {
+                displayProperties.IconVariant = MapIconVariant(urlSnapshot.DisplayProperties.IconVariant);
+            }
+            
             url.DisplayProperties = displayProperties;
             resource.Urls.Add(url);
         }

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -75,7 +75,7 @@ partial class Resource
             {
                 displayProperties.IconVariant = MapIconVariant(urlSnapshot.DisplayProperties.IconVariant);
             }
-            
+
             url.DisplayProperties = displayProperties;
             resource.Urls.Add(url);
         }

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -143,6 +143,11 @@ message UrlDisplayProperties {
   int32 sort_order = 1;
   // The display name of the url, to appear in the UI.
   string display_name = 2;
+  // Optional icon name. This name should be a valid FluentUI icon name.
+  // https://aka.ms/fluentui-system-icons
+  optional string icon_name = 3;
+  // Optional icon variant.
+  optional IconVariant icon_variant = 4;
 }
 
 // Data about a volume mounted to a container.

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -255,7 +255,7 @@ internal class ResourceSnapshotBuilder
                     var activeEndpoint = _resourceState.EndpointsMap.SingleOrDefault(e => e.Value.Spec.ServiceName == serviceName && e.Value.Metadata.OwnerReferences?.Any(or => or.Kind == resource.Kind && or.Name == name) == true).Value;
                     var isInactive = activeEndpoint is null;
 
-                    urls.Add(new(Name: endpointUrl.Endpoint!.EndpointName, Url: endpointUrl.Url, IsInternal: endpointUrl.IsInternal) { IsInactive = isInactive, DisplayProperties = new(endpointUrl.DisplayText ?? "", endpointUrl.DisplayOrder ?? 0) });
+                    urls.Add(new(Name: endpointUrl.Endpoint!.EndpointName, Url: endpointUrl.Url, IsInternal: endpointUrl.IsInternal) { IsInactive = isInactive, DisplayProperties = new(endpointUrl.DisplayText ?? "", endpointUrl.DisplayOrder ?? 0, endpointUrl.IconName, endpointUrl.IconVariant) });
                 }
             }
 
@@ -263,7 +263,7 @@ internal class ResourceSnapshotBuilder
             var resourceRunning = string.Equals(resourceState, KnownResourceStates.Running, StringComparisons.ResourceState);
             foreach (var url in nonEndpointUrls)
             {
-                urls.Add(new(Name: null, Url: url.Url, IsInternal: url.IsInternal) { IsInactive = !resourceRunning, DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0) });
+                urls.Add(new(Name: null, Url: url.Url, IsInternal: url.IsInternal) { IsInactive = !resourceRunning, DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0, url.IconName, url.IconVariant) });
             }
         }
 

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -147,7 +147,7 @@ internal sealed class ApplicationOrchestrator
                 // Endpoint URLs are inactive (hidden in the dashboard) when published here. It is assumed they will get activated later when the endpoint is considered active
                 // by whatever allocated the endpoint in the first place, e.g. for resources controlled by DCP, when DCP detects the endpoint is listening.
                 IsInactive = url.Endpoint is not null,
-                DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0)
+                DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0, url.IconName, url.IconVariant)
             });
         }
         return urls;

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceUrlHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceUrlHelpersTests.cs
@@ -244,10 +244,10 @@ public sealed class ResourceUrlHelpersTests
     public void GetUrls_SortOrder_Combinations()
     {
         var endpoints = GetUrls(ModelTestHelpers.CreateResource(urls: [
-            new("Zero-Https", new("https://localhost:8079"), isInternal: false, isInactive: false, displayProperties: new UrlDisplayPropertiesViewModel(string.Empty, 0)),
-            new("Zero-Http", new("http://localhost:8080"), isInternal: false, isInactive: false, displayProperties: new UrlDisplayPropertiesViewModel(string.Empty, 0)),
-            new("Positive", new("http://localhost:8082"), isInternal: false, isInactive: false, displayProperties: new UrlDisplayPropertiesViewModel(string.Empty, 1)),
-            new("Negative", new("http://localhost:8083"), isInternal: false, isInactive: false, displayProperties: new UrlDisplayPropertiesViewModel(string.Empty, -1))
+            new("Zero-Https", new("https://localhost:8079"), isInternal: false, isInactive: false, displayProperties: new UrlDisplayPropertiesViewModel(string.Empty, 0, null, null)),
+            new("Zero-Http", new("http://localhost:8080"), isInternal: false, isInactive: false, displayProperties: new UrlDisplayPropertiesViewModel(string.Empty, 0 null, null)),
+            new("Positive", new("http://localhost:8082"), isInternal: false, isInactive: false, displayProperties: new UrlDisplayPropertiesViewModel(string.Empty, 1 null, null)),
+            new("Negative", new("http://localhost:8083"), isInternal: false, isInactive: false, displayProperties: new UrlDisplayPropertiesViewModel(string.Empty, -1 null, null))
         ]));
 
         Assert.Collection(endpoints,


### PR DESCRIPTION

## Description

Added IconName, IconVarient to ResourceUrlAnnotation to display urls using Fluent Icons.

<img width="316" height="290" alt="image" src="https://github.com/user-attachments/assets/3fb204d2-e403-43b7-a08a-32adf9ca9afe" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
