### PR TITLE
Change issue assignee from 'copilot' to 'copilot-swe-agent'

### DIFF
--- a/.github/workflows/test-scenario.yml
+++ b/.github/workflows/test-scenario.yml
@@ -126,7 +126,7 @@ jobs:
             --repo "${REPO_OWNER}/${REPO_NAME}" \
             --title "$ISSUE_TITLE" \
             --body "$ISSUE_BODY" \
-            --assignee "copilot" \
+            --assignee "copilot-swe-agent" \
             2>&1)
 
           echo "Issue creation output:"


### PR DESCRIPTION
Quick fix to the identity that the playground repo issues are being assigned to.