### PR TITLE
Make *.localhost resource endpoint URLs the primary endpoint URL

### DIFF
--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -267,6 +267,9 @@ internal sealed class ApplicationOrchestrator
                         // If the additional URL is a *.localhost address we want to highlight that URL in the dashboard
                         additionalUrl.DisplayLocation = UrlDisplayLocation.SummaryAndDetails;
                         url.DisplayLocation = UrlDisplayLocation.DetailsOnly;
+
+                        // Swap so that the *.localhost URL is the primary URL shown in the dashboard and targeted by `WithUrlForEndpoint` calls.
+                        (additionalUrl, url) = (url, additionalUrl);
                     }
                     else if ((string.Equals(endpoint.UriScheme, "http", StringComparison.OrdinalIgnoreCase) || string.Equals(endpoint.UriScheme, "https", StringComparison.OrdinalIgnoreCase))
                              && additionalUrl is null && EndpointHostHelpers.IsDevLocalhostTld(_dashboardUri))
@@ -278,14 +281,18 @@ internal sealed class ApplicationOrchestrator
                         // Strip any "apphost" suffix that might be present on the dashboard name.
                         subdomainSuffix = TrimSuffix(subdomainSuffix, "apphost");
 
-                        additionalUrl = new ResourceUrlAnnotation
+                        // Make the existing localhost URL the additional URL so it's not the primary endpoint URL shown in the dashboard or targeted by `WithUrlForEndpoint` calls.
+                        additionalUrl = url;
+                        additionalUrl.DisplayLocation = UrlDisplayLocation.DetailsOnly;
+
+                        // Create the new primary URL using the *.dev.localhost pattern.
+                        url = new ResourceUrlAnnotation
                         {
                             // <scheme>://<resource-name>-<subdomain-suffix>.dev.localhost:<port>
                             Url = $"{allocatedEndpoint.UriScheme}://{resource.Name.ToLowerInvariant()}-{subdomainSuffix}.dev.localhost:{allocatedEndpoint.Port}",
                             Endpoint = endpointReference,
                             DisplayLocation = UrlDisplayLocation.SummaryAndDetails
                         };
-                        url.DisplayLocation = UrlDisplayLocation.DetailsOnly;
 
                         static string TrimSuffix(string value, string suffix)
                         {

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -637,8 +637,8 @@ public class WithEndpointTests
 
         var urls = projectA.Resource.Annotations.OfType<ResourceUrlAnnotation>();
         Assert.Collection(urls,
-            url => Assert.StartsWith("https://localhost:", url.Url),
-            url => Assert.StartsWith("https://example.localhost:", url.Url));
+            url => Assert.StartsWith("https://example.localhost:", url.Url),
+            url => Assert.StartsWith("https://localhost:", url.Url));
 
         EndpointAnnotation endpoint = Assert.Single(projectA.Resource.Annotations.OfType<EndpointAnnotation>());
         Assert.NotNull(endpoint.AllocatedEndpoint);


### PR DESCRIPTION
## Description

Make `*.localhost` resource endpoint URLs the primary endpoint URL so that callers of `WithUrlForEndpoint` update that URL instead of the `localhost` URL that isn't shown on the resources summary page.

Fixes #12465

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
