### PR TITLE
Refactor YarpResource and add PublishWithStaticFiles method for Dockerfile

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -279,10 +279,6 @@
   <Folder Name="/playground/python/">
     <Project Path="playground/python/Python.AppHost/Python.AppHost.csproj" />
   </Folder>
-  <Folder Name="/playground/pythonweb/">
-    <Project Path="playground/AspireWithPython/AspireWithPython.AppHost/AspireWithPython.AppHost.csproj" />
-    <Project Path="playground/AspireWithPython/AspireWithPython.ServiceDefaults/AspireWithPython.ServiceDefaults.csproj" />
-  </Folder>
   <Folder Name="/playground/qdrant/">
     <Project Path="playground/Qdrant/Qdrant.ApiService/Qdrant.ApiService.csproj" />
     <Project Path="playground/Qdrant/Qdrant.AppHost/Qdrant.AppHost.csproj" />

--- a/src/Aspire.Hosting.Yarp/YarpResource.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResource.cs
@@ -1,17 +1,36 @@
+#pragma warning disable ASPIREPIPELINES001
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Pipelines;
 
 namespace Aspire.Hosting.Yarp;
 
 /// <summary>
 /// A resource that represents a YARP resource independent of the hosting model.
 /// </summary>
-/// <param name="name">The name of the resource.</param>
-public class YarpResource(string name) : ContainerResource(name), IResourceWithServiceDiscovery
+public class YarpResource : ContainerResource, IResourceWithServiceDiscovery
 {
-    internal List<YarpRoute> Routes { get; } = new ();
+    internal List<YarpRoute> Routes { get; } = [];
 
-    internal List<YarpCluster> Clusters { get; } = new ();
+    internal List<YarpCluster> Clusters { get; } = [];
+
+    /// <param name="name">The name of the resource.</param>
+    public YarpResource(string name) : base(name)
+    {
+        Annotations.Add(new PipelineConfigurationAnnotation(context =>
+        {
+            // Ensure any static file references' images are built first
+            if (this.TryGetAnnotationsOfType<ContainerFilesDestinationAnnotation>(out var containerFilesAnnotations))
+            {
+                var buildSteps = context.GetSteps(this, WellKnownPipelineTags.BuildCompute);
+
+                foreach (var containerFile in containerFilesAnnotations)
+                {
+                    buildSteps.DependsOn(context.GetSteps(containerFile.Source, WellKnownPipelineTags.BuildCompute));
+                }
+            }
+        }));
+    }
 }

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -122,10 +122,7 @@ public static class YarpResourceExtensions
         {
             builder.WithDockerfileFactory(sourcePath, ctx =>
             {
-                if (!ctx.Resource.TryGetContainerImageName(useBuiltImage: false, out var imageName) || string.IsNullOrEmpty(imageName))
-                {
-                    imageName = $"{YarpContainerImageTags.Image}:{YarpContainerImageTags.Tag}";
-                }
+                var imageName = GetYarpImageName(ctx.Resource);
 
                 return $"""
                 FROM {imageName} AS yarp
@@ -164,13 +161,8 @@ public static class YarpResourceExtensions
                    var logger = ctx.Services.GetRequiredService<ILogger<YarpResource>>();
                    var source = resourceWithFiles.Resource;
 
-                   if (!ctx.Resource.TryGetContainerImageName(useBuiltImage: false, out var imageName) || string.IsNullOrEmpty(imageName))
-                   {
-                       imageName = $"{YarpContainerImageTags.Image}:{YarpContainerImageTags.Tag}";
-                   }
-
-                   var stage = ctx.Builder.From(imageName, "yarp")
-                              .WorkDir("/app");
+                   var imageName = GetYarpImageName(ctx.Resource);
+                   var stage = ctx.Builder.From(imageName);
 
                    if (!source.TryGetContainerImageName(out var sourceImageName))
                    {
@@ -185,4 +177,13 @@ public static class YarpResourceExtensions
                });
     }
 
+    private static string GetYarpImageName(IResource resource)
+    {
+        if (!resource.TryGetContainerImageName(useBuiltImage: false, out var imageName) || string.IsNullOrEmpty(imageName))
+        {
+            imageName = $"{YarpContainerImageTags.Image}:{YarpContainerImageTags.Tag}";
+        }
+
+        return imageName;
+    }
 }

--- a/tests/Aspire.Hosting.Yarp.Tests/AddYarpTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/AddYarpTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREDOCKERFILEBUILDER001
+
 using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;
@@ -199,5 +201,148 @@ public class AddYarpTests(ITestOutputHelper testOutputHelper)
         Assert.Contains("AS yarp", dockerfile);
         Assert.Contains("WORKDIR /app", dockerfile);
         Assert.Contains("COPY . /app/wwwroot", dockerfile);
+    }
+
+    [Fact]
+    public void VerifyPublishWithStaticFilesDoesNothingInRunMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        // Create a test container resource that implements IResourceWithContainerFiles
+        var sourceContainerResource = new TestContainerFilesResource("source");
+        var sourceContainer = builder.AddResource(sourceContainerResource)
+            .WithImage("myimage")
+            .WithAnnotation(new ContainerFilesSourceAnnotation { SourcePath = "/app/dist" });
+
+        var yarp = builder.AddYarp("yarp").PublishWithStaticFiles(sourceContainer);
+
+        // In run mode, PublishWithStaticFiles should not add any annotations
+        Assert.Empty(yarp.Resource.Annotations.OfType<ContainerFilesDestinationAnnotation>());
+        Assert.Empty(yarp.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
+    }
+
+    [Fact]
+    public async Task VerifyPublishWithStaticFilesAddsEnvironmentVariableInPublishMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // Create a test container resource that implements IResourceWithContainerFiles
+        var sourceContainerResource = new TestContainerFilesResource("source");
+        var sourceContainer = builder.AddResource(sourceContainerResource)
+            .WithImage("myimage")
+            .WithAnnotation(new ContainerFilesSourceAnnotation { SourcePath = "/app/dist" });
+
+        var yarp = builder.AddYarp("yarp").PublishWithStaticFiles(sourceContainer);
+
+        // Verify ContainerFilesDestinationAnnotation was added
+        var containerFilesAnnotation = Assert.Single(yarp.Resource.Annotations.OfType<ContainerFilesDestinationAnnotation>());
+        Assert.Equal(sourceContainer.Resource, containerFilesAnnotation.Source);
+        Assert.Equal("/app/wwwroot", containerFilesAnnotation.DestinationPath);
+
+        // Verify static files environment variable was set
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(yarp.Resource, DistributedApplicationOperation.Publish, TestServiceProvider.Instance);
+        var value = Assert.Contains("YARP_ENABLE_STATIC_FILES", env);
+        Assert.Equal("true", value);
+
+        // Verify DockerfileBuildAnnotation was added (instead of DockerfileBuilderCallbackAnnotation)
+        Assert.Single(yarp.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
+    }
+
+    [Fact]
+    public async Task VerifyPublishWithStaticFilesGeneratesCorrectDockerfile()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // Create a test container resource that implements IResourceWithContainerFiles
+        var sourceContainerResource = new TestContainerFilesResource("source");
+        var sourceContainer = builder.AddResource(sourceContainerResource)
+            .WithImage("sourceimage")
+            .WithAnnotation(new ContainerFilesSourceAnnotation { SourcePath = "/app/dist" });
+
+        var yarp = builder.AddYarp("yarp").PublishWithStaticFiles(sourceContainer);
+
+        // Get the DockerfileBuildAnnotation (added by WithDockerfileBuilder)
+        var buildAnnotation = Assert.Single(yarp.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
+        Assert.NotNull(buildAnnotation.DockerfileFactory);
+
+        using var app = builder.Build();
+
+        var context = new DockerfileFactoryContext
+        {
+            Resource = yarp.Resource,
+            Services = app.Services,
+            CancellationToken = CancellationToken.None
+        };
+
+        var dockerfile = await buildAnnotation.DockerfileFactory(context);
+
+        await Verify(dockerfile);
+    }
+
+    [Fact]
+    public async Task VerifyPublishWithStaticFilesHandlesMissingSourceImageGracefully()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // Create a test container resource without an image name
+        var sourceContainerResource = new TestContainerFilesResource("source");
+        var sourceContainer = builder.AddResource(sourceContainerResource)
+            .WithAnnotation(new ContainerFilesSourceAnnotation { SourcePath = "/app/dist" });
+
+        var yarp = builder.AddYarp("yarp").PublishWithStaticFiles(sourceContainer);
+
+        // Get the DockerfileBuildAnnotation
+        var buildAnnotation = Assert.Single(yarp.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
+        Assert.NotNull(buildAnnotation.DockerfileFactory);
+
+        // Build the app to get service provider
+        using var app = builder.Build();
+
+        var context = new DockerfileFactoryContext
+        {
+            Resource = yarp.Resource,
+            Services = app.Services,
+            CancellationToken = CancellationToken.None
+        };
+
+        var dockerfile = await buildAnnotation.DockerfileFactory(context);
+
+        await Verify(dockerfile);
+    }
+
+    [Fact]
+    public async Task VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleContainerFiles()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // Create a test container resource with multiple container file sources
+        var sourceContainerResource = new TestContainerFilesResource("source");
+        var sourceContainer = builder.AddResource(sourceContainerResource)
+            .WithImage("sourceimage")
+            .WithAnnotation(new ContainerFilesSourceAnnotation { SourcePath = "/app/dist" })
+            .WithAnnotation(new ContainerFilesSourceAnnotation { SourcePath = "/app/assets" });
+
+        var yarp = builder.AddYarp("yarp").PublishWithStaticFiles(sourceContainer);
+
+        // Get the DockerfileBuildAnnotation
+        var buildAnnotation = Assert.Single(yarp.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
+        Assert.NotNull(buildAnnotation.DockerfileFactory);
+
+        using var app = builder.Build();
+
+        var context = new DockerfileFactoryContext
+        {
+            Resource = yarp.Resource,
+            Services = app.Services,
+            CancellationToken = CancellationToken.None
+        };
+
+        var dockerfile = await buildAnnotation.DockerfileFactory(context);
+
+        await Verify(dockerfile);
+    }
+
+    private sealed class TestContainerFilesResource(string name) : ContainerResource(name), IResourceWithContainerFiles
+    {
     }
 }

--- a/tests/Aspire.Hosting.Yarp.Tests/AddYarpTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/AddYarpTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREDOCKERFILEBUILDER001
-
 using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfile.verified.txt
@@ -1,3 +1,2 @@
-﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4 AS yarp
-WORKDIR /app
+﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
 COPY --from=sourceimage:latest /app/dist /app/wwwroot

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfile.verified.txt
@@ -1,0 +1,3 @@
+﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4 AS yarp
+WORKDIR /app
+COPY --from=sourceimage:latest /app/dist /app/wwwroot

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleContainerFiles.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleContainerFiles.verified.txt
@@ -1,0 +1,4 @@
+﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4 AS yarp
+WORKDIR /app
+COPY --from=sourceimage:latest /app/dist /app/wwwroot
+COPY --from=sourceimage:latest /app/assets /app/wwwroot

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleContainerFiles.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleContainerFiles.verified.txt
@@ -1,4 +1,3 @@
-﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4 AS yarp
-WORKDIR /app
+﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
 COPY --from=sourceimage:latest /app/dist /app/wwwroot
 COPY --from=sourceimage:latest /app/assets /app/wwwroot

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleSourceContainerFiles.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleSourceContainerFiles.verified.txt
@@ -1,0 +1,5 @@
+﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
+COPY --from=sourceimage:latest /app/dist /app/wwwroot
+COPY --from=sourceimage:latest /app/assets /app/wwwroot
+COPY --from=sourceimage2:latest /app/dist2 /app/wwwroot
+COPY --from=sourceimage2:latest /app/assets2 /app/wwwroot

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesHandlesMissingSourceImageGracefully.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesHandlesMissingSourceImageGracefully.verified.txt
@@ -1,0 +1,2 @@
+﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4 AS yarp
+WORKDIR /app

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesHandlesMissingSourceImageGracefully.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesHandlesMissingSourceImageGracefully.verified.txt
@@ -1,2 +1,1 @@
-﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4 AS yarp
-WORKDIR /app
+﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4


### PR DESCRIPTION
## Description

Support yarp accepting resources with  IResourceWithContainerFiles as static files.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates): [[New article]: Add docs for PublishWithContainerFiles (dotnet/docs-aspire#5351)](https://github.com/dotnet/docs-aspire/issues/5351)
