### PR TITLE
Revert "Update dependencies from https://github.com/dotnet/arcade build 20251024.1 (#12399)"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -159,33 +159,33 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25524.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25509.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>904bfd153de2a88471c00a7cdd3450948e758db8</Sha>
+      <Sha>488413fe104056170673a048a07906314e101e5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="11.0.0-beta.25524.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="11.0.0-beta.25509.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>904bfd153de2a88471c00a7cdd3450948e758db8</Sha>
+      <Sha>488413fe104056170673a048a07906314e101e5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25524.1">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25509.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>904bfd153de2a88471c00a7cdd3450948e758db8</Sha>
+      <Sha>488413fe104056170673a048a07906314e101e5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.25524.1">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.25509.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>904bfd153de2a88471c00a7cdd3450948e758db8</Sha>
+      <Sha>488413fe104056170673a048a07906314e101e5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.25524.1">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.25509.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>904bfd153de2a88471c00a7cdd3450948e758db8</Sha>
+      <Sha>488413fe104056170673a048a07906314e101e5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitV3Extensions" Version="11.0.0-beta.25524.1">
+    <Dependency Name="Microsoft.DotNet.XUnitV3Extensions" Version="11.0.0-beta.25509.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>904bfd153de2a88471c00a7cdd3450948e758db8</Sha>
+      <Sha>488413fe104056170673a048a07906314e101e5d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="11.0.0-beta.25524.1">
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="11.0.0-beta.25509.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>904bfd153de2a88471c00a7cdd3450948e758db8</Sha>
+      <Sha>488413fe104056170673a048a07906314e101e5d</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,9 +37,9 @@
     <MicrosoftDeveloperControlPlanewindowsamd64Version>0.18.8</MicrosoftDeveloperControlPlanewindowsamd64Version>
     <MicrosoftDeveloperControlPlanewindowsarm64Version>0.18.8</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
-    <MicrosoftDotNetRemoteExecutorVersion>11.0.0-beta.25524.1</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetXUnitV3ExtensionsVersion>11.0.0-beta.25524.1</MicrosoftDotNetXUnitV3ExtensionsVersion>
-    <MicrosoftDotNetBuildTasksArchivesVersion>11.0.0-beta.25524.1</MicrosoftDotNetBuildTasksArchivesVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>11.0.0-beta.25509.1</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetXUnitV3ExtensionsVersion>11.0.0-beta.25509.1</MicrosoftDotNetXUnitV3ExtensionsVersion>
+    <MicrosoftDotNetBuildTasksArchivesVersion>11.0.0-beta.25509.1</MicrosoftDotNetBuildTasksArchivesVersion>
     <!-- dotnet/extensions -->
     <MicrosoftExtensionsAIVersion>9.10.1</MicrosoftExtensionsAIVersion>
     <MicrosoftExtensionsAIPreviewVersion>9.10.0-preview.1.25513.3</MicrosoftExtensionsAIPreviewVersion>

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -66,8 +66,10 @@ EnableInternalPackageSource() {
     grep -i "<add key=\"$PackageSourceName\" value=\"true\"" "$ConfigFile" > /dev/null
     if [ "$?" == "0" ]; then
         echo "Enabling internal source '$PackageSourceName'."
-        # Remove the disabled entry (including any surrounding comments or whitespace on the same line)
-        sed -i.bak "/<add key=\"$PackageSourceName\" value=\"true\" \/>/d" "$ConfigFile"
+        # Remove the disabled entry
+        local OldDisableValue="<add key=\"$PackageSourceName\" value=\"true\" />"
+        local NewDisableValue="<!-- Reenabled for build : $PackageSourceName -->"
+        sed -i.bak "s|$OldDisableValue|$NewDisableValue|" "$ConfigFile"
         
         # Add the source name to PackageSources for credential handling
         PackageSources+=("$PackageSourceName")

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -91,8 +91,8 @@ jobs:
       fetchDepth: 3
       clean: true
 
-    - ${{ if eq(parameters.isAssetlessBuild, 'false') }}:
-      - ${{ if eq(parameters.publishingVersion, 3) }}:
+    - ${{ if eq(parameters.isAssetlessBuild, 'false') }}: 
+      - ${{ if eq(parameters.publishingVersion, 3) }}: 
         - task: DownloadPipelineArtifact@2
           displayName: Download Asset Manifests
           inputs:
@@ -117,15 +117,8 @@ jobs:
             flattenFolders: true
           condition: ${{ parameters.condition }}
           continueOnError: ${{ parameters.continueOnError }}
-
+    
     - task: NuGetAuthenticate@1
-
-    # Populate internal runtime variables.
-    - template: /eng/common/templates/steps/enable-internal-sources.yml
-      parameters:
-        legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
-
-    - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 
     - task: AzureCLI@2
       displayName: Publish Build Assets
@@ -139,12 +132,9 @@ jobs:
           /p:IsAssetlessBuild=${{ parameters.isAssetlessBuild }}
           /p:MaestroApiEndpoint=https://maestro.dot.net
           /p:OfficialBuildId=$(OfficialBuildId)
-          -runtimeSourceFeed https://ci.dot.net/internal
-          -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
-
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-
+    
     - task: powershell@2
       displayName: Create ReleaseConfigs Artifact
       inputs:
@@ -172,7 +162,7 @@ jobs:
             artifactName: AssetManifests
             displayName: 'Publish Merged Manifest'
             retryCountOnTaskFailure: 10 # for any logs being locked
-            sbomEnabled: false # we don't need SBOM for logs
+            sbomEnabled: false  # we don't need SBOM for logs
 
     - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
       parameters:
@@ -205,11 +195,9 @@ jobs:
             -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
             -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
             -SkipAssetsPublishing '${{ parameters.isAssetlessBuild }}'
-            -runtimeSourceFeed https://ci.dot.net/internal 
-            -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
 
     - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
       - template: /eng/common/core-templates/steps/publish-logs.yml
         parameters:
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
-          JobLabel: 'Publish_Artifacts_Logs'
+          JobLabel: 'Publish_Artifacts_Logs'     

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -1,106 +1,106 @@
 parameters:
-# Which publishing infra should be used. THIS SHOULD MATCH THE VERSION ON THE BUILD MANIFEST.
-# Publishing V1 is no longer supported
-# Publishing V2 is no longer supported
-# Publishing V3 is the default
-- name: publishingInfraVersion
-  displayName: Which version of publishing should be used to promote the build definition?
-  type: number
-  default: 3
-  values:
-  - 3
+  # Which publishing infra should be used. THIS SHOULD MATCH THE VERSION ON THE BUILD MANIFEST.
+  # Publishing V1 is no longer supported
+  # Publishing V2 is no longer supported
+  # Publishing V3 is the default
+  - name: publishingInfraVersion
+    displayName: Which version of publishing should be used to promote the build definition?
+    type: number
+    default: 3
+    values:
+    - 3
 
-- name: BARBuildId
-  displayName: BAR Build Id
-  type: number
-  default: 0
+  - name: BARBuildId
+    displayName: BAR Build Id
+    type: number
+    default: 0
 
-- name: PromoteToChannelIds
-  displayName: Channel to promote BARBuildId to
-  type: string
-  default: ''
+  - name: PromoteToChannelIds
+    displayName: Channel to promote BARBuildId to
+    type: string
+    default: ''
 
-- name: enableSourceLinkValidation
-  displayName: Enable SourceLink validation
-  type: boolean
-  default: false
+  - name: enableSourceLinkValidation
+    displayName: Enable SourceLink validation
+    type: boolean
+    default: false
 
-- name: enableSigningValidation
-  displayName: Enable signing validation
-  type: boolean
-  default: true
+  - name: enableSigningValidation
+    displayName: Enable signing validation
+    type: boolean
+    default: true
 
-- name: enableSymbolValidation
-  displayName: Enable symbol validation
-  type: boolean
-  default: false
+  - name: enableSymbolValidation
+    displayName: Enable symbol validation
+    type: boolean
+    default: false
 
-- name: enableNugetValidation
-  displayName: Enable NuGet validation
-  type: boolean
-  default: true
+  - name: enableNugetValidation
+    displayName: Enable NuGet validation
+    type: boolean
+    default: true
+    
+  - name: publishInstallersAndChecksums
+    displayName: Publish installers and checksums
+    type: boolean
+    default: true
+    
+  - name: requireDefaultChannels
+    displayName: Fail the build if there are no default channel(s) registrations for the current build
+    type: boolean
+    default: false
 
-- name: publishInstallersAndChecksums
-  displayName: Publish installers and checksums
-  type: boolean
-  default: true
+  - name: SDLValidationParameters
+    type: object
+    default:
+      enable: false
+      publishGdn: false
+      continueOnError: false
+      params: ''
+      artifactNames: ''
+      downloadArtifacts: true
 
-- name: requireDefaultChannels
-  displayName: Fail the build if there are no default channel(s) registrations for the current build
-  type: boolean
-  default: false
+  - name: isAssetlessBuild
+    type: boolean
+    displayName: Is Assetless Build
+    default: false
 
-- name: SDLValidationParameters
-  type: object
-  default:
-    enable: false
-    publishGdn: false
-    continueOnError: false
-    params: ''
-    artifactNames: ''
-    downloadArtifacts: true
+  # These parameters let the user customize the call to sdk-task.ps1 for publishing
+  # symbols & general artifacts as well as for signing validation
+  - name: symbolPublishingAdditionalParameters
+    displayName: Symbol publishing additional parameters
+    type: string
+    default: ''
 
-- name: isAssetlessBuild
-  type: boolean
-  displayName: Is Assetless Build
-  default: false
+  - name: artifactsPublishingAdditionalParameters
+    displayName: Artifact publishing additional parameters
+    type: string
+    default: ''
 
-# These parameters let the user customize the call to sdk-task.ps1 for publishing
-# symbols & general artifacts as well as for signing validation
-- name: symbolPublishingAdditionalParameters
-  displayName: Symbol publishing additional parameters
-  type: string
-  default: ''
+  - name: signingValidationAdditionalParameters
+    displayName: Signing validation additional parameters
+    type: string
+    default: ''
 
-- name: artifactsPublishingAdditionalParameters
-  displayName: Artifact publishing additional parameters
-  type: string
-  default: ''
+  # Which stages should finish execution before post-build stages start
+  - name: validateDependsOn
+    type: object
+    default:
+    - build
 
-- name: signingValidationAdditionalParameters
-  displayName: Signing validation additional parameters
-  type: string
-  default: ''
+  - name: publishDependsOn
+    type: object
+    default:
+    - Validate
 
-# Which stages should finish execution before post-build stages start
-- name: validateDependsOn
-  type: object
-  default:
-  - build
+  # Optional: Call asset publishing rather than running in a separate stage
+  - name: publishAssetsImmediately
+    type: boolean
+    default: false
 
-- name: publishDependsOn
-  type: object
-  default:
-  - Validate
-
-# Optional: Call asset publishing rather than running in a separate stage
-- name: publishAssetsImmediately
-  type: boolean
-  default: false
-
-- name: is1ESPipeline
-  type: boolean
-  default: false
+  - name: is1ESPipeline
+    type: boolean
+    default: false
 
 stages:
 - ${{ if or(eq( parameters.enableNugetValidation, 'true'), eq(parameters.enableSigningValidation, 'true'), eq(parameters.enableSourceLinkValidation, 'true'), eq(parameters.SDLValidationParameters.enable, 'true')) }}:
@@ -108,10 +108,10 @@ stages:
     dependsOn: ${{ parameters.validateDependsOn }}
     displayName: Validate Build Assets
     variables:
-    - template: /eng/common/core-templates/post-build/common-variables.yml
-    - template: /eng/common/core-templates/variables/pool-providers.yml
-      parameters:
-        is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/common-variables.yml
+      - template: /eng/common/core-templates/variables/pool-providers.yml
+        parameters:
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
     jobs:
     - job:
       displayName: NuGet Validation
@@ -134,28 +134,28 @@ stages:
             demands: ImageOverride -equals windows.vs2022.amd64
 
       steps:
-      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-        parameters:
-          BARBuildId: ${{ parameters.BARBuildId }}
-          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+          parameters:
+            BARBuildId: ${{ parameters.BARBuildId }}
+            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+            is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Package Artifacts
-        inputs:
-          buildType: specific
-          buildVersionToDownload: specific
-          project: $(AzDOProjectName)
-          pipeline: $(AzDOPipelineId)
-          buildId: $(AzDOBuildId)
-          artifactName: PackageArtifacts
-          checkDownloadedFiles: true
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Package Artifacts
+          inputs:
+            buildType: specific
+            buildVersionToDownload: specific
+            project: $(AzDOProjectName)
+            pipeline: $(AzDOPipelineId)
+            buildId: $(AzDOBuildId)
+            artifactName: PackageArtifacts
+            checkDownloadedFiles: true
 
-      - task: PowerShell@2
-        displayName: Validate
-        inputs:
-          filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
-          arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
+        - task: PowerShell@2
+          displayName: Validate
+          inputs:
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
+            arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
 
     - job:
       displayName: Signing Validation
@@ -169,54 +169,54 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          ${{ if eq(parameters.is1ESPipeline, true) }}:
+          ${{ if eq(parameters.is1ESPipeline, true) }}:        
             name: $(DncEngInternalBuildPool)
             image: 1es-windows-2022
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64          
       steps:
-      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-        parameters:
-          BARBuildId: ${{ parameters.BARBuildId }}
-          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+          parameters:
+            BARBuildId: ${{ parameters.BARBuildId }}
+            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+            is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Package Artifacts
-        inputs:
-          buildType: specific
-          buildVersionToDownload: specific
-          project: $(AzDOProjectName)
-          pipeline: $(AzDOPipelineId)
-          buildId: $(AzDOBuildId)
-          artifactName: PackageArtifacts
-          checkDownloadedFiles: true
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Package Artifacts
+          inputs:
+            buildType: specific
+            buildVersionToDownload: specific
+            project: $(AzDOProjectName)
+            pipeline: $(AzDOPipelineId)
+            buildId: $(AzDOBuildId)
+            artifactName: PackageArtifacts
+            checkDownloadedFiles: true
 
-      # This is necessary whenever we want to publish/restore to an AzDO private feed
-      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
-      # otherwise it'll complain about accessing a private feed.
-      - task: NuGetAuthenticate@1
-        displayName: 'Authenticate to AzDO Feeds'
+        # This is necessary whenever we want to publish/restore to an AzDO private feed
+        # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+        # otherwise it'll complain about accessing a private feed.
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to AzDO Feeds'
 
-      # Signing validation will optionally work with the buildmanifest file which is downloaded from
-      # Azure DevOps above.
-      - task: PowerShell@2
-        displayName: Validate
-        inputs:
-          filePath: eng\common\sdk-task.ps1
-          arguments: -task SigningValidation -restore -msbuildEngine vs
-            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
-            /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
-            ${{ parameters.signingValidationAdditionalParameters }}
+        # Signing validation will optionally work with the buildmanifest file which is downloaded from
+        # Azure DevOps above.
+        - task: PowerShell@2
+          displayName: Validate
+          inputs:
+            filePath: eng\common\sdk-task.ps1
+            arguments: -task SigningValidation -restore -msbuildEngine vs
+              /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
+              /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
+              ${{ parameters.signingValidationAdditionalParameters }}
 
-      - template: /eng/common/core-templates/steps/publish-logs.yml
-        parameters:
-          is1ESPipeline: ${{ parameters.is1ESPipeline }}
-          StageLabel: 'Validation'
-          JobLabel: 'Signing'
-          BinlogToolVersion: $(BinlogToolVersion)
+        - template: /eng/common/core-templates/steps/publish-logs.yml
+          parameters:
+            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+            StageLabel: 'Validation'
+            JobLabel: 'Signing'
+            BinlogToolVersion: $(BinlogToolVersion)
 
     - job:
       displayName: SourceLink Validation
@@ -230,41 +230,41 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          ${{ if eq(parameters.is1ESPipeline, true) }}:
+          ${{ if eq(parameters.is1ESPipeline, true) }}:          
             name: $(DncEngInternalBuildPool)
             image: 1es-windows-2022
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64          
       steps:
-      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-        parameters:
-          BARBuildId: ${{ parameters.BARBuildId }}
-          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+          parameters:
+            BARBuildId: ${{ parameters.BARBuildId }}
+            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+            is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Blob Artifacts
-        inputs:
-          buildType: specific
-          buildVersionToDownload: specific
-          project: $(AzDOProjectName)
-          pipeline: $(AzDOPipelineId)
-          buildId: $(AzDOBuildId)
-          artifactName: BlobArtifacts
-          checkDownloadedFiles: true
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Blob Artifacts
+          inputs:
+            buildType: specific
+            buildVersionToDownload: specific
+            project: $(AzDOProjectName)
+            pipeline: $(AzDOPipelineId)
+            buildId: $(AzDOBuildId)
+            artifactName: BlobArtifacts
+            checkDownloadedFiles: true
 
-      - task: PowerShell@2
-        displayName: Validate
-        inputs:
-          filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/sourcelink-validation.ps1
-          arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
-            -ExtractPath $(Agent.BuildDirectory)/Extract/ 
-            -GHRepoName $(Build.Repository.Name) 
-            -GHCommit $(Build.SourceVersion)
-            -SourcelinkCliVersion $(SourceLinkCLIVersion)
-        continueOnError: true
+        - task: PowerShell@2
+          displayName: Validate
+          inputs:
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/sourcelink-validation.ps1
+            arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
+              -ExtractPath $(Agent.BuildDirectory)/Extract/ 
+              -GHRepoName $(Build.Repository.Name) 
+              -GHCommit $(Build.SourceVersion)
+              -SourcelinkCliVersion $(SourceLinkCLIVersion)
+          continueOnError: true
 
 - ${{ if ne(parameters.publishAssetsImmediately, 'true') }}:
   - stage: publish_using_darc
@@ -274,10 +274,10 @@ stages:
       dependsOn: ${{ parameters.validateDependsOn }}
     displayName: Publish using Darc
     variables:
-    - template: /eng/common/core-templates/post-build/common-variables.yml
-    - template: /eng/common/core-templates/variables/pool-providers.yml
-      parameters:
-        is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/common-variables.yml
+      - template: /eng/common/core-templates/variables/pool-providers.yml
+        parameters:
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
     jobs:
     - job:
       displayName: Publish Using Darc
@@ -291,36 +291,30 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          ${{ if eq(parameters.is1ESPipeline, true) }}:
+          ${{ if eq(parameters.is1ESPipeline, true) }}:          
             name: NetCore1ESPool-Publishing-Internal
             image: windows.vs2019.amd64
             os: windows
           ${{ else }}:
             name: NetCore1ESPool-Publishing-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64
+            demands: ImageOverride -equals windows.vs2019.amd64          
       steps:
-      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-        parameters:
-          BARBuildId: ${{ parameters.BARBuildId }}
-          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+          parameters:
+            BARBuildId: ${{ parameters.BARBuildId }}
+            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+            is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-      - task: NuGetAuthenticate@1 # Populate internal runtime variables.
+        - task: NuGetAuthenticate@1
 
-      - template: /eng/common/templates/steps/enable-internal-sources.yml
-        parameters:
-          legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
-
-      - template: /eng/common/templates/steps/enable-internal-runtimes.yml
-
-      - task: AzureCLI@2
-        displayName: Publish Using Darc
-        inputs:
-          azureSubscription: "Darc: Maestro Production"
-          scriptType: ps
-          scriptLocation: scriptPath
-          scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
-          arguments: >
+        - task: AzureCLI@2
+          displayName: Publish Using Darc
+          inputs:
+            azureSubscription: "Darc: Maestro Production"
+            scriptType: ps
+            scriptLocation: scriptPath
+            scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
+            arguments: >
               -BuildId $(BARBuildId)
               -PublishingInfraVersion ${{ parameters.publishingInfraVersion }}
               -AzdoToken '$(System.AccessToken)'
@@ -329,5 +323,3 @@ stages:
               -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
               -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
               -SkipAssetsPublishing '${{ parameters.isAssetlessBuild }}'
-              -runtimeSourceFeed https://ci.dot.net/internal 
-              -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -13,6 +13,9 @@ parameters:
   # Unfortunately, _SignType can't be used to exclude the use of the service connection in non-real sign scenarios. The
   # variable is not available in template expression. _SignType has a very large proliferation across .NET, so replacing it is tough.
   microbuildUseESRP: true
+  # Location of the MicroBuild output folder
+  # NOTE: There's something that relies on this being in the "default" source directory for tasks such as Signing to work properly.
+  microBuildOutputFolder: '$(Build.SourcesDirectory)'
   # Microbuild version
   microbuildPluginVersion: 'latest'
 
@@ -21,16 +24,14 @@ parameters:
 steps:
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
-      # Installing .NET 8 is required to use the MicroBuild signing plugin on non-Windows platforms
+      # Needed to download the MicroBuild plugin nupkgs on Mac and Linux when nuget.exe is unavailable
       - task: UseDotNet@2
         displayName: Install .NET 8.0 SDK for MicroBuild Plugin
         inputs:
           packageType: sdk
           version: 8.0.x
-          # Installing the SDK in a '.dotnet-microbuild' directory is required for signing.
-          # See target FindDotNetPathForMicroBuild in arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
-          # Do not remove '.dotnet-microbuild' from the path without changing the corresponding logic.
-          installationPath: $(Agent.TempDirectory)/.dotnet-microbuild
+          installationPath: ${{ parameters.microBuildOutputFolder }}/.dotnet
+          workingDirectory: ${{ parameters.microBuildOutputFolder }}
         condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
     - script: |
@@ -70,7 +71,7 @@ steps:
               ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
         microbuildEnv:
           TeamName: $(_TeamName)
-          MicroBuildOutputFolderOverride: $(Agent.TempDirectory)/MicroBuild
+          MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         continueOnError: ${{ parameters.continueOnError }}
         condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
@@ -92,7 +93,7 @@ steps:
                 ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
           microbuildEnv:
             TeamName: $(_TeamName)
-            MicroBuildOutputFolderOverride: $(Agent.TempDirectory)/MicroBuild
+            MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           continueOnError: ${{ parameters.continueOnError }}
           condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))

--- a/eng/common/generate-locproject.ps1
+++ b/eng/common/generate-locproject.ps1
@@ -89,36 +89,36 @@ $locJson = @{
         @{
             LanguageSet = $LanguageSet
             LocItems = @(
-                $locFiles | ForEach-Object {
-                    $outputPath = "$(($_.DirectoryName | Resolve-Path -Relative) + "\")"
-                    $continue = $true
-                    foreach ($exclusion in $exclusions.Exclusions) {
-                        if ($_.FullName.Contains($exclusion))
-                        {
-                            $continue = $false
-                        }
-                    }
-                    $sourceFile = ($_.FullName | Resolve-Path -Relative)
-                    if (!$CreateNeutralXlfs -and $_.Extension -eq '.xlf') {
-                        Remove-Item -Path $sourceFile
-                    }
-                    if ($continue)
+            $locFiles | ForEach-Object {
+                $outputPath = "$(($_.DirectoryName | Resolve-Path -Relative) + "\")"
+                $continue = $true
+                foreach ($exclusion in $exclusions.Exclusions) {
+                    if ($_.FullName.Contains($exclusion))
                     {
-                        if ($_.Directory.Name -eq 'en' -and $_.Extension -eq '.json') {
-                            return @{
-                                SourceFile = $sourceFile
-                                CopyOption = "LangIDOnPath"
-                                OutputPath = "$($_.Directory.Parent.FullName | Resolve-Path -Relative)\"
-                            }
-                        } else {
-                            return @{
-                                SourceFile = $sourceFile
-                                CopyOption = "LangIDOnName"
-                                OutputPath = $outputPath
-                            }
+                        $continue = $false
+                    }
+                }
+                $sourceFile = ($_.FullName | Resolve-Path -Relative)
+                if (!$CreateNeutralXlfs -and $_.Extension -eq '.xlf') {
+                    Remove-Item -Path $sourceFile
+                }
+                if ($continue)
+                {
+                    if ($_.Directory.Name -eq 'en' -and $_.Extension -eq '.json') {
+                        return @{
+                            SourceFile = $sourceFile
+                            CopyOption = "LangIDOnPath"
+                            OutputPath = "$($_.Directory.Parent.FullName | Resolve-Path -Relative)\"
+                        }
+                    } else {
+                        return @{
+                            SourceFile = $sourceFile
+                            CopyOption = "LangIDOnName"
+                            OutputPath = $outputPath
                         }
                     }
                 }
+            }
             )
         },
         @{
@@ -126,24 +126,24 @@ $locJson = @{
             CloneLanguageSet = "WiX_CloneLanguages"
             LssFiles = @( "wxl_loc.lss" )
             LocItems = @(
-                $wxlFilesV3 | ForEach-Object {
-                    $outputPath = "$($_.Directory.FullName | Resolve-Path -Relative)\"
-                    $continue = $true
-                    foreach ($exclusion in $exclusions.Exclusions) {
-                        if ($_.FullName.Contains($exclusion)) {
-                            $continue = $false
-                        }
-                    }
-                    $sourceFile = ($_.FullName | Resolve-Path -Relative)
-                    if ($continue)
-                    {
-                        return @{
-                            SourceFile = $sourceFile
-                            CopyOption = "LangIDOnPath"
-                            OutputPath = $outputPath
-                        }
+            $wxlFilesV3 | ForEach-Object {
+                $outputPath = "$($_.Directory.FullName | Resolve-Path -Relative)\"
+                $continue = $true
+                foreach ($exclusion in $exclusions.Exclusions) {
+                    if ($_.FullName.Contains($exclusion)) {
+                        $continue = $false
                     }
                 }
+                $sourceFile = ($_.FullName | Resolve-Path -Relative)
+                if ($continue)
+                {
+                    return @{
+                        SourceFile = $sourceFile
+                        CopyOption = "LangIDOnPath"
+                        OutputPath = $outputPath
+                    }
+                }
+            }
             )
         },
         @{
@@ -151,24 +151,24 @@ $locJson = @{
             CloneLanguageSet = "WiX_CloneLanguages"
             LssFiles = @( "P210WxlSchemaV4.lss" )
             LocItems = @(
-                $wxlFilesV5 | ForEach-Object {
-                    $outputPath = "$($_.Directory.FullName | Resolve-Path -Relative)\"
-                    $continue = $true
-                    foreach ($exclusion in $exclusions.Exclusions) {
-                        if ($_.FullName.Contains($exclusion)) {
-                            $continue = $false
-                        }
-                    }
-                    $sourceFile = ($_.FullName | Resolve-Path -Relative)
-                    if ($continue)
-                    {
-                        return @{
-                            SourceFile = $sourceFile
-                            CopyOption = "LangIDOnPath"
-                            OutputPath = $outputPath
-                        }
+            $wxlFilesV5 | ForEach-Object {
+                $outputPath = "$($_.Directory.FullName | Resolve-Path -Relative)\"
+                $continue = $true
+                foreach ($exclusion in $exclusions.Exclusions) {
+                    if ($_.FullName.Contains($exclusion)) {
+                        $continue = $false
                     }
                 }
+                $sourceFile = ($_.FullName | Resolve-Path -Relative)
+                if ($continue)
+                {
+                    return @{
+                        SourceFile = $sourceFile
+                        CopyOption = "LangIDOnPath"
+                        OutputPath = $outputPath
+                    }
+                }
+            }
             )
         },
         @{
@@ -176,28 +176,28 @@ $locJson = @{
             CloneLanguageSet = "VS_macOS_CloneLanguages"
             LssFiles = @( ".\eng\common\loc\P22DotNetHtmlLocalization.lss" )
             LocItems = @(
-                $macosHtmlFiles | ForEach-Object {
-                    $outputPath = "$($_.Directory.FullName | Resolve-Path -Relative)\"
-                    $continue = $true
-                    foreach ($exclusion in $exclusions.Exclusions) {
-                        if ($_.FullName.Contains($exclusion)) {
-                            $continue = $false
-                        }
-                    }
-                    $sourceFile = ($_.FullName | Resolve-Path -Relative)
-                    $lciFile = $sourceFile + ".lci"
-                    if ($continue) {
-                        $result = @{
-                            SourceFile = $sourceFile
-                            CopyOption = "LangIDOnPath"
-                            OutputPath = $outputPath
-                        }
-                        if (Test-Path $lciFile -PathType Leaf) {
-                            $result["LciFile"] = $lciFile
-                        }
-                        return $result
+            $macosHtmlFiles | ForEach-Object {
+                $outputPath = "$($_.Directory.FullName | Resolve-Path -Relative)\"
+                $continue = $true
+                foreach ($exclusion in $exclusions.Exclusions) {
+                    if ($_.FullName.Contains($exclusion)) {
+                        $continue = $false
                     }
                 }
+                $sourceFile = ($_.FullName | Resolve-Path -Relative)
+                $lciFile = $sourceFile + ".lci"
+                if ($continue) {
+                    $result = @{
+                        SourceFile = $sourceFile
+                        CopyOption = "LangIDOnPath"
+                        OutputPath = $outputPath
+                    }
+                    if (Test-Path $lciFile -PathType Leaf) {
+                        $result["LciFile"] = $lciFile
+                    }
+                    return $result
+                }
+            }
             )
         }
     )

--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -7,9 +7,7 @@ param(
   [Parameter(Mandatory=$false)][string] $ArtifactsPublishingAdditionalParameters,
   [Parameter(Mandatory=$false)][string] $SymbolPublishingAdditionalParameters,
   [Parameter(Mandatory=$false)][string] $RequireDefaultChannels,
-  [Parameter(Mandatory=$false)][string] $SkipAssetsPublishing,
-  [Parameter(Mandatory=$false)][string] $runtimeSourceFeed,
-  [Parameter(Mandatory=$false)][string] $runtimeSourceFeedKey
+  [Parameter(Mandatory=$false)][string] $SkipAssetsPublishing
 )
 
 try {

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -9,8 +9,6 @@ Param(
   [switch][Alias('nobl')]$excludeCIBinaryLog,
   [switch]$noWarnAsError,
   [switch] $help,
-  [string] $runtimeSourceFeed = '',
-  [string] $runtimeSourceFeedKey = '',
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 

--- a/global.json
+++ b/global.json
@@ -33,8 +33,8 @@
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.2.0",
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25524.1",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25524.1",
-    "Microsoft.DotNet.SharedFramework.Sdk": "11.0.0-beta.25524.1"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25509.1",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25509.1",
+    "Microsoft.DotNet.SharedFramework.Sdk": "11.0.0-beta.25509.1"
   }
 }


### PR DESCRIPTION
This reverts commit b98fbc8dee721343e97beeff12aa77731acfca3f.

The arcade update broke the official build for the microbuild step on OSX.