### PR TITLE
add interpreter path and module properties to IDE execution spec

### DIFF
--- a/docs/specs/IDE-execution.md
+++ b/docs/specs/IDE-execution.md
@@ -217,7 +217,7 @@ Python launch configuration contains details for launching python scripts.
 | `type` | Launch configuration type indicator; must be `python`.  | Required |
 | `program_path` | Path to the python startup file, or if `module` is specified a path to the working directory for the app. | Required |
 | `mode` | Specifies the launch mode. Currently supported modes are `Debug` (run the project under the debugger) and `NoDebug` (run the project without debugging). | Optional, defaults to `Debug`. |
-| `interpreter_path` | Path to the python interpreter to use. | Optional |
+| `interpreter_path` | Path to the python interpreter to use. If omitted, the global python installation will be used. | Optional |
 | `module` | The name of the module to execute, equivalent to python -m. | Optional |
 
 ## Run session change notifications

--- a/docs/specs/IDE-execution.md
+++ b/docs/specs/IDE-execution.md
@@ -217,6 +217,8 @@ Python launch configuration contains details for launching python scripts.
 | `type` | Launch configuration type indicator; must be `python`.  | Required |
 | `program_path` | Path to the python startup file. | Required |
 | `mode` | Specifies the launch mode. Currently supported modes are `Debug` (run the project under the debugger) and `NoDebug` (run the project without debugging). | Optional, defaults to `Debug`. |
+| `interpreter_path` | Path to the python interpreter to use. | Optional |
+| `module` | The name of the module to execute, equivalent to python -m. | Optional |
 
 ## Run session change notifications
 

--- a/docs/specs/IDE-execution.md
+++ b/docs/specs/IDE-execution.md
@@ -215,7 +215,7 @@ Python launch configuration contains details for launching python scripts.
 | Property | Description | Required? |
 |----------------|--------|-------|
 | `type` | Launch configuration type indicator; must be `python`.  | Required |
-| `program_path` | Path to the python startup file. | Required |
+| `program_path` | Path to the python startup file, or if `module` is specified a path to the working directory for the app. | Required |
 | `mode` | Specifies the launch mode. Currently supported modes are `Debug` (run the project under the debugger) and `NoDebug` (run the project without debugging). | Optional, defaults to `Debug`. |
 | `interpreter_path` | Path to the python interpreter to use. | Optional |
 | `module` | The name of the module to execute, equivalent to python -m. | Optional |


### PR DESCRIPTION
## Description

We have decided to support python modules, meaning we need a way to indicate which module to run and where to run it.

`program_path` should be a path to the python project folder containing source code when running a module. The module may then choose a script or entrypoint to execute based on program args.

We should support the ability to choose which python to run, important as most python applications use virtual environments. That property is `interpreter_path` and is optional, as when it is omitted the global python installation is used.

`module` specifies which module to run and it is optional.

`interpreter

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
