### PR TITLE
Enable universal support for container-to-host communication

### DIFF
--- a/playground/yarp/Yarp.AppHost/Program.cs
+++ b/playground/yarp/Yarp.AppHost/Program.cs
@@ -25,6 +25,8 @@ var staticGateway = builder.AddYarp("static-gateway")
                                    .WithTransformPathRemovePrefix("/api");
                            });
 
+frontendService.WithReference(gateway);
+
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code

--- a/playground/yarp/Yarp.Frontend/Program.cs
+++ b/playground/yarp/Yarp.Frontend/Program.cs
@@ -6,8 +6,21 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.AddServiceDefaults();
 
+builder.Services.AddHttpClient("gateway-client", client =>
+{
+    client.BaseAddress = new Uri("https+http://gateway");
+});
+
 var app = builder.Build();
 
 app.UseFileServer();
+
+app.MapGet("/api/weatherforecast", async (IHttpClientFactory httpClientFactory) =>
+{
+    var client = httpClientFactory.CreateClient("gateway-client");
+    var response = await client.GetAsync("/api/weatherforecast");
+    response.EnsureSuccessStatusCode();
+    return Results.Content(await response.Content.ReadAsStringAsync(), "application/json");
+});
 
 app.Run();

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -75,8 +75,8 @@ public class YarpCluster
 
         // NOTE: This should likely fallback to other endpoints with HTTP or HTTPS schemes in cases where they don't
         //       have the default names.
-        var httpsEndpoint = resource.GetEndpoint("https");
-        var httpEndpoint = resource.GetEndpoint("http");
+        var httpsEndpoint = resource.GetEndpoint("https", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+        var httpEndpoint = resource.GetEndpoint("http", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
 
         var scheme = (httpsEndpoint.Exists, httpEndpoint.Exists) switch
         {

--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpCluster.cs
@@ -75,8 +75,8 @@ public class YarpCluster
 
         // NOTE: This should likely fallback to other endpoints with HTTP or HTTPS schemes in cases where they don't
         //       have the default names.
-        var httpsEndpoint = resource.GetEndpoint("https", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
-        var httpEndpoint = resource.GetEndpoint("http", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+        var httpsEndpoint = resource.GetEndpoint("https");
+        var httpEndpoint = resource.GetEndpoint("http");
 
         var scheme = (httpsEndpoint.Exists, httpEndpoint.Exists) switch
         {

--- a/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
@@ -42,11 +42,17 @@ public class AllocatedEndpoint
     /// </summary>
     /// <param name="endpoint">The endpoint.</param>
     /// <param name="address">The IP address of the endpoint.</param>
-    /// <param name="containerHostAddress">The address of the container host.</param>
     /// <param name="port">The port number of the endpoint.</param>
     /// <param name="targetPortExpression">A string representing how to retrieve the target port of the <see cref="AllocatedEndpoint"/> instance.</param>
     /// <param name="bindingMode">The binding mode of the endpoint.</param>
-    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port, EndpointBindingMode bindingMode, string? containerHostAddress = null, string? targetPortExpression = null)
+    /// <param name="networkID">The network identifier for the network associated with the endpoint.</param>
+    public AllocatedEndpoint(
+        EndpointAnnotation endpoint,
+        string address, int port,
+        EndpointBindingMode bindingMode,
+        string? targetPortExpression = null,
+        NetworkIdentifier? networkID = null
+    )
     {
         ArgumentNullException.ThrowIfNull(endpoint);
         ArgumentOutOfRangeException.ThrowIfLessThan(port, 1, nameof(port));
@@ -55,9 +61,9 @@ public class AllocatedEndpoint
         Endpoint = endpoint;
         Address = address;
         BindingMode = bindingMode;
-        ContainerHostAddress = containerHostAddress;
         Port = port;
         TargetPortExpression = targetPortExpression;
+        NetworkID = networkID ?? endpoint.DefaultNetworkID;
     }
 
     /// <summary>
@@ -65,11 +71,27 @@ public class AllocatedEndpoint
     /// </summary>
     /// <param name="endpoint">The endpoint.</param>
     /// <param name="address">The IP address of the endpoint.</param>
-    /// <param name="containerHostAddress">The address of the container host.</param>
     /// <param name="port">The port number of the endpoint.</param>
     /// <param name="targetPortExpression">A string representing how to retrieve the target port of the <see cref="AllocatedEndpoint"/> instance.</param>
-    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port, string? containerHostAddress = null, string? targetPortExpression = null)
-        : this(endpoint, address, port, EndpointBindingMode.SingleAddress, containerHostAddress, targetPortExpression)
+    /// <param name="bindingMode">The binding mode of the endpoint.</param>
+    public AllocatedEndpoint(
+        EndpointAnnotation endpoint,
+        string address, int port,
+        EndpointBindingMode bindingMode,
+        string? targetPortExpression = null
+    ): this(endpoint, address, port, bindingMode, targetPortExpression, null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AllocatedEndpoint"/> class.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="address">The IP address of the endpoint.</param>
+    /// <param name="port">The port number of the endpoint.</param>
+    /// <param name="targetPortExpression">A string representing how to retrieve the target port of the <see cref="AllocatedEndpoint"/> instance.</param>
+    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port, string? targetPortExpression = null)
+        : this(endpoint, address, port, EndpointBindingMode.SingleAddress, targetPortExpression)
     {
     }
 
@@ -88,11 +110,6 @@ public class AllocatedEndpoint
     /// IPv4 or IPv6 addresses (or both).
     /// </summary>
     public EndpointBindingMode BindingMode { get; private set; }
-
-    /// <summary>
-    /// The address of the container host. This is only set for containerized services.
-    /// </summary>
-    public string? ContainerHostAddress { get; private set; }
 
     /// <summary>
     /// The port used by the endpoint
@@ -118,6 +135,11 @@ public class AllocatedEndpoint
     /// A string representing how to retrieve the target port of the <see cref="AllocatedEndpoint"/> instance.
     /// </summary>
     public string? TargetPortExpression { get; }
+
+    /// <summary>
+    /// Gets the network identifier for the network associated with the <see cref="AllocatedEndpoint"/> instance.
+    /// </summary>
+    public NetworkIdentifier NetworkID { get; private set; }
 
     /// <summary>
     /// Returns a string representation of the allocated endpoint URI.

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Collections.Concurrent;
 using System.Net.Sockets;
+using System.Collections;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -20,6 +22,8 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     private bool _portSetToNull;
     private int? _targetPort;
     private bool _targetPortSetToNull;
+    private readonly NetworkIdentifier _networkID;
+
     /// <summary>
     /// Initializes a new instance of <see cref="EndpointAnnotation"/>.
     /// </summary>
@@ -31,7 +35,52 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// <param name="targetPort">This is the port the resource is listening on. If the endpoint is used for the container, it is the container port.</param>
     /// <param name="isExternal">Indicates that this endpoint should be exposed externally at publish time.</param>
     /// <param name="isProxied">Specifies if the endpoint will be proxied by DCP. Defaults to true.</param>
-    public EndpointAnnotation(ProtocolType protocol, string? uriScheme = null, string? transport = null, [EndpointName] string? name = null, int? port = null, int? targetPort = null, bool? isExternal = null, bool isProxied = true)
+    public EndpointAnnotation(
+        ProtocolType protocol,
+        string? uriScheme = null,
+        string? transport = null,
+        [EndpointName] string? name = null,
+        int? port = null,
+        int? targetPort = null,
+        bool? isExternal = null,
+        bool isProxied = true
+    ) : this(
+        protocol,
+        null,
+        uriScheme,
+        transport,
+        name,
+        port,
+        targetPort,
+        isExternal,
+        isProxied
+    )
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="EndpointAnnotation"/>.
+    /// </summary>
+    /// <param name="protocol">Network protocol: TCP or UDP are supported today, others possibly in future.</param>
+    /// <param name="networkID">The ID of the network that is the "default" network for the Endpoint.
+    /// <param name="uriScheme">If a service is URI-addressable, this is the URI scheme to use for constructing service URI.</param>
+    /// <param name="transport">Transport that is being used (e.g. http, http2, http3 etc).</param>
+    /// <param name="name">Name of the service.</param>
+    /// <param name="port">Desired port for the service.</param>
+    /// <param name="targetPort">This is the port the resource is listening on. If the endpoint is used for the container, it is the container port.</param>
+    /// <param name="isExternal">Indicates that this endpoint should be exposed externally at publish time.</param>
+    /// <param name="isProxied">Specifies if the endpoint will be proxied by DCP. Defaults to true.</param>
+    /// Clients connected to the same network can reach the endpoint without any routing or network address translation.</param>
+    public EndpointAnnotation(
+        ProtocolType protocol,
+        NetworkIdentifier? networkID,
+        string? uriScheme = null,
+        string? transport = null,
+        [EndpointName] string? name = null,
+        int? port = null,
+        int? targetPort = null,
+        bool? isExternal = null,
+        bool isProxied = true
+    )
     {
         // If the URI scheme is null, we'll adopt either udp:// or tcp:// based on the
         // protocol. If the name is null, we'll use the URI scheme as the default. This
@@ -51,6 +100,8 @@ public sealed class EndpointAnnotation : IResourceAnnotation
         _targetPort = targetPort;
         IsExternal = isExternal ?? false;
         IsProxied = isProxied;
+        _networkID = networkID ?? KnownNetworkIdentifiers.LocalhostNetwork;
+        AllAllocatedEndpoints.TryAdd(_networkID, AllocatedEndpointSnapshot);
     }
 
     /// <summary>
@@ -142,7 +193,12 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     internal string? TargetPortEnvironmentVariable { get; set; }
 
     /// <summary>
-    /// Gets or sets the allocated endpoint.
+    /// Gets the ID of the network that is the "default" network for the Endpoint (the one the Endpoint is associated with and can be reached without routing or network address translation).
+    /// </summary>
+    public NetworkIdentifier DefaultNetworkID => _networkID;
+
+    /// <summary>
+    /// Gets or sets the default <see cref="AllocatedEndpoint"/> for this Endpoint.
     /// </summary>
     public AllocatedEndpoint? AllocatedEndpoint
     {
@@ -173,7 +229,56 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     }
 
     /// <summary>
-    /// Gets the allocated endpoint snapshot.
+    /// Gets the <see cref="AllocatedEndpointSnapshot"/> for the default <see cref="AllocatedEndpoint"/>.
     /// </summary>
     public ValueSnapshot<AllocatedEndpoint> AllocatedEndpointSnapshot { get; } = new();
+
+    /// <summary>
+    /// Gets the list of all AllocatedEndpoints associated with this Endpoint.
+    /// </summary>
+    public NetworkEndpointSnapshotList AllAllocatedEndpoints { get; } = new();
+}
+
+/// <summary>
+/// Represents an AllocatedEndpoint snapshot associated with a specific network.
+/// </summary>
+/// <param name="Snapshot">AllocatedEndpoint snapshot</param>
+/// <param name="NetworkID">The ID of the network that is associated with the AllocatedEndpoint snapshot.</param>
+public record class NetworkEndpointSnapshot(ValueSnapshot<AllocatedEndpoint> Snapshot, NetworkIdentifier NetworkID);
+
+/// <summary>
+/// Holds a list of <see cref="NetworkEndpointSnapshot"/> for an Endpoint, providing thread-safe enumeration and addition.
+/// </summary>
+public class NetworkEndpointSnapshotList : IEnumerable<NetworkEndpointSnapshot>
+{
+    private readonly ConcurrentBag<NetworkEndpointSnapshot> _snapshots = new();
+
+    /// <summary>
+    /// Provides a thread-safe enumerator over the network endpoint snapshots.
+    /// </summary>
+    public IEnumerator<NetworkEndpointSnapshot> GetEnumerator()
+    {
+        return _snapshots.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    /// <summary>
+    /// Adds an AllocatedEndpoint snapshot for a specific network if one does not already exist.
+    /// </summary>
+    public bool TryAdd(NetworkIdentifier networkID, ValueSnapshot<AllocatedEndpoint> snapshot)
+    {
+        lock (_snapshots)
+        {
+            if (_snapshots.Any(s => s.NetworkID.Equals(networkID)))
+            {
+                return false;
+            }
+            _snapshots.Add(new NetworkEndpointSnapshot(snapshot, networkID));
+            return true;
+        }
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -59,6 +59,14 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default) => Property(EndpointProperty.Url).GetValueAsync(cancellationToken);
 
     /// <summary>
+    /// Gets the URL of the endpoint asynchronously. Waits for the endpoint to be allocated if necessary.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="context">The context for value resolution.</param>
+    /// <returns>The URL of the endpoint.</returns>
+    public ValueTask<string?> GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken = default) => Property(EndpointProperty.Url).GetValueAsync(context, cancellationToken);
+
+    /// <summary>
     /// The ID of the network that serves as the context for the EndpointReference.
     /// The reference will be resolved in the context of this network, which may be different
     /// from the network associated with the default network of the referenced Endpoint.
@@ -263,7 +271,7 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
     /// <summary>
     /// Gets the value of the property of the endpoint.
     /// </summary>
-    /// <param name="context">The optional <see cref="NetworkIdentifier"/> context to use when resolving the endpoint property.</param>
+    /// <param name="context">The context to use when resolving the endpoint property.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="string"/> containing the selected <see cref="EndpointProperty"/> value.</returns>
     /// <exception cref="InvalidOperationException">Throws when the selected <see cref="EndpointProperty"/> enumeration is not known.</exception>

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -15,6 +15,7 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     // A reference to the endpoint annotation if it exists.
     private EndpointAnnotation? _endpointAnnotation;
     private bool? _isAllocated;
+    private readonly NetworkIdentifier _contextNetworkID;
 
     /// <summary>
     /// Gets the endpoint annotation associated with the endpoint reference.
@@ -58,6 +59,13 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default) => Property(EndpointProperty.Url).GetValueAsync(cancellationToken);
 
     /// <summary>
+    /// The ID of the network that serves as the context for the EndpointReference.
+    /// The reference will be resolved in the context of this network, which may be different
+    /// from the network associated with the default network of the referenced Endpoint.
+    /// </summary>
+    public NetworkIdentifier ContextNetworkID => _contextNetworkID;
+
+    /// <summary>
     /// Gets the specified property expression of the endpoint. Defaults to the URL if no property is specified.
     /// </summary>
     internal string GetExpression(EndpointProperty property = EndpointProperty.Url)
@@ -99,12 +107,7 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     /// <summary>
     /// Gets the host for this endpoint.
     /// </summary>
-    public string Host => AllocatedEndpoint.Address ?? "localhost";
-
-    /// <summary>
-    /// Gets the container host for this endpoint.
-    /// </summary>
-    public string ContainerHost => AllocatedEndpoint.ContainerHostAddress ?? throw new InvalidOperationException($"The endpoint \"{EndpointName}\" has no associated container host name.");
+    public string Host => AllocatedEndpoint.Address ?? KnownHostNames.Localhost;
 
     /// <summary>
     /// Gets the scheme for this endpoint.
@@ -123,17 +126,55 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
         GetAllocatedEndpoint()
         ?? throw new InvalidOperationException($"The endpoint `{EndpointName}` is not allocated for the resource `{Resource.Name}`.");
 
-    private EndpointAnnotation? GetEndpointAnnotation() =>
-        _endpointAnnotation ??= Resource.Annotations.OfType<EndpointAnnotation>().SingleOrDefault(a => StringComparers.EndpointAnnotationName.Equals(a.Name, EndpointName));
+    private EndpointAnnotation? GetEndpointAnnotation()
+    {
+        if (_endpointAnnotation is not null)
+        {
+            return _endpointAnnotation;
+        }
 
-    private AllocatedEndpoint? GetAllocatedEndpoint() => GetEndpointAnnotation()?.AllocatedEndpoint;
+        _endpointAnnotation ??= Resource.Annotations.OfType<EndpointAnnotation>()
+            .SingleOrDefault(a => StringComparers.EndpointAnnotationName.Equals(a.Name, EndpointName));
+        return _endpointAnnotation;
+    }
+
+    private AllocatedEndpoint? GetAllocatedEndpoint()
+    {
+        var endpointAnnotation = GetEndpointAnnotation();
+        if (endpointAnnotation is null)
+        {
+            return null;
+        }
+
+        foreach (var nes in endpointAnnotation.AllAllocatedEndpoints)
+        {
+            if (StringComparers.NetworkID.Equals(nes.NetworkID, _contextNetworkID))
+            {
+                if (!nes.Snapshot.IsValueSet)
+                {
+                    continue;
+                }
+
+                return nes.Snapshot.GetValueAsync().GetAwaiter().GetResult();
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>
     /// Creates a new instance of <see cref="EndpointReference"/> with the specified endpoint name.
     /// </summary>
-    /// <param name="owner">The resource with endpoints that owns the endpoint reference.</param>
+    /// <param name="owner">The resource with endpoints that owns the referenced endpoint.</param>
     /// <param name="endpoint">The endpoint annotation.</param>
-    public EndpointReference(IResourceWithEndpoints owner, EndpointAnnotation endpoint)
+    /// <param name="contextNetworkID">The ID of the network that serves as the context for the EndpointReference.</param>
+    /// <remarks>
+    /// Most Aspire resources are accessed in the context of the "localhost" network (host proceses calling other host processes,
+    /// or host processes calling container via mapped ports). This is why EndpointReference assumes this
+    /// context unless specified otherwise. However, for container-to-container, or container-to-host communication,
+    /// you must specify a container network context for the EndpointReference to be resolved correctly.
+    /// </remarks>
+    public EndpointReference(IResourceWithEndpoints owner, EndpointAnnotation endpoint, NetworkIdentifier? contextNetworkID = null)
     {
         ArgumentNullException.ThrowIfNull(owner);
         ArgumentNullException.ThrowIfNull(endpoint);
@@ -141,20 +182,47 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
         Resource = owner;
         EndpointName = endpoint.Name;
         _endpointAnnotation = endpoint;
+        _contextNetworkID = contextNetworkID ?? KnownNetworkIdentifiers.LocalhostNetwork;
     }
 
     /// <summary>
     /// Creates a new instance of <see cref="EndpointReference"/> with the specified endpoint name.
     /// </summary>
-    /// <param name="owner">The resource with endpoints that owns the endpoint reference.</param>
+    /// <param name="owner">The resource with endpoints that owns the referenced endpoint.</param>
+    /// <param name="endpoint">The endpoint annotation.</param>
+    public EndpointReference(IResourceWithEndpoints owner, EndpointAnnotation endpoint): this(owner, endpoint, null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="EndpointReference"/> with the specified endpoint name.
+    /// </summary>
+    /// <param name="owner">The resource with endpoints that owns the referenced endpoint.</param>
     /// <param name="endpointName">The name of the endpoint.</param>
-    public EndpointReference(IResourceWithEndpoints owner, string endpointName)
+    /// <param name="contextNetworkID">The ID of the network that serves as the context for the EndpointReference.</param>
+    /// <remarks>
+    /// Most Aspire resources are accessed in the context of the "localhost" network (host proceses calling other host processes,
+    /// or host processes calling container via mapped ports). This is why EndpointReference assumes this
+    /// context unless specified otherwise. However, for container-to-container, or container-to-host communication,
+    /// you must specify a container network context for the EndpointReference to be resolved correctly.
+    /// </remarks>
+    public EndpointReference(IResourceWithEndpoints owner, string endpointName, NetworkIdentifier? contextNetworkID = null)
     {
         ArgumentNullException.ThrowIfNull(owner);
         ArgumentNullException.ThrowIfNull(endpointName);
 
         Resource = owner;
         EndpointName = endpointName;
+        _contextNetworkID = contextNetworkID ?? KnownNetworkIdentifiers.LocalhostNetwork;
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="EndpointReference"/> with the specified endpoint name.
+    /// </summary>
+    /// <param name="owner">The resource with endpoints that owns the referenced endpoint.</param>
+    /// <param name="endpointName">The name of the endpoint.</param>
+    public EndpointReference(IResourceWithEndpoints owner, string endpointName): this(owner, endpointName, null)
+    {
     }
 }
 
@@ -187,24 +255,57 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="string"/> containing the selected <see cref="EndpointProperty"/> value.</returns>
     /// <exception cref="InvalidOperationException">Throws when the selected <see cref="EndpointProperty"/> enumeration is not known.</exception>
-    public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
+    public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default)
+    {
+        return GetNetworkValueAsync(null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the value of the property of the endpoint.
+    /// </summary>
+    /// <param name="context">The optional <see cref="NetworkIdentifier"/> context to use when resolving the endpoint property.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    /// <returns>A <see cref="string"/> containing the selected <see cref="EndpointProperty"/> value.</returns>
+    /// <exception cref="InvalidOperationException">Throws when the selected <see cref="EndpointProperty"/> enumeration is not known.</exception>
+    public ValueTask<string?> GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken = default)
+    {
+        return context.Network switch
+        {
+            NetworkIdentifier networkID => GetNetworkValueAsync(networkID, cancellationToken),
+            _ => GetNetworkValueAsync(null, cancellationToken)
+        };
+    }
+
+    
+    private async ValueTask<string?> GetNetworkValueAsync(NetworkIdentifier? context, CancellationToken cancellationToken = default)
     {
         return Property switch
         {
             EndpointProperty.Scheme => new(Endpoint.Scheme),
-            EndpointProperty.IPV4Host => new("127.0.0.1"),
+            EndpointProperty.IPV4Host when context is null || context == KnownNetworkIdentifiers.LocalhostNetwork => "127.0.0.1",
             EndpointProperty.TargetPort when Endpoint.TargetPort is int port => new(port.ToString(CultureInfo.InvariantCulture)),
             _ => await ResolveValueWithAllocatedAddress().ConfigureAwait(false)
         };
 
         async ValueTask<string?> ResolveValueWithAllocatedAddress()
         {
-            var allocatedEndpoint = await Endpoint.AllocatedEndpointSnapshot.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            var effectiveContext = context ?? Endpoint.ContextNetworkID;
+
+            // We are going to take the first snapshot that matches the context network ID. In general there might be multiple endpoints for a single service,
+            // and in future we might need some sort of policy to choose between them, but for now we just take the first one.
+            var nes = Endpoint.EndpointAnnotation.AllAllocatedEndpoints.Where(nes => nes.NetworkID == effectiveContext).FirstOrDefault();
+            if (nes is null)
+            {
+                return null;
+            }
+
+            var allocatedEndpoint = await nes.Snapshot.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
             return Property switch
             {
                 EndpointProperty.Url => new(allocatedEndpoint.UriString),
                 EndpointProperty.Host => new(allocatedEndpoint.Address),
+                EndpointProperty.IPV4Host => new(allocatedEndpoint.Address),
                 EndpointProperty.Port => new(allocatedEndpoint.Port.ToString(CultureInfo.InvariantCulture)),
                 EndpointProperty.TargetPort => new(ComputeTargetPort(allocatedEndpoint)),
                 EndpointProperty.HostAndPort => new($"{allocatedEndpoint.Address}:{allocatedEndpoint.Port.ToString(CultureInfo.InvariantCulture)}"),

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReferenceAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReferenceAnnotation.cs
@@ -11,4 +11,6 @@ internal sealed class EndpointReferenceAnnotation(IResourceWithEndpoints resourc
     public IResourceWithEndpoints Resource { get; } = resource ?? throw new ArgumentNullException(nameof(resource));
     public bool UseAllEndpoints { get; set; }
     public HashSet<string> EndpointNames { get; } = new(StringComparers.EndpointAnnotationName);
+
+    public NetworkIdentifier ContextNetworkID { get; set; } = KnownNetworkIdentifiers.LocalhostNetwork;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -6,10 +6,10 @@ using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.ApplicationModel;
 
-internal class ExpressionResolver(string containerHostName, CancellationToken cancellationToken, bool sourceIsContainer)
+internal class ExpressionResolver(CancellationToken cancellationToken)
 {
 
-    async Task<string?> EvalContainerEndpointAsync(EndpointReference endpointReference, EndpointProperty property)
+    async Task<string?> ResolveInContainerContextAsync(EndpointReference endpointReference, EndpointProperty property, NetworkIdentifier? context)
     {
         // We need to use the root resource, e.g. AzureStorageResource instead of AzureBlobResource
         // Otherwise, we get the wrong values for IsContainer and Name
@@ -17,23 +17,24 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
 
         return (property, target.IsContainer()) switch
         {
-            // If Container -> Container, we go directly to the container name and target port, bypassing the host
+            // If Container -> Container, we use container name as host, and target port as port
+            // This assumes both containers are on the same container network.
+            // Different networks will require addtional routing/tunneling that we do not support today.
             (EndpointProperty.Host or EndpointProperty.IPV4Host, true) => target.Name,
             (EndpointProperty.Port, true) => await endpointReference.Property(EndpointProperty.TargetPort).GetValueAsync(cancellationToken).ConfigureAwait(false),
-            // If Container -> Exe, we need to go through the container host
-            (EndpointProperty.Host or EndpointProperty.IPV4Host, false) => containerHostName,
+
             (EndpointProperty.Url, _) => string.Format(CultureInfo.InvariantCulture, "{0}://{1}:{2}",
                                             endpointReference.Scheme,
-                                            await EvalContainerEndpointAsync(endpointReference, EndpointProperty.Host).ConfigureAwait(false),
-                                            await EvalContainerEndpointAsync(endpointReference, EndpointProperty.Port).ConfigureAwait(false)),
+                                            await ResolveInContainerContextAsync(endpointReference, EndpointProperty.Host, context).ConfigureAwait(false),
+                                            await ResolveInContainerContextAsync(endpointReference, EndpointProperty.Port, context).ConfigureAwait(false)),
             (EndpointProperty.HostAndPort, _) => string.Format(CultureInfo.InvariantCulture, "{0}:{1}",
-                                            await EvalContainerEndpointAsync(endpointReference, EndpointProperty.Host).ConfigureAwait(false),
-                                            await EvalContainerEndpointAsync(endpointReference, EndpointProperty.Port).ConfigureAwait(false)),
-            _ => await endpointReference.Property(property).GetValueAsync(cancellationToken).ConfigureAwait(false)
+                                            await ResolveInContainerContextAsync(endpointReference, EndpointProperty.Host, context).ConfigureAwait(false),
+                                            await ResolveInContainerContextAsync(endpointReference, EndpointProperty.Port, context).ConfigureAwait(false)),
+            _ => await endpointReference.Property(property).GetValueAsync(new ValueProviderContext { Network = context }, cancellationToken).ConfigureAwait(false)
         };
     }
 
-    async Task<ResolvedValue> EvalExpressionAsync(ReferenceExpression expr)
+    async Task<ResolvedValue> EvalExpressionAsync(ReferenceExpression expr, NetworkIdentifier? context)
     {
         // This logic is similar to ReferenceExpression.GetValueAsync, except that we recurse on
         // our own resolver method
@@ -42,7 +43,7 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
 
         for (var i = 0; i < expr.ValueProviders.Count; i++)
         {
-            var result = await ResolveInternalAsync(expr.ValueProviders[i]).ConfigureAwait(false);
+            var result = await ResolveInternalAsync(expr.ValueProviders[i], context).ConfigureAwait(false);
             args[i] = result?.Value;
 
             // Apply string format if needed
@@ -63,63 +64,22 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
         return new ResolvedValue(value, isSensitive);
     }
 
-    async Task<ResolvedValue> EvalValueProvider(IValueProvider vp)
+    async Task<ResolvedValue> EvalValueProvider(IValueProvider vp, NetworkIdentifier? context)
     {
-        var value = await vp.GetValueAsync(cancellationToken).ConfigureAwait(false);
-
+        var value = await vp.GetValueAsync(new ValueProviderContext { Network = context }, cancellationToken).ConfigureAwait(false);
         if (vp is ParameterResource pr)
         {
             return new ResolvedValue(value, pr.Secret);
         }
-
-        // No need to do extra work, since the below will only be valid for containers.
-        if (!sourceIsContainer)
-        {
-            return new ResolvedValue(value, false);
-        }
-
-        if (vp is HostUrl && value != null)
-        {
-            // HostUrl is a bit of a hack that is not modeled as an expression
-            // So in this one case, we need to fix up the container host name 'manually'
-            // Internally, this is only used for OTEL_EXPORTER_OTLP_ENDPOINT, but HostUrl
-            // is public, so we don't control how it is used
-            try
-            {
-                var uri = new UriBuilder(value);
-                if (uri.Host is "localhost" or "127.0.0.1" or "[::1]")
-                {
-                    var hasEndingSlash = value.EndsWith('/');
-                    uri.Host = containerHostName;
-                    value = uri.ToString();
-
-                    // Remove trailing slash if we didn't have one before (UriBuilder always adds one)
-                    if (!hasEndingSlash && value.EndsWith('/'))
-                    {
-                        value = value[..^1];
-                    }
-                }
-            }
-            catch (UriFormatException)
-            {
-                // HostUrl was meant to only be used with valid URLs. However, this was not
-                // previously enforced. So we need to handle the case where it's not a valid URL,
-                // by falling back to a simple string replacement.
-                value = value.Replace("localhost", containerHostName, StringComparison.OrdinalIgnoreCase)
-                             .Replace("127.0.0.1", containerHostName)
-                             .Replace("[::1]", containerHostName);
-            }
-        }
-
         return new ResolvedValue(value, false);
     }
 
-    async Task<ResolvedValue> ResolveConnectionStringReferenceAsync(ConnectionStringReference cs)
+    async Task<ResolvedValue> ResolveConnectionStringReferenceAsync(ConnectionStringReference cs, NetworkIdentifier? context)
     {
         // We are substituting our own logic for ConnectionStringReference's GetValueAsync.
         // However, ConnectionStringReference#GetValueAsync will throw if the connection string is not optional but is not present.
         // so we need to do the same here.
-        var value = await ResolveInternalAsync(cs.Resource.ConnectionStringExpression).ConfigureAwait(false);
+        var value = await ResolveInternalAsync(cs.Resource.ConnectionStringExpression, context).ConfigureAwait(false);
 
         // Throw if the connection string is required but not present
         if (string.IsNullOrEmpty(value.Value) && !cs.Optional)
@@ -133,29 +93,24 @@ internal class ExpressionResolver(string containerHostName, CancellationToken ca
     /// <summary>
     /// Resolve an expression. When it is being used from inside a container, endpoints may be evaluated (either in a container-to-container or container-to-exe communication).
     /// </summary>
-    async ValueTask<ResolvedValue> ResolveInternalAsync(object? value)
+    async ValueTask<ResolvedValue> ResolveInternalAsync(object? value, NetworkIdentifier? context)
     {
         return value switch
         {
-            ConnectionStringReference cs => await ResolveConnectionStringReferenceAsync(cs).ConfigureAwait(false),
-            IResourceWithConnectionString cs and not ConnectionStringParameterResource => await ResolveInternalAsync(cs.ConnectionStringExpression).ConfigureAwait(false),
-            ReferenceExpression ex => await EvalExpressionAsync(ex).ConfigureAwait(false),
-            EndpointReference endpointReference when sourceIsContainer => new ResolvedValue(await EvalContainerEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false), false),
-            EndpointReferenceExpression ep when sourceIsContainer => new ResolvedValue(await EvalContainerEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false), false),
-            IValueProvider vp => await EvalValueProvider(vp).ConfigureAwait(false),
+            ConnectionStringReference cs => await ResolveConnectionStringReferenceAsync(cs, context).ConfigureAwait(false),
+            IResourceWithConnectionString cs and not ConnectionStringParameterResource => await ResolveInternalAsync(cs.ConnectionStringExpression, context).ConfigureAwait(false),
+            ReferenceExpression ex => await EvalExpressionAsync(ex, context).ConfigureAwait(false),
+            EndpointReference er when context == KnownNetworkIdentifiers.DefaultAspireContainerNetwork => new ResolvedValue(await ResolveInContainerContextAsync(er, EndpointProperty.Url, context).ConfigureAwait(false), false),
+            EndpointReferenceExpression ep when context == KnownNetworkIdentifiers.DefaultAspireContainerNetwork => new ResolvedValue(await ResolveInContainerContextAsync(ep.Endpoint, ep.Property, context).ConfigureAwait(false), false),
+            IValueProvider vp => await EvalValueProvider(vp, context).ConfigureAwait(false),
             _ => throw new NotImplementedException()
         };
     }
 
-    static async ValueTask<ResolvedValue> ResolveWithContainerSourceAsync(IValueProvider valueProvider, string containerHostName, bool sourceIsContainer, CancellationToken cancellationToken)
+    internal static async ValueTask<ResolvedValue> ResolveAsync(IValueProvider valueProvider, NetworkIdentifier? context, CancellationToken cancellationToken)
     {
-        var resolver = new ExpressionResolver(containerHostName, cancellationToken, sourceIsContainer);
-        return await resolver.ResolveInternalAsync(valueProvider).ConfigureAwait(false);
-    }
-
-    internal static async ValueTask<ResolvedValue> ResolveAsync(bool sourceIsContainer, IValueProvider valueProvider, string containerHostName, CancellationToken cancellationToken)
-    {
-        return await ResolveWithContainerSourceAsync(valueProvider, containerHostName, sourceIsContainer, cancellationToken).ConfigureAwait(false);
+        var resolver = new ExpressionResolver(cancellationToken);
+        return await resolver.ResolveInternalAsync(valueProvider, context).ConfigureAwait(false);
     }
 }
 

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -21,7 +21,7 @@ internal class ExpressionResolver(CancellationToken cancellationToken)
             // This assumes both containers are on the same container network.
             // Different networks will require addtional routing/tunneling that we do not support today.
             (EndpointProperty.Host or EndpointProperty.IPV4Host, true) => target.Name,
-            (EndpointProperty.Port, true) => await endpointReference.Property(EndpointProperty.TargetPort).GetValueAsync(cancellationToken).ConfigureAwait(false),
+            (EndpointProperty.Port, true) => await endpointReference.Property(EndpointProperty.TargetPort).GetValueAsync(new ValueProviderContext { Network = context }, cancellationToken).ConfigureAwait(false),
 
             (EndpointProperty.Url, _) => string.Format(CultureInfo.InvariantCulture, "{0}://{1}:{2}",
                                             endpointReference.Scheme,

--- a/src/Aspire.Hosting/ApplicationModel/HostUrl.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HostUrl.cs
@@ -13,8 +13,58 @@ public record HostUrl(string Url) : IValueProvider, IManifestExpressionProvider
     string IManifestExpressionProvider.ValueExpression => Url;
 
     // Returns the url
-    ValueTask<string?> IValueProvider.GetValueAsync(System.Threading.CancellationToken cancellationToken)
+    ValueTask<string?> IValueProvider.GetValueAsync(System.Threading.CancellationToken _) => GetNetworkValueAsync(null);
+
+    // Returns the url
+    ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken _)
     {
-        return new(Url);
+        return context.Network switch
+        {
+            NetworkIdentifier networkContext => GetNetworkValueAsync(networkContext),
+            _ => GetNetworkValueAsync(null)
+        };
+    }
+
+    private ValueTask<string?> GetNetworkValueAsync(NetworkIdentifier? context)
+    {
+        // HostUrl is a bit of a hack that is not modeled as an expression
+        // So in this one case, we need to fix up the container host name 'manually'
+        // Internally, this is only used for OTEL_EXPORTER_OTLP_ENDPOINT, but HostUrl
+        // is public, so we don't control how it is used
+
+        if (context is null || context == KnownNetworkIdentifiers.LocalhostNetwork)
+        {
+            return new(Url);
+        }
+
+        var retval = Url;
+
+        try
+        {
+            var uri = new UriBuilder(Url);
+            if (uri.Host is "localhost" or "127.0.0.1" or "[::1]")
+            {
+                var hasEndingSlash = Url.EndsWith('/');
+                uri.Host = KnownHostNames.DefaultContainerTunnelHostName;
+                retval = uri.ToString();
+
+                // Remove trailing slash if we didn't have one before (UriBuilder always adds one)
+                if (!hasEndingSlash && retval.EndsWith('/'))
+                {
+                    retval = retval[..^1];
+                }
+            }
+        }
+        catch (UriFormatException)
+        {
+            // HostUrl was meant to only be used with valid URLs. However, this was not
+            // previously enforced. So we need to handle the case where it's not a valid URL,
+            // by falling back to a simple string replacement.
+            retval = retval.Replace(KnownHostNames.Localhost, KnownHostNames.DefaultContainerTunnelHostName, StringComparison.OrdinalIgnoreCase)
+                         .Replace("127.0.0.1", KnownHostNames.DefaultContainerTunnelHostName)
+                         .Replace("[::1]", KnownHostNames.DefaultContainerTunnelHostName);
+        }
+
+        return new(retval);
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
@@ -20,6 +20,12 @@ public interface IResourceWithConnectionString : IResource, IManifestExpressionP
 
     ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => GetConnectionStringAsync(cancellationToken);
 
+    ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken) => context.Network switch
+    {
+        NetworkIdentifier networkContext => ConnectionStringExpression.GetValueAsync(new ValueProviderContext { Network = networkContext }, cancellationToken),
+        _ => GetConnectionStringAsync(cancellationToken),
+    };
+
     /// <summary>
     /// Describes the connection string format string used for this resource.
     /// </summary>

--- a/src/Aspire.Hosting/ApplicationModel/IValueProvider.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IValueProvider.cs
@@ -4,6 +4,27 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
+/// Provides context for value resolution.
+/// </summary>
+public class ValueProviderContext
+{
+    /// <summary>
+    /// Additional services that can be used during value resolution.
+    /// </summary>
+    public IServiceProvider? Services { get; init; }
+
+    /// <summary>
+    /// The resource that is requesting the value.
+    /// </summary>
+    public IResource? Caller { get; init; }
+
+    /// <summary>
+    /// The identifier of the network that serves as the context for value resolution.
+    /// </summary>
+    public NetworkIdentifier? Network { get; init; }
+}
+
+/// <summary>
 /// An interface that allows the value to be provided for an environment variable.
 /// </summary>
 public interface IValueProvider
@@ -14,4 +35,10 @@ public interface IValueProvider
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns></returns>
     public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the value for use as an environment variable in the specified context.
+    /// </summary>
+    public ValueTask<string?> GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken = default) =>
+        GetValueAsync(cancellationToken);
 }

--- a/src/Aspire.Hosting/ApplicationModel/Network.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Network.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// A network identifier used to specify the network context for resources within an Aspire application model.
+/// </summary>
+public readonly record struct NetworkIdentifier(string Value);
+
+/// <summary>
+/// Provides known network identifiers for use within the Aspire application model API.
+/// </summary> 
+public static class KnownNetworkIdentifiers
+{
+    /// <summary>
+    /// The network associated with the IP loopback interface (localhost).
+    /// </summary>
+    public static readonly NetworkIdentifier LocalhostNetwork = new NetworkIdentifier("localhost");
+
+    /// <summary>
+    /// Represents public Internet (globally routable).
+    /// </summary>
+    public static readonly NetworkIdentifier PublicInternet = new NetworkIdentifier(".");
+
+    /// <summary>
+    /// Represents Aspire default, auto-created container network resource (not actual Docker/Podman network).
+    /// </summary>
+    public static readonly NetworkIdentifier DefaultAspireContainerNetwork = new NetworkIdentifier("aspire-container-network");
+}
+
+/// <summary>
+/// Provides known host names for use within the Aspire application model API.
+/// </summary>
+public static class KnownHostNames
+{
+    /// <summary>
+    /// The host name associated with the IP loopback interface (localhost).
+    /// </summary>
+    /// <remarks>
+    /// In general, "localhost" resolves to multiple addresses. E.g. in dual-stack systems (IPv4 and IPv6, very common)
+    /// "localhost" resolves at least to 127.0.0.1 and [::1]. On some systems there are multiple IPv4 networks associated
+    /// with loopback interface and the number of potential addresses for "localhost" increases accordingly.
+    /// </remarks>
+    public const string Localhost = "localhost";
+
+    /// <summary>
+    /// The host name used to facilitate connections originating from containers and ending on the host network.
+    /// </summary>
+    public const string DefaultContainerTunnelHostName = "aspire.dev.internal";
+
+    /// <summary>
+    /// The host name used by Docker Desktop host network bridge.
+    /// </summary>
+    public const string DockerDesktopHostBridge = "host.docker.internal";
+}

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -95,6 +95,17 @@ public class ParameterResource : Resource, IManifestExpressionProvider, IValuePr
     }
 
     /// <summary>
+    /// Gets the value of the parameter asynchronously, waiting if necessary for the value to be set.
+    /// </summary>
+    public ValueTask<string?> GetValueAsync(ValueProviderContext _, CancellationToken cancellationToken)
+    {
+        // It might look like this does not provide any additional functionality over GetValueAsync,
+        // but we need to ensure that types derived from ParameterResource implement IValueProvider.GetValueAsync(ValueProviderContext, CancellationToken)
+        // using WaitForValueTcs, and not via an interface default implementation.
+        return GetValueAsync(cancellationToken);
+    }
+
+    /// <summary>
     /// Gets a description of the parameter resource.
     /// </summary>
     public string? Description { get; set; }

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -66,9 +66,9 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
     /// <summary>
     /// Gets the value of the expression. The final string value after evaluating the format string and its parameters.
     /// </summary>
+    /// <param name="context">A context for resolving the value.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
-    /// <returns></returns>
-    public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
+    public async ValueTask<string?> GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken)
     {
         // NOTE: any logical changes to this method should also be made to ExpressionResolver.EvalExpressionAsync
         if (Format.Length == 0)
@@ -79,7 +79,7 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
         var args = new object?[ValueProviders.Count];
         for (var i = 0; i < ValueProviders.Count; i++)
         {
-            args[i] = await ValueProviders[i].GetValueAsync(cancellationToken).ConfigureAwait(false);
+            args[i] = await ValueProviders[i].GetValueAsync(context, cancellationToken).ConfigureAwait(false);
 
             // Apply string format if needed
             var stringFormat = _stringFormats[i];
@@ -90,6 +90,15 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
         }
 
         return string.Format(CultureInfo.InvariantCulture, Format, args);
+    }
+
+    /// <summary>
+    /// Gets the value of the expression. The final string value after evaluating the format string and its parameters.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
+    {
+        return this.GetValueAsync(new ValueProviderContext(), cancellationToken);
     }
 
     internal static ReferenceExpression Create(string format, IValueProvider[] valueProviders, string[] manifestExpressions, string?[] stringFormats)

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -673,7 +673,15 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <returns>An enumeration of <see cref="EndpointReference"/> based on the <see cref="EndpointAnnotation"/> annotations from the resources' <see cref="IResource.Annotations"/> collection.</returns>
-    public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource) => resource.GetEndpoints(null);
+    public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource)
+    {
+        if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
+        {
+            return endpoints.Select(e => new EndpointReference(resource, e));
+        }
+
+        return [];
+    }
    
 
     /// <summary>
@@ -682,7 +690,7 @@ public static class ResourceExtensions
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <param name="contextNetworkID">The ID of the network that serves as the context context for the endpoint references.</param>
     /// <returns>An enumeration of <see cref="EndpointReference"/> based on the <see cref="EndpointAnnotation"/> annotations from the resources' <see cref="IResource.Annotations"/> collection.</returns>
-    public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource, NetworkIdentifier? contextNetworkID = null)
+    public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource, NetworkIdentifier contextNetworkID)
     {
         if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
         {
@@ -698,7 +706,7 @@ public static class ResourceExtensions
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <param name="endpointName">The name of the endpoint.</param>
     /// <returns>An <see cref="EndpointReference"/>object providing resolvable reference for the specified endpoint.</returns>
-    public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName) => resource.GetEndpoint(endpointName, null);
+    public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName) => resource.GetEndpoint(endpointName);
 
     /// <summary>
     /// Gets an endpoint reference for the specified endpoint name.
@@ -707,7 +715,7 @@ public static class ResourceExtensions
     /// <param name="endpointName">The name of the endpoint.</param>
     /// <param name="contextNetworkID">The network ID of the network that provides the context for the returned <see cref="EndpointReference"/></param>
     /// <returns>An <see cref="EndpointReference"/>object providing resolvable reference for the specified endpoint.</returns>
-    public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName, NetworkIdentifier? contextNetworkID = null)
+    public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName, NetworkIdentifier contextNetworkID)
     {
 
         var endpoint = resource.TryGetEndpoints(out var endpoints) ?
@@ -719,7 +727,6 @@ public static class ResourceExtensions
         }
         else
         {
-            contextNetworkID ??= endpoint.DefaultNetworkID;
             return new EndpointReference(resource, endpoint, contextNetworkID);
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -598,9 +598,9 @@ public static class ResourceExtensions
         }
     }
 
-    private static async Task<ResolvedValue?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, NetworkIdentifier? context, CancellationToken cancellationToken)
+    private static async Task<ResolvedValue?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, NetworkIdentifier? networkContext, CancellationToken cancellationToken)
     {
-        var task = ExpressionResolver.ResolveAsync(valueProvider, context, cancellationToken);
+        var task = ExpressionResolver.ResolveAsync(valueProvider, new ValueProviderContext() { Network = networkContext }, cancellationToken);
 
         if (!task.IsCompleted)
         {
@@ -682,7 +682,6 @@ public static class ResourceExtensions
 
         return [];
     }
-   
 
     /// <summary>
     /// Gets references to all endpoints for the specified resource.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -706,7 +706,20 @@ public static class ResourceExtensions
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <param name="endpointName">The name of the endpoint.</param>
     /// <returns>An <see cref="EndpointReference"/>object providing resolvable reference for the specified endpoint.</returns>
-    public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName) => resource.GetEndpoint(endpointName);
+    public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName)
+    {
+        var endpoint = resource.TryGetEndpoints(out var endpoints) ?
+            endpoints.FirstOrDefault(e => StringComparers.EndpointAnnotationName.Equals(e.Name, endpointName)) :
+            null;
+        if (endpoint is null)
+        {
+            return new EndpointReference(resource, endpointName);
+        }
+        else
+        {
+            return new EndpointReference(resource, endpoint);
+        }
+    }
 
     /// <summary>
     /// Gets an endpoint reference for the specified endpoint name.
@@ -729,7 +742,6 @@ public static class ResourceExtensions
         {
             return new EndpointReference(resource, endpoint, contextNetworkID);
         }
-
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -270,8 +270,8 @@ public static class ResourceExtensions
     /// an exception if one occurs, and a boolean indicating the success of processing.
     /// </param>
     /// <param name="logger">The logger used for logging information or errors during the argument processing.</param>
-    /// <param name="containerHostName">An optional container host name to consider during processing, if applicable.</param>
     /// <param name="cancellationToken">A token for cancelling the operation, if needed.</param>
+    /// <param name="networkContext">An optional network identifier providing context for resolving network-related values.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     public static async ValueTask ProcessArgumentValuesAsync(
         this IResource resource,
@@ -279,8 +279,8 @@ public static class ResourceExtensions
         // (unprocessed, processed, exception, isSensitive)
         Action<object?, string?, Exception?, bool> processValue,
         ILogger logger,
-        string? containerHostName = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        NetworkIdentifier? networkContext = null)
     {
         if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var callbacks))
         {
@@ -296,11 +296,13 @@ public static class ResourceExtensions
                 await callback.Callback(context).ConfigureAwait(false);
             }
 
+            networkContext ??= resource.GetDefaultResourceNetwork();
+
             foreach (var a in args)
             {
                 try
                 {
-                    var resolvedValue = await ResolveValueAsync(resource, executionContext, logger, a, containerHostName, key: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var resolvedValue = await ResolveValueAsync(executionContext, logger, a, null, networkContext, cancellationToken).ConfigureAwait(false);
 
                     if (resolvedValue?.Value != null)
                     {
@@ -322,16 +324,16 @@ public static class ResourceExtensions
     /// <param name="executionContext">The execution context to be used for processing the environment variables.</param>
     /// <param name="processValue">An action delegate invoked for each environment variable, providing the key, the unprocessed value, the processed value (if available), and any exception encountered during processing.</param>
     /// <param name="logger">The logger used to log any information or errors during the environment variables processing.</param>
-    /// <param name="containerHostName">The optional container host name associated with the resource being processed.</param>
     /// <param name="cancellationToken">A cancellation token to observe during the asynchronous operation.</param>
+    /// <param name="networkContext">An optional network identifier providing context for resolving network-related values.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static async ValueTask ProcessEnvironmentVariableValuesAsync(
         this IResource resource,
         DistributedApplicationExecutionContext executionContext,
         Action<string, object?, string?, Exception?> processValue,
         ILogger logger,
-        string? containerHostName = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        NetworkIdentifier? networkContext = null)
     {
         if (resource.TryGetEnvironmentVariables(out var callbacks))
         {
@@ -346,11 +348,13 @@ public static class ResourceExtensions
                 await callback.Callback(context).ConfigureAwait(false);
             }
 
+            networkContext ??= resource.GetDefaultResourceNetwork();
+
             foreach (var (key, expr) in config)
             {
                 try
                 {
-                    var resolvedValue = await ResolveValueAsync(resource, executionContext, logger, expr, containerHostName, key, cancellationToken).ConfigureAwait(false);
+                    var resolvedValue = await ResolveValueAsync(executionContext, logger, expr, key, networkContext, cancellationToken).ConfigureAwait(false);
 
                     if (resolvedValue?.Value is not null)
                     {
@@ -365,26 +369,39 @@ public static class ResourceExtensions
         }
     }
 
+    internal static NetworkIdentifier GetDefaultResourceNetwork(this IResource resource)
+    {
+        return resource.IsContainer() ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork : KnownNetworkIdentifiers.LocalhostNetwork;
+    }
+
     /// <summary>
     /// Processes trusted certificates configuration for the specified resource within the given execution context.
     /// This may produce additional <see cref="CommandLineArgsCallbackAnnotation"/> and <see cref="EnvironmentCallbackAnnotation"/>
     /// annotations on the resource to configure certificate trust as needed and therefore must be run before
-    /// <see cref="ProcessArgumentValuesAsync(IResource, DistributedApplicationExecutionContext, Action{object?, string?, Exception?, bool}, ILogger, string?, CancellationToken)"/>
-    /// and <see cref="ProcessEnvironmentVariableValuesAsync(IResource, DistributedApplicationExecutionContext, Action{string, object?, string?, Exception?}, ILogger, string?, CancellationToken)"/> are called.
+    /// <see cref="ProcessArgumentValuesAsync(IResource, DistributedApplicationExecutionContext, Action{object?, string?, Exception?, bool}, ILogger, CancellationToken, NetworkIdentifier?)"/>
+    /// and <see cref="ProcessEnvironmentVariableValuesAsync(IResource, DistributedApplicationExecutionContext, Action{string, object?, string?, Exception?}, ILogger, CancellationToken, NetworkIdentifier?)"/> are called.
     /// </summary>
     /// <param name="resource">The resource for which to process the certificate trust configuration.</param>
     /// <param name="executionContext">The execution context used during the processing.</param>
+    /// <param name="processArgumentValue">A function that processes argument values.</param>
+    /// <param name="processEnvironmentVariableValue">A function that processes environment variable values.</param>
     /// <param name="logger">The logger used for logging information during the processing.</param>
     /// <param name="bundlePathFactory">A function that takes the active <see cref="CertificateTrustScope"/> and returns a <see cref="ReferenceExpression"/> representing the path to a custom certificate bundle for the resource.</param>
     /// <param name="certificateDirectoryPathsFactory">A function that takes the active <see cref="CertificateTrustScope"/> and returns a <see cref="ReferenceExpression"/> representing path(s) to a directory containing the custom certificates for the resource.</param>
+    /// <param name="networkContext">An optional network identifier providing context for resolving network-related values.</param>
     /// <param name="cancellationToken">A cancellation token to observe while processing.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static async ValueTask<(CertificateTrustScope, X509Certificate2Collection?)> ProcessCertificateTrustConfigAsync(
         this IResource resource,
         DistributedApplicationExecutionContext executionContext,
+        // (unprocessed, processed, exception, isSensitive)
+        Action<object?, string?, Exception?, bool> processArgumentValue,
+        // (key, unprocessed, processed, exception)
+        Action<string, object?, string?, Exception?> processEnvironmentVariableValue,
         ILogger logger,
         Func<CertificateTrustScope, ReferenceExpression> bundlePathFactory,
         Func<CertificateTrustScope, ReferenceExpression> certificateDirectoryPathsFactory,
+        NetworkIdentifier? networkContext = null,
         CancellationToken cancellationToken = default)
     {
         var developerCertificateService = executionContext.ServiceProvider.GetRequiredService<IDeveloperCertificateService>();
@@ -473,42 +490,56 @@ public static class ResourceExtensions
             logger.LogInformation("Resource '{ResourceName}' has a certificate trust scope of '{Scope}'. Automatically including system root certificates in the trusted configuration.", resource.Name, Enum.GetName(scope));
         }
 
-        if (context.Arguments.Any())
+        foreach (var a in context.Arguments)
         {
-            resource.Annotations.Add(new CommandLineArgsCallbackAnnotation((args) =>
+            try
             {
-                args.AddRange(context.Arguments);
-            }));
+                var resolvedValue = await ResolveValueAsync(executionContext, logger, a, null, networkContext, cancellationToken).ConfigureAwait(false);
+
+                if (resolvedValue?.Value != null)
+                {
+                    processArgumentValue(a, resolvedValue.Value, null, resolvedValue.IsSensitive);
+                }
+            }
+            catch (Exception ex)
+            {
+                processArgumentValue(a, a.ToString(), ex, false);
+            }
         }
 
-        if (context.EnvironmentVariables.Any())
+        foreach (var (key, expr) in context.EnvironmentVariables)
         {
-            resource.Annotations.Add(new EnvironmentCallbackAnnotation((env) =>
+            try
             {
-                foreach (var (key, value) in context.EnvironmentVariables)
+                var resolvedValue = await ResolveValueAsync(executionContext, logger, expr, key, networkContext, cancellationToken).ConfigureAwait(false);
+
+                if (resolvedValue?.Value is not null)
                 {
-                    env[key] = value;
+                    processEnvironmentVariableValue(key, expr, resolvedValue.Value, null);
                 }
-            }));
+            }
+            catch (Exception ex)
+            {
+                processEnvironmentVariableValue(key, expr, expr?.ToString(), ex);
+            }
         }
 
         return (scope, certificates);
     }
 
     private static async ValueTask<ResolvedValue?> ResolveValueAsync(
-        IResource resource,
         DistributedApplicationExecutionContext executionContext,
         ILogger logger,
         object value,
-        string? containerHostName = null,
         string? key = null,
+        NetworkIdentifier? networkContext = null,
         CancellationToken cancellationToken = default)
     {
         return (executionContext.Operation, value) switch
         {
             (_, string s) => new(s, false),
-            (DistributedApplicationOperation.Run, IValueProvider provider) => await GetValue(key, provider, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
-            (DistributedApplicationOperation.Run, IResourceBuilder<IResource> rb) when rb.Resource is IValueProvider provider => await GetValue(key, provider, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false),
+            (DistributedApplicationOperation.Run, IValueProvider provider) => await GetValue(key, provider, logger, networkContext, cancellationToken).ConfigureAwait(false),
+            (DistributedApplicationOperation.Run, IResourceBuilder<IResource> rb) when rb.Resource is IValueProvider provider => await GetValue(key, provider, logger, networkContext, cancellationToken).ConfigureAwait(false),
             (DistributedApplicationOperation.Publish, IManifestExpressionProvider provider) => new(provider.ValueExpression, false),
             (DistributedApplicationOperation.Publish, IResourceBuilder<IResource> rb) when rb.Resource is IManifestExpressionProvider provider => new(provider.ValueExpression, false),
             (_, { } o) => new(o.ToString(), false),
@@ -527,8 +558,8 @@ public static class ResourceExtensions
         this IResource resource,
         Action<string?, Exception?> processValue,
         ILogger logger,
-        string? containerHostName = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        NetworkIdentifier? context = null)
     {
         // Apply optional extra arguments to the container run command.
         if (resource.TryGetAnnotationsOfType<ContainerRuntimeArgsCallbackAnnotation>(out var runArgsCallback))
@@ -549,7 +580,7 @@ public static class ResourceExtensions
                     var value = arg switch
                     {
                         string s => s,
-                        IValueProvider valueProvider => (await GetValue(key: null, valueProvider, logger, resource.IsContainer(), containerHostName, cancellationToken).ConfigureAwait(false))?.Value,
+                        IValueProvider valueProvider => (await GetValue(key: null, valueProvider, logger, context, cancellationToken).ConfigureAwait(false))?.Value,
                         { } obj => obj.ToString(),
                         null => null
                     };
@@ -567,11 +598,9 @@ public static class ResourceExtensions
         }
     }
 
-    private static async Task<ResolvedValue?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, bool isContainer, string? containerHostName, CancellationToken cancellationToken)
+    private static async Task<ResolvedValue?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, NetworkIdentifier? context, CancellationToken cancellationToken)
     {
-        containerHostName ??= "host.docker.internal";
-
-        var task = ExpressionResolver.ResolveAsync(isContainer, valueProvider, containerHostName, cancellationToken);
+        var task = ExpressionResolver.ResolveAsync(valueProvider, context, cancellationToken);
 
         if (!task.IsCompleted)
         {
@@ -640,15 +669,24 @@ public static class ResourceExtensions
     }
 
     /// <summary>
-    /// Gets the endpoints for the specified resource.
+    /// Gets references to all endpoints for the specified resource.
     /// </summary>
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <returns>An enumeration of <see cref="EndpointReference"/> based on the <see cref="EndpointAnnotation"/> annotations from the resources' <see cref="IResource.Annotations"/> collection.</returns>
-    public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource)
+    public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource) => resource.GetEndpoints(null);
+   
+
+    /// <summary>
+    /// Gets references to all endpoints for the specified resource.
+    /// </summary>
+    /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
+    /// <param name="contextNetworkID">The ID of the network that serves as the context context for the endpoint references.</param>
+    /// <returns>An enumeration of <see cref="EndpointReference"/> based on the <see cref="EndpointAnnotation"/> annotations from the resources' <see cref="IResource.Annotations"/> collection.</returns>
+    public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource, NetworkIdentifier? contextNetworkID = null)
     {
         if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
         {
-            return endpoints.Select(e => new EndpointReference(resource, e));
+            return endpoints.Select(e => new EndpointReference(resource, e, contextNetworkID));
         }
 
         return [];
@@ -659,11 +697,32 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <param name="endpointName">The name of the endpoint.</param>
-    /// <returns>An <see cref="EndpointReference"/> object representing the endpoint reference
-    /// for the specified endpoint.</returns>
-    public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName)
+    /// <returns>An <see cref="EndpointReference"/>object providing resolvable reference for the specified endpoint.</returns>
+    public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName) => resource.GetEndpoint(endpointName, null);
+
+    /// <summary>
+    /// Gets an endpoint reference for the specified endpoint name.
+    /// </summary>
+    /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
+    /// <param name="endpointName">The name of the endpoint.</param>
+    /// <param name="contextNetworkID">The network ID of the network that provides the context for the returned <see cref="EndpointReference"/></param>
+    /// <returns>An <see cref="EndpointReference"/>object providing resolvable reference for the specified endpoint.</returns>
+    public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName, NetworkIdentifier? contextNetworkID = null)
     {
-        return new EndpointReference(resource, endpointName);
+
+        var endpoint = resource.TryGetEndpoints(out var endpoints) ?
+            endpoints.FirstOrDefault(e => StringComparers.EndpointAnnotationName.Equals(e.Name, endpointName)) :
+            null;
+        if (endpoint is null)
+        {
+            return new EndpointReference(resource, endpointName, contextNetworkID);
+        }
+        else
+        {
+            contextNetworkID ??= endpoint.DefaultNetworkID;
+            return new EndpointReference(resource, endpoint, contextNetworkID);
+        }
+
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUrlsCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUrlsCallbackContext.cs
@@ -38,7 +38,7 @@ public class ResourceUrlsCallbackContext(DistributedApplicationExecutionContext 
     /// </summary>
     /// <param name="name">The name of the endpoint.</param>
     /// <param name="contextNetworkID">The identifier of the network that serves as the context for the endpoint reference.</param>
-    public EndpointReference? GetEndpoint(string name, NetworkIdentifier? contextNetworkID) =>
+    public EndpointReference? GetEndpoint(string name, NetworkIdentifier contextNetworkID) =>
         Resource switch
         {
             IResourceWithEndpoints resourceWithEndpoints => resourceWithEndpoints.GetEndpoint(name, contextNetworkID),

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUrlsCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUrlsCallbackContext.cs
@@ -24,12 +24,24 @@ public class ResourceUrlsCallbackContext(DistributedApplicationExecutionContext 
     /// Gets an endpoint reference from <see cref="Resource"/> for the specified endpoint name.<br/>
     /// If <see cref="Resource"/> does not implement <see cref="IResourceWithEndpoints"/> then returns <c>null</c>.
     /// </summary>
-    /// <param name="name"></param>
-    /// <returns></returns>
+    /// <param name="name">The name of the endpoint.</param>
     public EndpointReference? GetEndpoint(string name) =>
         Resource switch
         {
             IResourceWithEndpoints resourceWithEndpoints => resourceWithEndpoints.GetEndpoint(name),
+            _ => null
+        };
+
+    /// <summary>
+    /// Gets an endpoint reference from <see cref="Resource"/> for the specified endpoint name.<br/>
+    /// If <see cref="Resource"/> does not implement <see cref="IResourceWithEndpoints"/> then returns <c>null</c>.
+    /// </summary>
+    /// <param name="name">The name of the endpoint.</param>
+    /// <param name="contextNetworkID">The identifier of the network that serves as the context for the endpoint reference.</param>
+    public EndpointReference? GetEndpoint(string name, NetworkIdentifier? contextNetworkID) =>
+        Resource switch
+        {
+            IResourceWithEndpoints resourceWithEndpoints => resourceWithEndpoints.GetEndpoint(name, contextNetworkID),
             _ => null
         };
 

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -66,6 +66,48 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.ApplicationModel.AllocatedEndpoint.#ctor(Aspire.Hosting.ApplicationModel.EndpointAnnotation,System.String,System.Int32,Aspire.Hosting.ApplicationModel.EndpointBindingMode,System.String,System.String)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.ApplicationModel.AllocatedEndpoint.#ctor(Aspire.Hosting.ApplicationModel.EndpointAnnotation,System.String,System.Int32,System.String,System.String)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.ApplicationModel.AllocatedEndpoint.get_ContainerHostAddress</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.ApplicationModel.EndpointReference.get_ContainerHost</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.ApplicationModel.ResourceExtensions.ProcessArgumentValuesAsync(Aspire.Hosting.ApplicationModel.IResource,Aspire.Hosting.DistributedApplicationExecutionContext,System.Action{System.Object,System.String,System.Exception,System.Boolean},Microsoft.Extensions.Logging.ILogger,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.ApplicationModel.ResourceExtensions.ProcessEnvironmentVariableValuesAsync(Aspire.Hosting.ApplicationModel.IResource,Aspire.Hosting.DistributedApplicationExecutionContext,System.Action{System.String,System.Object,System.String,System.Exception},Microsoft.Extensions.Logging.ILogger,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aspire.Hosting.IInteractionService.PromptInputsAsync(System.String,System.String,System.Collections.Generic.IReadOnlyList{Aspire.Hosting.InteractionInput},Aspire.Hosting.InputsDialogInteractionOptions,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -2498,22 +2498,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         return (args, env, createFiles, failedToApplyConfig);
     }
 
-    private string[]? GetSupportedLaunchConfigurations()
-    {
-        try
-        {
-            if (_configuration[KnownConfigNames.DebugSessionInfo] is { } debugSessionInfoJson && JsonSerializer.Deserialize<RunSessionInfo>(debugSessionInfoJson) is { } debugSessionInfo)
-            {
-                return debugSessionInfo.SupportedLaunchConfigurations;
-            }
-        }
-        catch (JsonException)
-        {
-        }
-
-        return null;
-    }
-
     private static List<ContainerPortSpec> BuildContainerPorts(RenderedModelResource cr)
     {
         var ports = new List<ContainerPortSpec>();

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Data;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
@@ -38,13 +39,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 {
     internal const string DebugSessionPortVar = "DEBUG_SESSION_PORT";
 
-    // The resource name for the Aspire network resource.
-    internal const string DefaultAspireNetworkResourceName = "aspire-network";
-
-    // The base name for ephemeral networks
+    // The base name for ephemeral container (Docker, Pdman etc) networks
     internal const string DefaultAspireNetworkName = "aspire-session-network";
 
-    // The base name for persistent networks
+    // The base name for persistent container (Docker, Pdman etc) networks
     internal const string DefaultAspirePersistentNetworkName = "aspire-persistent-network";
 
     // Disposal of the DcpExecutor means shutting down watches and log streams,
@@ -81,7 +79,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
     // Internal for testing.
     internal ResiliencePipeline<bool> DeleteResourceRetryPipeline { get; set; }
-    internal ResiliencePipeline CreateServiceRetryPipeline { get; set; }
     internal ResiliencePipeline WatchResourceRetryPipeline { get; set; }
 
     private readonly ConcurrentDictionary<string, (CancellationTokenSource Cancellation, Task Task)> _logStreams = new();
@@ -130,11 +127,11 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         _developerCertificateService = developerCertificateService;
 
         DeleteResourceRetryPipeline = DcpPipelineBuilder.BuildDeleteRetryPipeline(logger);
-        CreateServiceRetryPipeline = DcpPipelineBuilder.BuildCreateServiceRetryPipeline(options.Value, logger);
         WatchResourceRetryPipeline = DcpPipelineBuilder.BuildWatchResourcePipeline(logger);
     }
 
-    private string DefaultContainerHostName => _configuration["AppHost:ContainerHostname"] ?? _dcpInfo?.Containers?.ContainerHostName ?? "host.docker.internal";
+    private string ContainerHostName => _configuration["AppHost:ContainerHostname"] ??
+        (_options.Value.EnableAspireContainerTunnel ? KnownHostNames.DefaultContainerTunnelHostName : KnownHostNames.DockerDesktopHostBridge);
 
     public async Task RunApplicationAsync(CancellationToken cancellationToken = default)
     {
@@ -144,22 +141,65 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
         Debug.Assert(_dcpInfo is not null, "DCP info should not be null at this point");
 
+        // TODO: in the current Aspire implementation there a requirement that Executables and Containers backing Aspire resources
+        // must be created only we created all AllocatedEndpoints these resource needed (e.g. for resolving environment variable values etc)
+        // This is why we create objects in very specific order here.
+        //
+        // In future we should be able to make the model more flexible and streamline the DCP object creation logic by:
+        // 1. Asynchronously publish AllocatdEndpoints as the Services associated with them transition to Ready state.
+        // 2. Asynchronously create Executables and Containers as soon as all their dependencies are ready.
+
         try
         {
+            PrepareContainerNetworks();
             PrepareServices();
             PrepareContainers();
             PrepareExecutables();
 
             await _executorEvents.PublishAsync(new OnResourcesPreparedContext(cancellationToken)).ConfigureAwait(false);
 
-            // Watch for changes to the resource state.
             WatchResourceChanges();
 
-            await CreateServicesAsync(cancellationToken).ConfigureAwait(false);
+            await Task.WhenAll(
+                Task.Run(() => CreateAllDcpObjectsAsync<Service>(cancellationToken), cancellationToken),
+                Task.Run(() => CreateAllDcpObjectsAsync<ContainerNetwork>(cancellationToken), cancellationToken)
+            ).WaitAsync(cancellationToken).ConfigureAwait(false);
 
-            await CreateContainerNetworksAsync(cancellationToken).ConfigureAwait(false);
+            var proxiedWithNoAddress = _appResources.Where(r => r.DcpResource is Service { }).Select(r => (Service)r.DcpResource)
+                .Where(sr => !sr.HasCompleteAddress && sr.Spec.AddressAllocationMode != AddressAllocationModes.Proxyless);
+            await UpdateWithEffectiveAddressInfo(proxiedWithNoAddress, cancellationToken).ConfigureAwait(false);
 
-            await CreateContainersAndExecutablesAsync(cancellationToken).ConfigureAwait(false);
+            await CreateAllDcpObjectsAsync<ContainerNetworkTunnelProxy>(cancellationToken).ConfigureAwait(false);
+            await EnsureContainerServiceAddressInfo(cancellationToken).ConfigureAwait(false);
+
+            var executables = _appResources.OfType<RenderedModelResource>().Where(ar => ar.DcpResource is Executable);
+            AddAllocatedEndpointInfo(executables, AllocatedEndpointsMode.All);
+            var containers = _appResources.OfType<RenderedModelResource>().Where(ar => ar.DcpResource is Container);
+            AddAllocatedEndpointInfo(containers, AllocatedEndpointsMode.Workload);
+            var containerExes = _appResources.OfType<RenderedModelResource>().Where(ar => ar.DcpResource is ContainerExec);
+            await _executorEvents.PublishAsync(new OnEndpointsAllocatedContext(cancellationToken)).ConfigureAwait(false);
+
+            // Ensure we fire the event only once for each app model resource. There may be multiple physical replicas of
+            // the same app model resource which can result in the event being fired multiple times.
+            HashSet<string> allocatedEndpointsAdvertised = new(StringComparers.ResourceName);
+
+            foreach (var resource in executables.Concat(containers))
+            {
+                if (allocatedEndpointsAdvertised.Add(resource.ModelResource.Name))
+                {
+                    await _distributedApplicationEventing.PublishAsync(
+                        new ResourceEndpointsAllocatedEvent(resource.ModelResource, _executionContext.ServiceProvider),
+                        EventDispatchBehavior.NonBlockingConcurrent,
+                        cancellationToken
+                    ).ConfigureAwait(false);
+                }
+            }
+
+            await Task.WhenAll(
+                CreateExecutablesAsync(executables, cancellationToken),
+                CreateContainersAsync(containers, cancellationToken),
+                CreateContainerExecutablesAsync(containerExes, cancellationToken)
+            ).WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -719,148 +759,273 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         return true;
     }
 
-    private async Task CreateServicesAsync(CancellationToken cancellationToken = default)
+    // Waits till provided set of Services have their addresses allocated by the orchestrator
+    // and updates them with the allocated address information.
+    private async Task UpdateWithEffectiveAddressInfo(IEnumerable<Service> services, CancellationToken cancellationToken, TimeSpan? timeout = null)
     {
+        List<Service> needAddressAllocated = new(services);
+        if (needAddressAllocated.Count == 0)
+        {
+            return;
+        }
+
+        var createServicePipeline = DcpPipelineBuilder.BuildCreateServiceRetryPipeline(_options.Value, _logger, timeout);
+
+        await createServicePipeline.ExecuteAsync(async (attemptCancellationToken) =>
+        {
+            var serviceChangeEnumerator = _kubernetesService.WatchAsync<Service>(cancellationToken: attemptCancellationToken);
+            await foreach (var (evt, updated) in serviceChangeEnumerator.ConfigureAwait(false))
+            {
+                if (evt == WatchEventType.Bookmark)
+                {
+                    // Bookmarks do not contain any data.
+                    continue;
+                }
+
+                var srvResource = needAddressAllocated.FirstOrDefault(sr => sr.Metadata.Name == updated.Metadata.Name);
+                if (srvResource == null)
+                {
+                    // This service most likely already has full address information, so it is not on needAddressAllocated list.
+                    continue;
+                }
+
+                if (updated.HasCompleteAddress)
+                {
+                    srvResource.ApplyAddressInfoFrom(updated);
+                    needAddressAllocated.Remove(srvResource);
+                }
+
+                if (needAddressAllocated.Count == 0)
+                {
+                    return; // We are done
+                }
+            }
+        }, cancellationToken).ConfigureAwait(false);
+
+        // If there are still services that need address allocated, try a final direct query in case the watch missed some updates.
+        foreach (var sar in needAddressAllocated)
+        {
+            var dcpSvc = await _kubernetesService.GetAsync<Service>(sar.Metadata.Name, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (dcpSvc.HasCompleteAddress)
+            {
+                sar.ApplyAddressInfoFrom(dcpSvc);
+            }
+            else
+            {
+                _distributedApplicationLogger.LogWarning("Unable to allocate a network port for service '{ServiceName}'; service may be unreachable and its clients may not work properly.", sar.Metadata.Name);
+            }
+        }
+    }
+
+    // Ensures that services used by containers have their address info.
+    private async Task EnsureContainerServiceAddressInfo(CancellationToken cancellationToken)
+    {
+        if (_options.Value.EnableAspireContainerTunnel)
+        {
+            var containerTunnelProxies = _appResources.Where(r => r.DcpResource is ContainerNetworkTunnelProxy { }).ToImmutableArray();
+            foreach (var ctp in containerTunnelProxies)
+            {
+                var containerNetworkName = (ctp.DcpResource as ContainerNetworkTunnelProxy)?.Spec.ContainerNetworkName;
+
+                // Need to wait for all tunnels to start before advertising AllocatedEndpoints that the tunnel proxy projected
+                // from host network into container network(s).
+                var tunnelServices = _appResources.Where(r => r.DcpResource is Service { }).Select(r => (Service)r.DcpResource)
+                .Where(
+                    sr => !sr.HasCompleteAddress &&
+                    sr.Metadata.Annotations?.TryGetValue(CustomResource.ContainerTunnelInstanceName, out var _) is true &&
+                    sr.Metadata.Annotations?.TryGetValue(CustomResource.ContainerNetworkAnnotation, out var containerNetwork) is true &&
+                    containerNetwork == containerNetworkName
+                );
+
+                _logger.LogInformation($"Waiting for container network '{containerNetworkName}' tunnel initialization...");
+                // Container tunnel initialization can take a while if the container tunnel image needs to be built,
+                // expecially if the network is slow, hence 10 minute timeout here.
+                await UpdateWithEffectiveAddressInfo(tunnelServices, cancellationToken, TimeSpan.FromMinutes(10)).ConfigureAwait(false);
+                _logger.LogInformation($"Tunnel for container network '{containerNetworkName}' initialized");
+            }
+        }
+        else
+        {
+            // Container services are services that "mirror" their primary (host) service counterparts, but expose addresses usable from container network. 
+            // We just need to update their ports from primary services, changing the address to container host.
+            var containerServices = _appResources.Where(r => r.DcpResource is Service { }).Select(r => (
+                Service: r.DcpResource as Service,
+                PrimaryServiceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.PrimaryServiceNameAnnotation, out var psn) == true ? psn : null)
+            )
+            .Where(cs => !string.IsNullOrEmpty(cs.PrimaryServiceName) && cs.Service?.HasCompleteAddress is not true);
+
+            foreach (var cs in containerServices)
+            {
+                var primaryService = _appResources.OfType<ServiceWithModelResource>().Select(sar => sar.Service)
+                    .Where(svc => svc.Metadata.Name.Equals(cs.PrimaryServiceName)).ToImmutableArray();
+                cs.Service!.ApplyAddressInfoFrom(primaryService[0]);
+                cs.Service!.Status!.EffectiveAddress = ContainerHostName;
+            }
+        }
+    }
+
+    private Task CreateAllDcpObjectsAsync<RT>(CancellationToken cancellationToken) where RT : CustomResource
+    {
+        var toCreate = _appResources.Select(r => r.DcpResource).OfType<RT>();
+        return CreateDcpObjectsAsync(toCreate, cancellationToken);
+    }
+
+    private async Task CreateDcpObjectsAsync<RT>(IEnumerable<RT> toCreate, CancellationToken cancellationToken) where RT : CustomResource
+    {
+        if (!toCreate.Any())
+        {
+            return;
+        }
+
+        var tasks = new List<Task>();
+        foreach (var rtc in toCreate)
+        {
+            tasks.Add(Task.Run(() => _kubernetesService.CreateAsync(rtc, cancellationToken), cancellationToken));
+        }
         try
         {
-            AspireEventSource.Instance.DcpServicesCreationStart();
-
-            var needAddressAllocated = _appResources.OfType<ServiceAppResource>()
-                .Where(sr => !sr.Service.HasCompleteAddress && sr.Service.Spec.AddressAllocationMode != AddressAllocationModes.Proxyless)
-                .ToList();
-
-            await CreateResourcesAsync<Service>(cancellationToken).ConfigureAwait(false);
-
-            if (needAddressAllocated.Count == 0)
-            {
-                // No need to wait for any updates to Service objects from the orchestrator.
-                return;
-            }
-
-            await CreateServiceRetryPipeline.ExecuteAsync(async (attemptCancellationToken) =>
-            {
-                var serviceChangeEnumerator = _kubernetesService.WatchAsync<Service>(cancellationToken: attemptCancellationToken);
-                await foreach (var (evt, updated) in serviceChangeEnumerator.ConfigureAwait(false))
-                {
-                    if (evt == WatchEventType.Bookmark)
-                    {
-                        // Bookmarks do not contain any data.
-                        continue;
-                    }
-
-                    var srvResource = needAddressAllocated.FirstOrDefault(sr => sr.Service.Metadata.Name == updated.Metadata.Name);
-                    if (srvResource == null)
-                    {
-                        // This service most likely already has full address information, so it is not on needAddressAllocated list.
-                        continue;
-                    }
-
-                    if (updated.HasCompleteAddress)
-                    {
-                        srvResource.Service.ApplyAddressInfoFrom(updated);
-                        needAddressAllocated.Remove(srvResource);
-                    }
-
-                    if (needAddressAllocated.Count == 0)
-                    {
-                        return; // We are done
-                    }
-                }
-            }, cancellationToken).ConfigureAwait(false);
-
-            // If there are still services that need address allocated, try a final direct query in case the watch missed some updates.
-            foreach (var sar in needAddressAllocated)
-            {
-                var dcpSvc = await _kubernetesService.GetAsync<Service>(sar.Service.Metadata.Name, cancellationToken: cancellationToken).ConfigureAwait(false);
-                if (dcpSvc.HasCompleteAddress)
-                {
-                    sar.Service.ApplyAddressInfoFrom(dcpSvc);
-                }
-                else
-                {
-                    _distributedApplicationLogger.LogWarning("Unable to allocate a network port for service '{ServiceName}'; service may be unreachable and its clients may not work properly.", sar.Service.Metadata.Name);
-                }
-            }
-
+            await Task.WhenAll(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
         }
-        finally
+        catch (OperationCanceledException ex)
         {
-            AspireEventSource.Instance.DcpServicesCreationStop();
+            // We catch and suppress the OperationCancelledException because the user may CTRL-C
+            // during start up of the resources.
+            _logger.LogDebug(ex, "Cancellation during creation of resources.");
         }
     }
 
-    private async Task CreateContainerNetworksAsync(CancellationToken cancellationToken)
+    // Specifies which endpoints to process when creating AllocatedEndpoint info
+    [Flags]
+    private enum AllocatedEndpointsMode
     {
-        var toCreate = _appResources.Where(r => r.DcpResource is ContainerNetwork);
-        foreach (var containerNetwork in toCreate)
-        {
-            if (containerNetwork.DcpResource is ContainerNetwork cn)
-            {
-                await _kubernetesService.CreateAsync(cn, cancellationToken).ConfigureAwait(false);
-            }
-        }
+        Workload = 0x1, // Process endpoints produced by workload resources (Executables and Containers)
+        ContainerTunnel = 0x2, // Process endpoints produced by container tunnels
+        All = 0xFF // Process endpoints produced by all resources, including container tunnels
     }
 
-    private async Task CreateContainersAndExecutablesAsync(CancellationToken cancellationToken)
+    // Adds allocated endpoints for all relevant resources in the model
+    private void AddAllocatedEndpointInfo(IEnumerable<RenderedModelResource> resources, AllocatedEndpointsMode mode = AllocatedEndpointsMode.Workload)
     {
-        var toCreate = _appResources.Where(r => r.DcpResource is Container or Executable or ContainerExec);
-        AddAllocatedEndpointInfo(toCreate);
-
-        await _executorEvents.PublishAsync(new OnEndpointsAllocatedContext(cancellationToken)).ConfigureAwait(false);
-
-        var allocatedResources = new HashSet<string>(StringComparer.Ordinal);
-
-        // Fire the endpoints allocated event for all DCP managed resources with endpoints.
-        foreach (var resource in toCreate.Select(r => r.ModelResource).OfType<IResourceWithEndpoints>())
-        {
-            // Ensure we fire the event only once for each app model resource. There may be multiple physical replicas of
-            // the same app model resource which can result in the event being fired multiple times.
-            if (allocatedResources.Add(resource.Name))
-            {
-                var resourceEvent = new ResourceEndpointsAllocatedEvent(resource, _executionContext.ServiceProvider);
-                await _distributedApplicationEventing.PublishAsync(resourceEvent, EventDispatchBehavior.NonBlockingConcurrent, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        var containersTask = CreateContainersAsync(toCreate.Where(ar => ar.DcpResource is Container), cancellationToken);
-        var executablesTask = CreateExecutablesAsync(toCreate.Where(ar => ar.DcpResource is Executable), cancellationToken);
-        var containerExecsTask = CreateContainerExecutablesAsync(toCreate.Where(ar => ar.DcpResource is ContainerExec), cancellationToken);
-
-        await Task.WhenAll(containersTask, executablesTask, containerExecsTask).WaitAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private void AddAllocatedEndpointInfo(IEnumerable<AppResource> resources)
-    {
-        var containerHost = DefaultContainerHostName;
-
         foreach (var appResource in resources)
         {
-            foreach (var sp in appResource.ServicesProduced)
+            if ((mode & AllocatedEndpointsMode.Workload) != 0)
             {
-                var svc = (Service)sp.DcpResource;
-
-                if (!svc.HasCompleteAddress && sp.EndpointAnnotation.IsProxied)
+                foreach (var sp in appResource.ServicesProduced)
                 {
-                    // This should never happen; if it does, we have a bug without a workaround for th the user.
-                    throw new InvalidDataException($"Service {svc.Metadata.Name} should have valid address at this point");
-                }
+                    var svc = (Service)sp.DcpResource;
 
-                if (!sp.EndpointAnnotation.IsProxied && svc.AllocatedPort is null)
+                    if (!svc.HasCompleteAddress && sp.EndpointAnnotation.IsProxied)
+                    {
+                        // This should never happen; if it does, we have a bug without a workaround for the user.
+                        // We should have waited for the service to have a complete address before getting here.
+                        throw new InvalidDataException($"Service {svc.Metadata.Name} should have valid address at this point");
+                    }
+
+                    if (!sp.EndpointAnnotation.IsProxied && svc.AllocatedPort is null)
+                    {
+                        throw new InvalidOperationException($"Service '{svc.Metadata.Name}' needs to specify a port for endpoint '{sp.EndpointAnnotation.Name}' since it isn't using a proxy.");
+                    }
+
+                    var (targetHost, bindingMode) = NormalizeTargetHost(sp.EndpointAnnotation.TargetHost);
+
+                    sp.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(
+                        sp.EndpointAnnotation,
+                        targetHost,
+                        (int)svc.AllocatedPort!,
+                        bindingMode,
+                        targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
+                        KnownNetworkIdentifiers.LocalhostNetwork);
+                }
+            }
+
+            if ((mode & AllocatedEndpointsMode.ContainerTunnel) != 0)
+            {
+                // If there are any additional services that are not directly produced by this resource,
+                // but leverage its endpoints via container tunnel, we want to add allocated endpoint info for them as well.
+
+                var tunnelServices = _appResources.Select(r => (
+                    Service: r.DcpResource as Service,
+                    ResourceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ResourceNameAnnotation, out var resourceName) == true ? resourceName : null,
+                    EndpointName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.EndpointNameAnnotation, out var endpointName) == true ? endpointName : null,
+                    TunnelInstanceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerTunnelInstanceName, out var tunnelInstanceName) == true ? tunnelInstanceName : null,
+                    ContainerNetworkName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.ContainerNetworkAnnotation, out var containerNetworkName) == true ? containerNetworkName : null
+                ))
+                .Where(ts =>
+                    ts.Service is not null &&
+                    StringComparers.ResourceName.Equals(ts.ResourceName, appResource.ModelResource.Name) &&
+                    !string.IsNullOrEmpty(ts.EndpointName) &&
+                    !string.IsNullOrEmpty(ts.ContainerNetworkName)
+                );
+
+                foreach (var ts in tunnelServices)
                 {
-                    throw new InvalidOperationException($"Service '{svc.Metadata.Name}' needs to specify a port for endpoint '{sp.EndpointAnnotation.Name}' since it isn't using a proxy.");
+                    if (!TryGetEndpoint(appResource.ModelResource, ts.EndpointName, out var endpoint))
+                    {
+                        throw new InvalidDataException($"Service '{ts.Service!.Metadata.Name}' refers to endpoint '{ts.EndpointName}' that does not exist");
+                    }
+
+                    if (ts.Service?.HasCompleteAddress is not true)
+                    {
+                        // This should never happen; if it does, we have a bug without a workaround for the user.
+                        throw new InvalidDataException($"Container tunnel service {ts.Service?.Metadata.Name} should have valid address at this point");
+                    }
+
+                    var serverSvc = _appResources.OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
+                         StringComparers.ResourceName.Equals(swr.ModelResource.Name, ts.ResourceName) &&
+                         StringComparers.EndpointAnnotationName.Equals(swr.EndpointAnnotation.Name, endpoint.Name)
+                     );
+                    if (serverSvc is null)
+                    {
+                        // Should never happen -- we should have created a Service for every endpoint exposed from a resource.
+                        throw new InvalidDataException($"The '{endpoint.Name}' on resource '{ts.ResourceName}' should have an associated DCP Service resource already set up");
+                    }
+
+                    var networkID = new NetworkIdentifier(ts.ContainerNetworkName!);
+                    var address = string.IsNullOrEmpty(ts.TunnelInstanceName) ? ContainerHostName : KnownHostNames.DefaultContainerTunnelHostName;
+                    var port = _options.Value.EnableAspireContainerTunnel ? (int)ts.Service!.AllocatedPort! : serverSvc.EndpointAnnotation.AllocatedEndpoint!.Port;
+
+                    var tunnelAllocatedEndpoint = new AllocatedEndpoint(
+                        endpoint,
+                        address,
+                        (int)port,
+                        EndpointBindingMode.SingleAddress,
+                        targetPortExpression: $$$"""{{- portForServing "{{{ts.Service.Name}}}" -}}""",
+                        networkID
+                    );
+                    var snapshot = new ValueSnapshot<AllocatedEndpoint>();
+                    snapshot.SetValue(tunnelAllocatedEndpoint);
+                    endpoint.AllAllocatedEndpoints.TryAdd(networkID, snapshot);
                 }
-
-                var (targetHost, bindingMode) = NormalizeTargetHost(sp.EndpointAnnotation.TargetHost);
-
-                sp.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(
-                    sp.EndpointAnnotation,
-                    targetHost,
-                    (int)svc.AllocatedPort!,
-                    bindingMode,
-                    containerHostAddress: appResource.ModelResource.IsContainer() ? containerHost : null,
-                    targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""");
             }
         }
+    }
+
+    private void PrepareContainerNetworks()
+    {
+        var containerResources = _model.Resources.Where(mr => mr.IsContainer());
+        if (!containerResources.Any()) { return; }
+
+        var network = ContainerNetwork.Create(KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value);
+        if (containerResources.Any(cr => cr.GetContainerLifetimeType() == ContainerLifetime.Persistent))
+        {
+            // If we have any persistent container resources
+            network.Spec.Persistent = true;
+            // Persistent networks require a predictable name to be reused between runs.
+            // Append the same project hash suffix used for persistent container names.
+            network.Spec.NetworkName = $"{DefaultAspirePersistentNetworkName}-{_nameGenerator.GetProjectHashSuffix()}";
+        }
+        else
+        {
+            network.Spec.NetworkName = $"{DefaultAspireNetworkName}-{DcpNameGenerator.GetRandomNameSuffix()}";
+        }
+
+        if (!string.IsNullOrEmpty(_normalizedApplicationName))
+        {
+            var shortApplicationName = _normalizedApplicationName.Length < 32 ? _normalizedApplicationName : _normalizedApplicationName.Substring(0, 32);
+            network.Spec.NetworkName += $"-{shortApplicationName}"; // Limit to 32 characters to avoid exceeding resource name length limits.
+        }
+
+        _appResources.Add(new AppResource(network));
     }
 
     private void PrepareServices()
@@ -891,9 +1056,9 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 var port = _options.Value.RandomizePorts && endpoint.IsProxied ? null : endpoint.Port;
                 svc.Spec.Port = port;
                 svc.Spec.Protocol = PortProtocol.FromProtocolType(endpoint.Protocol);
-                if (string.Equals("localhost", endpoint.TargetHost, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(KnownHostNames.Localhost, endpoint.TargetHost, StringComparison.OrdinalIgnoreCase))
                 {
-                    svc.Spec.Address = "localhost";
+                    svc.Spec.Address = KnownHostNames.Localhost;
                 }
                 else
                 {
@@ -909,7 +1074,125 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 svc.Annotate(CustomResource.ResourceNameAnnotation, sp.ModelResource.Name);
                 svc.Annotate(CustomResource.EndpointNameAnnotation, endpoint.Name);
 
-                _appResources.Add(new ServiceAppResource(sp.ModelResource, svc, endpoint));
+                _appResources.Add(new ServiceWithModelResource(sp.ModelResource, svc, endpoint));
+            }
+        }
+
+        // For container-to-host communication we create a tunnel proxy with a Service/tunnel for each host Endpoint.
+
+        var containers = _model.Resources.Where(r => r.IsContainer());
+        if (!containers.Any())
+        {
+            return; // No container resources--no need to set up container-to-host tunnels.
+        }
+
+        var hostResourcesWithEndpoints = _model.Resources.Where(r => r is IResourceWithEndpoints && !r.IsContainer())
+            .Select(r => (
+                Resource: r,
+                Endpoints: r.Annotations.OfType<EndpointAnnotation>()
+            ))
+            .Where(re => re.Endpoints.Any()).ToImmutableArray();
+
+        if (!hostResourcesWithEndpoints.Any())
+        {
+            return; // No host resources referenced by container resources--nothing more to do.
+        }
+
+        // Eventually we might want to support multiple container networks, including user-defined ones,
+        // but for now we just have one container network per application, and so we need only one tunnel proxy.
+        ContainerNetworkTunnelProxy? tunnelProxy = null;
+        AppResource? tunnelAppResource = null;
+        var useTunnel = _options.Value.EnableAspireContainerTunnel;
+        if (useTunnel)
+        {
+            tunnelProxy = ContainerNetworkTunnelProxy.Create(KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value + "-tunnelproxy");
+            tunnelProxy.Spec.ContainerNetworkName = KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value;
+            tunnelProxy.Spec.Aliases = [ContainerHostName];
+            tunnelProxy.Spec.Tunnels = [];
+            tunnelAppResource = new AppResource(tunnelProxy);
+            _appResources.Add(tunnelAppResource);
+        }
+
+        // If multiple Containers take a reference to the same host endpoint, we should only create one Service for it.
+        HashSet<(string HostResourceName, string OriginalEndpointName)> processedEndpoints = new();
+
+        foreach (var re in hostResourcesWithEndpoints)
+        {
+            var resourceLogger = _loggerService.GetLogger(re.Resource);
+
+            foreach (var endpoint in re.Endpoints)
+            {
+                if (!processedEndpoints.Add((re.Resource.Name, endpoint.Name)))
+                {
+                    continue; // Already processed this endpoint reference.
+                }
+
+                if (useTunnel)
+                {
+                    if (endpoint.Protocol != ProtocolType.Tcp)
+                    {
+                        resourceLogger.LogWarning("Host endpoint '{EndpointName}' on resource '{HostResource}' is referenced by a container resource, but the endpoint is using a network protocol '{Protocol}' other than TCP. Only TCP is supported for container-to-host references.",
+                            endpoint.Name,
+                            re.Resource.Name,
+                            endpoint.Protocol);
+                        continue;
+                    }
+                    if (!endpoint.IsProxied)
+                    {
+                        resourceLogger.LogWarning("Host endpoint '{EndpointName}' on resource '{HostResource}' is referenced by a container resource, but the endpoint is not configured to use a proxy. This may cause application startup failure due to circular dependencies.",
+                            endpoint.Name,
+                            re.Resource.Name);
+                    }
+                }
+
+                var hasManyEndpoints = re.Resource.Annotations.OfType<EndpointAnnotation>().Count() > 1;
+                var serviceName = _nameGenerator.GetServiceName(re.Resource, endpoint, hasManyEndpoints, serviceNames);
+                var svc = Service.Create(serviceName);
+                svc.Spec.AddressAllocationMode = AddressAllocationModes.Proxyless;
+                svc.Spec.Protocol = PortProtocol.TCP;
+                // Address and port will be set automatically by DCP.
+
+                var serverSvc = _appResources.OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
+                    StringComparers.ResourceName.Equals(swr.ModelResource.Name, re.Resource.Name) &&
+                    StringComparers.EndpointAnnotationName.Equals(swr.EndpointAnnotation.Name, endpoint.Name)
+                );
+                if (serverSvc is null)
+                {
+                    // This should never happen--if a host resource has an Endpoint, we should have created a Service for it.
+                    throw new InvalidDataException($"Host endpoint '{endpoint.Name}' on resource '{re.Resource.Name}' should have an associated DCP Service resource already set up");
+                }
+
+                if (useTunnel)
+                {
+                    var tunnelConfig = new TunnelConfiguration
+                    {
+                        Name = serviceName,
+                        ServerServiceName = serverSvc.DcpResource.Metadata.Name,
+                        ServerServiceNamespace = string.Empty,
+                        ClientServiceName = svc.Metadata.Name,
+                        ClientServiceNamespace = string.Empty
+                    };
+
+                    // The tunnelProxy is guaranteed to be non-null here but the compiler is not smart enough to realize it.
+                    tunnelProxy?.Spec?.Tunnels?.Add(tunnelConfig);
+                }
+
+                svc.Annotate(CustomResource.ResourceNameAnnotation, re.Resource.Name);  // Resource that implements the service behind the Endpoint.
+                svc.Annotate(CustomResource.EndpointNameAnnotation, endpoint.Name);
+                svc.Annotate(CustomResource.ContainerNetworkAnnotation, tunnelProxy?.Spec?.ContainerNetworkName ?? KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value);
+                svc.Annotate(CustomResource.PrimaryServiceNameAnnotation, serverSvc.DcpResource.Metadata.Name);
+
+                // We use this to distinguish services based on real tunnel proxies vs "placeholders" for when tunnels are disabled.
+                svc.Annotate(CustomResource.ContainerTunnelInstanceName, tunnelProxy?.Metadata?.Name ?? "");
+
+                var svcAppResource = new ServiceAppResource(svc);
+                
+                _appResources.Add(svcAppResource);
+
+                if (useTunnel)
+                {
+                    tunnelAppResource!.ServicesProduced.Add(svcAppResource);
+                }
             }
         }
     }
@@ -945,7 +1228,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             containerExec.Annotate(CustomResource.ResourceNameAnnotation, containerExecutable.Name);
             SetInitialResourceState(containerExecutable, containerExec);
 
-            var exeAppResource = new AppResource(containerExecutable, containerExec);
+            var exeAppResource = new RenderedModelResource(containerExecutable, containerExec);
             _appResources.Add(exeAppResource);
         }
     }
@@ -987,7 +1270,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             SetInitialResourceState(executable, exe);
 
-            var exeAppResource = new AppResource(executable, exe);
+            var exeAppResource = new RenderedModelResource(executable, exe);
             AddServicesProducedInfo(executable, exe, exeAppResource);
             _appResources.Add(exeAppResource);
         }
@@ -1087,7 +1370,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 exeSpec.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, projectLaunchConfiguration);
                 exeSpec.SetAnnotationAsObjectList(CustomResource.ResourceProjectArgsAnnotation, projectArgs);
 
-                var exeAppResource = new AppResource(project, exeSpec);
+                var exeAppResource = new RenderedModelResource(project, exeSpec);
                 AddServicesProducedInfo(project, exeSpec, exeAppResource);
                 _appResources.Add(exeAppResource);
             }
@@ -1112,82 +1395,19 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         }
     }
 
-    private Task CreateSnapshotableResourcesAsync(
-        Func<AppResource, ILogger, CancellationToken, Task> createResourceFunc,
-        IEnumerable<AppResource> executables,
-        CancellationToken cancellationToken)
+    private Task CreateContainerExecutablesAsync(IEnumerable<RenderedModelResource> containerExecAppResources, CancellationToken cancellationToken)
+        => CreateRenderedResourcesAsync(CreateContainerExecutableAsync, containerExecAppResources, cancellationToken);
+
+    private Task CreateExecutablesAsync(IEnumerable<RenderedModelResource> execAppResources, CancellationToken cancellationToken)
+        => CreateRenderedResourcesAsync(CreateExecutableAsync, execAppResources, cancellationToken);
+
+    private async Task CreateRenderedResourcesAsync(
+       Func<RenderedModelResource, ILogger, CancellationToken, Task> createResourceFunc,
+       IEnumerable<RenderedModelResource> executables,
+       CancellationToken cancellationToken)
     {
-        var executablesList = executables.ToList();
-
-        async Task CreateResourceExecutablesAsyncCore(IResource resource, IEnumerable<AppResource> executables, CancellationToken cancellationToken)
-        {
-            var resourceLogger = _loggerService.GetLogger(resource);
-            var resourceType = resource is ProjectResource ? KnownResourceTypes.Project : KnownResourceTypes.Executable;
-
-            try
-            {
-                // Publish snapshots built from DCP resources. Do this now to populate more values from DCP (source) to ensure they're
-                // available if the resource isn't immediately started because it's waiting or is configured for explicit start.
-                foreach (var er in executables)
-                {
-                    Func<CustomResourceSnapshot, CustomResourceSnapshot> snapshotBuild = er.DcpResource switch
-                    {
-                        Executable exe => s => _snapshotBuilder.ToSnapshot(exe, s),
-                        ContainerExec exe => s => _snapshotBuilder.ToSnapshot(exe, s),
-                        _ => throw new NotImplementedException($"Does not support snapshots for resources of type like '{er.DcpResourceName}' is ")
-                    };
-
-                    await _executorEvents.PublishAsync(new OnResourceChangedContext(
-                        _shutdownCancellation.Token, resourceType, resource,
-                        er.DcpResourceName, new ResourceStatus(null, null, null),
-                        snapshotBuild)
-                    ).ConfigureAwait(false);
-                }
-
-                await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resource, DcpResourceName: null)).ConfigureAwait(false);
-
-                foreach (var er in executables)
-                {
-                    if (er.ModelResource.TryGetAnnotationsOfType<ExplicitStartupAnnotation>(out _))
-                    {
-                        await _executorEvents.PublishAsync(new OnResourceChangedContext(cancellationToken, resourceType, resource, er.DcpResource.Metadata.Name, new ResourceStatus(KnownResourceStates.NotStarted, null, null), s => s with { State = new ResourceStateSnapshot(KnownResourceStates.NotStarted, null) })).ConfigureAwait(false);
-                        continue;
-                    }
-
-                    try
-                    {
-                        await createResourceFunc(er, resourceLogger, cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (FailedToApplyEnvironmentException)
-                    {
-                        // For this exception we don't want the noise of the stack trace, we've already
-                        // provided more detail where we detected the issue (e.g. envvar name). To get
-                        // more diagnostic information reduce logging level for DCP log category to Debug.
-                        await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, er.ModelResource, er.DcpResource.Metadata.Name)).ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        // The purpose of this catch block is to ensure that if an individual executable resource fails
-                        // to start that it doesn't tear down the entire app host AND that we route the error to the
-                        // appropriate replica.
-                        resourceLogger.LogError(ex, "Failed to create resource {ResourceName}", er.ModelResource.Name);
-                        await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, er.ModelResource, er.DcpResource.Metadata.Name)).ConfigureAwait(false);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                // The purpose of this catch block is to ensure that if an error processing the overall
-                // configuration of the executable resource files. This is different to the exception handling
-                // block above because at this stage of processing we don't necessarily have any replicas
-                // yet. For example if a dependency fails to start.
-                resourceLogger.LogError(ex, "Failed to create resource {ResourceName}", resource.Name);
-                await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, resource, DcpResourceName: null)).ConfigureAwait(false);
-            }
-        }
-
         var tasks = new List<Task>();
-        var groups = executablesList.GroupBy(e => e.ModelResource).ToList();
+        var groups = executables.GroupBy(e => e.ModelResource).ToList();
 
         foreach (var group in groups)
         {
@@ -1195,19 +1415,84 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             var groupKey = group.Key;
             // Materialize the group with ToList() to avoid issues with deferred execution of IGrouping.
             // Force this to be async so that blocking code does not stop other executables from being created.
-            tasks.Add(Task.Run(() => CreateResourceExecutablesAsyncCore(groupKey, groupList, cancellationToken), cancellationToken));
+            tasks.Add(Task.Run(() => CreateResourceExecutablesAsyncCore(groupKey, groupList, createResourceFunc, cancellationToken), cancellationToken));
         }
 
-        return Task.WhenAll(tasks).WaitAsync(cancellationToken);
+        await Task.WhenAll(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private Task CreateContainerExecutablesAsync(IEnumerable<AppResource> containerExecAppResources, CancellationToken cancellationToken)
-        => CreateSnapshotableResourcesAsync(CreateContainerExecutableAsync, containerExecAppResources, cancellationToken);
+    async Task CreateResourceExecutablesAsyncCore(
+        IResource resource,
+        IEnumerable<RenderedModelResource> executables,
+         Func<RenderedModelResource, ILogger, CancellationToken, Task> createResourceFunc,
+        CancellationToken cancellationToken)
+    {
+        var resourceLogger = _loggerService.GetLogger(resource);
+        var resourceType = resource is ProjectResource ? KnownResourceTypes.Project : KnownResourceTypes.Executable;
 
-    private Task CreateExecutablesAsync(IEnumerable<AppResource> execAppResources, CancellationToken cancellationToken)
-        => CreateSnapshotableResourcesAsync(CreateExecutableAsync, execAppResources, cancellationToken);
+        try
+        {
+            // Publish snapshots built from DCP resources. Do this now to populate more values from DCP (source) to ensure they're
+            // available if the resource isn't immediately started because it's waiting or is configured for explicit start.
+            foreach (var er in executables)
+            {
+                Func<CustomResourceSnapshot, CustomResourceSnapshot> snapshotBuild = er.DcpResource switch
+                {
+                    Executable exe => s => _snapshotBuilder.ToSnapshot(exe, s),
+                    ContainerExec exe => s => _snapshotBuilder.ToSnapshot(exe, s),
+                    _ => throw new NotImplementedException($"Does not support snapshots for resources of type like '{er.DcpResourceName}' is ")
+                };
 
-    private async Task CreateContainerExecutableAsync(AppResource er, ILogger resourceLogger, CancellationToken cancellationToken)
+                await _executorEvents.PublishAsync(new OnResourceChangedContext(
+                    _shutdownCancellation.Token, resourceType, resource,
+                    er.DcpResourceName, new ResourceStatus(null, null, null),
+                    snapshotBuild)
+                ).ConfigureAwait(false);
+            }
+
+            await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resource, DcpResourceName: null)).ConfigureAwait(false);
+
+            foreach (var er in executables)
+            {
+                if (er.ModelResource.TryGetAnnotationsOfType<ExplicitStartupAnnotation>(out _) is true)
+                {
+                    await _executorEvents.PublishAsync(new OnResourceChangedContext(cancellationToken, resourceType, resource, er.DcpResource.Metadata.Name, new ResourceStatus(KnownResourceStates.NotStarted, null, null), s => s with { State = new ResourceStateSnapshot(KnownResourceStates.NotStarted, null) })).ConfigureAwait(false);
+                    continue;
+                }
+
+                try
+                {
+                    await createResourceFunc(er, resourceLogger, cancellationToken).ConfigureAwait(false);
+                }
+                catch (FailedToApplyEnvironmentException)
+                {
+                    // For this exception we don't want the noise of the stack trace, we've already
+                    // provided more detail where we detected the issue (e.g. envvar name). To get
+                    // more diagnostic information reduce logging level for DCP log category to Debug.
+                    await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, er.ModelResource, er.DcpResource.Metadata.Name)).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // The purpose of this catch block is to ensure that if an individual executable resource fails
+                    // to start that it doesn't tear down the entire app host AND that we route the error to the
+                    // appropriate replica.
+                    resourceLogger.LogError(ex, "Failed to create resource {ResourceName}", er.ModelResource.Name);
+                    await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, er.ModelResource, er.DcpResource.Metadata.Name)).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // The purpose of this catch block is to ensure that if an error processing the overall
+            // configuration of the executable resource files. This is different to the exception handling
+            // block above because at this stage of processing we don't necessarily have any replicas
+            // yet. For example if a dependency fails to start.
+            resourceLogger.LogError(ex, "Failed to create resource {ResourceName}", resource.Name);
+            await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, resource, DcpResourceName: null)).ConfigureAwait(false);
+        }
+    }
+
+    private async Task CreateContainerExecutableAsync(RenderedModelResource er, ILogger resourceLogger, CancellationToken cancellationToken)
     {
         if (er.DcpResource is not ContainerExec containerExe)
         {
@@ -1226,7 +1511,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         }
     }
 
-    private async Task CreateExecutableAsync(AppResource er, ILogger resourceLogger, CancellationToken cancellationToken)
+    private async Task CreateExecutableAsync(RenderedModelResource er, ILogger resourceLogger, CancellationToken cancellationToken)
     {
         if (er.DcpResource is not Executable exe)
         {
@@ -1246,26 +1531,31 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             spec.Args.AddRange(projectArgs);
         }
 
-        await PrepareExecutableCertificateTrustConfigAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
-
         // Get args from app host model resource.
         (var appHostArgs, var failedToApplyArgs) = await BuildArgsAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
 
-        var launchArgs = BuildLaunchArgs(er, spec, appHostArgs);
+        // Build environment variables
+        (var env, var failedToApplyConfiguration) = await BuildEnvVarsAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
 
+        // Build certificate trust configuration (args and env vars)
+        (var certificateArgs, var certificateEnv, var failedToApplyCertificateConfig) = await BuildExecutableCertificateTrustConfigAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
+
+        appHostArgs.AddRange(certificateArgs);
+        var launchArgs = BuildLaunchArgs(er, spec, appHostArgs);
         var executableArgs = launchArgs.Where(a => !a.AnnotationOnly).Select(a => a.Value).ToList();
         if (executableArgs.Count > 0)
         {
             spec.Args ??= [];
             spec.Args.AddRange(executableArgs);
         }
-
         // Arg annotations are what is displayed in the dashboard.
         er.DcpResource.SetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, launchArgs.Select(a => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive)));
 
-        (spec.Env, var failedToApplyConfiguration) = await BuildEnvVarsAsync(resourceLogger, er.ModelResource, cancellationToken).ConfigureAwait(false);
+        env.AddRange(certificateEnv);
 
-        if (failedToApplyConfiguration || failedToApplyArgs)
+        spec.Env = env;
+
+        if (failedToApplyConfiguration || failedToApplyArgs || failedToApplyCertificateConfig)
         {
             throw new FailedToApplyEnvironmentException();
         }
@@ -1281,7 +1571,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         }
     }
 
-    private static List<(string Value, bool IsSensitive, bool AnnotationOnly)> BuildLaunchArgs(AppResource er, ExecutableSpec spec, List<(string Value, bool IsSensitive)> appHostArgs)
+    private static List<(string Value, bool IsSensitive, bool AnnotationOnly)> BuildLaunchArgs(RenderedModelResource er, ExecutableSpec spec, List<(string Value, bool IsSensitive)> appHostArgs)
     {
         // Launch args is the final list of args that are displayed in the UI and possibly added to the executable spec.
         // They're built from app host resource model args and any args in the effective launch profile.
@@ -1374,12 +1664,12 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             {
                 new ContainerNetworkConnection
                 {
-                    Name = DefaultAspireNetworkResourceName,
+                    Name = KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value,
                     Aliases = new List<string> { container.Name },
                 }
             };
 
-            var containerAppResource = new AppResource(container, ctr);
+            var containerAppResource = new RenderedModelResource(container, ctr);
             AddServicesProducedInfo(container, ctr, containerAppResource);
             _appResources.Add(containerAppResource);
         }
@@ -1406,13 +1696,13 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         throw new DistributedApplicationException($"Couldn't find required instance ID for index {instanceIndex} on resource {resource.Name}.");
     }
 
-    private async Task CreateContainersAsync(IEnumerable<AppResource> containerResources, CancellationToken cancellationToken)
+    private async Task CreateContainersAsync(IEnumerable<RenderedModelResource> containerResources, CancellationToken cancellationToken)
     {
         try
         {
             AspireEventSource.Instance.DcpContainersCreateStart();
 
-            async Task CreateContainerAsyncCore(AppResource cr, CancellationToken cancellationToken)
+            async Task CreateContainerAsyncCore(RenderedModelResource cr, CancellationToken cancellationToken)
             {
                 var logger = _loggerService.GetLogger(cr.ModelResource);
 
@@ -1435,32 +1725,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             }
 
             var tasks = new List<Task>();
-
-            // Create a custom container network for Aspire if there are container resources
-            if (containerResources.Any())
-            {
-                var network = ContainerNetwork.Create(DefaultAspireNetworkResourceName);
-                if (containerResources.Any(cr => cr.ModelResource.GetContainerLifetimeType() == ContainerLifetime.Persistent))
-                {
-                    // If we have any persistent container resources
-                    network.Spec.Persistent = true;
-                    // Persistent networks require a predictable name to be reused between runs.
-                    // Append the same project hash suffix used for persistent container names.
-                    network.Spec.NetworkName = $"{DefaultAspirePersistentNetworkName}-{_nameGenerator.GetProjectHashSuffix()}";
-                }
-                else
-                {
-                    network.Spec.NetworkName = $"{DefaultAspireNetworkName}-{DcpNameGenerator.GetRandomNameSuffix()}";
-                }
-
-                if (!string.IsNullOrEmpty(_normalizedApplicationName))
-                {
-                    var shortApplicationName = _normalizedApplicationName.Length < 32 ? _normalizedApplicationName : _normalizedApplicationName.Substring(0, 32);
-                    network.Spec.NetworkName += $"-{shortApplicationName}"; // Limit to 32 characters to avoid exceeding resource name length limits.
-                }
-
-                tasks.Add(_kubernetesService.CreateAsync(network, cancellationToken));
-            }
 
             foreach (var cr in containerResources)
             {
@@ -1488,7 +1752,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         }
     }
 
-    private async Task CreateContainerAsync(AppResource cr, ILogger resourceLogger, CancellationToken cancellationToken)
+    private async Task CreateContainerAsync(RenderedModelResource cr, ILogger resourceLogger, CancellationToken cancellationToken)
     {
         await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResource.Metadata.Name)).ConfigureAwait(false);
 
@@ -1506,28 +1770,36 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
         spec.VolumeMounts = BuildContainerMounts(modelContainerResource);
 
-        spec.CreateFiles = await BuildCreateFilesAsync(modelContainerResource, cancellationToken).ConfigureAwait(false);
-
-        var certificateFiles = await BuildContainerCertificateAuthorityTrustAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
-        if (certificateFiles?.Any() == true)
-        {
-            spec.CreateFiles.AddRange(certificateFiles);
-        }
-
         (spec.RunArgs, var failedToApplyRunArgs) = await BuildRunArgsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
 
+        // Build the arguments to pass to the container entrypoint
         (var args, var failedToApplyArgs) = await BuildArgsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
+
+        // Build the environment variables to apply to the container
+        (var env, var failedToApplyConfiguration) = await BuildEnvVarsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
+
+        // Build files that need to be created inside the container
+        var createFiles = await BuildCreateFilesAsync(modelContainerResource, cancellationToken).ConfigureAwait(false);
+
+        // Build certificate specific arguments, environment variables, and files
+        (var certificateArgs, var certificateEnv, var certificateFiles, var failedToApplyCertificateConfig) = await BuildContainerCertificateAuthorityTrustAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
+
+        args.AddRange(certificateArgs);
+        env.AddRange(certificateEnv);
+        createFiles.AddRange(certificateFiles);
+
+        // Set the final args, env vars, and create files on the container spec
         spec.Args = args.Select(a => a.Value).ToList();
         dcpContainerResource.SetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, args.Select(a => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive)));
-
-        (spec.Env, var failedToApplyConfiguration) = await BuildEnvVarsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
+        spec.Env = env;
+        spec.CreateFiles = createFiles;
 
         if (modelContainerResource is ContainerResource containerResource)
         {
             spec.Command = containerResource.Entrypoint;
         }
 
-        if (failedToApplyRunArgs || failedToApplyArgs || failedToApplyConfiguration)
+        if (failedToApplyRunArgs || failedToApplyArgs || failedToApplyConfiguration || failedToApplyCertificateConfig)
         {
             throw new FailedToApplyEnvironmentException();
         }
@@ -1621,7 +1893,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         }
     }
 
-    private void AddServicesProducedInfo(IResource modelResource, IAnnotationHolder dcpResource, AppResource appResource)
+    private void AddServicesProducedInfo(IResource modelResource, IAnnotationHolder dcpResource, RenderedModelResource appResource)
     {
         var modelResourceName = "(unknown)";
         try
@@ -1630,7 +1902,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         }
         catch { } // For error messages only, OK to fall back to (unknown)
 
-        var servicesProduced = _appResources.OfType<ServiceAppResource>().Where(r => r.ModelResource == modelResource);
+        var servicesProduced = _appResources.OfType<ServiceWithModelResource>().Where(r => r.ModelResource == modelResource);
         foreach (var sp in servicesProduced)
         {
             var ea = sp.EndpointAnnotation;
@@ -1704,40 +1976,17 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     {
         return targetHost switch
         {
-            null or "" => ("localhost", EndpointBindingMode.SingleAddress), // Default is localhost
-            var s when EndpointHostHelpers.IsLocalhostOrLocalhostTld(s) => ("localhost", EndpointBindingMode.SingleAddress), // Explicitly set to localhost when using localhost or .localhost subdomain
+            null or "" => (KnownHostNames.Localhost, EndpointBindingMode.SingleAddress), // Default is localhost
+            var s when EndpointHostHelpers.IsLocalhostOrLocalhostTld(s) => (KnownHostNames.Localhost, EndpointBindingMode.SingleAddress), // Explicitly set to localhost or .localhost subdomain
+
             var s when IPAddress.TryParse(s, out var ipAddress) => ipAddress switch // The host is an IP address
             {
-                var ip when IPAddress.Any.Equals(ip) => ("localhost", EndpointBindingMode.IPv4AnyAddresses), // 0.0.0.0 (IPv4 all addresses)
-                var ip when IPAddress.IPv6Any.Equals(ip) => ("localhost", EndpointBindingMode.IPv6AnyAddresses), // :: (IPv6 all addresses)
+                var ip when IPAddress.Any.Equals(ip) => (KnownHostNames.Localhost, EndpointBindingMode.IPv4AnyAddresses), // 0.0.0.0 (IPv4 all addresses)
+                var ip when IPAddress.IPv6Any.Equals(ip) => (KnownHostNames.Localhost, EndpointBindingMode.IPv6AnyAddresses), // :: (IPv6 all addresses)
                 _ => (s, EndpointBindingMode.SingleAddress), // Any other IP address is returned as-is as that will be the only address the service is bound to
             },
-            _ => ("localhost", EndpointBindingMode.DualStackAnyAddresses), // Any other target host is treated as binding to all IPv4 AND IPv6 addresses
+            _ => (KnownHostNames.Localhost, EndpointBindingMode.DualStackAnyAddresses), // Any other target host is treated as binding to all IPv4 AND IPv6 addresses
         };
-    }
-
-    private async Task CreateResourcesAsync<RT>(CancellationToken cancellationToken) where RT : CustomResource
-    {
-        try
-        {
-            var resourcesToCreate = _appResources.Select(r => r.DcpResource).OfType<RT>();
-            if (!resourcesToCreate.Any())
-            {
-                return;
-            }
-
-            // CONSIDER batched creation
-            foreach (var res in resourcesToCreate)
-            {
-                await _kubernetesService.CreateAsync(res, cancellationToken).ConfigureAwait(false);
-            }
-        }
-        catch (OperationCanceledException ex)
-        {
-            // We catch and suppress the OperationCancelledException because the user may CTRL-C
-            // during start up of the resources.
-            _logger.LogDebug(ex, "Cancellation during creation of resources.");
-        }
     }
 
     /// <summary>
@@ -1765,7 +2014,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
         var result = await DeleteResourceRetryPipeline.ExecuteAsync(async (resourceName, attemptCancellationToken) =>
         {
-            var appResource = (AppResource)resourceReference;
+            var appResource = (RenderedModelResource)resourceReference;
 
             V1Patch patch;
             switch (appResource.DcpResource)
@@ -1814,6 +2063,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     public IResourceReference GetResource(string resourceName)
     {
         var matchingResource = _appResources
+            .OfType<RenderedModelResource>()
             .Where(r => r.DcpResource is not Service)
             .SingleOrDefault(r => string.Equals(r.DcpResource.Metadata.Name, resourceName, StringComparisons.ResourceName));
         if (matchingResource == null)
@@ -1826,7 +2076,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
     public async Task StartResourceAsync(IResourceReference resourceReference, CancellationToken cancellationToken)
     {
-        var appResource = (AppResource)resourceReference;
+        var appResource = (RenderedModelResource)resourceReference;
         var resourceType = GetResourceType(appResource.DcpResource, appResource.ModelResource);
         var resourceLogger = _loggerService.GetLogger(appResource.DcpResourceName);
 
@@ -1949,7 +2199,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 }
             },
             resourceLogger,
-            DefaultContainerHostName,
             cancellationToken).ConfigureAwait(false);
 
         return (args, failedToApplyArgs);
@@ -2006,7 +2255,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 }
             },
             resourceLogger,
-            DefaultContainerHostName,
             cancellationToken).ConfigureAwait(false);
 
         return (env, failedToApplyConfiguration);
@@ -2032,7 +2280,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 }
             },
             resourceLogger,
-            DefaultContainerHostName,
             cancellationToken).ConfigureAwait(false);
 
         return (runArgs, failedToApplyArgs);
@@ -2045,7 +2292,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     /// <param name="modelResource">The executable IResource.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
-    private async ValueTask PrepareExecutableCertificateTrustConfigAsync(
+    private async Task<(List<(string, bool)>, List<EnvVar>, bool)> BuildExecutableCertificateTrustConfigAsync(
         ILogger resourceLogger,
         IResource modelResource,
         CancellationToken cancellationToken)
@@ -2054,11 +2301,44 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         var bundleOutputPath = Path.Join(certificatesRootDir, "cert.pem");
         var certificatesOutputPath = Path.Join(certificatesRootDir, "certs");
 
+        bool failedToApplyConfig = false;
+        var args = new List<(string Value, bool IsSensitive)>();
+        var env = new List<EnvVar>();
+
         (_, var certificates) = await modelResource.ProcessCertificateTrustConfigAsync(
             _executionContext,
+            (unprocessed, value, ex, isSensitive) =>
+            {
+                if (ex is not null)
+                {
+                    failedToApplyConfig = true;
+
+                    resourceLogger.LogCritical(ex, "Failed to apply argument value '{ArgKey}'. A dependency may have failed to start.", ex.Data["ArgKey"]);
+                    _logger.LogDebug(ex, "Failed to apply argument value '{ArgKey}' to '{ResourceName}'. A dependency may have failed to start.", ex.Data["ArgKey"], modelResource.Name);
+                }
+                else if (value is { } argument)
+                {
+                    args.Add((argument, isSensitive));
+                }
+            },
+            (key, unprocessed, value, ex) =>
+            {
+                if (ex is not null)
+                {
+                    failedToApplyConfig = true;
+
+                    resourceLogger.LogCritical(ex, "Failed to apply environment variable '{Name}'. A dependency may have failed to start.", key);
+                    _logger.LogDebug(ex, "Failed to apply environment variable '{Name}' to '{ResourceName}'. A dependency may have failed to start.", key, modelResource.Name);
+                }
+                else if (value is string s)
+                {
+                    env.Add(new EnvVar { Name = key, Value = s });
+                }
+            },
             resourceLogger,
             (scope) => ReferenceExpression.Create($"{bundleOutputPath}"),
             (scope) => ReferenceExpression.Create($"{certificatesOutputPath}"),
+            networkContext: null,
             cancellationToken).ConfigureAwait(false);
 
         if (certificates?.Any() == true)
@@ -2078,6 +2358,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             File.WriteAllText(bundleOutputPath, caBundleBuilder.ToString());
         }
+
+        return (args, env, failedToApplyConfig);
     }
 
     /// <summary>
@@ -2087,7 +2369,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     /// <param name="modelResource">The container IResource.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
-    private async Task<List<ContainerCreateFileSystem>?> BuildContainerCertificateAuthorityTrustAsync(
+    private async Task<(List<(string Value, bool isSensitive)>, List<EnvVar>, List<ContainerCreateFileSystem>, bool)> BuildContainerCertificateAuthorityTrustAsync(
         ILogger resourceLogger,
         IResource modelResource,
         CancellationToken cancellationToken)
@@ -2103,9 +2385,42 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             certificateDirsPaths ??= pathsAnnotation.DefaultCertificateDirectories;
         }
 
+        bool failedToApplyConfig = false;
+        var args = new List<(string Value, bool IsSensitive)>();
+        var env = new List<EnvVar>();
+        var createFiles = new List<ContainerCreateFileSystem>();
+
         var pathsProvider = new CertificateTrustConfigurationPathsProvider();
         (var scope, var certificates) = await modelResource.ProcessCertificateTrustConfigAsync(
             _executionContext,
+            (unprocessed, value, ex, isSensitive) =>
+            {
+                if (ex is not null)
+                {
+                    failedToApplyConfig = true;
+
+                    resourceLogger.LogCritical(ex, "Failed to apply argument value '{ArgKey}'. A dependency may have failed to start.", ex.Data["ArgKey"]);
+                    _logger.LogDebug(ex, "Failed to apply argument value '{ArgKey}' to '{ResourceName}'. A dependency may have failed to start.", ex.Data["ArgKey"], modelResource.Name);
+                }
+                else if (value is { } argument)
+                {
+                    args.Add((argument, isSensitive));
+                }
+            },
+            (key, unprocessed, value, ex) =>
+            {
+                if (ex is not null)
+                {
+                    failedToApplyConfig = true;
+
+                    resourceLogger.LogCritical(ex, "Failed to apply environment variable '{Name}'. A dependency may have failed to start.", key);
+                    _logger.LogDebug(ex, "Failed to apply environment variable '{Name}' to '{ResourceName}'. A dependency may have failed to start.", key, modelResource.Name);
+                }
+                else if (value is string s)
+                {
+                    env.Add(new EnvVar { Name = key, Value = s });
+                }
+            },
             resourceLogger,
             (scope) => ReferenceExpression.Create($"{certificatesDestination}/cert.pem"),
             (scope) =>
@@ -2120,6 +2435,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 // Build Linux PATH style colon-separated list of directories
                 return ReferenceExpression.Create($"{string.Join(':', dirs)}");
             },
+            networkContext: null,
             cancellationToken).ConfigureAwait(false);
 
         if (certificates?.Any() == true)
@@ -2140,12 +2456,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 });
             }
 
-            var createFiles = new List<ContainerCreateFileSystem>
+            createFiles.Add(new()
             {
-                new ContainerCreateFileSystem
-                {
-                    Destination = certificatesDestination,
-                    Entries = [
+                Destination = certificatesDestination,
+                Entries = [
                     new ContainerFileSystemEntry
                     {
                         Name = "cert.pem",
@@ -2158,8 +2472,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                         Entries = certificateFiles.ToList(),
                     }
                 ],
-                }
-            };
+            });
 
             if (scope != CertificateTrustScope.Append)
             {
@@ -2180,14 +2493,28 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     });
                 }
             }
+        }
 
-            return createFiles;
+        return (args, env, createFiles, failedToApplyConfig);
+    }
+
+    private string[]? GetSupportedLaunchConfigurations()
+    {
+        try
+        {
+            if (_configuration[KnownConfigNames.DebugSessionInfo] is { } debugSessionInfoJson && JsonSerializer.Deserialize<RunSessionInfo>(debugSessionInfoJson) is { } debugSessionInfo)
+            {
+                return debugSessionInfo.SupportedLaunchConfigurations;
+            }
+        }
+        catch (JsonException)
+        {
         }
 
         return null;
     }
 
-    private static List<ContainerPortSpec> BuildContainerPorts(AppResource cr)
+    private static List<ContainerPortSpec> BuildContainerPorts(RenderedModelResource cr)
     {
         var ports = new List<ContainerPortSpec>();
 
@@ -2215,7 +2542,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     break;
             }
 
-            if (sp.EndpointAnnotation.TargetHost != "localhost")
+            if (sp.EndpointAnnotation.TargetHost != KnownHostNames.Localhost)
             {
                 portSpec.HostIP = sp.EndpointAnnotation.TargetHost;
             }
@@ -2247,5 +2574,15 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         }
 
         return volumeMounts;
+    }
+
+    private static bool TryGetEndpoint(IResource resource, string? endpointName, [NotNullWhen(true)] out EndpointAnnotation? endpoint)
+    {
+        endpoint = null;
+        if (resource.TryGetAnnotationsOfType<EndpointAnnotation>(out var endpoints))
+        {
+            endpoint = endpoints.FirstOrDefault(e => StringComparers.EndpointAnnotationName.Equals(e.Name, endpointName));
+        }
+        return endpoint is not null;
     }
 }

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -857,8 +857,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             foreach (var cs in containerServices)
             {
                 var primaryService = _appResources.OfType<ServiceWithModelResource>().Select(sar => sar.Service)
-                    .Where(svc => svc.Metadata.Name.Equals(cs.PrimaryServiceName)).ToImmutableArray();
-                cs.Service!.ApplyAddressInfoFrom(primaryService[0]);
+                    .Where(svc => svc.Metadata.Name.Equals(cs.PrimaryServiceName)).First();
+                cs.Service!.ApplyAddressInfoFrom(primaryService);
                 cs.Service!.Status!.EffectiveAddress = ContainerHostName;
             }
         }

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -94,6 +94,11 @@ internal sealed class DcpOptions
     /// By default log file name suffix defaults to the current process ID.
     /// </summary>
     public string? LogFileNameSuffix { get; set; }
+
+    /// <summary>
+    /// Enables Aspire container tunnel for container-to-host connectivity across all container orchestrators.
+    /// </summary>
+    public bool EnableAspireContainerTunnel { get; set; }
 }
 
 internal class ValidateDcpOptions : IValidateOptions<DcpOptions>
@@ -197,6 +202,7 @@ internal class ConfigureDefaultDcpOptions(
         options.ServiceStartupWatchTimeout = configuration.GetValue(KnownConfigNames.ServiceStartupWatchTimeout, KnownConfigNames.Legacy.ServiceStartupWatchTimeout, options.ServiceStartupWatchTimeout);
         options.ContainerRuntimeInitializationTimeout = dcpPublisherConfiguration.GetValue(nameof(options.ContainerRuntimeInitializationTimeout), options.ContainerRuntimeInitializationTimeout);
         options.LogFileNameSuffix = dcpPublisherConfiguration[nameof(options.LogFileNameSuffix)];
+        options.EnableAspireContainerTunnel = dcpPublisherConfiguration.GetValue(nameof(options.EnableAspireContainerTunnel), options.EnableAspireContainerTunnel);
     }
 
     private static string? GetMetadataValue(IEnumerable<AssemblyMetadataAttribute>? assemblyMetadata, string key)

--- a/src/Aspire.Hosting/Dcp/DcpPipelineBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/DcpPipelineBuilder.cs
@@ -31,11 +31,11 @@ internal static class DcpPipelineBuilder
         return execution;
     }
 
-    public static ResiliencePipeline BuildCreateServiceRetryPipeline(DcpOptions dcpOptions, ILogger logger)
+    public static ResiliencePipeline BuildCreateServiceRetryPipeline(DcpOptions dcpOptions, ILogger logger, TimeSpan? timeout = null)
     {
         var withTimeout = new TimeoutStrategyOptions()
         {
-            Timeout = dcpOptions.ServiceStartupWatchTimeout
+            Timeout = timeout ?? dcpOptions.ServiceStartupWatchTimeout
         };
 
         var tryTwice = new RetryStrategyOptions()

--- a/src/Aspire.Hosting/Dcp/DcpVersion.cs
+++ b/src/Aspire.Hosting/Dcp/DcpVersion.cs
@@ -5,7 +5,7 @@ namespace Aspire.Hosting.Dcp;
 
 internal static class DcpVersion
 {
-    public static Version MinimumVersionInclusive = new Version(0, 12, 3); // Aspire 9.2 release
+    public static Version MinimumVersionInclusive = new Version(0, 18, 6); // Aspire 13 release
 
     /// <summary>
     /// Development build version proxy, considered always "current" and supporting latest features. 

--- a/src/Aspire.Hosting/Dcp/Model/ContainerTunnel.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ContainerTunnel.cs
@@ -1,0 +1,276 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+using k8s.Models;
+
+namespace Aspire.Hosting.Dcp.Model;
+
+/// <summary>
+/// Defines a single tunnel for communications between container clients and services on the host.
+/// </summary>
+internal sealed class TunnelConfiguration
+{
+    /// <summary>
+    /// User-friendly name for the tunnel (used in status reporting and debugging).
+    /// Must be unique within the ContainerNetworkTunnelProxy and cannot be empty.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Namespace of the Service that identifies the server the tunnel connects to.
+    /// </summary>
+    [JsonPropertyName("serverServiceNamespace")]
+    public string? ServerServiceNamespace { get; set; }
+
+    /// <summary>
+    /// Name of the Service that identifies the server the tunnel connects to.
+    /// </summary>
+    [JsonPropertyName("serverServiceName")]
+    public string? ServerServiceName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the namespace of the Service associated with the client proxy on the container network.
+    /// </summary>
+    [JsonPropertyName("clientServiceNamespace")]
+    public string? ClientServiceNamespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the Service associated with the client proxy on the container network.
+    /// </summary>
+    [JsonPropertyName("clientServiceName")]
+    public string? ClientServiceName { get; set; }
+}
+
+internal sealed class ContainerNetworkTunnelProxySpec
+{
+    /// <summary>
+    /// Reference to the ContainerNetwork that the client proxy should connect to.
+    /// This field is required and must reference an existing ContainerNetwork resource.
+    /// </summary>
+    [JsonPropertyName("containerNetworkName")]
+    public string? ContainerNetworkName { get; set; }
+
+    /// <summary>
+    /// Aliases (DNS names) that can be used to reach the client proxy container on the container network.
+    /// </summary>
+    [JsonPropertyName("aliases")]
+    public List<string>? Aliases { get; set; }
+
+    /// <summary>
+    /// List of tunnels to prepare. Each tunnel enables clients on the container network
+    /// to connect to a server on the host (establish a tunnel stream).
+    /// </summary>
+    [JsonPropertyName("tunnels")]
+    public List<TunnelConfiguration>? Tunnels { get; set; }
+
+    /// <summary>
+    /// Base container image to use for the client proxy container.
+    /// Defaults to mcr.microsoft.com/azurelinux/base/core:3.0 if not specified.
+    /// </summary>
+    [JsonPropertyName("baseImage")]
+    public string? BaseImage { get; set; }
+}
+
+internal static class TunnelState
+{
+    /// <summary>
+    /// Tunnel is ready and accepting connections.
+    /// </summary>
+    public const string Ready = "Ready";
+
+    /// <summary>
+    /// Tunnel preparation failed, see <see cref="TunnelStatus.ErrorMessage"/> for details.
+    /// </summary>
+    public const string Failed = "Failed";
+
+    /// <summary>
+    /// Initial state -- no attempt to prepare the tunnel have been made yet.
+    /// </summary>
+    public const string Empty = "";
+
+    /// <summary>
+    /// Tunnel is being prepared, or is waiting for required services to become ready.
+    /// </summary>
+    public const string NotReady = "NotReady";
+}
+
+/// <summary>
+/// Represents the status of a single tunnel managed by <see cref="ContainerNetworkTunnelProxy"/>.
+/// </summary>
+internal sealed class TunnelStatus
+{
+    /// <summary>
+    /// Name of the tunnel (matches <see cref="TunnelConfiguration.Name"/>).
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Internal tunnel ID assigned by the proxy pair.
+    /// </summary>
+    [JsonPropertyName("tunnelId")]
+    public uint TunnelId { get; set; }
+
+    /// <summary>
+    /// Current state of the tunnel. <seealso cref="TunnelState"/>
+    /// </summary>
+    [JsonPropertyName("state")]
+    public string State { get; set; } = TunnelState.Empty;
+
+    /// <summary>
+    /// Human-readable explanation for why the tunnel preparation failed (if it did).
+    /// </summary>
+    [JsonPropertyName("errorMessage")]
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Addresses on the container network that client proxy is listening on for this tunnel.
+    /// May be empty if the tunnel is not ready.
+    /// </summary>
+    [JsonPropertyName("clientProxyAddresses")]
+    public List<string>? ClientProxyAddresses { get; set; }
+
+    /// <summary>
+    /// Port on the container network that client proxy is listening on for this tunnel.
+    /// May be zero if the tunnel is not ready.
+    /// </summary>
+    [JsonPropertyName("clientProxyPort")]
+    public int ClientProxyPort { get; set; }
+
+    /// <summary>
+    /// The timestamp for the status (last update).
+    /// </summary>
+    [JsonPropertyName("timestamp")]
+    public DateTime? Timestamp { get; set; }
+}
+
+internal static class ContainerNetworkTunnelProxyState
+{
+    /// <summary>
+    /// Equivalent to <see cref="Pending"/>.
+    /// May be encountered when ContainerNetworkTunnelProxy status has not been initialized yet.
+    /// </summary>
+    public const string Empty = "";
+
+    /// <summary>
+    /// Initial state - proxy pair is being created.
+    /// </summary>
+    public const string Pending = "Pending";
+
+    /// <summary>
+    /// Building the client proxy container image.
+    /// </summary>
+    public const string BuildingImage = "BuildingImage";
+
+    /// <summary>
+    /// Starting the proxy pair.
+    /// </summary>
+    public const string Starting = "Starting";
+
+    /// <summary>
+    /// Proxy pair is ready with all tunnels operational.
+    /// </summary>
+    public const string Running = "Running";
+
+    /// <summary>
+    /// Proxy pair encountered an unrecoverable error, either during startup, or during execution.
+    /// </summary>
+    public const string Failed = "Failed";
+}
+
+internal sealed record ContainerNetworkTunnelProxyStatus : V1Status
+{
+    /// <summary>
+    /// Current overall state of the tunnel proxy. <seealso cref="ContainerNetworkTunnelProxyState"/>
+    /// </summary>
+    [JsonPropertyName("state")]
+    public string State { get; set; } = ContainerNetworkTunnelProxyState.Empty;
+
+    /// <summary>
+    /// Status of individual tunnels within the proxy pair.
+    /// </summary>
+    [JsonPropertyName("tunnelStatuses")]
+    public List<TunnelStatus>? TunnelStatuses { get; set; }
+
+    /// <summary>
+    /// Monotonically increasing version number of the tunnel configuration that was applied to the proxy pair.
+    /// Can be used by clients changing tunnel configuration (<see cref="ContainerNetworkTunnelProxySpec.Tunnels"/>)
+    /// to learn that the new configuration has become effective.
+    /// </summary>
+    [JsonPropertyName("tunnelConfigurationVersion")]
+    public int TunnelConfigurationVersion { get; set; }
+
+    /// <summary>
+    /// The name and tag of the container image used for the client proxy container.
+    /// </summary>
+    [JsonPropertyName("clientProxyContainerImage")]
+    public string? ClientProxyContainerImage { get; set; }
+
+    /// <summary>
+    /// Container ID of the running client proxy container.
+    /// </summary>
+    [JsonPropertyName("clientProxyContainerId")]
+    public string? ClientProxyContainerId { get; set; }
+
+    /// <summary>
+    /// Server proxy process ID.
+    /// </summary>
+    [JsonPropertyName("serverProxyProcessId")]
+    public long? ServerProxyProcessId { get; set; }
+
+    /// <summary>
+    /// Server proxy process startup timestamp.
+    /// </summary>
+    [JsonPropertyName("serverProxyStartupTimestamp")]
+    public DateTime? ServerProxyStartupTimestamp { get; set; }
+
+    /// <summary>
+    /// The path of a temporary file that contains captured standard output data from the server proxy process.
+    /// </summary>
+    [JsonPropertyName("serverProxyStdOutFile")]
+    public string? ServerProxyStdOutFile { get; set; }
+
+    /// <summary>
+    /// The path of a temporary file that contains captured standard error data from the server proxy process.
+    /// </summary>
+    [JsonPropertyName("serverProxyStdErrFile")]
+    public string? ServerProxyStdErrFile { get; set; }
+
+    /// <summary>
+    /// Published (host) port for client proxy control endpoint.
+    /// </summary>
+    [JsonPropertyName("clientProxyControlPort")]
+    public int ClientProxyControlPort { get; set; }
+
+    /// <summary>
+    /// Published (host) port for client proxy data endpoint.
+    /// </summary>
+    [JsonPropertyName("clientProxyDataPort")]
+    public int ClientProxyDataPort { get; set; }
+
+    /// <summary>
+    /// Server proxy control port (for controlling the proxy pair).
+    /// </summary>
+    [JsonPropertyName("serverProxyControlPort")]
+    public int ServerProxyControlPort { get; set; }
+}
+
+internal sealed class ContainerNetworkTunnelProxy : CustomResource<ContainerNetworkTunnelProxySpec, ContainerNetworkTunnelProxyStatus>
+{
+    [JsonConstructor]
+    public ContainerNetworkTunnelProxy(ContainerNetworkTunnelProxySpec spec) : base(spec) { }
+
+    public static ContainerNetworkTunnelProxy Create(string name)
+    {
+        var tp = new ContainerNetworkTunnelProxy(new ContainerNetworkTunnelProxySpec());
+
+        tp.Kind = Dcp.ContainerNetworkTunnelProxyKind;
+        tp.ApiVersion = Dcp.GroupVersion.ToString();
+        tp.Metadata.Name = name;
+        tp.Metadata.NamespaceProperty = string.Empty;
+
+        return tp;
+    }
+}

--- a/src/Aspire.Hosting/Dcp/Model/GroupVersion.cs
+++ b/src/Aspire.Hosting/Dcp/Model/GroupVersion.cs
@@ -29,6 +29,7 @@ internal static class Dcp
     public static string EndpointKind { get; } = "Endpoint";
     public static string ExecutableReplicaSetKind { get; } = "ExecutableReplicaSet";
     public static string ContainerVolumeKind { get; } = "ContainerVolume";
+    public static string ContainerNetworkTunnelProxyKind { get; } = "ContainerNetworkTunnelProxy";
 
     static Dcp()
     {
@@ -40,5 +41,6 @@ internal static class Dcp
         Schema.Add<ExecutableReplicaSet>(ExecutableReplicaSetKind, "executablereplicasets");
         Schema.Add<ContainerVolume>(ContainerVolumeKind, "containervolumes");
         Schema.Add<ContainerExec>(ContainerExecKind, "containerexecs");
+        Schema.Add<ContainerNetworkTunnelProxy>(ContainerNetworkTunnelProxyKind, "containernetworktunnelproxies");
     }
 }

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -22,6 +22,9 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
     public const string ServiceConsumerAnnotation = "service-consumer";
     public const string EndpointNameAnnotation = "endpoint-name";
     public const string ResourceNameAnnotation = "resource-name";
+    public const string ContainerTunnelInstanceName = "container-tunnel-instance-name";
+    public const string ContainerNetworkAnnotation = "container-network";
+    public const string PrimaryServiceNameAnnotation = "primary-service-name";
     public const string OtelServiceNameAnnotation = "otel-service-name";
     public const string OtelServiceInstanceIdAnnotation = "otel-service-instance-id";
     public const string ResourceStateAnnotation = "resource-state";

--- a/src/Aspire.Hosting/Dcp/Model/Service.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Service.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Text.Json.Serialization;
 using k8s.Models;
 
@@ -67,6 +68,7 @@ internal static class AddressAllocationModes
     public const string Proxyless = "Proxyless";
 }
 
+[DebuggerDisplay("Service {Metadata.Name} State={Status?.State}")]
 internal sealed class Service : CustomResource<ServiceSpec, ServiceStatus>
 {
     [JsonConstructor]

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -240,7 +240,7 @@ internal class ResourceSnapshotBuilder
             var endpointUrls = resourceUrls.Where(u => u.Endpoint is not null).ToList();
             var nonEndpointUrls = resourceUrls.Where(u => u.Endpoint is null).ToList();
 
-            var resourceServices = _resourceState.AppResources.OfType<ServiceAppResource>().Where(r => r.Service.AppModelResourceName == resource.AppModelResourceName).Select(s => s.Service).ToList();
+            var resourceServices = _resourceState.AppResources.OfType<ServiceWithModelResource>().Where(r => r.Service.AppModelResourceName == resource.AppModelResourceName).Select(s => s.Service).ToList();
             var name = resource.Metadata.Name;
 
             // Add the endpoint URLs

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -234,7 +234,7 @@ internal sealed class ApplicationOrchestrator
                     // will be "localhost" as that's a valid address for the .NET developer certificate. However,
                     // if a service is bound to a specific IP address, the allocated endpoint will be that same IP
                     // address.
-                    var endpointReference = new EndpointReference(resourceWithEndpoints, endpoint);
+                    var endpointReference = new EndpointReference(resourceWithEndpoints, endpoint, endpoint.DefaultNetworkID);
                     var url = new ResourceUrlAnnotation { Url = allocatedEndpoint.UriString, Endpoint = endpointReference };
 
                     // In the case that a service is bound to multiple addresses or a *.localhost address, we generate

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -807,7 +807,7 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Exposes an endpoint on a resource. A reference to this endpoint can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier?)"/>.
+    /// Exposes an endpoint on a resource. A reference to this endpoint can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier)"/>.
     /// The endpoint name will be the scheme name if not specified.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
@@ -863,7 +863,7 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Exposes an endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier?)"/>.
+    /// Exposes an endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier)"/>.
     /// The endpoint name will be the scheme name if not specified.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
@@ -883,7 +883,7 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Exposes an HTTP endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier?)"/>.
+    /// Exposes an HTTP endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier)"/>.
     /// The endpoint name will be "http" if not specified.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
@@ -903,7 +903,7 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Exposes an HTTPS endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier?)"/>.
+    /// Exposes an HTTPS endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier)"/>.
     /// The endpoint name will be "https" if not specified.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
@@ -957,7 +957,7 @@ public static class ResourceBuilderExtensions
     /// <param name="name">The name of the endpoint.</param>
     /// <param name="contextNetworkID">The network context in which to resolve the endpoint. If null, localhost (loopback) network context will be used.</param>
     /// <returns>An <see cref="EndpointReference"/> that can be used to resolve the address of the endpoint after resource allocation has occurred.</returns>
-    public static EndpointReference GetEndpoint<T>(this IResourceBuilder<T> builder, [EndpointName] string name, NetworkIdentifier? contextNetworkID = null) where T : IResourceWithEndpoints
+    public static EndpointReference GetEndpoint<T>(this IResourceBuilder<T> builder, [EndpointName] string name, NetworkIdentifier contextNetworkID) where T : IResourceWithEndpoints
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -976,7 +976,7 @@ public static class ResourceBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.Resource.GetEndpoint(name, null);
+        return builder.Resource.GetEndpoint(name);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -791,10 +791,11 @@ public static class ResourceBuilderExtensions
 
         if (endpoint == null && createIfNotExists)
         {
-            var defaultNetwork = builder.Resource.IsContainer()
-                ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork
-                : KnownNetworkIdentifiers.LocalhostNetwork;
-            endpoint = new EndpointAnnotation(ProtocolType.Tcp, name: endpointName, networkID: defaultNetwork);
+            // Endpoints for a Container will be consumed from localhost network by default, but the same EndpointAnnotation
+            // can also be resolved in the context of container-to-container communication by using the target port
+            // and the container name as the host. This is why we only set the context network to localhost,
+            // for both container and non-container resources.
+            endpoint = new EndpointAnnotation(ProtocolType.Tcp, name: endpointName, networkID: KnownNetworkIdentifiers.LocalhostNetwork);
             callback(endpoint);
             builder.Resource.Annotations.Add(endpoint);
         }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -398,7 +398,7 @@ public static class ResourceBuilderExtensions
             context.Resource.TryGetLastAnnotation<ReferenceEnvironmentInjectionAnnotation>(out var injectionAnnotation);
             var flags = injectionAnnotation?.Flags ?? ReferenceEnvironmentInjectionFlags.All;
 
-            foreach (var endpoint in annotation.Resource.GetEndpoints())
+            foreach (var endpoint in annotation.Resource.GetEndpoints(annotation.ContextNetworkID))
             {
                 if (specificEndpointName != null && !string.Equals(endpoint.EndpointName, specificEndpointName, StringComparison.OrdinalIgnoreCase))
                 {
@@ -719,6 +719,10 @@ public static class ResourceBuilderExtensions
         if (endpointReferenceAnnotation == null)
         {
             endpointReferenceAnnotation = new EndpointReferenceAnnotation(resourceWithEndpoints);
+            if (builder.Resource.IsContainer())
+            {
+                endpointReferenceAnnotation.ContextNetworkID = KnownNetworkIdentifiers.DefaultAspireContainerNetwork;
+            }
             builder.WithAnnotation(endpointReferenceAnnotation);
 
             var callback = CreateEndpointReferenceEnvironmentPopulationCallback(endpointReferenceAnnotation, null, name);
@@ -787,7 +791,10 @@ public static class ResourceBuilderExtensions
 
         if (endpoint == null && createIfNotExists)
         {
-            endpoint = new EndpointAnnotation(ProtocolType.Tcp, name: endpointName);
+            var defaultNetwork = builder.Resource.IsContainer()
+                ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork
+                : KnownNetworkIdentifiers.LocalhostNetwork;
+            endpoint = new EndpointAnnotation(ProtocolType.Tcp, name: endpointName, networkID: defaultNetwork);
             callback(endpoint);
             builder.Resource.Annotations.Add(endpoint);
         }
@@ -800,7 +807,7 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Exposes an endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string)"/>.
+    /// Exposes an endpoint on a resource. A reference to this endpoint can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier?)"/>.
     /// The endpoint name will be the scheme name if not specified.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
@@ -820,6 +827,10 @@ public static class ResourceBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        // Endpoints for a Container will be consumed from localhost network by default, but the same EndpointAnnotation
+        // can also be resolved in the context of container-to-container communication by using the target port
+        // and the container name as the host. This is why we only set the context network to localhost,
+        // for both container and non-container resources.
         var annotation = new EndpointAnnotation(
             protocol: protocol ?? ProtocolType.Tcp,
             uriScheme: scheme,
@@ -827,7 +838,8 @@ public static class ResourceBuilderExtensions
             port: port,
             targetPort: targetPort,
             isExternal: isExternal,
-            isProxied: isProxied);
+            isProxied: isProxied,
+            networkID: KnownNetworkIdentifiers.LocalhostNetwork);
 
         if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, annotation.Name, StringComparisons.EndpointAnnotationName)))
         {
@@ -839,7 +851,7 @@ public static class ResourceBuilderExtensions
         {
             annotation.TargetPortEnvironmentVariable = env;
 
-            var endpointReference = new EndpointReference(resourceWithEndpoints, annotation);
+            var endpointReference = new EndpointReference(resourceWithEndpoints, annotation, KnownNetworkIdentifiers.LocalhostNetwork);
 
             builder.WithAnnotation(new EnvironmentCallbackAnnotation(context =>
             {
@@ -851,7 +863,7 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Exposes an endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string)"/>.
+    /// Exposes an endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier?)"/>.
     /// The endpoint name will be the scheme name if not specified.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
@@ -871,7 +883,7 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Exposes an HTTP endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string)"/>.
+    /// Exposes an HTTP endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier?)"/>.
     /// The endpoint name will be "http" if not specified.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
@@ -891,7 +903,7 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Exposes an HTTPS endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string)"/>.
+    /// Exposes an HTTPS endpoint on a resource. This endpoint reference can be retrieved using <see cref="ResourceBuilderExtensions.GetEndpoint{T}(IResourceBuilder{T}, string, NetworkIdentifier?)"/>.
     /// The endpoint name will be "https" if not specified.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
@@ -943,12 +955,28 @@ public static class ResourceBuilderExtensions
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The the resource builder.</param>
     /// <param name="name">The name of the endpoint.</param>
+    /// <param name="contextNetworkID">The network context in which to resolve the endpoint. If null, localhost (loopback) network context will be used.</param>
+    /// <returns>An <see cref="EndpointReference"/> that can be used to resolve the address of the endpoint after resource allocation has occurred.</returns>
+    public static EndpointReference GetEndpoint<T>(this IResourceBuilder<T> builder, [EndpointName] string name, NetworkIdentifier? contextNetworkID = null) where T : IResourceWithEndpoints
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.Resource.GetEndpoint(name, contextNetworkID);
+    }
+
+    /// <summary>
+    /// Gets an <see cref="EndpointReference"/> by name from the resource. These endpoints are declared either using <see cref="WithEndpoint{T}(IResourceBuilder{T}, int?, int?, string?, string?, string?, bool, bool?, ProtocolType?)"/> or by launch settings (for project resources).
+    /// The <see cref="EndpointReference"/> can be used to resolve the address of the endpoint in <see cref="WithEnvironment{T}(IResourceBuilder{T}, Action{EnvironmentCallbackContext})"/>.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The the resource builder.</param>
+    /// <param name="name">The name of the endpoint.</param>
     /// <returns>An <see cref="EndpointReference"/> that can be used to resolve the address of the endpoint after resource allocation has occurred.</returns>
     public static EndpointReference GetEndpoint<T>(this IResourceBuilder<T> builder, [EndpointName] string name) where T : IResourceWithEndpoints
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.Resource.GetEndpoint(name);
+        return builder.Resource.GetEndpoint(name, null);
     }
 
     /// <summary>

--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -32,6 +32,7 @@ internal static class StringComparers
     public static StringComparer CommandName => StringComparer.Ordinal;
     public static StringComparer CliInputOrOutput => StringComparer.Ordinal;
     public static StringComparer InteractionInputName => StringComparer.OrdinalIgnoreCase;
+    public static StringComparer NetworkID => StringComparer.Ordinal;
 }
 
 internal static class StringComparisons
@@ -61,4 +62,5 @@ internal static class StringComparisons
     public static StringComparison CommandName => StringComparison.Ordinal;
     public static StringComparison CliInputOrOutput => StringComparison.Ordinal;
     public static StringComparison InteractionInputName => StringComparison.OrdinalIgnoreCase;
+    public static StringComparison NetworkID => StringComparison.Ordinal;
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
@@ -415,9 +415,13 @@ public class AzureKeyVaultTests
         {
             Image = "mcr.microsoft.com/azure-key-vault/emulator:latest"
         });
-        
-        // Add https endpoint for emulator
-        keyVault.WithEndpoint("https", endpoint => endpoint.AllocatedEndpoint = new(endpoint, "localhost", 8443));
+
+        // Add https endpoint for emulator and simulate port mapping to host network
+        keyVault.WithEndpoint("https", endpoint => {
+            var endpointSnapshot = new ValueSnapshot<AllocatedEndpoint>();
+            endpointSnapshot.SetValue(new AllocatedEndpoint(endpoint, "localhost", 8443, EndpointBindingMode.SingleAddress, null, KnownNetworkIdentifiers.LocalhostNetwork));
+            endpoint.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.LocalhostNetwork, endpointSnapshot);
+        });
 
         var connectionString = keyVault.Resource.ConnectionStringExpression;
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
@@ -416,12 +416,8 @@ public class AzureKeyVaultTests
             Image = "mcr.microsoft.com/azure-key-vault/emulator:latest"
         });
 
-        // Add https endpoint for emulator and simulate port mapping to host network
-        keyVault.WithEndpoint("https", endpoint => {
-            var endpointSnapshot = new ValueSnapshot<AllocatedEndpoint>();
-            endpointSnapshot.SetValue(new AllocatedEndpoint(endpoint, "localhost", 8443, EndpointBindingMode.SingleAddress, null, KnownNetworkIdentifiers.LocalhostNetwork));
-            endpoint.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.LocalhostNetwork, endpointSnapshot);
-        });
+        // Add https endpoint for emulator
+        keyVault.WithEndpoint("https", endpoint => endpoint.AllocatedEndpoint = new(endpoint, "localhost", 8443));
 
         var connectionString = keyVault.Resource.ConnectionStringExpression;
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -112,7 +112,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         Assert.Same(container.Resource, dashboard);
 
-        var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout())
+        var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance, KnownNetworkIdentifiers.LocalhostNetwork).DefaultTimeout())
             .OrderBy(c => c.Key)
             .ToList();
 
@@ -209,7 +209,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         Assert.Same(container.Resource, dashboard);
 
-        var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout())
+        var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance, KnownNetworkIdentifiers.LocalhostNetwork).DefaultTimeout())
             .OrderBy(c => c.Key)
             .ToList();
 

--- a/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
@@ -247,19 +247,6 @@ public class EndpointReferenceTests
     }
 
     [Fact]
-    public void ContainerHost_ThrowsWhenEndpointNotAllocated()
-    {
-        var resource = new TestResource("test");
-        var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http");
-        resource.Annotations.Add(annotation);
-
-        var endpointRef = new EndpointReference(resource, annotation);
-
-        var ex = Assert.Throws<InvalidOperationException>(() => endpointRef.ContainerHost);
-        Assert.Equal("The endpoint `http` is not allocated for the resource `test`.", ex.Message);
-    }
-
-    [Fact]
     public void Scheme_DoesNotThrowWhenEndpointNotAllocated()
     {
         var resource = new TestResource("test");

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -36,7 +36,7 @@ public class ExecutableResourceTests
                  context.Args.Add("arg2");
                  context.Args.Add(exe1.GetEndpoint("ep"));
                  context.Args.Add(testResource2);
-                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep"));
+                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep", null));
              });
 
         using var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -36,7 +36,7 @@ public class ExecutableResourceTests
                  context.Args.Add("arg2");
                  context.Args.Add(exe1.GetEndpoint("ep"));
                  context.Args.Add(testResource2);
-                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep", null));
+                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep"));
              });
 
         using var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -12,19 +12,20 @@ public class ExpressionResolverTests
     [MemberData(nameof(ResolveInternalAsync_ResolvesCorrectly_MemberData))]
     public async Task ResolveInternalAsync_ResolvesCorrectly(ExpressionResolverTestData testData, Type? exceptionType, (string Value, bool IsSensitive)? expectedValue)
     {
+        NetworkIdentifier? context = testData.SourceIsContainer ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork : KnownNetworkIdentifiers.LocalhostNetwork;
         if (exceptionType is not null)
         {
             await Assert.ThrowsAsync(exceptionType, ResolveAsync);
         }
         else
         {
-            var resolvedValue = await ExpressionResolver.ResolveAsync(testData.SourceIsContainer, testData.ValueProvider, string.Empty, CancellationToken.None);
+            var resolvedValue = await ExpressionResolver.ResolveAsync(testData.ValueProvider, context, CancellationToken.None);
 
             Assert.Equal(expectedValue?.Value, resolvedValue.Value);
             Assert.Equal(expectedValue?.IsSensitive, resolvedValue.IsSensitive);
         }
 
-        async Task<ResolvedValue> ResolveAsync() => await ExpressionResolver.ResolveAsync(testData.SourceIsContainer, testData.ValueProvider, string.Empty, CancellationToken.None);
+        async Task<ResolvedValue> ResolveAsync() => await ExpressionResolver.ResolveAsync(testData.ValueProvider, context, CancellationToken.None);
     }
 
     public static TheoryData<ExpressionResolverTestData, Type?, (string? Value, bool IsSensitive)?> ResolveInternalAsync_ResolvesCorrectly_MemberData()
@@ -54,23 +55,23 @@ public class ExpressionResolverTests
     [Theory]
     [InlineData("TwoFullEndpoints", false, false, "Test1=http://127.0.0.1:12345/;Test2=https://localhost:12346/;")]
     [InlineData("TwoFullEndpoints", false, true, "Test1=http://127.0.0.1:12345/;Test2=https://localhost:12346/;")]
-    [InlineData("TwoFullEndpoints", true, false, "Test1=http://ContainerHostName:12345/;Test2=https://ContainerHostName:12346/;")]
+    [InlineData("TwoFullEndpoints", true, false, "Test1=http://aspire.dev.internal:12345/;Test2=https://aspire.dev.internal:12346/;")]
     [InlineData("TwoFullEndpoints", true, true, "Test1=http://testresource:10000/;Test2=https://testresource:10001/;")]
     [InlineData("Url", false, false, "Url=http://localhost:12345;")]
     [InlineData("Url", false, true, "Url=http://localhost:12345;")]
-    [InlineData("Url", true, false, "Url=http://ContainerHostName:12345;")]
+    [InlineData("Url", true, false, "Url=http://aspire.dev.internal:12345;")]
     [InlineData("Url", true, true, "Url=http://testresource:10000;")]
-    [InlineData("Url2", true, false, "Url=http://ContainerHostName:12345;")]
+    [InlineData("Url2", true, false, "Url=http://aspire.dev.internal:12345;")]
     [InlineData("Url2", true, true, "Url=http://testresource:10000;")]
-    [InlineData("OnlyHost", true, false, "Host=ContainerHostName;")]
+    [InlineData("OnlyHost", true, false, "Host=aspire.dev.internal;")]
     [InlineData("OnlyHost", true, true, "Host=testresource;")] // host now replaced to container name
     [InlineData("OnlyPort", true, false, "Port=12345;")]
     [InlineData("OnlyPort", true, true, "Port=10000;")] // port now replaced with target port
-    [InlineData("HostAndPort", true, false, "HostPort=ContainerHostName:12345")]
+    [InlineData("HostAndPort", true, false, "HostPort=aspire.dev.internal:12345")]
     [InlineData("HostAndPort", true, true, "HostPort=testresource:10000")] // host not replaced since no port
-    [InlineData("PortBeforeHost", true, false, "Port=12345;Host=ContainerHostName;")]
+    [InlineData("PortBeforeHost", true, false, "Port=12345;Host=aspire.dev.internal;")]
     [InlineData("PortBeforeHost", true, true, "Port=10000;Host=testresource;")]
-    [InlineData("FullAndPartial", true, false, "Test1=http://ContainerHostName:12345/;Test2=https://localhost:12346/;")]
+    [InlineData("FullAndPartial", true, false, "Test1=http://aspire.dev.internal:12345/;Test2=https://localhost:12346/;")]
     [InlineData("FullAndPartial", true, true, "Test1=http://testresource:10000/;Test2=https://localhost:10001/;")]
     [InlineData("UrlEncodedHost", false, false, "Host=host%20with%20space;")]
     public async Task ExpressionResolverGeneratesCorrectEndpointStrings(string exprName, bool sourceIsContainer, bool targetIsContainer, string expectedConnectionString)
@@ -81,17 +82,38 @@ public class ExpressionResolverTests
             .WithEndpoint("endpoint1", e =>
             {
                 e.UriScheme = "http";
-                e.AllocatedEndpoint = new(e, "localhost", 12345, containerHostAddress: targetIsContainer ? "ContainerHostName" : null, targetPortExpression: "10000");
+                e.AllocatedEndpoint = new(e, "localhost", 12345, targetPortExpression: "10000");
+                if (sourceIsContainer)
+                {
+                    var ae = new AllocatedEndpoint(e, KnownHostNames.DefaultContainerTunnelHostName, 12345, EndpointBindingMode.SingleAddress, targetPortExpression: "12345", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+                    var snapshot = new ValueSnapshot<AllocatedEndpoint>();
+                    snapshot.SetValue(ae);
+                    e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                }
             })
             .WithEndpoint("endpoint2", e =>
              {
                  e.UriScheme = "https";
-                 e.AllocatedEndpoint = new(e, "localhost", 12346, containerHostAddress: "ContainerHostName", targetPortExpression: "10001");
+                 e.AllocatedEndpoint = new(e, "localhost", 12346, targetPortExpression: "10001");
+                 if (sourceIsContainer)
+                 {
+                     var ae = new AllocatedEndpoint(e, KnownHostNames.DefaultContainerTunnelHostName, 12346, EndpointBindingMode.SingleAddress, targetPortExpression: "12346", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+                     var snapshot = new ValueSnapshot<AllocatedEndpoint>();
+                     snapshot.SetValue(ae);
+                     e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                 }
              })
              .WithEndpoint("endpoint3", e =>
              {
                  e.UriScheme = "https";
-                 e.AllocatedEndpoint = new(e, "host with space", 12346);
+                 e.AllocatedEndpoint = new(e, "host with space", 12347);
+                 if (sourceIsContainer)
+                 {
+                     var ae = new AllocatedEndpoint(e, KnownHostNames.DefaultContainerTunnelHostName, 12347, EndpointBindingMode.SingleAddress, targetPortExpression: "12347", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+                     var snapshot = new ValueSnapshot<AllocatedEndpoint>();
+                     snapshot.SetValue(ae);
+                     e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                 }
              });
 
         if (targetIsContainer)
@@ -101,7 +123,8 @@ public class ExpressionResolverTests
 
         // First test ExpressionResolver directly
         var csRef = new ConnectionStringReference(target.Resource, false);
-        var connectionString = await ExpressionResolver.ResolveAsync(sourceIsContainer, csRef, "ContainerHostName", CancellationToken.None).DefaultTimeout();
+        var context = sourceIsContainer ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork : KnownNetworkIdentifiers.LocalhostNetwork;
+        var connectionString = await ExpressionResolver.ResolveAsync(csRef, context, CancellationToken.None).DefaultTimeout();
         Assert.Equal(expectedConnectionString, connectionString.Value);
 
         // Then test it indirectly with a resource reference, which exercises a more complete code path
@@ -112,24 +135,24 @@ public class ExpressionResolverTests
             source = source.WithImage("someimage");
         }
 
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(source.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance, "ContainerHostName").DefaultTimeout();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(source.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
         Assert.Equal(expectedConnectionString, config["ConnectionStrings__testresource"]);
     }
 
     [Theory]
     [InlineData(false, "http://localhost:18889", "http://localhost:18889")]
-    [InlineData(true, "http://localhost:18889", "http://ContainerHostName:18889")]
+    [InlineData(true, "http://localhost:18889", "http://aspire.dev.internal:18889")]
     [InlineData(false, "http://127.0.0.1:18889", "http://127.0.0.1:18889")]
-    [InlineData(true, "http://127.0.0.1:18889", "http://ContainerHostName:18889")]
+    [InlineData(true, "http://127.0.0.1:18889", "http://aspire.dev.internal:18889")]
     [InlineData(false, "http://[::1]:18889", "http://[::1]:18889")]
-    [InlineData(true, "http://[::1]:18889", "http://ContainerHostName:18889")]
+    [InlineData(true, "http://[::1]:18889", "http://aspire.dev.internal:18889")]
     [InlineData(false, "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy", "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(true, "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy", "Server=ContainerHostName,1433;User ID=sa;Password=xxx;Database=yyy")]
+    [InlineData(true, "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy", "Server=aspire.dev.internal,1433;User ID=sa;Password=xxx;Database=yyy")]
     [InlineData(false, "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy", "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(true, "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy", "Server=ContainerHostName,1433;User ID=sa;Password=xxx;Database=yyy")]
+    [InlineData(true, "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy", "Server=aspire.dev.internal,1433;User ID=sa;Password=xxx;Database=yyy")]
     [InlineData(false, "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy", "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(true, "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy", "Server=ContainerHostName,1433;User ID=sa;Password=xxx;Database=yyy")]
-    public async Task HostUrlPropertyGetsResolved(bool container, string hostUrlVal, string expectedValue)
+    [InlineData(true, "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy", "Server=aspire.dev.internal,1433;User ID=sa;Password=xxx;Database=yyy")]
+    public async Task HostUrlPropertyGetsResolved(bool targetIsContainer, string hostUrlVal, string expectedValue)
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -141,18 +164,18 @@ public class ExpressionResolverTests
                 env.EnvironmentVariables["envname"] = new HostUrl(hostUrlVal);
             });
 
-        if (container)
+        if (targetIsContainer)
         {
             test = test.WithImage("someimage");
         }
 
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(test.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance, "ContainerHostName").DefaultTimeout();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(test.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
         Assert.Equal(expectedValue, config["envname"]);
     }
 
     [Theory]
     [InlineData(false, "http://localhost:18889")]
-    [InlineData(true, "http://ContainerHostName:18889")]
+    [InlineData(true, "http://aspire.dev.internal:18889")]
     public async Task HostUrlPropertyGetsResolvedInOtlpExporterEndpoint(bool container, string expectedValue)
     {
         var builder = DistributedApplication.CreateBuilder();
@@ -165,7 +188,7 @@ public class ExpressionResolverTests
             test = test.WithImage("someimage");
         }
 
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(test.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance, "ContainerHostName").DefaultTimeout();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(test.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
         Assert.Equal(expectedValue, config["OTEL_EXPORTER_OTLP_ENDPOINT"]);
     }
 
@@ -179,14 +202,14 @@ public class ExpressionResolverTests
            .WithHttpEndpoint(targetPort: 8080)
            .WithEndpoint("http", e =>
            {
-               e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 8001, "ContainerHostName", "{{ targetPort }}");
+               e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 8001, EndpointBindingMode.SingleAddress, "{{ targetPort }}", KnownNetworkIdentifiers.LocalhostNetwork);
            });
 
         var dep = builder.AddContainer("container", "redis")
            .WithReference(connectionStringResource)
            .WaitFor(connectionStringResource);
 
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dep.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance, "ContainerHostName").DefaultTimeout();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dep.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.Equal("http://myContainer:8080", config["ConnectionStrings__myContainer"]);
     }
@@ -196,7 +219,7 @@ sealed class MyContainerResource : ContainerResource, IResourceWithConnectionStr
 {
     public MyContainerResource(string name) : base(name)
     {
-        PrimaryEndpoint = new(this, "http");
+        PrimaryEndpoint = new(this, "http", KnownNetworkIdentifiers.LocalhostNetwork);
     }
 
     public EndpointReference PrimaryEndpoint { get; }
@@ -216,9 +239,9 @@ sealed class TestValueProviderResource(string name) : Resource(name), IValueProv
 sealed class TestExpressionResolverResource : ContainerResource, IResourceWithEndpoints, IResourceWithConnectionString
 {
     readonly string _exprName;
-    EndpointReference Endpoint1 => new(this, "endpoint1");
-    EndpointReference Endpoint2 => new(this, "endpoint2");
-    EndpointReference Endpoint3 => new(this, "endpoint3");
+    EndpointReference Endpoint1 => new(this, "endpoint1", KnownNetworkIdentifiers.LocalhostNetwork);
+    EndpointReference Endpoint2 => new(this, "endpoint2", KnownNetworkIdentifiers.LocalhostNetwork);
+    EndpointReference Endpoint3 => new(this, "endpoint3", KnownNetworkIdentifiers.LocalhostNetwork);
     Dictionary<string, ReferenceExpression> Expressions { get; }
     public TestExpressionResolverResource(string exprName) : base("testresource")
     {

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -12,7 +12,10 @@ public class ExpressionResolverTests
     [MemberData(nameof(ResolveInternalAsync_ResolvesCorrectly_MemberData))]
     public async Task ResolveInternalAsync_ResolvesCorrectly(ExpressionResolverTestData testData, Type? exceptionType, (string Value, bool IsSensitive)? expectedValue)
     {
-        NetworkIdentifier? context = testData.SourceIsContainer ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork : KnownNetworkIdentifiers.LocalhostNetwork;
+        ValueProviderContext context = new ValueProviderContext()
+        {
+            Network = testData.SourceIsContainer ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork : KnownNetworkIdentifiers.LocalhostNetwork
+        };
         if (exceptionType is not null)
         {
             await Assert.ThrowsAsync(exceptionType, ResolveAsync);
@@ -64,11 +67,11 @@ public class ExpressionResolverTests
     [InlineData("Url2", true, false, "Url=http://aspire.dev.internal:22345;")]
     [InlineData("Url2", true, true, "Url=http://testresource:22345;")]
     [InlineData("OnlyHost", true, false, "Host=aspire.dev.internal;")]
-    [InlineData("OnlyHost", true, true, "Host=testresource;")] 
+    [InlineData("OnlyHost", true, true, "Host=testresource;")]
     [InlineData("OnlyPort", true, false, "Port=22345;")]
-    [InlineData("OnlyPort", true, true, "Port=22345;")] 
+    [InlineData("OnlyPort", true, true, "Port=22345;")]
     [InlineData("HostAndPort", true, false, "HostPort=aspire.dev.internal:22345")]
-    [InlineData("HostAndPort", true, true, "HostPort=testresource:22345")] 
+    [InlineData("HostAndPort", true, true, "HostPort=testresource:22345")]
     [InlineData("PortBeforeHost", true, false, "Port=22345;Host=aspire.dev.internal;")]
     [InlineData("PortBeforeHost", true, true, "Port=22345;Host=testresource;")]
     [InlineData("FullAndPartial", true, false, "Test1=http://aspire.dev.internal:22345/;Test2=https://localhost:22346/;")]
@@ -124,7 +127,10 @@ public class ExpressionResolverTests
 
         // First test ExpressionResolver directly
         var csRef = new ConnectionStringReference(target.Resource, false);
-        var context = sourceIsContainer ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork : KnownNetworkIdentifiers.LocalhostNetwork;
+        var context = new ValueProviderContext()
+        {
+            Network = sourceIsContainer ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork : KnownNetworkIdentifiers.LocalhostNetwork
+        };
         var connectionString = await ExpressionResolver.ResolveAsync(csRef, context, CancellationToken.None).DefaultTimeout();
         Assert.Equal(expectedConnectionString, connectionString.Value);
 

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -55,24 +55,24 @@ public class ExpressionResolverTests
     [Theory]
     [InlineData("TwoFullEndpoints", false, false, "Test1=http://127.0.0.1:12345/;Test2=https://localhost:12346/;")]
     [InlineData("TwoFullEndpoints", false, true, "Test1=http://127.0.0.1:12345/;Test2=https://localhost:12346/;")]
-    [InlineData("TwoFullEndpoints", true, false, "Test1=http://aspire.dev.internal:12345/;Test2=https://aspire.dev.internal:12346/;")]
-    [InlineData("TwoFullEndpoints", true, true, "Test1=http://testresource:10000/;Test2=https://testresource:10001/;")]
+    [InlineData("TwoFullEndpoints", true, false, "Test1=http://aspire.dev.internal:22345/;Test2=https://aspire.dev.internal:22346/;")]
+    [InlineData("TwoFullEndpoints", true, true, "Test1=http://testresource:22345/;Test2=https://testresource:22346/;")]
     [InlineData("Url", false, false, "Url=http://localhost:12345;")]
     [InlineData("Url", false, true, "Url=http://localhost:12345;")]
-    [InlineData("Url", true, false, "Url=http://aspire.dev.internal:12345;")]
-    [InlineData("Url", true, true, "Url=http://testresource:10000;")]
-    [InlineData("Url2", true, false, "Url=http://aspire.dev.internal:12345;")]
-    [InlineData("Url2", true, true, "Url=http://testresource:10000;")]
+    [InlineData("Url", true, false, "Url=http://aspire.dev.internal:22345;")]
+    [InlineData("Url", true, true, "Url=http://testresource:22345;")]
+    [InlineData("Url2", true, false, "Url=http://aspire.dev.internal:22345;")]
+    [InlineData("Url2", true, true, "Url=http://testresource:22345;")]
     [InlineData("OnlyHost", true, false, "Host=aspire.dev.internal;")]
-    [InlineData("OnlyHost", true, true, "Host=testresource;")] // host now replaced to container name
-    [InlineData("OnlyPort", true, false, "Port=12345;")]
-    [InlineData("OnlyPort", true, true, "Port=10000;")] // port now replaced with target port
-    [InlineData("HostAndPort", true, false, "HostPort=aspire.dev.internal:12345")]
-    [InlineData("HostAndPort", true, true, "HostPort=testresource:10000")] // host not replaced since no port
-    [InlineData("PortBeforeHost", true, false, "Port=12345;Host=aspire.dev.internal;")]
-    [InlineData("PortBeforeHost", true, true, "Port=10000;Host=testresource;")]
-    [InlineData("FullAndPartial", true, false, "Test1=http://aspire.dev.internal:12345/;Test2=https://localhost:12346/;")]
-    [InlineData("FullAndPartial", true, true, "Test1=http://testresource:10000/;Test2=https://localhost:10001/;")]
+    [InlineData("OnlyHost", true, true, "Host=testresource;")] 
+    [InlineData("OnlyPort", true, false, "Port=22345;")]
+    [InlineData("OnlyPort", true, true, "Port=22345;")] 
+    [InlineData("HostAndPort", true, false, "HostPort=aspire.dev.internal:22345")]
+    [InlineData("HostAndPort", true, true, "HostPort=testresource:22345")] 
+    [InlineData("PortBeforeHost", true, false, "Port=22345;Host=aspire.dev.internal;")]
+    [InlineData("PortBeforeHost", true, true, "Port=22345;Host=testresource;")]
+    [InlineData("FullAndPartial", true, false, "Test1=http://aspire.dev.internal:22345/;Test2=https://localhost:22346/;")]
+    [InlineData("FullAndPartial", true, true, "Test1=http://testresource:22345/;Test2=https://localhost:22346/;")]
     [InlineData("UrlEncodedHost", false, false, "Host=host%20with%20space;")]
     public async Task ExpressionResolverGeneratesCorrectEndpointStrings(string exprName, bool sourceIsContainer, bool targetIsContainer, string expectedConnectionString)
     {
@@ -85,7 +85,8 @@ public class ExpressionResolverTests
                 e.AllocatedEndpoint = new(e, "localhost", 12345, targetPortExpression: "10000");
                 if (sourceIsContainer)
                 {
-                    var ae = new AllocatedEndpoint(e, KnownHostNames.DefaultContainerTunnelHostName, 12345, EndpointBindingMode.SingleAddress, targetPortExpression: "12345", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+                    // Note: on the container network side the port and target port are always the same for AllocatedEndpoint.
+                    var ae = new AllocatedEndpoint(e, KnownHostNames.DefaultContainerTunnelHostName, 22345, EndpointBindingMode.SingleAddress, targetPortExpression: "22345", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
                     var snapshot = new ValueSnapshot<AllocatedEndpoint>();
                     snapshot.SetValue(ae);
                     e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
@@ -97,7 +98,7 @@ public class ExpressionResolverTests
                  e.AllocatedEndpoint = new(e, "localhost", 12346, targetPortExpression: "10001");
                  if (sourceIsContainer)
                  {
-                     var ae = new AllocatedEndpoint(e, KnownHostNames.DefaultContainerTunnelHostName, 12346, EndpointBindingMode.SingleAddress, targetPortExpression: "12346", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+                     var ae = new AllocatedEndpoint(e, KnownHostNames.DefaultContainerTunnelHostName, 22346, EndpointBindingMode.SingleAddress, targetPortExpression: "22346", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
                      var snapshot = new ValueSnapshot<AllocatedEndpoint>();
                      snapshot.SetValue(ae);
                      e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
@@ -109,7 +110,7 @@ public class ExpressionResolverTests
                  e.AllocatedEndpoint = new(e, "host with space", 12347);
                  if (sourceIsContainer)
                  {
-                     var ae = new AllocatedEndpoint(e, KnownHostNames.DefaultContainerTunnelHostName, 12347, EndpointBindingMode.SingleAddress, targetPortExpression: "12347", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+                     var ae = new AllocatedEndpoint(e, KnownHostNames.DefaultContainerTunnelHostName, 22347, EndpointBindingMode.SingleAddress, targetPortExpression: "22346", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
                      var snapshot = new ValueSnapshot<AllocatedEndpoint>();
                      snapshot.SetValue(ae);
                      e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -602,7 +602,7 @@ public class ProjectResourceTests
              {
                  context.Args.Add("arg1");
                  context.Args.Add(c1.GetEndpoint("ep"));
-                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep"));
+                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep", null));
              });
 
         using var app = appBuilder.Build();
@@ -648,8 +648,8 @@ public class ProjectResourceTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        var http = resource.GetEndpoint("http");
-        var https = resource.GetEndpoint("https");
+        var http = resource.GetEndpoint("http", null);
+        var https = resource.GetEndpoint("https", null);
 
         if (isProxied)
         {

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -602,7 +602,7 @@ public class ProjectResourceTests
              {
                  context.Args.Add("arg1");
                  context.Args.Add(c1.GetEndpoint("ep"));
-                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep", null));
+                 context.Args.Add(((IResourceWithEndpoints)context.Resource).GetEndpoint("ep"));
              });
 
         using var app = appBuilder.Build();
@@ -648,8 +648,8 @@ public class ProjectResourceTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        var http = resource.GetEndpoint("http", null);
-        var https = resource.GetEndpoint("https", null);
+        var http = resource.GetEndpoint("http");
+        var https = resource.GetEndpoint("https");
 
         if (isProxied)
         {

--- a/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
@@ -8,9 +8,11 @@ namespace Aspire.Hosting.Tests.Utils;
 
 public static class EnvironmentVariableEvaluator
 {
-    public static async ValueTask<Dictionary<string, string>> GetEnvironmentVariablesAsync(IResource resource,
+    public static async ValueTask<Dictionary<string, string>> GetEnvironmentVariablesAsync(
+        IResource resource,
         DistributedApplicationOperation applicationOperation = DistributedApplicationOperation.Run,
-        IServiceProvider? serviceProvider = null, string? containerHostName = null)
+        IServiceProvider? serviceProvider = null,
+        NetworkIdentifier? networkContext = null)
     {
         var executionContext = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(applicationOperation)
         {
@@ -33,7 +35,8 @@ public static class EnvironmentVariableEvaluator
                 }
             },
             NullLogger.Instance,
-            containerHostName: containerHostName);
+            CancellationToken.None,
+            networkContext);
 
         return environmentVariables;
     }

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
+using System.Text.RegularExpressions;
 
 namespace Aspire.Hosting.Tests;
 
@@ -576,7 +577,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         var logs = collector.GetSnapshot();
 
         // Just looking for a common message in Docker build output.
-        Assert.Contains(logs, log => log.Message.Contains("The resource ready event failed!"));
+        Assert.Contains(logs, log => Regex.IsMatch(log.Message, @"(?i).*resource.*nginx.*failed.*"));
 
         await app.StopAsync();
     }

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -223,24 +223,6 @@ public class WithEndpointTests
     }
 
     [Fact]
-    public void GettingContainerHostNameFailsIfNoContainerHostNameSet()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create();
-        var container = builder.AddContainer("app", "image")
-            .WithEndpoint("ep", e =>
-            {
-                e.AllocatedEndpoint = new(e, "localhost", 8031);
-            });
-
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-        {
-            return container.GetEndpoint("ep").ContainerHost;
-        });
-
-        Assert.Equal("The endpoint \"ep\" has no associated container host name.", ex.Message);
-    }
-
-    [Fact]
     public void WithExternalHttpEndpointsMarkExistingHttpEndpointsAsExternal()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -301,7 +301,16 @@ public class WithEnvironmentTests
                                .WithHttpEndpoint(name: "primary")
                                .WithEndpoint("primary", ep =>
                                {
-                                   ep.AllocatedEndpoint = new AllocatedEndpoint(ep, "localhost", 90, targetPortExpression: """{{- portForServing "container1_primary" -}}""");
+                                   var endpointSnapshot = new ValueSnapshot<AllocatedEndpoint>();
+                                   endpointSnapshot.SetValue(new AllocatedEndpoint(
+                                       ep,
+                                       "localhost",
+                                       90,
+                                       EndpointBindingMode.SingleAddress,
+                                       """{{- portForServing "container1_primary" -}}""",
+                                       KnownNetworkIdentifiers.DefaultAspireContainerNetwork
+                                   ));
+                                   ep.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, endpointSnapshot);
                                });
 
         var endpoint = container.GetEndpoint("primary");


### PR DESCRIPTION
## Description

Leverages the container tunnel capability that has been recently added to DCP to provide container-to-host connectivity independent from what is supported by container orchestrators.

To make this work, I had to make some changes to how `EndpointReferences` work. Specifically, `EndpointReferences` are not resolved _in context_ of a network (represented by abstract `NetworkIdentifier`). They are also tracked by their `EndpointAnnotation` so we can answer questions like "who is referencing this particular `Endpoint`".

Marking as draft for now because this is a big change that affects the core of Aspire application model. It needs more testing, automated tests, and most likely, fixes to existing tests.

Fixes #6547

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship. KarolZ: the feature is usable as-is; there are no major parts missing. 
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No KarolZ: but I am planning to work on adding more tests in near future
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
