### PR TITLE
Fix OpenApi dependency version to align with the rest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -248,7 +248,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <!-- ASP.NET Core -->
-    <PackageVersion Update="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCorePackageVersionForNet10)" />
+    <PackageVersion Update="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiPreviewVersion)" />
     <!-- Runtime -->
     <PackageVersion Update="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPreviewVersion)" />
     <PackageVersion Update="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingPreviewVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,9 +49,6 @@
     <MicrosoftExtensionsTimeProviderTestingVersion>9.10.0</MicrosoftExtensionsTimeProviderTestingVersion>
     <MicrosoftExtensionsServiceDiscoveryVersion>9.5.0</MicrosoftExtensionsServiceDiscoveryVersion>
     <MicrosoftExtensionsServiceDiscoveryYarpVersion>9.5.0</MicrosoftExtensionsServiceDiscoveryYarpVersion>
-    <!-- for templates -->
-    <MicrosoftAspNetCorePackageVersionForNet9>9.0.9</MicrosoftAspNetCorePackageVersionForNet9>
-    <MicrosoftAspNetCorePackageVersionForNet10>10.0.0-rc.1.25451.107</MicrosoftAspNetCorePackageVersionForNet10>
     <!-- Fuzzing tests -->
     <SharpFuzzPackageVersion>2.1.1</SharpFuzzPackageVersion>
     <!-- Aspire.Cli uses a preview version of StreamJsonRpc which is needed for native AOT support. -->
@@ -59,6 +56,8 @@
   </PropertyGroup>
   <!-- .NET 10.0 Package Versions -->
   <PropertyGroup Label="Preview">
+    <!-- ASP.NET Core -->
+    <MicrosoftAspNetCoreOpenApiPreviewVersion>10.0.0-rc.2.25502.107</MicrosoftAspNetCoreOpenApiPreviewVersion>
     <!-- Runtime -->
     <MicrosoftExtensionsHostingAbstractionsPreviewVersion>10.0.0-rc.2.25502.107</MicrosoftExtensionsHostingAbstractionsPreviewVersion>
     <MicrosoftExtensionsHostingPreviewVersion>10.0.0-rc.2.25502.107</MicrosoftExtensionsHostingPreviewVersion>

--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -70,8 +70,8 @@
     <WriteLinesToFile File="%(TemplateProjectFiles.DestinationFile)"
                       Lines="$([System.IO.File]::ReadAllText('%(TemplateProjectFiles.FullPath)')
                                                  .Replace('!!REPLACE_WITH_LATEST_VERSION!!', '$(PackageVersion)')
-                                                 .Replace('!!REPLACE_WITH_ASPNETCORE_9_VERSION!!', '$(MicrosoftAspNetCorePackageVersionForNet9)')
-                                                 .Replace('!!REPLACE_WITH_ASPNETCORE_10_VERSION!!', '$(MicrosoftAspNetCorePackageVersionForNet10)')
+                                                 .Replace('!!REPLACE_WITH_ASPNETCORE_OPENAPI_9_VERSION!!', '$(MicrosoftAspNetCoreOpenApiVersion)')
+                                                 .Replace('!!REPLACE_WITH_ASPNETCORE_OPENAPI_10_VERSION!!', '$(MicrosoftAspNetCoreOpenApiPreviewVersion)')
                                                  .Replace('!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!', '$(MicrosoftExtensionsHttpResilienceVersion)')
                                                  .Replace('!!REPLACE_WITH_SERVICE_DISCOVERY_VERSION!!', '$(MicrosoftExtensionsServiceDiscoveryVersion)')
                                                  .Replace('!!REPLACE_WITH_OTEL_NET8_VERSION!!', '$(OpenTelemetryNet8Version)')

--- a/src/Aspire.ProjectTemplates/README.md
+++ b/src/Aspire.ProjectTemplates/README.md
@@ -26,17 +26,17 @@ For each template:
 5. If supported TFMs changed between old previous version and new previous version, or old current version and new current version, add or update `AspireNetXVersion` options appropriately. Note that the `AspireVersion` option maps to the `net8.0` TFM.
 6. In all *.csproj* files in the content folder named for the new previous version, e.g. *./9.4/**/*.csproj*:
    1. Update all versions for Aspire-produced packages (and SDKs) referenced to the new previous package version (`major.minor.patch` for latest patch), replacing the replacement token value with a static version value, e.g. `!!REPLACE_WITH_LATEST_VERSION!!` -> `9.4.2`
-   2. Update all versions for non-Aspire packages to the version referenced by current released version of the template, replacing the replacement token value with the relevant static version value, e.g. `!!REPLACE_WITH_ASPNETCORE_10_VERSION!!` -> `10.0.0-preview.7.25380.108`. Some non-Aspire packages referenced don't use a replacement token and instead just use a static value. In these cases simply leave the value as is.
+   2. Update all versions for non-Aspire packages to the version referenced by current released version of the template, replacing the replacement token value with the relevant static version value, e.g. `!!REPLACE_WITH_ASPNETCORE_OPENAPI_10_VERSION!!` -> `10.0.0-preview.7.25380.108`. Some non-Aspire packages referenced don't use a replacement token and instead just use a static value. In these cases simply leave the value as is.
 
       **Note:** There's a few ways to determine the static version value:
       - Look at the contents of the latest released version of the templates package at https://nuget.info/packages/Aspire.ProjectTemplates and find the version from the relvant *.csproj* file in the template package content
-      - Checkout the relevant `release/X.X` branch for the latest public release, e.g. `release/9.4`, and in the *./src/Aspire.ProjectTemplates/* directory, run the `dotnet` CLI command to extract the appropriate version from the build system, e.g. `dotnet msbuild -getProperty:MicrosoftAspNetCorePackageVersionForNet9`. The property name to pass for a given replacement token can be determined by looking in the *./src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj* file, at the `<WriteLinesToFile ...>` task, which should look something like the following:
+      - Checkout the relevant `release/X.X` branch for the latest public release, e.g. `release/9.4`, and in the *./src/Aspire.ProjectTemplates/* directory, run the `dotnet` CLI command to extract the appropriate version from the build system, e.g. `dotnet msbuild -getProperty:MicrosoftAspNetCoreOpenApiVersion`. The property name to pass for a given replacement token can be determined by looking in the *./src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj* file, at the `<WriteLinesToFile ...>` task, which should look something like the following:
          ```xml
          <WriteLinesToFile File="%(TemplateProjectFiles.DestinationFile)"
                            Lines="$([System.IO.File]::ReadAllText('%(TemplateProjectFiles.FullPath)')
                                     .Replace('!!REPLACE_WITH_LATEST_VERSION!!', '$(PackageVersion)')
-                                    .Replace('!!REPLACE_WITH_ASPNETCORE_9_VERSION!!', '$(MicrosoftAspNetCorePackageVersionForNet9)')
-                                    .Replace('!!REPLACE_WITH_ASPNETCORE_10_VERSION!!', '$(MicrosoftAspNetCorePackageVersionForNet10)')
+                                    .Replace('!!REPLACE_WITH_ASPNETCORE_OPENAPI_9_VERSION!!', '$(MicrosoftAspNetCoreOpenApiVersion)')
+                                    .Replace('!!REPLACE_WITH_ASPNETCORE_OPENAPI_10_VERSION!!', '$(MicrosoftAspNetCoreOpenApiPreviewVersion)')
                                     .Replace('!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!', '$(MicrosoftExtensionsHttpResilienceVersion)')
                                     .Replace('!!REPLACE_WITH_OTEL_NET8_VERSION!!', '$(OpenTelemetryNet8Version)')
                                     .Replace('!!REPLACE_WITH_OTEL_EXPORTER_VERSION!!', '$(OpenTelemetryExporterOpenTelemetryProtocolVersion)')

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/13.0/Aspire-StarterApplication.1.ApiService/Aspire-StarterApplication.1.ApiService.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/13.0/Aspire-StarterApplication.1.ApiService/Aspire-StarterApplication.1.ApiService.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_9_VERSION!!" Condition=" '$(Framework)' == 'net9.0' " />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_10_VERSION!!" Condition=" '$(Framework)' == 'net10.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_OPENAPI_9_VERSION!!" Condition=" '$(Framework)' == 'net9.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_OPENAPI_10_VERSION!!" Condition=" '$(Framework)' == 'net10.0' " />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We are currently not updating the template versions for OpenApi when we update the rest of the dependency versions. Making those versions look like the rest should help with this.
