### PR TITLE
Use dotnet script for MAUI workload restore

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -7,8 +7,8 @@ Param(
   [switch]$vs,
   [ValidateSet("windows","linux","osx")][string]$os,
   [switch]$testnobuild,
-  [switch]$restoremaui,
   [ValidateSet("x86","x64","arm","arm64")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
+  [switch]$mauirestore,
 
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
@@ -37,7 +37,7 @@ function Get-Help() {
   Write-Host "                          This assumes -build has been run already."
   Write-Host "  -rebuild                Rebuild all source projects."
   Write-Host "  -restore                Restore dependencies."
-  Write-Host "  -restoremaui            Restore dependencies and install MAUI workload (only on Windows/macOS)."
+  Write-Host "  -mauirestore            Restore dependencies and install MAUI workload (only on Windows/macOS)."
   Write-Host "  -sign                   Sign build outputs."
   Write-Host "  -test (-t)              Incrementally builds and runs tests."
   Write-Host "                          Use in conjunction with -testnobuild to only run tests."
@@ -101,7 +101,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "arch"                   { $arguments += " /p:TargetArchitecture=$($PSBoundParameters[$argument])" }
     "testnobuild"            { $arguments += " /p:VSTestNoBuild=true" }
     "buildExtension"         { $arguments += " /p:BuildExtension=true" }
-    "restoremaui"            { $arguments += " -restoreMaui" }
+    "mauirestore"            { $arguments += " -restoreMaui" }
     default                  { $arguments += " /p:$argument=$($PSBoundParameters[$argument])" }
   }
 }

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -118,27 +118,21 @@ $restoreMauiPassed = $properties -contains "-restore-maui"
 $isWindowsOrMac = ($IsWindows -or $IsMacOS -or (-not (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue)))
 if ($restoreMauiPassed -and $buildExitCode -eq 0 -and $isWindowsOrMac) {
   Write-Host ""
-  Write-Host "Installing MAUI workload into local .dotnet..."
+  Write-Host "Installing MAUI workload..."
   
   $repoRoot = Split-Path $PSScriptRoot -Parent
-  $dotnetRoot = Join-Path $repoRoot ".dotnet"
-  $dotnetExe = Join-Path $dotnetRoot "dotnet.exe"
+  $dotnetCmd = Join-Path $repoRoot "dotnet.cmd"
   
-  if (Test-Path $dotnetExe) {
-    $env:DOTNET_ROOT = $dotnetRoot
-    $env:PATH = "$dotnetRoot;$env:PATH"
-    
-    & $dotnetExe workload install maui 2>&1 | Out-Host
-    if ($LASTEXITCODE -ne 0) {
-      Write-Host ""
-      Write-Warning "Failed to install MAUI workload. You may need to run this command manually:"
-      Write-Warning "  $dotnetExe workload install maui"
-      Write-Host ""
-      Write-Host "The MAUI playground may not work without the MAUI workload installed."
-    }
-    else {
-      Write-Host "MAUI workload installed successfully."
-    }
+  & $dotnetCmd workload install maui 2>&1 | Out-Host
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Warning "Failed to install MAUI workload. You may need to run this command manually:"
+    Write-Warning "  $dotnetCmd workload install maui"
+    Write-Host ""
+    Write-Host "The MAUI playground may not work without the MAUI workload installed."
+  }
+  else {
+    Write-Host "MAUI workload installed successfully."
   }
 }
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -7,6 +7,7 @@ Param(
   [switch]$vs,
   [ValidateSet("windows","linux","osx")][string]$os,
   [switch]$testnobuild,
+  [switch]$restoremaui,
   [ValidateSet("x86","x64","arm","arm64")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
 
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
@@ -36,6 +37,7 @@ function Get-Help() {
   Write-Host "                          This assumes -build has been run already."
   Write-Host "  -rebuild                Rebuild all source projects."
   Write-Host "  -restore                Restore dependencies."
+  Write-Host "  -restoremaui            Restore dependencies and install MAUI workload (only on Windows/macOS)."
   Write-Host "  -sign                   Sign build outputs."
   Write-Host "  -test (-t)              Incrementally builds and runs tests."
   Write-Host "                          Use in conjunction with -testnobuild to only run tests."
@@ -44,7 +46,6 @@ function Get-Help() {
   Write-Host "Libraries settings:"
   Write-Host "  -testnobuild            Skip building tests when invoking -test."
   Write-Host "  -buildExtension         Build the VS Code extension."
-  Write-Host "  -restore-maui           Restore the MAUI workload after restore (only on Windows/macOS)."
   Write-Host ""
 
   Write-Host "Command-line arguments not listed above are passed through to MSBuild."
@@ -100,6 +101,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "arch"                   { $arguments += " /p:TargetArchitecture=$($PSBoundParameters[$argument])" }
     "testnobuild"            { $arguments += " /p:VSTestNoBuild=true" }
     "buildExtension"         { $arguments += " /p:BuildExtension=true" }
+    "restoremaui"            { $arguments += " -restoreMaui" }
     default                  { $arguments += " /p:$argument=$($PSBoundParameters[$argument])" }
   }
 }
@@ -110,30 +112,4 @@ if ($env:TreatWarningsAsErrors -eq 'false') {
 
 Write-Host "& `"$PSScriptRoot/common/build.ps1`" $arguments"
 Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $arguments"
-$buildExitCode = $LASTEXITCODE
-
-# Install MAUI workload after restore if -restore-maui was passed
-# Only on Windows and macOS (MAUI doesn't support Linux)
-$restoreMauiPassed = $properties -contains "-restore-maui"
-$isWindowsOrMac = ($IsWindows -or $IsMacOS -or (-not (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue)))
-if ($restoreMauiPassed -and $buildExitCode -eq 0 -and $isWindowsOrMac) {
-  Write-Host ""
-  Write-Host "Installing MAUI workload..."
-  
-  $repoRoot = Split-Path $PSScriptRoot -Parent
-  $dotnetCmd = Join-Path $repoRoot "dotnet.cmd"
-  
-  & $dotnetCmd workload install maui 2>&1 | Out-Host
-  if ($LASTEXITCODE -ne 0) {
-    Write-Host ""
-    Write-Warning "Failed to install MAUI workload. You may need to run this command manually:"
-    Write-Warning "  $dotnetCmd workload install maui"
-    Write-Host ""
-    Write-Host "The MAUI playground may not work without the MAUI workload installed."
-  }
-  else {
-    Write-Host "MAUI workload installed successfully."
-  }
-}
-
-exit $buildExitCode
+exit $LASTEXITCODE

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -38,7 +38,7 @@ usage()
   echo "                             This assumes --build has been run already."
   echo "  --rebuild                  Rebuild all source projects."
   echo "  --restore (-r)             Restore dependencies."
-  echo "  --restoremaui              Restore dependencies and install MAUI workload (only on macOS)."
+  echo "  --mauirestore              Restore dependencies and install MAUI workload (only on macOS)."
   echo "  --sign                     Sign build outputs."
   echo "  --test (-t)                Incrementally builds and runs tests."
   echo "                             Use in conjunction with --testnobuild to only run tests."
@@ -143,7 +143,7 @@ while [[ $# > 0 ]]; do
       shift 1
       ;;
 
-     -restoremaui)
+     -mauirestore)
       extraargs="$extraargs -restoreMaui"
       shift 1
       ;;

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -174,25 +174,19 @@ if [ "$restore_maui" = true ] && [ $buildExitCode -eq 0 ]; then
   # Check if we're on macOS
   if [[ "$(uname -s)" == "Darwin" ]]; then
     echo ""
-    echo "Installing MAUI workload into local .dotnet..."
+    echo "Installing MAUI workload..."
     
     repo_root="$(cd "$scriptroot/.." && pwd)"
-    dotnet_root="$repo_root/.dotnet"
-    dotnet_exe="$dotnet_root/dotnet"
+    dotnet_sh="$repo_root/dotnet.sh"
     
-    if [ -f "$dotnet_exe" ]; then
-      export DOTNET_ROOT="$dotnet_root"
-      export PATH="$dotnet_root:$PATH"
-      
-      if "$dotnet_exe" workload install maui; then
-        echo "MAUI workload installed successfully."
-      else
-        echo ""
-        echo "WARNING: Failed to install MAUI workload. You may need to run this command manually:"
-        echo "  $dotnet_exe workload install maui"
-        echo ""
-        echo "The MAUI playground may not work without the MAUI workload installed."
-      fi
+    if "$dotnet_sh" workload install maui; then
+      echo "MAUI workload installed successfully."
+    else
+      echo ""
+      echo "WARNING: Failed to install MAUI workload. You may need to run this command manually:"
+      echo "  $dotnet_sh workload install maui"
+      echo ""
+      echo "The MAUI playground may not work without the MAUI workload installed."
     fi
   fi
 fi

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -38,6 +38,7 @@ usage()
   echo "                             This assumes --build has been run already."
   echo "  --rebuild                  Rebuild all source projects."
   echo "  --restore (-r)             Restore dependencies."
+  echo "  --restoremaui              Restore dependencies and install MAUI workload (only on macOS)."
   echo "  --sign                     Sign build outputs."
   echo "  --test (-t)                Incrementally builds and runs tests."
   echo "                             Use in conjunction with --testnobuild to only run tests."
@@ -46,7 +47,6 @@ usage()
   echo "Libraries settings:"
   echo "  --testnobuild              Skip building tests when invoking -test."
   echo "  --build-extension          Build the VS Code extension."
-  echo "  --restore-maui             Restore the MAUI workload after restore (only on macOS)."
   echo ""
 
   echo "Command line arguments starting with '/p:' are passed through to MSBuild."
@@ -56,7 +56,6 @@ usage()
 
 arguments=''
 extraargs=''
-restore_maui=false
 
 # Check if an action is passed in
 declare -a actions=("b" "build" "r" "restore" "rebuild" "testnobuild" "sign" "publish" "clean" "t" "test" "build-extension")
@@ -144,8 +143,8 @@ while [[ $# > 0 ]]; do
       shift 1
       ;;
 
-     -restore-maui)
-      restore_maui=true
+     -restoremaui)
+      extraargs="$extraargs -restoreMaui"
       shift 1
       ;;
 
@@ -166,29 +165,5 @@ fi
 
 arguments="$arguments $extraargs"
 "$scriptroot/common/build.sh" $arguments
-buildExitCode=$?
 
-# Install MAUI workload after restore if --restore-maui was passed
-# Only on macOS (MAUI doesn't support Linux, Windows uses .cmd)
-if [ "$restore_maui" = true ] && [ $buildExitCode -eq 0 ]; then
-  # Check if we're on macOS
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    echo ""
-    echo "Installing MAUI workload..."
-    
-    repo_root="$(cd "$scriptroot/.." && pwd)"
-    dotnet_sh="$repo_root/dotnet.sh"
-    
-    if "$dotnet_sh" workload install maui; then
-      echo "MAUI workload installed successfully."
-    else
-      echo ""
-      echo "WARNING: Failed to install MAUI workload. You may need to run this command manually:"
-      echo "  $dotnet_sh workload install maui"
-      echo ""
-      echo "The MAUI playground may not work without the MAUI workload installed."
-    fi
-  fi
-fi
-
-exit $buildExitCode
+exit $?

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -30,6 +30,7 @@ Param(
   [string] $runtimeSourceFeedKey = '',
   [switch] $excludePrereleaseVS,
   [switch] $nativeToolsOnMachine,
+  [switch] $restoreMaui,
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
@@ -76,6 +77,7 @@ function Print-Usage() {
   Write-Host "  -nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
   Write-Host "  -buildCheck             Sets /check msbuild parameter"
   Write-Host "  -fromVMR                Set when building from within the VMR"
+  Write-Host "  -restoreMaui            Restore the MAUI workload after restore (only on Windows/macOS)"
   Write-Host ""
 
   Write-Host "Command line arguments not listed above are passed thru to msbuild."

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -44,6 +44,7 @@ usage()
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   echo "  --buildCheck <value>     Sets /check msbuild parameter"
   echo "  --fromVMR                Set when building from within the VMR"
+  echo "  --restoreMaui            Restore the MAUI workload after restore (only on macOS)"
   echo ""
   echo "Command line arguments not listed above are passed thru to msbuild."
   echo "Arguments can also be passed in with a single hyphen."
@@ -76,6 +77,7 @@ sign=false
 public=false
 ci=false
 clean=false
+restore_maui=false
 
 warn_as_error=true
 node_reuse=true
@@ -182,6 +184,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     -buildcheck)
       build_check=true
+      ;;
+    -restoremaui|-restore-maui)
+      restore_maui=true
       ;;
     -runtimesourcefeed)
       runtime_source_feed=$2

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -1,0 +1,33 @@
+# Install MAUI workload if -restoreMaui was passed
+# Only on Windows and macOS (MAUI doesn't support Linux)
+
+if ($restoreMaui) {
+  $isWindowsOrMac = ($IsWindows -or $IsMacOS -or (-not (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue)))
+  
+  if ($isWindowsOrMac) {
+    Write-Host "Installing MAUI workload..."
+    
+    $dotnetCmd = if ($IsWindows -or (-not (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue))) {
+      Join-Path $RepoRoot "dotnet.cmd"
+    } else {
+      Join-Path $RepoRoot "dotnet.sh"
+    }
+    
+    & $dotnetCmd workload install maui 2>&1 | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+      Write-Host ""
+      Write-Warning "Failed to install MAUI workload. You may need to run this command manually:"
+      Write-Warning "  $dotnetCmd workload install maui"
+      Write-Host ""
+      Write-Host "The MAUI playground may not work without the MAUI workload installed."
+      Write-Host ""
+    }
+    else {
+      Write-Host "MAUI workload installed successfully."
+      Write-Host ""
+    }
+  }
+  else {
+    Write-Host "Skipping MAUI workload installation on Linux (not supported)."
+  }
+}

--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Install MAUI workload if -restoreMaui was passed
+# Only on macOS (MAUI doesn't support Linux, Windows uses .cmd)
+
+if [[ "$restore_maui" == true ]]; then
+  # Check if we're on macOS
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo ""
+    echo "Installing MAUI workload..."
+    
+    dotnet_sh="$repo_root/dotnet.sh"
+    
+    if "$dotnet_sh" workload install maui; then
+      echo "MAUI workload installed successfully."
+      echo ""
+    else
+      echo ""
+      echo "WARNING: Failed to install MAUI workload. You may need to run this command manually:"
+      echo "  $dotnet_sh workload install maui"
+      echo ""
+      echo "The MAUI playground may not work without the MAUI workload installed."
+      echo ""
+    fi
+  else
+    echo "Skipping MAUI workload installation on Linux (not supported)."
+  fi
+fi

--- a/playground/AspireWithMaui/README.md
+++ b/playground/AspireWithMaui/README.md
@@ -17,12 +17,12 @@ Run the following commands from the repository root:
 
 **Windows:**
 ```cmd
-.\restore.cmd -restore-maui
+.\restore.cmd -mauirestore
 ```
 
 **Linux/macOS:**
 ```bash
-./restore.sh --restore-maui
+./restore.sh --mauirestore
 ```
 
 This will:
@@ -34,22 +34,22 @@ This will:
 
 ### Running the Playground
 
-After running the restore script with `-restore-maui`, you can build and run the playground:
+After running the restore script with `-mauirestore`, you can build and run the playground:
 
 **Using Visual Studio:**
-1. Run `.\restore.cmd -restore-maui` from the repository root (Windows)
+1. Run `.\restore.cmd -mauirestore` from the repository root (Windows)
 2. Open `AspireWithMaui.AppHost` project
 3. Set it as the startup project
 4. Press F5 to run
 
 **Using VS Code:**
-1. Run `.\restore.cmd -restore-maui` (Windows) or `./restore.sh --restore-maui` (Linux/macOS) from the repository root
+1. Run `.\restore.cmd -mauirestore` (Windows) or `./restore.sh --mauirestore` (Linux/macOS) from the repository root
 2. From the repository root, run: `./start-code.sh` or `start-code.cmd`
 3. Open the `AspireWithMaui` folder
 4. Use the debugger to run the AppHost
 
 **Using Command Line:**
-1. Run `.\restore.cmd -restore-maui` (Windows) or `./restore.sh --restore-maui` (Linux/macOS) from the repository root
+1. Run `.\restore.cmd -mauirestore` (Windows) or `./restore.sh --mauirestore` (Linux/macOS) from the repository root
 2. Navigate to `playground/AspireWithMaui/AspireWithMaui.AppHost` directory
 3. Run: `dotnet run`
 
@@ -86,13 +86,13 @@ The architecture is designed to support additional platforms (Android, iOS) thro
 
 ### "MAUI workload not detected" Warning
 If you see this warning in the Aspire dashboard:
-1. Make sure you ran `.\restore.cmd -restore-maui` or `./restore.sh --restore-maui` from the repository root
+1. Make sure you ran `.\restore.cmd -mauirestore` or `./restore.sh --mauirestore` from the repository root
 2. The warning indicates the MAUI workload is not installed in the local `.dotnet` folder
-3. Re-run the restore command with the `-restore-maui` or `--restore-maui` flag
+3. Re-run the restore command with the `-mauirestore` or `--mauirestore` flag
 
 ### Build Errors
 If you encounter build errors:
-1. Ensure you ran the restore script with the MAUI flag first: `.\restore.cmd -restore-maui`
+1. Ensure you ran the restore script with the MAUI flag first: `.\restore.cmd -mauirestore`
 2. Make sure you're using .NET 10 RC or later
 3. Try running `dotnet build` from the repository root first
 


### PR DESCRIPTION
## Description

Switched the .NET MAUI workload restore portion of the script to use the dotnet script to find the right .NET installation rather than assuming the `.dotnet` folder

Fixes https://github.com/dotnet/aspire/pull/12284#discussion_r2461257023
