### PR TITLE
Support for other project file extensions on upgrade

### DIFF
--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -481,9 +481,9 @@ internal abstract class PipelineCommandBase : BaseCommand
                             "CRITICAL" => "CRT",
                             _ => "INF"
                         };
-
+                        
                         var prefixedMessage = $"[[{logPrefix}]] {message}";
-
+                        
                         // Map log levels to appropriate console logger methods
                         switch (logLevel.ToUpperInvariant())
                         {

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -125,7 +125,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                 return ExitCodeConstants.FailedToFindProject;
             }
 
-            var isSingleFileAppHost = effectiveAppHostFile.Extension != ".csproj";
+            var isSingleFileAppHost = string.Equals(effectiveAppHostFile.Extension, ".cs", StringComparison.OrdinalIgnoreCase);
 
             var env = new Dictionary<string, string>();
 
@@ -481,9 +481,9 @@ internal abstract class PipelineCommandBase : BaseCommand
                             "CRITICAL" => "CRT",
                             _ => "INF"
                         };
-                        
+
                         var prefixedMessage = $"[[{logPrefix}]] {message}";
-                        
+
                         // Map log levels to appropriate console logger methods
                         switch (logLevel.ToUpperInvariant())
                         {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -123,7 +123,7 @@ internal sealed class RunCommand : BaseCommand
                 return ExitCodeConstants.FailedToFindProject;
             }
 
-            var isSingleFileAppHost = effectiveAppHostFile.Extension != ".csproj";
+            var isSingleFileAppHost = string.Equals(effectiveAppHostFile.Extension, ".cs", StringComparison.OrdinalIgnoreCase);
 
             var env = new Dictionary<string, string>();
 

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Caching;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
@@ -1136,7 +1137,7 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
         // Parse output - skip header lines (Project(s) and ----------)
         var projects = new List<FileInfo>();
         var startParsing = false;
-        
+
         foreach (var line in stdoutLines)
         {
             if (string.IsNullOrWhiteSpace(line))
@@ -1152,7 +1153,7 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
                 continue;
             }
 
-            if (startParsing && line.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            if (startParsing && ProjectFileExtensions.Supported.Any(supportedProjectFileExtension => line.EndsWith(supportedProjectFileExtension, StringComparison.OrdinalIgnoreCase)))
             {
                 var projectPath = Path.IsPathRooted(line)
                     ? line

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -1137,7 +1137,7 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
         // Parse output - skip header lines (Project(s) and ----------)
         var projects = new List<FileInfo>();
         var startParsing = false;
-
+        
         foreach (var line in stdoutLines)
         {
             if (string.IsNullOrWhiteSpace(line))

--- a/src/Aspire.Cli/Projects/ProjectFileExtensions.cs
+++ b/src/Aspire.Cli/Projects/ProjectFileExtensions.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Projects;
+
+internal static class ProjectFileExtensions
+{
+    public static readonly HashSet<string> Supported = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".csproj", ".fsproj", ".vbproj" };
+}

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -22,8 +22,6 @@ internal interface IProjectLocator
 
 internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliRunner runner, CliExecutionContext executionContext, IInteractionService interactionService, IConfigurationService configurationService, AspireCliTelemetry telemetry) : IProjectLocator
 {
-    private static readonly HashSet<string> s_supportedProjectFileExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".csproj", ".fsproj", ".vbproj" };
-
     public async Task<List<FileInfo>> FindAppHostProjectFilesAsync(string searchDirectory, CancellationToken cancellationToken)
     {
         var allCandidates = await FindAppHostProjectFilesAsync(new DirectoryInfo(searchDirectory), cancellationToken);
@@ -354,7 +352,7 @@ internal sealed class ProjectLocator(ILogger<ProjectLocator> logger, IDotNetCliR
                     }
                 }
                 // Handle .cs|fs|vbproj files
-                else if (s_supportedProjectFileExtensions.Contains(projectFile.Extension))
+                else if (ProjectFileExtensions.Supported.Contains(projectFile.Extension))
                 {
                     logger.LogDebug("Using project file {ProjectFile}", projectFile.FullName);
                     return new AppHostProjectSearchResult(projectFile, [projectFile]);

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -271,7 +271,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
     private static async Task UpdateSdkVersionInAppHostAsync(FileInfo projectFile, NuGetPackageCli package)
     {
-        if (string.Equals(projectFile.Extension, ".csproj", StringComparison.OrdinalIgnoreCase))
+        if (ProjectFileExtensions.Supported.Contains(projectFile.Extension))
         {
             await UpdateSdkVersionInCsprojAppHostAsync(projectFile, package);
         }


### PR DESCRIPTION
## Description

Support other project file extensions on `aspire update`. I scanned the code base for all occurrences of `.csproj`, and where I figured it made sense, I've adjusted the code to check for a supported project file extension. Exceptions are `Aspire.Dashboard`, which has support for showing icons on a per project file extension basis already, and `Aspire.Hosting` which specifically mentions adding a C# project as part of its experimental feature set. I'm not well versed enough in the code base to figure out how to add tests for these changes.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
