### PR TITLE
Return message at root for api service in starter template

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-py-starter/13.0/app/app.py
+++ b/src/Aspire.ProjectTemplates/templates/aspire-py-starter/13.0/app/app.py
@@ -59,10 +59,11 @@ def get_redis_client():
 logger = logging.getLogger(__name__)
 
 
-@app.get("/")
-async def root():
-    """Root endpoint."""
-    return "API service is running. Navigate to /weatherforecast to see sample data."
+if not os.path.exists("static"):
+    @app.get("/")
+    async def root():
+        """Root endpoint."""
+        return "API service is running. Navigate to /weatherforecast to see sample data."
 
 @app.get("/api/weatherforecast")
 //#if UseRedisCache

--- a/src/Aspire.ProjectTemplates/templates/aspire-py-starter/13.0/app/app.py
+++ b/src/Aspire.ProjectTemplates/templates/aspire-py-starter/13.0/app/app.py
@@ -59,6 +59,11 @@ def get_redis_client():
 logger = logging.getLogger(__name__)
 
 
+@app.get("/")
+async def root():
+    """Root endpoint."""
+    return "API service is running. Navigate to /weatherforecast to see sample data."
+
 @app.get("/api/weatherforecast")
 //#if UseRedisCache
 async def weather_forecast(redis_client=fastapi.Depends(get_redis_client)):

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/13.0/Aspire-StarterApplication.1.ApiService/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/13.0/Aspire-StarterApplication.1.ApiService/Program.cs
@@ -25,6 +25,8 @@ if (app.Environment.IsDevelopment())
 #endif
 string[] summaries = ["Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"];
 
+app.MapGet("/", () => "API service is running. Navigate to /weatherforecast to see sample data.");
+
 app.MapGet("/weatherforecast", () =>
 {
     var forecast = Enumerable.Range(1, 5).Select(index =>


### PR DESCRIPTION
## Description

Changes the starter templates so that the API service returns a response from the root path `/` to improve the end-to-end experience when a user first deploys the app.

Fixes #12405

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
