### PR TITLE
Remove dotnet10-workloads NuGet feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -35,9 +35,6 @@
     <packageSource key="dotnet10">
       <package pattern="*" />
     </packageSource>
-    <packageSource key="dotnet10-workloads">
-      <package pattern="*" />
-    </packageSource>
     <packageSource key="dotnet-libraries">
       <package pattern="Microsoft.DeveloperControlPlane*" />
       <package pattern="System.CommandLine" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -16,7 +16,6 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
-    <add key="dotnet10-workloads" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-workloads/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
## Description

Removes the added dotnet10-workloads feed added in #12284 

Fixes https://github.com/dotnet/aspire/pull/12284#discussion_r2461249278
