### PR TITLE
MCP result improvements: Provide links to resources, traces, logs. Shorten resource names.

### DIFF
--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -208,6 +208,9 @@ public sealed class FrontendOptions
     public FrontendAuthMode? AuthMode { get; set; }
     public string? BrowserToken { get; set; }
 
+    // Public URL could be different from the endpoint URL (e.g., when behind a proxy).
+    public string? PublicUrl { get; set; }
+
     /// <summary>
     /// Gets and sets an optional limit on the number of console log messages to be retained in the viewer.
     /// </summary>

--- a/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
+++ b/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.ConsoleLogs;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
 using Aspire.Hosting.ConsoleLogs;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
@@ -17,10 +19,12 @@ namespace Aspire.Dashboard.Mcp;
 internal sealed class AspireResourceMcpTools
 {
     private readonly IDashboardClient _dashboardClient;
+    private readonly IOptionsMonitor<DashboardOptions> _dashboardOptions;
 
-    public AspireResourceMcpTools(IDashboardClient dashboardClient)
+    public AspireResourceMcpTools(IDashboardClient dashboardClient, IOptionsMonitor<DashboardOptions> dashboardOptions)
     {
         _dashboardClient = dashboardClient;
+        _dashboardOptions = dashboardOptions;
     }
 
     [McpServerTool(Name = "list_resources")]
@@ -31,10 +35,10 @@ internal sealed class AspireResourceMcpTools
         {
             var resources = _dashboardClient.GetResources();
 
-            var resourceGraphData = AIHelpers.GetResponseGraphJson(resources.ToList());
+            var resourceGraphData = AIHelpers.GetResponseGraphJson(resources.ToList(), _dashboardOptions.CurrentValue, includeDashboardUrl: true);
 
             var response = $"""
-            Always format resource_name in the response as code like this: `frontend-abcxyz`
+            resource_name is the identifier of resources. Use the dashboard_link when displaying resource_name. For example: [`frontend-abcxyz`](https://localhost:1234/resource?name=frontend-abcxyz)
             Console logs for a resource can provide more information about why a resource is not in a running state.
 
             # RESOURCE DATA

--- a/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
+++ b/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
@@ -33,9 +33,13 @@ internal sealed class AspireResourceMcpTools
     {
         try
         {
-            var resources = _dashboardClient.GetResources();
+            var resources = _dashboardClient.GetResources().ToList();
 
-            var resourceGraphData = AIHelpers.GetResponseGraphJson(resources.ToList(), _dashboardOptions.CurrentValue, includeDashboardUrl: true);
+            var resourceGraphData = AIHelpers.GetResponseGraphJson(
+                resources,
+                _dashboardOptions.CurrentValue,
+                includeDashboardUrl: true,
+                getResourceName: r => ResourceViewModel.GetResourceName(r, resources));
 
             var response = $"""
             resource_name is the identifier of resources. Use the dashboard_link when displaying resource_name. For example: [`frontend-abcxyz`](https://localhost:1234/resource?name=frontend-abcxyz)

--- a/src/Aspire.Dashboard/Mcp/AspireTelemetryMcpTools.cs
+++ b/src/Aspire.Dashboard/Mcp/AspireTelemetryMcpTools.cs
@@ -7,6 +7,7 @@ using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
 using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
@@ -50,7 +51,13 @@ internal sealed class AspireTelemetryMcpTools
             Filters = []
         });
 
-        var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(logs.Items, _dashboardOptions.CurrentValue, includeDashboardUrl: true);
+        var resources = _telemetryRepository.GetResources();
+
+        var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(
+            logs.Items,
+            _dashboardOptions.CurrentValue,
+            includeDashboardUrl: true,
+            getResourceName: r => OtlpResource.GetResourceName(r, resources));
 
         var response = $"""
             Always format log_id in the response as code like this: `log_id: 123`.
@@ -84,7 +91,14 @@ internal sealed class AspireTelemetryMcpTools
             FilterText = string.Empty
         });
 
-        var (tracesData, limitMessage) = AIHelpers.GetTracesJson(traces.PagedResult.Items, _outgoingPeerResolvers, _dashboardOptions.CurrentValue, includeDashboardUrl: true);
+        var resources = _telemetryRepository.GetResources();
+
+        var (tracesData, limitMessage) = AIHelpers.GetTracesJson(
+            traces.PagedResult.Items,
+            _outgoingPeerResolvers,
+            _dashboardOptions.CurrentValue,
+            includeDashboardUrl: true,
+            getResourceName: r => OtlpResource.GetResourceName(r, resources));
 
         var response = $"""
             {limitMessage}
@@ -119,7 +133,13 @@ internal sealed class AspireTelemetryMcpTools
             Filters = [traceIdFilter]
         });
 
-        var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(logs.Items, _dashboardOptions.CurrentValue, includeDashboardUrl: true);
+        var resources = _telemetryRepository.GetResources();
+
+        var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(
+            logs.Items,
+            _dashboardOptions.CurrentValue,
+            includeDashboardUrl: true,
+            getResourceName: r => OtlpResource.GetResourceName(r, resources));
 
         var response = $"""
             {limitMessage}

--- a/src/Aspire.Dashboard/Mcp/McpExtensions.cs
+++ b/src/Aspire.Dashboard/Mcp/McpExtensions.cs
@@ -39,7 +39,7 @@ public static class McpExtensions
 
                 ## Instructions
                 - When a resource, structured log or trace is returned, include a link to the Aspire dashboard using dashboard_link
-                - When a resource state (running, stopped, starting, ...) is returned, render it in italic chars like *running*, and add an emoji colored badge next to it (green, red, orange, ...).
+                - When a resource state (running, stopped, starting, ...) is returned, and add an emoji colored badge next to it (green, red, orange, etc).
 
                 ## Tools
 

--- a/src/Aspire.Dashboard/Mcp/McpExtensions.cs
+++ b/src/Aspire.Dashboard/Mcp/McpExtensions.cs
@@ -38,8 +38,8 @@ public static class McpExtensions
                 This MCP Server provides various tools for managing Aspire resources, logs, traces and commands.
 
                 ## Instructions
-                - When a resource name is returned, render it in bold chars like **resourceName**
-                - When a resource state (running, stopped, starting, ...) is returned, render it in italic chars like *running*, and add a colored badge next to it (green, red, orange, ...).
+                - When a resource, structured log or trace is returned, include a link to the Aspire dashboard using dashboard_link
+                - When a resource state (running, stopped, starting, ...) is returned, render it in italic chars like *running*, and add an emoji colored badge next to it (green, red, orange, ...).
 
                 ## Tools
 

--- a/src/Aspire.Dashboard/Model/Assistant/AIContextProvider.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIContextProvider.cs
@@ -186,7 +186,7 @@ public class AIContextProvider : IAIContextProvider
         var initializeTask = viewModel.InitializeWithInitialPromptAsync(async () =>
         {
             var chatBuilder = new ChatViewModelBuilder(viewModel.MarkdownProcessor);
-            await sendInitialPrompt(new InitializePromptContext(chatBuilder, viewModel.DataContext, _serviceProvider)).ConfigureAwait(false);
+            await sendInitialPrompt(new InitializePromptContext(chatBuilder, viewModel.DataContext, _serviceProvider, _dashboardOptions.CurrentValue)).ConfigureAwait(false);
 
             await viewModel.AddFollowUpPromptAsync(chatBuilder.Build()).ConfigureAwait(false);
         });

--- a/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
@@ -170,7 +170,7 @@ internal static class AIHelpers
                 ["type"] = resource.ResourceType,
                 ["state"] = resource.State,
                 ["state_description"] = ResourceStateViewModel.GetResourceStateTooltip(resource, s_columnsLoc),
-                ["relationships"] = GetResourceRelationships(resources, resource),
+                ["relationships"] = GetResourceRelationships(resources, resource, getResourceName),
                 ["endpoint_urls"] = resource.Urls.Where(u => !u.IsInternal).Select(u => new
                 {
                     name = u.EndpointName,
@@ -206,7 +206,7 @@ internal static class AIHelpers
         var resourceGraphData = SerializeJson(data);
         return resourceGraphData;
 
-        static List<object> GetResourceRelationships(List<ResourceViewModel> allResources, ResourceViewModel resourceViewModel)
+        static List<object> GetResourceRelationships(List<ResourceViewModel> allResources, ResourceViewModel resourceViewModel, Func<ResourceViewModel, string>? getResourceName)
         {
             var relationships = new List<object>();
 
@@ -221,7 +221,7 @@ internal static class AIHelpers
                 {
                     relationships.Add(new
                     {
-                        resource_name = match.Name,
+                        resource_name = getResourceName?.Invoke(match) ?? match.Name,
                         Types = relationship.Type
                     });
                 }

--- a/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
@@ -80,7 +80,7 @@ internal static class AIHelpers
 
         if (includeDashboardUrl)
         {
-            traceData["dashboard_link"] = GetFrontendUrl(options, DashboardUrls.TraceDetailUrl(traceId), traceId);
+            traceData["dashboard_link"] = GetDashboardLink(options, DashboardUrls.TraceDetailUrl(traceId), traceId);
         }
 
         return traceData;
@@ -195,7 +195,7 @@ internal static class AIHelpers
 
             if (includeDashboardUrl)
             {
-                resourceObj["dashboard_link"] = GetFrontendUrl(options, DashboardUrls.ResourcesUrl(resource: resource.Name), resource.Name);
+                resourceObj["dashboard_link"] = GetDashboardLink(options, DashboardUrls.ResourcesUrl(resource: resource.Name), resource.Name);
             }
 
             return resourceObj;
@@ -254,19 +254,35 @@ internal static class AIHelpers
         }
     }
 
-    private static object GetFrontendUrl(DashboardOptions options, string path, string text)
+    public static object? GetDashboardLink(DashboardOptions options, string path, string text)
+    {
+        var url = GetDashboardUrl(options, path);
+        if (string.IsNullOrEmpty(url))
+        {
+            return null;
+        }
+
+        return new
+        {
+            url = url,
+            text = text
+        };
+    }
+
+    public static string? GetDashboardUrl(DashboardOptions options, string path)
     {
         var frontendEndpoints = options.Frontend.GetEndpointAddresses();
 
         var frontendUrl = options.Frontend.PublicUrl
             ?? frontendEndpoints.FirstOrDefault(e => string.Equals(e.Scheme, "https", StringComparison.Ordinal))?.ToString()
-            ?? frontendEndpoints.First(e => string.Equals(e.Scheme, "http", StringComparison.Ordinal)).ToString();
+            ?? frontendEndpoints.FirstOrDefault(e => string.Equals(e.Scheme, "http", StringComparison.Ordinal))?.ToString();
 
-        return new
+        if (frontendUrl == null)
         {
-            url = new Uri(new Uri(frontendUrl), path).ToString(),
-            text = text
-        };
+            return null;
+        }
+
+        return new Uri(new Uri(frontendUrl), path).ToString();
     }
 
     public static int EstimateTokenCount(string text)
@@ -330,7 +346,7 @@ internal static class AIHelpers
 
         if (includeDashboardUrl)
         {
-            log["dashboard_link"] = GetFrontendUrl(options, DashboardUrls.StructuredLogsUrl(logEntryId: l.InternalId), $"log_id: {l.InternalId}");
+            log["dashboard_link"] = GetDashboardLink(options, DashboardUrls.StructuredLogsUrl(logEntryId: l.InternalId), $"log_id: {l.InternalId}");
         }
 
         return log;

--- a/src/Aspire.Dashboard/Model/Assistant/IAIContextProvider.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/IAIContextProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model.Assistant.Ghcp;
 using Aspire.Dashboard.Model.Assistant.Prompts;
 
@@ -39,4 +40,4 @@ public static class AIContextExtensions
     }
 }
 
-public record InitializePromptContext(ChatViewModelBuilder ChatBuilder, AssistantChatDataContext DataContext, IServiceProvider ServiceProvider);
+public record InitializePromptContext(ChatViewModelBuilder ChatBuilder, AssistantChatDataContext DataContext, IServiceProvider ServiceProvider, DashboardOptions DashboardOptions);

--- a/src/Aspire.Dashboard/Model/Assistant/Prompts/KnownChatMessages.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/Prompts/KnownChatMessages.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Utils;
 using Microsoft.Extensions.AI;
@@ -41,9 +42,9 @@ internal static class KnownChatMessages
             return new ChatMessage(ChatRole.System, systemChatMessage);
         }
 
-        public static ChatMessage CreateInitialMessage(string promptText, string applicationName, List<ResourceViewModel> resources)
+        public static ChatMessage CreateInitialMessage(string promptText, string applicationName, List<ResourceViewModel> resources, DashboardOptions dashboardOptions)
         {
-            var resourceGraph = AIHelpers.GetResponseGraphJson(resources);
+            var resourceGraph = AIHelpers.GetResponseGraphJson(resources, dashboardOptions);
 
             var resolvedPromptText =
                 $"""
@@ -175,9 +176,9 @@ internal static class KnownChatMessages
 
     public static class StructuredLogs
     {
-        public static ChatMessage CreateErrorStructuredLogsMessage(List<OtlpLogEntry> errorLogs)
+        public static ChatMessage CreateErrorStructuredLogsMessage(List<OtlpLogEntry> errorLogs, DashboardOptions options)
         {
-            var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(errorLogs);
+            var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(errorLogs, options);
 
             var prompt =
                 $"""
@@ -193,7 +194,7 @@ internal static class KnownChatMessages
             return new(ChatRole.User, prompt);
         }
 
-        public static ChatMessage CreateAnalyzeLogEntryMessage(OtlpLogEntry logEntry)
+        public static ChatMessage CreateAnalyzeLogEntryMessage(OtlpLogEntry logEntry, DashboardOptions options)
         {
             var prompt =
                 $"""
@@ -203,7 +204,7 @@ internal static class KnownChatMessages
 
                 # LOG ENTRY DATA
 
-                {AIHelpers.GetStructuredLogJson(logEntry)}
+                {AIHelpers.GetStructuredLogJson(logEntry, options)}
                 """;
 
             return new(ChatRole.User, prompt);
@@ -279,9 +280,9 @@ internal static class KnownChatMessages
             return new ChatMessage(ChatRole.User, message);
         }
 
-        public static ChatMessage CreateAnalyzeTraceMessage(OtlpTrace trace, List<OtlpLogEntry> traceLogEntries, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+        public static ChatMessage CreateAnalyzeTraceMessage(OtlpTrace trace, List<OtlpLogEntry> traceLogEntries, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers, DashboardOptions options)
         {
-            var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(traceLogEntries);
+            var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(traceLogEntries, options);
 
             var prompt =
                 $"""
@@ -290,7 +291,7 @@ internal static class KnownChatMessages
 
                 # DISTRIBUTED TRACE DATA
 
-                {AIHelpers.GetTraceJson(trace, outgoingPeerResolvers, new PromptContext())}
+                {AIHelpers.GetTraceJson(trace, outgoingPeerResolvers, new PromptContext(), options)}
                 
                 # STRUCTURED LOGS DATA
 
@@ -302,9 +303,9 @@ internal static class KnownChatMessages
             return new(ChatRole.User, prompt);
         }
 
-        public static ChatMessage CreateAnalyzeSpanMessage(OtlpSpan span, List<OtlpLogEntry> traceLogEntries, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+        public static ChatMessage CreateAnalyzeSpanMessage(OtlpSpan span, List<OtlpLogEntry> traceLogEntries, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers, DashboardOptions options)
         {
-            var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(traceLogEntries);
+            var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(traceLogEntries, options);
 
             var prompt =
                 $"""
@@ -313,7 +314,7 @@ internal static class KnownChatMessages
 
                 # DISTRIBUTED TRACE DATA
 
-                {AIHelpers.GetTraceJson(span.Trace, outgoingPeerResolvers, new PromptContext())}
+                {AIHelpers.GetTraceJson(span.Trace, outgoingPeerResolvers, new PromptContext(), options)}
                 
                 # STRUCTURED LOGS DATA
                 
@@ -325,9 +326,9 @@ internal static class KnownChatMessages
             return new(ChatRole.User, prompt);
         }
 
-        public static ChatMessage CreateErrorTracesMessage(List<OtlpTrace> errorTraces, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+        public static ChatMessage CreateErrorTracesMessage(List<OtlpTrace> errorTraces, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers, DashboardOptions options)
         {
-            var (tracesData, limitMessage) = AIHelpers.GetTracesJson(errorTraces, outgoingPeerResolvers);
+            var (tracesData, limitMessage) = AIHelpers.GetTracesJson(errorTraces, outgoingPeerResolvers, options);
 
             var prompt =
                 $"""

--- a/src/Aspire.Dashboard/Model/Assistant/Prompts/PromptContextsBuilder.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/Prompts/PromptContextsBuilder.cs
@@ -20,7 +20,7 @@ internal static class PromptContextsBuilder
 
         promptContext.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.Traces.CreateErrorTracesMessage(errorTraces.Items, outgoingPeerResolvers).Text);
+            KnownChatMessages.Traces.CreateErrorTracesMessage(errorTraces.Items, outgoingPeerResolvers, promptContext.DashboardOptions).Text);
 
         return Task.CompletedTask;
     }
@@ -35,7 +35,7 @@ internal static class PromptContextsBuilder
 
         promptContext.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.StructuredLogs.CreateErrorStructuredLogsMessage(errorLogs.Items).Text);
+            KnownChatMessages.StructuredLogs.CreateErrorStructuredLogsMessage(errorLogs.Items, promptContext.DashboardOptions).Text);
 
         return Task.CompletedTask;
     }
@@ -54,7 +54,7 @@ internal static class PromptContextsBuilder
         promptContext.DataContext.AddReferencedLogEntry(logEntry);
         promptContext.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.StructuredLogs.CreateAnalyzeLogEntryMessage(logEntry).Text);
+            KnownChatMessages.StructuredLogs.CreateAnalyzeLogEntryMessage(logEntry, promptContext.DashboardOptions).Text);
 
         return Task.CompletedTask;
     }
@@ -79,7 +79,7 @@ internal static class PromptContextsBuilder
 
         context.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.Traces.CreateAnalyzeTraceMessage(trace, traceLogs.Items, outgoingPeerResolvers).Text);
+            KnownChatMessages.Traces.CreateAnalyzeTraceMessage(trace, traceLogs.Items, outgoingPeerResolvers, context.DashboardOptions).Text);
 
         return Task.CompletedTask;
     }
@@ -104,7 +104,7 @@ internal static class PromptContextsBuilder
 
         context.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.Traces.CreateAnalyzeSpanMessage(span, traceLogs.Items, outgoingPeerResolvers).Text);
+            KnownChatMessages.Traces.CreateAnalyzeSpanMessage(span, traceLogs.Items, outgoingPeerResolvers, context.DashboardOptions).Text);
 
         return Task.CompletedTask;
     }

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -160,13 +160,13 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
         {
             // Apply transformers to the peer address cumulatively
             var transformedAddress = address;
-            
+
             // First check exact match
             if (TryMatchAgainstResources(transformedAddress, resources, out name, out resourceMatch))
             {
                 return true;
             }
-            
+
             // Then apply each transformer cumulatively and check
             foreach (var transformer in s_addressTransformers)
             {

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -31,6 +31,7 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DashboardFrontendAuthModeName = new("Dashboard:Frontend:AuthMode", "DASHBOARD__FRONTEND__AUTHMODE");
     public static readonly ConfigName DashboardFrontendBrowserTokenName = new("Dashboard:Frontend:BrowserToken", "DASHBOARD__FRONTEND__BROWSERTOKEN");
     public static readonly ConfigName DashboardFrontendMaxConsoleLogCountName = new("Dashboard:Frontend:MaxConsoleLogCount", "DASHBOARD__FRONTEND__MAXCONSOLELOGCOUNT");
+    public static readonly ConfigName DashboardFrontendPublicUrlName = new("Dashboard:Frontend:PublicUrl", "DASHBOARD__FRONTEND__PUBLICURL");
     public static readonly ConfigName ResourceServiceClientAuthModeName = new("Dashboard:ResourceServiceClient:AuthMode", "DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE");
     public static readonly ConfigName ResourceServiceClientCertificateSourceName = new("Dashboard:ResourceServiceClient:ClientCertificate:Source", "DASHBOARD__RESOURCESERVICECLIENT__CLIENTCERTIFICATE__SOURCE");
     public static readonly ConfigName ResourceServiceClientCertificateFilePathName = new("Dashboard:ResourceServiceClient:ClientCertificate:FilePath", "DASHBOARD__RESOURCESERVICECLIENT__CLIENTCERTIFICATE__FILEPATH");

--- a/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model.Assistant;
 using Aspire.Dashboard.Model.Assistant.Markdown;
 using Aspire.Dashboard.Model.Markdown;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
+using Aspire.Dashboard.Tests.Model;
 using Aspire.Tests.Shared.DashboardModel;
 using Aspire.Tests.Shared.Telemetry;
 using Markdig;
@@ -369,7 +371,8 @@ public class MarkdownProcessorTests
             telemetryRepository ?? TelemetryTestHelpers.CreateRepository(),
             dashboardClient ?? new MockDashboardClient(),
             [],
-            new TestStringLocalizer<Dashboard.Resources.AIAssistant>());
+            new TestStringLocalizer<Dashboard.Resources.AIAssistant>(),
+            new TestOptionsMonitor<DashboardOptions>(new DashboardOptions()));
 
         return context;
     }

--- a/tests/Aspire.Dashboard.Tests/Mcp/AspireResourceMcpToolsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Mcp/AspireResourceMcpToolsTests.cs
@@ -44,6 +44,7 @@ public class AspireResourceMcpToolsTests
         // Assert
         Assert.NotNull(result);
         Assert.Contains("# RESOURCE DATA", result);
+        Assert.Contains("app1", result);
     }
 
     [Fact]
@@ -61,6 +62,8 @@ public class AspireResourceMcpToolsTests
         // Assert
         Assert.NotNull(result);
         Assert.Contains("# RESOURCE DATA", result);
+        Assert.Contains("app1", result);
+        Assert.Contains("app2", result);
     }
 
     [Fact]
@@ -152,8 +155,13 @@ public class AspireResourceMcpToolsTests
 
     private static AspireResourceMcpTools CreateTools(IDashboardClient dashboardClient)
     {
+        var options = new DashboardOptions();
+        options.Frontend.EndpointUrls = "https://localhost:1234";
+        options.Frontend.PublicUrl = "https://localhost:8080";
+        Assert.True(options.Frontend.TryParseOptions(out _));
+
         return new AspireResourceMcpTools(
             dashboardClient,
-            new TestOptionsMonitor<DashboardOptions>(new DashboardOptions()));
+            new TestOptionsMonitor<DashboardOptions>(options));
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Mcp/AspireResourceMcpToolsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Mcp/AspireResourceMcpToolsTests.cs
@@ -3,8 +3,10 @@
 
 using System.Collections.Immutable;
 using System.Threading.Channels;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Mcp;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Tests.Model;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Tests.Shared.DashboardModel;
 using Xunit;
@@ -150,6 +152,8 @@ public class AspireResourceMcpToolsTests
 
     private static AspireResourceMcpTools CreateTools(IDashboardClient dashboardClient)
     {
-        return new AspireResourceMcpTools(dashboardClient);
+        return new AspireResourceMcpTools(
+            dashboardClient,
+            new TestOptionsMonitor<DashboardOptions>(new DashboardOptions()));
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Mcp/AspireTelemetryMcpToolsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Mcp/AspireTelemetryMcpToolsTests.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Mcp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Tests.Model;
 using Aspire.Tests.Shared.Telemetry;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Trace.V1;
@@ -148,7 +150,7 @@ public class AspireTelemetryMcpToolsTests
 
     private static AspireTelemetryMcpTools CreateTools(TelemetryRepository repository)
     {
-        return new AspireTelemetryMcpTools(repository, []);
+        return new AspireTelemetryMcpTools(repository, [], new TestOptionsMonitor<DashboardOptions>(new DashboardOptions()));
     }
 
     private static TelemetryRepository CreateRepository()

--- a/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AIHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AIHelpersTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model.Assistant;
 using Xunit;
 
@@ -173,5 +174,51 @@ public class AIHelpersTests
             s => Assert.Equal(new string('i', textLength), s),
             s => Assert.Equal(new string('j', textLength), s));
         Assert.Equal("Returned latest 4 test items. Earlier 6 test items not returned because of size limits.", message);
+    }
+
+    [Fact]
+    public void GetDashboardUrl_PublicUrl()
+    {
+        // Arrange
+        var options = new DashboardOptions();
+        options.Frontend.EndpointUrls = "http://localhost:5000;https://localhost:1234";
+        options.Frontend.PublicUrl = "https://localhost:1234";
+        Assert.True(options.Frontend.TryParseOptions(out _));
+
+        // Act
+        var url = AIHelpers.GetDashboardUrl(options, "/path");
+
+        // Assert
+        Assert.Equal("https://localhost:1234/path", url);
+    }
+
+    [Fact]
+    public void GetDashboardUrl_HttpsAndHttpEndpointUrls()
+    {
+        // Arrange
+        var options = new DashboardOptions();
+        options.Frontend.EndpointUrls = "http://localhost:5000;https://localhost:1234";
+        Assert.True(options.Frontend.TryParseOptions(out _));
+
+        // Act
+        var url = AIHelpers.GetDashboardUrl(options, "/path");
+
+        // Assert
+        Assert.Equal("https://localhost:1234/path", url);
+    }
+
+    [Fact]
+    public void GetDashboardUrl_HttpEndpointUrl()
+    {
+        // Arrange
+        var options = new DashboardOptions();
+        options.Frontend.EndpointUrls = "http://localhost:5000;";
+        Assert.True(options.Frontend.TryParseOptions(out _));
+
+        // Act
+        var url = AIHelpers.GetDashboardUrl(options, "/path");
+
+        // Assert
+        Assert.Equal("http://localhost:5000/path", url);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AssistantChatDataContextTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AssistantChatDataContextTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Channels;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
 using Aspire.Dashboard.Otlp.Model;
@@ -130,7 +131,8 @@ public class AssistantChatDataContextTests
             telemetryRepository ?? CreateRepository(),
             dashboardClient ?? new MockDashboardClient(),
             [],
-            new TestStringLocalizer<Dashboard.Resources.AIAssistant>());
+            new TestStringLocalizer<Dashboard.Resources.AIAssistant>(),
+            new TestOptionsMonitor<DashboardOptions>(new DashboardOptions()));
 
         return context;
     }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -149,6 +149,11 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
             },
             e =>
             {
+                Assert.Equal("DASHBOARD__FRONTEND__PUBLICURL", e.Key);
+                Assert.Equal("http://localhost:5003", e.Value);
+            },
+            e =>
+            {
                 Assert.Equal("DASHBOARD__MCP__AUTHMODE", e.Key);
                 Assert.Equal("Unsecured", e.Value);
             },


### PR DESCRIPTION
## Description

Resources, structured logs and traces data now includes a field with a link to the dashboard. This allows the AI client to display that link in its result UI, and then user then to click on it to view details directly in the dashboard.

For example, the links rendered here in AI results can be clicked on to view the resource detail in the dashboard:
<img width="568" height="396" alt="image" src="https://github.com/user-attachments/assets/3f0db414-9edc-41fe-bb5a-11c88becc388" />

**Update:**

PR also shortens resource names when possible.
<img width="554" height="921" alt="image" src="https://github.com/user-attachments/assets/3a2eefcd-1f69-45d8-97cb-71fdd0201684" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
