### PR TITLE
Aspire CLI global tool target net8

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -19,6 +19,7 @@
 
   <!-- Set the nuget properties when building as a global tool. -->
   <PropertyGroup Condition="'$(IsCliToolProject)' == 'true'">
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>aspire</ToolCommandName>

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -707,6 +707,10 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
         var serverCertificate = _configuration[KnownConfigNames.ExtensionCert];
         Debug.Assert(!string.IsNullOrEmpty(serverCertificate));
         var data = Convert.FromBase64String(serverCertificate);
+#if NET9_0_OR_GREATER
         return X509CertificateLoader.LoadCertificate(data);
+#else
+        return new X509Certificate2(data);
+#endif
     }
 }


### PR DESCRIPTION
## Description

The Aspire CLI "global .net tool" now targets net10 with #10167. This means anyone using the `dotnet tool install` version will need the .NET 10 SDK to use it.

Revert back to targeting `net8.0` for the global tool.

@DamianEdwards @davidfowl @maddymontaquila - I assume we don't want to require users to have the .NET 10 SDK to use Aspire. Is that a correct assumption?