### PR TITLE
Add `ExcludeFromMcp()` resource extension

### DIFF
--- a/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
@@ -581,4 +581,9 @@ internal static class AIHelpers
 
         return $"Returned latest {itemName.ToQuantity(returnedCount, formatProvider: CultureInfo.InvariantCulture)}. Earlier {itemName.ToQuantity(totalValues - returnedCount, formatProvider: CultureInfo.InvariantCulture)} not returned because of size limits.";
     }
+
+    public static bool IsResourceAIOptOut(ResourceViewModel r)
+    {
+        return r.Properties.TryGetValue(KnownProperties.Resource.ExcludeFromMcp, out var v) && v.Value.TryConvertToBool(out var b) && b;
+    }
 }

--- a/src/Aspire.Dashboard/Utils/ValueExtensions.cs
+++ b/src/Aspire.Dashboard/Utils/ValueExtensions.cs
@@ -28,6 +28,22 @@ internal static class ValueExtensions
         return false;
     }
 
+    public static bool TryConvertToBool(this Value value, out bool b)
+    {
+        if (value.HasStringValue && bool.TryParse(value.StringValue, out b))
+        {
+            return true;
+        }
+        else if (value.HasBoolValue)
+        {
+            b = value.BoolValue;
+            return true;
+        }
+
+        b = false;
+        return false;
+    }
+
     public static bool TryConvertToString(this Value value, [NotNullWhen(returnValue: true)] out string? s)
     {
         if (value.HasStringValue)

--- a/src/Aspire.Hosting/ApplicationModel/ExcludeFromMcpAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExcludeFromMcpAnnotation.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+internal sealed class ExcludeFromMcpAnnotation : IResourceAnnotation
+{
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Aspire.Dashboard.Model;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
@@ -604,6 +605,14 @@ public class ResourceNotificationService : IDisposable
             newState = UpdateCommands(resource, newState);
 
             newState = UpdateIcons(resource, newState);
+
+            if (resource.TryGetAnnotationsOfType<ExcludeFromMcpAnnotation>(out _))
+            {
+                newState = newState with
+                {
+                    Properties = newState.Properties.SetResourceProperty(KnownProperties.Resource.ExcludeFromMcp, true)
+                };
+            }
 
             notificationState.LastSnapshot = newState;
 

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -2876,4 +2876,17 @@ public static class ResourceBuilderExtensions
 
         return builder.WithAnnotation(probeAnnotation);
     }
+
+    /// <summary>
+    /// Exclude the resource from MCP operations using the Aspire MCP server. The resource is excluded from results that return resources, console logs and telemetry.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> ExcludeFromMcp<T>(this IResourceBuilder<T> builder) where T : IResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithAnnotation(new ExcludeFromMcpAnnotation());
+    }
 }

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -29,6 +29,7 @@ internal static class KnownProperties
         public const string ParentName = "resource.parentName";
         public const string AppArgs = "resource.appArgs";
         public const string AppArgsSensitivity = "resource.appArgsSensitivity";
+        public const string ExcludeFromMcp = "resource.excludeFromMcp";
     }
 
     public static class Container

--- a/tests/Aspire.Dashboard.Tests/Mcp/AspireTelemetryMcpToolsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Mcp/AspireTelemetryMcpToolsTests.cs
@@ -3,11 +3,17 @@
 
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Mcp;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Model;
+using Aspire.Dashboard.Tests.Shared;
+using Aspire.Tests.Shared.DashboardModel;
 using Aspire.Tests.Shared.Telemetry;
 using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
 using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
@@ -16,6 +22,9 @@ namespace Aspire.Dashboard.Tests.Mcp;
 
 public class AspireTelemetryMcpToolsTests
 {
+    private static readonly ResourcePropertyViewModel s_excludeFromMcpProperty = new ResourcePropertyViewModel(KnownProperties.Resource.ExcludeFromMcp, Value.ForBool(true), isValueSensitive: false, knownProperty: null, priority: 0);
+    private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
     [Fact]
     public void ListTraces_NoResources_ReturnsEmptyResult()
     {
@@ -45,6 +54,33 @@ public class AspireTelemetryMcpToolsTests
         // Assert
         Assert.NotNull(result);
         Assert.Contains("# TRACES DATA", result);
+        Assert.Contains("app1", result);
+    }
+
+    [Fact]
+    public void ListTraces_ResourceOptOut_FilterTraces()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        AddResource(repository, "app1", "instance1");
+        AddResource(repository, "app2", "instance1");
+
+        var resource = ModelTestHelpers.CreateResource(
+            resourceName: "app1-instance1",
+            displayName: "app1",
+            properties: new Dictionary<string, ResourcePropertyViewModel> { [KnownProperties.Resource.ExcludeFromMcp] = s_excludeFromMcpProperty });
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: [resource]);
+
+        var tools = CreateTools(repository, dashboardClient);
+
+        // Act
+        var result = tools.ListTraces();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("# TRACES DATA", result);
+        Assert.DoesNotContain("app1", result);
+        Assert.Contains("app2", result);
     }
 
     [Fact]
@@ -98,6 +134,49 @@ public class AspireTelemetryMcpToolsTests
     }
 
     [Fact]
+    public void ListStructuredLogs_HasResource_ReturnsLogs()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        AddResource(repository, "app1");
+        var tools = CreateTools(repository);
+
+        // Act
+        var result = tools.ListStructuredLogs();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("# STRUCTURED LOGS DATA", result);
+        Assert.Contains("app1", result);
+    }
+
+    [Fact]
+    public void ListStructuredLogs_ResourceOptOut_FiltersLogs()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        AddResource(repository, "app1", "instance1");
+        AddResource(repository, "app2", "instance1");
+
+        var resource = ModelTestHelpers.CreateResource(
+            resourceName: "app1-instance1",
+            displayName: "app1",
+            properties: new Dictionary<string, ResourcePropertyViewModel> { [KnownProperties.Resource.ExcludeFromMcp] = s_excludeFromMcpProperty });
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: [resource]);
+
+        var tools = CreateTools(repository, dashboardClient);
+
+        // Act
+        var result = tools.ListStructuredLogs();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("# STRUCTURED LOGS DATA", result);
+        Assert.DoesNotContain("app1", result);
+        Assert.Contains("app2", result);
+    }
+
+    [Fact]
     public void ListStructuredLogs_SingleResource_ReturnsLogs()
     {
         // Arrange
@@ -111,6 +190,7 @@ public class AspireTelemetryMcpToolsTests
         // Assert
         Assert.NotNull(result);
         Assert.Contains("# STRUCTURED LOGS DATA", result);
+        Assert.Contains("app1", result);
     }
 
     [Fact]
@@ -148,9 +228,19 @@ public class AspireTelemetryMcpToolsTests
         Assert.Contains("# STRUCTURED LOGS DATA", result);
     }
 
-    private static AspireTelemetryMcpTools CreateTools(TelemetryRepository repository)
+    private static AspireTelemetryMcpTools CreateTools(TelemetryRepository repository, IDashboardClient? dashboardClient = null)
     {
-        return new AspireTelemetryMcpTools(repository, [], new TestOptionsMonitor<DashboardOptions>(new DashboardOptions()));
+        var options = new DashboardOptions();
+        options.Frontend.EndpointUrls = "https://localhost:1234";
+        options.Frontend.PublicUrl = "https://localhost:8080";
+        Assert.True(options.Frontend.TryParseOptions(out _));
+
+        return new AspireTelemetryMcpTools(
+            repository,
+            [],
+            new TestOptionsMonitor<DashboardOptions>(options),
+            dashboardClient ?? new TestDashboardClient(),
+            NullLogger<AspireTelemetryMcpTools>.Instance);
     }
 
     private static TelemetryRepository CreateRepository()
@@ -160,12 +250,48 @@ public class AspireTelemetryMcpToolsTests
 
     private static void AddResource(TelemetryRepository repository, string name, string? instanceId = null)
     {
+        var idPrefix = instanceId != null ? $"{name}-{instanceId}" : name;
+
         var addContext = new AddContext();
         repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
-                Resource = CreateResource(name: name, instanceId: instanceId)
+                Resource = CreateResource(name: name, instanceId: instanceId),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: idPrefix + "1", spanId: idPrefix + "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10)),
+                            CreateSpan(traceId: idPrefix + "1", spanId: idPrefix + "1-2", startTime: s_testTime.AddMinutes(5), endTime: s_testTime.AddMinutes(10), parentSpanId: idPrefix + "1-1"),
+                            CreateSpan(traceId: idPrefix + "2", spanId: idPrefix + "2-1", startTime: s_testTime.AddMinutes(6), endTime: s_testTime.AddMinutes(10))
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: name, instanceId: instanceId),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(),
+                        LogRecords =
+                        {
+                            CreateLogRecord(time: s_testTime, message: "Log entry!")
+                        }
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
## Description

This PR adds a way for resources to opt-out of being included in AI results. When opted out, a resource won't be returned with `list_resources`, won't be a target of `execute_resource_command`, and no telemetry/consoles logs will be returned for it.

For example, adding `frontendBuilder.WithOptOutAI()` will exclude the frontend resource from all AI results.

Fixes https://github.com/dotnet/aspire/issues/12504

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
