### PR TITLE
Fix the logging pipeline so that logger provider filtering works

### DIFF
--- a/src/Aspire.Cli/Commands/DeployCommand.cs
+++ b/src/Aspire.Cli/Commands/DeployCommand.cs
@@ -56,7 +56,7 @@ internal sealed class DeployCommand : PipelineCommandBase
         var includeExceptionDetails = parseResult.GetValue(_includeExceptionDetailsOption);
         if (includeExceptionDetails)
         {
-            baseArgs.Add("--include-exception-details");
+            baseArgs.AddRange(["--include-exception-details", "true"]);
         }
 
         var environment = parseResult.GetValue(_environmentOption);

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -68,6 +68,6 @@ internal sealed class DoCommand : PipelineCommandBase
     protected override string GetProgressMessage(ParseResult parseResult)
     {
         var step = parseResult.GetValue(_stepArgument);
-        return $"Executing step \"{step}\"";
+        return $"Executing step {step}";
     }
 }

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -52,6 +52,12 @@ internal sealed class DoCommand : PipelineCommandBase
             baseArgs.AddRange(["--log-level", logLevel!]);
         }
 
+        var includeExceptionDetails = parseResult.GetValue(_includeExceptionDetailsOption);
+        if (includeExceptionDetails)
+        {
+            baseArgs.AddRange(["--include-exception-details", "true"]);
+        }
+
         var environment = parseResult.GetValue(_environmentOption);
         if (!string.IsNullOrEmpty(environment))
         {

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -34,6 +34,11 @@ internal abstract class PipelineCommandBase : BaseCommand
         Description = "Set the minimum log level for pipeline logging (trace, debug, information, warning, error, critical). The default is 'information'."
     };
 
+    protected readonly Option<bool> _includeExceptionDetailsOption = new("--include-exception-details")
+    {
+        Description = "Include exception details (stack traces) in pipeline logs."
+    };
+
     protected readonly Option<string?> _environmentOption = new("--environment", "-e")
     {
         Description = "The environment to use for the operation. The default is 'Production'."
@@ -82,6 +87,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
         Options.Add(_logLevelOption);
         Options.Add(_environmentOption);
+        Options.Add(_includeExceptionDetailsOption);
 
         // In the publish and deploy commands we forward all unrecognized tokens
         // through to the underlying tooling when we launch the app host.

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -66,7 +66,7 @@ internal sealed class PublishCommand : PipelineCommandBase
         var includeExceptionDetails = parseResult.GetValue(_includeExceptionDetailsOption);
         if (includeExceptionDetails)
         {
-            baseArgs.Add("--include-exception-details");
+            baseArgs.AddRange(["--include-exception-details", "true"]);
         }
 
         var environment = parseResult.GetValue(_environmentOption);

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -63,6 +63,12 @@ internal sealed class PublishCommand : PipelineCommandBase
             baseArgs.AddRange(["--log-level", logLevel!]);
         }
 
+        var includeExceptionDetails = parseResult.GetValue(_includeExceptionDetailsOption);
+        if (includeExceptionDetails)
+        {
+            baseArgs.Add("--include-exception-details");
+        }
+
         var environment = parseResult.GetValue(_environmentOption);
         if (!string.IsNullOrEmpty(environment))
         {
@@ -76,5 +82,5 @@ internal sealed class PublishCommand : PipelineCommandBase
 
     protected override string GetCanceledMessage() => InteractionServiceStrings.OperationCancelled;
 
-    protected override string GetProgressMessage(ParseResult parseResult) => "Executing step \"publish\"";
+    protected override string GetProgressMessage(ParseResult parseResult) => "Executing step publish";
 }

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -178,7 +178,7 @@ internal sealed class ConsoleActivityLogger
         }
     }
 
-    public void WriteSummary(string? dashboardUrl = null)
+    public void WriteSummary()
     {
         lock (_lock)
         {
@@ -252,19 +252,6 @@ internal sealed class ConsoleActivityLogger
             if (!string.IsNullOrEmpty(_finalStatusHeader))
             {
                 AnsiConsole.MarkupLine(_finalStatusHeader!);
-            }
-            if (!string.IsNullOrEmpty(dashboardUrl))
-            {
-                // Render dashboard URL as clickable link in interactive terminals, plain in non-interactive
-                var url = dashboardUrl;
-                if (!_hostEnvironment.SupportsInteractiveOutput || !_enableColor)
-                {
-                    AnsiConsole.MarkupLine($"Dashboard: {url.EscapeMarkup()}");
-                }
-                else
-                {
-                    AnsiConsole.MarkupLine($"Dashboard: [link={url}]{url}[/]");
-                }
             }
             AnsiConsole.MarkupLine(line);
             AnsiConsole.WriteLine(); // Ensure final newline after deployment summary

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -537,19 +537,19 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
                 try
                 {
                     var activityReporter = context.Services.GetRequiredService<IPipelineActivityReporter>();
-                    var publishingStep = await activityReporter.CreateStepAsync(step.Name, context.CancellationToken).ConfigureAwait(false);
+                    var reportingStep = await activityReporter.CreateStepAsync(step.Name, context.CancellationToken).ConfigureAwait(false);
 
-                    await using (publishingStep.ConfigureAwait(false))
+                    await using (reportingStep.ConfigureAwait(false))
                     {
                         var stepContext = new PipelineStepContext
                         {
                             PipelineContext = context,
-                            ReportingStep = publishingStep
+                            ReportingStep = reportingStep
                         };
 
                         try
                         {
-                            PipelineLoggerProvider.CurrentStep = publishingStep;
+                            PipelineLoggerProvider.CurrentStep = reportingStep;
 
                             await ExecuteStepAsync(step, stepContext).ConfigureAwait(false);
                         }
@@ -558,7 +558,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
                             stepContext.Logger.LogError(ex, "Step '{StepName}' failed.", step.Name);
 
                             // Report the failure to the activity reporter before disposing
-                            await publishingStep.FailAsync(ex.Message, CancellationToken.None).ConfigureAwait(false);
+                            await reportingStep.FailAsync(ex.Message).ConfigureAwait(false);
                             throw;
                         }
                         finally

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -15,7 +15,6 @@ using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Pipelines;
@@ -550,7 +549,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
 
                         try
                         {
-                            PipelineLoggerProvider.CurrentLogger = stepContext.Logger;
+                            PipelineLoggerProvider.CurrentStep = publishingStep;
 
                             await ExecuteStepAsync(step, stepContext).ConfigureAwait(false);
                         }
@@ -564,7 +563,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
                         }
                         finally
                         {
-                            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+                            PipelineLoggerProvider.CurrentStep = null;
                         }
                     }
 

--- a/src/Aspire.Hosting/Pipelines/IPipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/IPipelineActivityReporter.cs
@@ -24,7 +24,6 @@ public interface IPipelineActivityReporter
     /// </summary>
     /// <param name="completionMessage">The completion message of the publishing process.</param>
     /// <param name="completionState">The completion state of the publishing process. When null, the state is automatically aggregated from all steps.</param>
-    /// <param name="isDeploy">Whether this is a deployment operation rather than a publishing operation.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, bool isDeploy = false, CancellationToken cancellationToken = default);
+    Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, CancellationToken cancellationToken = default);
 }

--- a/src/Aspire.Hosting/Pipelines/NullPipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/NullPipelineActivityReporter.cs
@@ -21,7 +21,7 @@ public sealed class NullPublishingActivityReporter : IPipelineActivityReporter
     }
 
     /// <inheritdoc />
-    public Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, bool isDeploy = false, CancellationToken cancellationToken = default)
+    public Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;
     }

--- a/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
@@ -228,12 +228,11 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
         await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, bool isDeploy = false, CancellationToken cancellationToken = default)
+    public async Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, CancellationToken cancellationToken = default)
     {
         // Use provided state or aggregate from all steps
         var finalState = completionState ?? CalculateOverallAggregatedState();
 
-        var operationName = "Pipeline";
         var state = new PublishingActivity
         {
             Type = PublishingActivityTypes.PublishComplete,
@@ -242,10 +241,10 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                 Id = PublishingActivityTypes.PublishComplete,
                 StatusText = completionMessage ?? finalState switch
                 {
-                    CompletionState.Completed => $"{operationName} completed successfully",
-                    CompletionState.CompletedWithWarning => $"{operationName} completed with warnings",
-                    CompletionState.CompletedWithError => $"{operationName} completed with errors",
-                    _ => $"{operationName} completed"
+                    CompletionState.Completed => "Pipeline completed successfully",
+                    CompletionState.CompletedWithWarning => "Pipeline completed with warnings",
+                    CompletionState.CompletedWithError => "Pipeline completed with errors",
+                    _ => "Pipeline completed"
                 },
                 CompletionState = ToBackchannelCompletionState(finalState)
             }

--- a/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
@@ -31,7 +31,7 @@ internal sealed class PipelineLoggerProvider(IOptions<PipelineLoggingOptions> op
             // Clear the current logger from AsyncLocal context
             s_currentStep.Value = null;
 
-            if (value is not null && value != NullLogger.Instance)
+            if (value is not null)
             {
                 // Use an object indirection to hold the logger in the AsyncLocal,
                 // so it can be cleared in all ExecutionContexts when cleared.

--- a/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
@@ -4,7 +4,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Pipelines;

--- a/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
@@ -1,8 +1,11 @@
+#pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Pipelines;
 
@@ -13,33 +16,33 @@ namespace Aspire.Hosting.Pipelines;
 /// This logger provider uses AsyncLocal storage to maintain the current logger context across async operations.
 /// This enables pipeline steps to log through a contextual logger that can be set per execution.
 /// </remarks>
-internal sealed class PipelineLoggerProvider : ILoggerProvider
+internal sealed class PipelineLoggerProvider(IOptions<PipelineLoggingOptions> options) : ILoggerProvider
 {
-    private static readonly AsyncLocal<StepLoggerHolder?> s_currentLogger = new();
+    private static readonly AsyncLocal<StepLoggerHolder?> s_currentStep = new();
 
     /// <summary>
     /// Gets or sets the current logger for the executing pipeline step.
     /// </summary>
-    public static ILogger CurrentLogger
+    public static IReportingStep? CurrentStep
     {
-        get => s_currentLogger.Value?.Logger ?? NullLogger.Instance;
+        get => s_currentStep.Value?.Step;
         set
         {
             // Clear the current logger from AsyncLocal context
-            s_currentLogger.Value = null;
+            s_currentStep.Value = null;
 
             if (value is not null && value != NullLogger.Instance)
             {
                 // Use an object indirection to hold the logger in the AsyncLocal,
                 // so it can be cleared in all ExecutionContexts when cleared.
-                s_currentLogger.Value = new StepLoggerHolder { Logger = value };
+                s_currentStep.Value = new StepLoggerHolder { Step = value };
             }
         }
     }
 
     /// <inheritdoc/>
     public ILogger CreateLogger(string categoryName) =>
-        new PipelineLogger(() => CurrentLogger);
+        new StepLogger(() => CurrentStep, options.Value);
 
     /// <inheritdoc/>
     public void Dispose()
@@ -52,7 +55,7 @@ internal sealed class PipelineLoggerProvider : ILoggerProvider
     /// </summary>
     private sealed class StepLoggerHolder
     {
-        public ILogger? Logger;
+        public IReportingStep? Step;
     }
 
     /// <summary>
@@ -63,18 +66,36 @@ internal sealed class PipelineLoggerProvider : ILoggerProvider
     /// allowing the target logger to change between calls.
     /// When logging exceptions, stack traces are only included when the configured minimum log level is Debug or Trace.
     /// </remarks>
-    private sealed class PipelineLogger(Func<ILogger> currentLoggerAccessor) : ILogger
+    private sealed class StepLogger(Func<IReportingStep?> currentStepAccessor, PipelineLoggingOptions options) : ILogger
     {
         /// <inheritdoc/>
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull =>
-            currentLoggerAccessor().BeginScope(state);
+            null;
 
         /// <inheritdoc/>
         public bool IsEnabled(LogLevel logLevel) =>
-            currentLoggerAccessor().IsEnabled(logLevel);
+            true;
 
         /// <inheritdoc/>
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
-            currentLoggerAccessor().Log(logLevel, eventId, state, exception, formatter);
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var step = currentStepAccessor();
+
+            if (step is null)
+            {
+                // No current step logger; nothing to log to
+                return;
+            }
+
+            // Also log to the step logger (for publishing output display)
+            var message = formatter(state, exception);
+
+            if (options.IncludeExceptionDetails && exception != null)
+            {
+                message = $"{message} {exception}";
+            }
+
+            step.Log(logLevel, message, enableMarkdown: false);
+        }
     }
 }

--- a/src/Aspire.Hosting/Pipelines/PipelineLoggingOptions.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineLoggingOptions.cs
@@ -18,8 +18,5 @@ internal sealed class PipelineLoggingOptions
     /// <summary>
     /// Gets a value indicating whether exception details (stack traces) should be included in logs.
     /// </summary>
-    /// <remarks>
-    /// Exception details are included when the minimum log level is Debug or Trace.
-    /// </remarks>
-    public bool IncludeExceptionDetails => MinimumLogLevel <= LogLevel.Debug;
+    public bool IncludeExceptionDetails { get; set; }
 }

--- a/src/Aspire.Hosting/Pipelines/PipelineStepContext.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineStepContext.cs
@@ -3,9 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Pipelines;
 
@@ -47,12 +45,10 @@ public sealed class PipelineStepContext
     /// </summary>
     public IServiceProvider Services => PipelineContext.Services;
 
-    internal PipelineLoggingOptions PipelineLoggingOptions => Services.GetRequiredService<IOptions<PipelineLoggingOptions>>().Value;
-
     /// <summary>
     /// Gets the logger for pipeline operations that writes to both the pipeline logger and the step logger.
     /// </summary>
-    public ILogger Logger => field ??= new StepLogger(ReportingStep, PipelineLoggingOptions);
+    public ILogger Logger => PipelineContext.Logger;
 
     /// <summary>
     /// Gets the cancellation token for the pipeline operation.
@@ -63,37 +59,4 @@ public sealed class PipelineStepContext
     /// Gets the output path for deployment artifacts.
     /// </summary>
     public string? OutputPath => PipelineContext.OutputPath;
-}
-
-/// <summary>
-/// A logger that writes to the step logger.
-/// </summary>
-[Experimental("ASPIREPIPELINES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-internal sealed class StepLogger(IReportingStep step, PipelineLoggingOptions options) : ILogger
-{
-    private readonly IReportingStep _step = step;
-    private readonly PipelineLoggingOptions _options = options;
-
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
-    {
-        return null;
-    }
-
-    public bool IsEnabled(LogLevel logLevel)
-    {
-        return true;
-    }
-
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-    {
-        // Also log to the step logger (for publishing output display)
-        var message = formatter(state, exception);
-
-        if (_options.IncludeExceptionDetails && exception != null)
-        {
-            message = $"{message} {exception}";
-        }
-
-        _step.Log(logLevel, message, enableMarkdown: false);
-    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1183,7 +1183,7 @@ public class AzureDeployerTests
         public List<(string TaskStatusText, string StatusText)> UpdatedTasks { get; } = [];
         public List<(string StepTitle, LogLevel LogLevel, string Message)> LoggedMessages { get; } = [];
 
-        public Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, bool isDeploy = false, CancellationToken cancellationToken = default)
+        public Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, CancellationToken cancellationToken = default)
         {
             CompletePublishCalled = true;
             CompletionMessage = completionMessage;

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -1132,7 +1132,7 @@ public class DistributedApplicationPipelineTests
             step1Logger = loggerFactory.CreateLogger("Step1Category");
 
             // Verify this step has its own contextual logger
-            Assert.Same(context.Logger, PipelineLoggerProvider.CurrentLogger);
+            Assert.Same(context.ReportingStep, PipelineLoggerProvider.CurrentStep);
 
             step1Logger.LogInformation("Message from step 1");
             await Task.CompletedTask;
@@ -1144,7 +1144,7 @@ public class DistributedApplicationPipelineTests
             step2Logger = loggerFactory.CreateLogger("Step2Category");
 
             // Verify this step has its own contextual logger (different from step1)
-            Assert.Same(context.Logger, PipelineLoggerProvider.CurrentLogger);
+            Assert.Same(context.ReportingStep, PipelineLoggerProvider.CurrentStep);
 
             step2Logger.LogInformation("Message from step 2");
             return Task.CompletedTask;
@@ -1220,8 +1220,8 @@ public class DistributedApplicationPipelineTests
                 Assert.Equal(step2Activity.First().Data.Id, logActivity.Data.StepId);
             });
 
-        // After execution, current logger should be NullLogger
-        Assert.Same(NullLogger.Instance, PipelineLoggerProvider.CurrentLogger);
+        // After execution, current step should be null
+        Assert.Null(PipelineLoggerProvider.CurrentStep);
     }
 
     [Fact]
@@ -1282,7 +1282,7 @@ public class DistributedApplicationPipelineTests
         Assert.Equal(failingStepActivity.First().Data.Id, aboutToFailLogActivity.Data.StepId);
 
         // Verify logger is cleaned up even after failure
-        Assert.Same(NullLogger.Instance, PipelineLoggerProvider.CurrentLogger);
+        Assert.Null(PipelineLoggerProvider.CurrentStep);
     }
 
     [Fact]
@@ -1297,17 +1297,17 @@ public class DistributedApplicationPipelineTests
         builder.Services.AddSingleton<IPipelineActivityReporter>(reporter);
 
         var pipeline = new DistributedApplicationPipeline();
-        var capturedLoggers = new List<ILogger>();
+        var capturedSteps = new List<IReportingStep?>();
 
         for (var i = 1; i <= 3; i++)
         {
             var stepNumber = i; // Capture for closure
             pipeline.AddStep($"step{stepNumber}", (context) =>
             {
-                // Capture the current logger for this step
-                lock (capturedLoggers)
+                // Capture the current step for this step
+                lock (capturedSteps)
                 {
-                    capturedLoggers.Add(PipelineLoggerProvider.CurrentLogger);
+                    capturedSteps.Add(PipelineLoggerProvider.CurrentStep);
                 }
 
                 var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
@@ -1324,14 +1324,14 @@ public class DistributedApplicationPipelineTests
         await pipeline.ExecuteAsync(context);
 
         // Assert
-        Assert.Equal(3, capturedLoggers.Count);
+        Assert.Equal(3, capturedSteps.Count);
 
-        // Each step should have had a different logger context
+        // Each step should have had a different step context
         // (We can't easily verify they're different instances since they're created per step,
-        // but we can verify none of them are NullLogger during execution)
-        foreach (var logger in capturedLoggers)
+        // but we can verify none of them are null during execution)
+        foreach (var step in capturedSteps)
         {
-            Assert.NotSame(NullLogger.Instance, logger);
+            Assert.NotNull(step);
         }
 
         // Collect all activities for easier assertion
@@ -1377,8 +1377,8 @@ public class DistributedApplicationPipelineTests
             Assert.Contains(stepActivities, stepGroup => stepGroup.First().Data.Id == logActivity.Data.StepId);
         }
 
-        // After all steps complete, should be back to NullLogger
-        Assert.Same(NullLogger.Instance, PipelineLoggerProvider.CurrentLogger);
+        // After all steps complete, should be back to null
+        Assert.Null(PipelineLoggerProvider.CurrentStep);
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Tests/Pipelines/PipelineLoggerProviderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/PipelineLoggerProviderTests.cs
@@ -5,42 +5,41 @@
 
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Tests.Pipelines;
 
 public class PipelineLoggerProviderTests
 {
     [Fact]
-    public void CurrentLogger_WhenNotSet_ReturnsNullLogger()
+    public void CurrentLogger_WhenNotSet_ReturnsNull()
     {
         // Arrange & Act
-        var currentLogger = PipelineLoggerProvider.CurrentLogger;
+        var currentStep = PipelineLoggerProvider.CurrentStep;
 
         // Assert
-        Assert.Same(NullLogger.Instance, currentLogger);
+        Assert.Null(currentStep);
     }
 
     [Fact]
     public void CurrentLogger_WhenSetToValidLogger_ReturnsSetLogger()
     {
         // Arrange
-        var testLogger = new FakeLogger();
+        var testStep = new FakeReportingStep();
 
         try
         {
             // Act
-            PipelineLoggerProvider.CurrentLogger = testLogger;
-            var retrievedLogger = PipelineLoggerProvider.CurrentLogger;
+            PipelineLoggerProvider.CurrentStep = testStep;
+            var retrievedStep = PipelineLoggerProvider.CurrentStep;
 
             // Assert
-            Assert.Same(testLogger, retrievedLogger);
+            Assert.Same(testStep, retrievedStep);
         }
         finally
         {
             // Cleanup
-            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+            PipelineLoggerProvider.CurrentStep = null;
         }
     }
 
@@ -48,22 +47,22 @@ public class PipelineLoggerProviderTests
     public void CurrentLogger_WhenSetToNull_ReturnsNullLogger()
     {
         // Arrange
-        var testLogger = new FakeLogger();
-        PipelineLoggerProvider.CurrentLogger = testLogger;
+        var testStep = new FakeReportingStep();
+        PipelineLoggerProvider.CurrentStep = testStep;
 
         try
         {
             // Act
-            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
-            var retrievedLogger = PipelineLoggerProvider.CurrentLogger;
+            PipelineLoggerProvider.CurrentStep = null;
+            var retrievedStep = PipelineLoggerProvider.CurrentStep;
 
             // Assert
-            Assert.Same(NullLogger.Instance, retrievedLogger);
+            Assert.Null(retrievedStep);
         }
         finally
         {
             // Cleanup
-            PipelineLoggerProvider.CurrentLogger = NullLogger.Instance;
+            PipelineLoggerProvider.CurrentStep = null;
         }
     }
 
@@ -71,7 +70,8 @@ public class PipelineLoggerProviderTests
     public void CreateLogger_ReturnsValidLogger()
     {
         // Arrange
-        var provider = new PipelineLoggerProvider();
+        var options = Options.Create(new PipelineLoggingOptions());
+        var provider = new PipelineLoggerProvider(options);
 
         // Act
         var logger = provider.CreateLogger("TestCategory");
@@ -84,14 +84,15 @@ public class PipelineLoggerProviderTests
     public async Task CurrentLogger_IsAsyncLocal_IsolatedBetweenTasks()
     {
         // Arrange
-        var fakeLogger1 = new FakeLogger();
-        var fakeLogger2 = new FakeLogger();
-        var provider = new PipelineLoggerProvider();
+        var fakeStep1 = new FakeReportingStep();
+        var fakeStep2 = new FakeReportingStep();
+        var options = Options.Create(new PipelineLoggingOptions());
+        var provider = new PipelineLoggerProvider(options);
 
         // Act
         var task1 = Task.Run(async () =>
         {
-            PipelineLoggerProvider.CurrentLogger = fakeLogger1;
+            PipelineLoggerProvider.CurrentStep = fakeStep1;
             var logger = provider.CreateLogger("Task1");
 
             logger.LogInformation("Task 1 message");
@@ -99,7 +100,7 @@ public class PipelineLoggerProviderTests
 
         var task2 = Task.Run(async () =>
         {
-            PipelineLoggerProvider.CurrentLogger = fakeLogger2;
+            PipelineLoggerProvider.CurrentStep = fakeStep2;
             var logger = provider.CreateLogger("Task2");
 
             logger.LogInformation("Task 2 message");
@@ -108,14 +109,41 @@ public class PipelineLoggerProviderTests
         await Task.WhenAll(task1, task2);
 
         // Assert
-        var logs1 = fakeLogger1.Collector.GetSnapshot();
+        var logs1 = fakeStep1.LoggedMessages;
         var logEntry1 = Assert.Single(logs1);
         Assert.Equal(LogLevel.Information, logEntry1.Level);
         Assert.Equal("Task 1 message", logEntry1.Message);
 
-        var logs2 = fakeLogger2.Collector.GetSnapshot();
+        var logs2 = fakeStep2.LoggedMessages;
         var logEntry2 = Assert.Single(logs2);
         Assert.Equal(LogLevel.Information, logEntry2.Level);
         Assert.Equal("Task 2 message", logEntry2.Message);
+    }
+}
+
+public class FakeReportingStep : IReportingStep
+{
+    public List<(LogLevel Level, string Message)> LoggedMessages { get; } = [];
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<IReportingTask> CreateTaskAsync(string statusText, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task CompleteAsync(string statusText, CompletionState completionState, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task FailAsync(string errorText, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Log(LogLevel logLevel, string message, bool enableMarkdown = false)
+    {
+        LoggedMessages.Add((logLevel, message));
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
@@ -287,7 +287,7 @@ public class PublishingActivityReporterTests
         var reporter = CreatePublishingReporter();
 
         // Act
-        await reporter.CompletePublishAsync(null, completionState, isDeploy: false, CancellationToken.None);
+        await reporter.CompletePublishAsync(null, completionState, CancellationToken.None);
 
         // Assert
         var activityReader = reporter.ActivityItemUpdated.Reader;
@@ -308,7 +308,7 @@ public class PublishingActivityReporterTests
         var expectedStatusText = "Some error occurred";
 
         // Act
-        await reporter.CompletePublishAsync(expectedStatusText, CompletionState.CompletedWithError, isDeploy: false, CancellationToken.None);
+        await reporter.CompletePublishAsync(expectedStatusText, CompletionState.CompletedWithError, CancellationToken.None);
 
         // Assert
         var activityReader = reporter.ActivityItemUpdated.Reader;
@@ -348,7 +348,7 @@ public class PublishingActivityReporterTests
         while (activityReader.TryRead(out _)) { }
 
         // Act - Complete publish without specifying state (should aggregate)
-        await reporter.CompletePublishAsync(isDeploy: false, cancellationToken: CancellationToken.None);
+        await reporter.CompletePublishAsync(cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.True(activityReader.TryRead(out var activity));
@@ -753,7 +753,7 @@ public class PublishingActivityReporterTests
         var reporter = CreatePublishingReporter();
 
         // Act
-        await reporter.CompletePublishAsync(null, completionState, isDeploy: true, CancellationToken.None);
+        await reporter.CompletePublishAsync(null, completionState, CancellationToken.None);
 
         // Assert
         var activityReader = reporter.ActivityItemUpdated.Reader;
@@ -774,7 +774,7 @@ public class PublishingActivityReporterTests
         var expectedStatusText = "Some deployment error occurred";
 
         // Act
-        await reporter.CompletePublishAsync(expectedStatusText, CompletionState.CompletedWithError, isDeploy: true, CancellationToken.None);
+        await reporter.CompletePublishAsync(expectedStatusText, CompletionState.CompletedWithError, CancellationToken.None);
 
         // Assert
         var activityReader = reporter.ActivityItemUpdated.Reader;


### PR DESCRIPTION
## Description

- Including stack traces in logs of steps is another flag
- Step loggers are normal ILoggers and Logging to the current step is via an async local and PipelineLoggerProvider.
- Wrap everything in an ephemeral step to support the same logging patterns for errors that happen *before* pipeline execution.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No

Fixes https://github.com/dotnet/aspire/issues/12388
