### PR TITLE
Update/bump container image tags for hosting components

### DIFF
--- a/src/Aspire.Hosting.Azure.ServiceBus/ServiceBusEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/ServiceBusEmulatorContainerImageTags.cs
@@ -20,6 +20,6 @@ internal static class ServiceBusEmulatorContainerImageTags
     /// <remarks>mssql/server</remarks>
     public const string SqlServerImage = "mssql/server";
 
-    /// <remarks>2025-latest</remarks>
-    public const string SqlServerTag = "2025-latest";
+    /// <remarks>2022-latest</remarks>
+    public const string SqlServerTag = "2022-latest";
 }

--- a/src/Aspire.Hosting.Azure.ServiceBus/ServiceBusEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/ServiceBusEmulatorContainerImageTags.cs
@@ -20,6 +20,6 @@ internal static class ServiceBusEmulatorContainerImageTags
     /// <remarks>mssql/server</remarks>
     public const string SqlServerImage = "mssql/server";
 
-    /// <remarks>2022-latest</remarks>
-    public const string SqlServerTag = "2022-latest";
+    /// <remarks>2025-latest</remarks>
+    public const string SqlServerTag = "2025-latest";
 }

--- a/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
@@ -11,8 +11,8 @@ internal static class KafkaContainerImageTags
     /// <remarks>confluentinc/confluent-local</remarks>
     public const string Image = "confluentinc/confluent-local";
 
-    /// <remarks>8.0.0</remarks>
-    public const string Tag = "8.0.0";
+    /// <remarks>8.1.0</remarks>
+    public const string Tag = "8.1.0";
 
     /// <remarks>kafbat/kafka-ui</remarks>
     public const string KafkaUiImage = "kafbat/kafka-ui";

--- a/src/Aspire.Hosting.Keycloak/KeycloakContainerImageTags.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakContainerImageTags.cs
@@ -11,8 +11,8 @@ internal static class KeycloakContainerImageTags
     /// <remarks>keycloak/keycloak</remarks>
     public const string Image = "keycloak/keycloak";
 
-    /// <remarks>26.3</remarks>
-    public const string Tag = "26.3";
+    /// <remarks>26.4</remarks>
+    public const string Tag = "26.4";
 
     // <remarks>1000</remarks>>
     public const int ContainerUser = 1000;

--- a/src/Aspire.Hosting.MongoDB/MongoDBContainerImageTags.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBContainerImageTags.cs
@@ -11,8 +11,8 @@ internal static class MongoDBContainerImageTags
     /// <remarks>library/mongo</remarks>
     public const string Image = "library/mongo";
 
-    /// <remarks>8.0</remarks>
-    public const string Tag = "8.0";
+    /// <remarks>8.2</remarks>
+    public const string Tag = "8.2";
 
     /// <remarks>docker.io</remarks>
     public const string MongoExpressRegistry = "docker.io";

--- a/src/Aspire.Hosting.MySql/MySqlContainerImageTags.cs
+++ b/src/Aspire.Hosting.MySql/MySqlContainerImageTags.cs
@@ -11,8 +11,8 @@ internal static class MySqlContainerImageTags
     /// <remarks>library/mysql</remarks>
     public const string Image = "library/mysql";
 
-    /// <remarks>9.4</remarks>
-    public const string Tag = "9.4";
+    /// <remarks>9.5</remarks>
+    public const string Tag = "9.5";
 
     /// <remarks>library/phpmyadmin</remarks>
     public const string PhpMyAdminImage = "library/phpmyadmin";

--- a/src/Aspire.Hosting.Nats/NatsContainerImageTags.cs
+++ b/src/Aspire.Hosting.Nats/NatsContainerImageTags.cs
@@ -11,6 +11,6 @@ internal static class NatsContainerImageTags
     /// <remarks>library/nats</remarks>
     public const string Image = "library/nats";
 
-    /// <remarks>2.11</remarks>
-    public const string Tag = "2.11";
+    /// <remarks>2.12</remarks>
+    public const string Tag = "2.12";
 }

--- a/src/Aspire.Hosting.Oracle/OracleContainerImageTags.cs
+++ b/src/Aspire.Hosting.Oracle/OracleContainerImageTags.cs
@@ -11,6 +11,6 @@ internal static class OracleContainerImageTags
     /// <remarks>database/free</remarks>
     public const string Image = "database/free";
 
-    /// <remarks>23.9.0.0</remarks>
-    public const string Tag = "23.9.0.0";
+    /// <remarks>23.26.0.0</remarks>
+    public const string Tag = "23.26.0.0";
 }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -106,7 +106,10 @@ public static class PostgresBuilderExtensions
                       .WithImage(PostgresContainerImageTags.Image, PostgresContainerImageTags.Tag)
                       .WithImageRegistry(PostgresContainerImageTags.Registry)
                       .WithEnvironment("POSTGRES_HOST_AUTH_METHOD", "scram-sha-256")
-                      .WithEnvironment("POSTGRES_INITDB_ARGS", "--auth-host=scram-sha-256 --auth-local=scram-sha-256")
+                      // PostgreSQL 18+ enables data checksums by default. We disable them to maintain backward compatibility
+                      // with existing volumes that don't have checksums enabled, preventing initialization failures when
+                      // reusing data directories from earlier versions.
+                      .WithEnvironment("POSTGRES_INITDB_ARGS", "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums")
                       .WithEnvironment(context =>
                       {
                           context.EnvironmentVariables[UserEnvVarName] = postgresServer.UserNameReference;
@@ -369,8 +372,12 @@ public static class PostgresBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        // PostgreSQL 18+ Docker images changed the data directory structure to use major-version-specific
+        // subdirectories (e.g., /var/lib/postgresql/data/18). The mount point must be /var/lib/postgresql
+        // instead of /var/lib/postgresql/data to accommodate this change. Prior to PostgreSQL 18, the
+        // mount point was /var/lib/postgresql/data.
         return builder.WithVolume(name ?? VolumeNameGenerator.Generate(builder, "data"),
-            "/var/lib/postgresql/data", isReadOnly);
+            "/var/lib/postgresql", isReadOnly);
     }
 
     /// <summary>
@@ -385,7 +392,11 @@ public static class PostgresBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(source);
 
-        return builder.WithBindMount(source, "/var/lib/postgresql/data", isReadOnly);
+        // PostgreSQL 18+ Docker images changed the data directory structure to use major-version-specific
+        // subdirectories (e.g., /var/lib/postgresql/data/18). The mount point must be /var/lib/postgresql
+        // instead of /var/lib/postgresql/data to accommodate this change. Prior to PostgreSQL 18, the
+        // mount point was /var/lib/postgresql/data.
+        return builder.WithBindMount(source, "/var/lib/postgresql", isReadOnly);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
@@ -11,8 +11,8 @@ internal static class PostgresContainerImageTags
     /// <remarks>library/postgres</remarks>
     public const string Image = "library/postgres";
 
-    /// <remarks>17.6</remarks>
-    public const string Tag = "17.6";
+    /// <remarks>18.0</remarks>
+    public const string Tag = "18.0";
 
     /// <remarks>docker.io</remarks>
     public const string PgAdminRegistry = "docker.io";
@@ -20,8 +20,8 @@ internal static class PostgresContainerImageTags
     /// <remarks>dpage/pgadmin4</remarks>
     public const string PgAdminImage = "dpage/pgadmin4";
 
-    /// <remarks>9.7.0</remarks>
-    public const string PgAdminTag = "9.7.0";
+    /// <remarks>9.9.0</remarks>
+    public const string PgAdminTag = "9.9.0";
 
     /// <remarks>docker.io</remarks>
     public const string PgWebRegistry = "docker.io";

--- a/src/Aspire.Hosting.Qdrant/QdrantContainerImageTags.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantContainerImageTags.cs
@@ -11,7 +11,7 @@ internal static class QdrantContainerImageTags
     /// <remarks>qdrant/qdrant</remarks>
     public const string Image = "qdrant/qdrant";
 
-    /// <remarks>v1.15.4</remarks>
-    public const string Tag = "v1.15.4";
+    /// <remarks>v1.15.5</remarks>
+    public const string Tag = "v1.15.5";
 }
 

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQContainerImageTags.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQContainerImageTags.cs
@@ -11,8 +11,8 @@ internal static class RabbitMQContainerImageTags
     /// <remarks>library/rabbitmq</remarks>
     public const string Image = "library/rabbitmq";
 
-    /// <remarks>4.1</remarks>
-    public const string Tag = "4.1";
+    /// <remarks>4.2</remarks>
+    public const string Tag = "4.2";
 
     /// <remarks><inheritdoc cref="Tag"/>-management</remarks>
     public const string ManagementTag = $"{Tag}-management";

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -79,7 +79,7 @@ public class AddPostgresTests
             env =>
             {
                 Assert.Equal("POSTGRES_INITDB_ARGS", env.Key);
-                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256", env.Value);
+                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums", env.Value);
             },
             env =>
             {
@@ -133,7 +133,7 @@ public class AddPostgresTests
             env =>
             {
                 Assert.Equal("POSTGRES_INITDB_ARGS", env.Key);
-                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256", env.Value);
+                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums", env.Value);
             },
             env =>
             {
@@ -226,7 +226,7 @@ public class AddPostgresTests
             env =>
             {
                 Assert.Equal("POSTGRES_INITDB_ARGS", env.Key);
-                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256", env.Value);
+                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums", env.Value);
             },
             env =>
             {
@@ -257,7 +257,7 @@ public class AddPostgresTests
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
                 "POSTGRES_USER": "postgres",
                 "POSTGRES_PASSWORD": "{pg-password.value}"
               },
@@ -300,7 +300,7 @@ public class AddPostgresTests
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
                 "POSTGRES_USER": "{user.value}",
                 "POSTGRES_PASSWORD": "{pass.value}"
               },
@@ -326,7 +326,7 @@ public class AddPostgresTests
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
                 "POSTGRES_USER": "{user.value}",
                 "POSTGRES_PASSWORD": "{pg2-password.value}"
               },
@@ -352,7 +352,7 @@ public class AddPostgresTests
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
                 "POSTGRES_USER": "postgres",
                 "POSTGRES_PASSWORD": "{pass.value}"
               },

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -441,7 +441,7 @@ public class ManifestGenerationTests
                   "image": "{{ComponentTestConstants.AspireTestContainerRegistry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
                   "env": {
                     "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                    "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+                    "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
                     "POSTGRES_USER": "postgres",
                     "POSTGRES_PASSWORD": "{postgres-password.value}",
                     "POSTGRES_DB": "postgresdb"


### PR DESCRIPTION
- ServiceBus: SqlServerTag 2022-latest -> 2025-latest
- Kafka: Tag 8.0.0 -> 8.1.0
- Keycloak: Tag 26.3 -> 26.4
- MongoDB: Tag 8.0 -> 8.2
- MySql: Tag 9.4 -> 9.5
- NATS: Tag 2.11 -> 2.12
- Oracle: Tag 23.9.0.0 -> 23.26.0.0
- Postgres: Tag 17.6 -> 18.0; PgAdminTag 9.7.0 -> 9.9.0
- Qdrant: Tag v1.15.4 -> v1.15.5
- RabbitMQ: Tag 4.1 -> 4.2

## Description

This PR updates container image tags for all database and infrastructure services to their latest stable versions to ensure we're testing against the most current images.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
