### PR TITLE
Fixed FormatBicepExpression to support string and `FormattableString` types, improving flexibility.

### DIFF
--- a/src/Shared/BicepFormattingHelpers.cs
+++ b/src/Shared/BicepFormattingHelpers.cs
@@ -24,6 +24,8 @@ internal static class BicepFormattingHelpers
         {
             ProvisioningParameter p => p.Value.Compile(),
             IBicepValue b => b.Compile(),
+            string s => new StringLiteralExpression(s),
+            FormattableString fs => BicepFunction.Interpolate(fs).Compile(),
             _ => throw new ArgumentException($"Invalid expression type for '{format}' encoding: {val.GetType()}")
         };
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -272,6 +272,8 @@ public class AzureContainerAppsTests
         var db = builder.AddAzureCosmosDB("mydb");
         db.AddCosmosDatabase("cosmosdb", databaseName: "db");
 
+        var pgContainer = builder.AddPostgres("pgc");
+
         // Postgres uses secret outputs + a literal connection string
         var pgdb = builder.AddAzurePostgresFlexibleServer("pg").WithPasswordAuthentication().AddDatabase("db");
 
@@ -295,7 +297,8 @@ public class AzureContainerAppsTests
             .WithEnvironment("SecretVal", secretValue)
             .WithEnvironment("secret_value_1", secretValue)
             .WithEnvironment("Value", value)
-            .WithEnvironment("CS", rawCs);
+            .WithEnvironment("CS", rawCs)
+            .WithEnvironment("DATABASE_URL", pgContainer.Resource.UriExpression);
 
         project.WithEnvironment(context =>
         {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
@@ -29,6 +29,9 @@ param value1_value string
 @secure()
 param cs_connectionstring string
 
+@secure()
+param pgc_password_value string
+
 param api_identity_outputs_clientid string
 
 resource pg_kv 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
@@ -62,6 +65,10 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
         {
           name: 'cs'
           value: cs_connectionstring
+        }
+        {
+          name: 'database-url'
+          value: 'postgresql://${uriComponent('postgres')}:${uriComponent(pgc_password_value)}@pgc:5432'
         }
       ]
       activeRevisionsMode: 'Single'
@@ -146,6 +153,10 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
             {
               name: 'CS'
               secretRef: 'cs'
+            }
+            {
+              name: 'DATABASE_URL'
+              secretRef: 'database-url'
             }
             {
               name: 'HTTP_EP'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.json
@@ -15,6 +15,7 @@
     "value0_value": "{value0.value}",
     "value1_value": "{value1.value}",
     "cs_connectionstring": "{cs.connectionString}",
+    "pgc_password_value": "{pgc-password.value}",
     "api_identity_outputs_clientid": "{api-identity.outputs.clientId}"
   }
 }


### PR DESCRIPTION
## Description

Fixed FormatBicepExpression to support string and `FormattableString` types, improving flexibility.
- Updated tests

Fixes #12368

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
