### PR TITLE
Allow HostUrl to remap both address and port

### DIFF
--- a/playground/yarp/Yarp.AppHost/Program.cs
+++ b/playground/yarp/Yarp.AppHost/Program.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.Yarp.Transforms;
 
 var builder = DistributedApplication.CreateBuilder(args);
-builder.Configuration["DcpPublisher:EnableAspireContainerTunnel"] = "true";
 
 var backendService = builder.AddProject<Projects.Yarp_Backend>("backend");
 

--- a/playground/yarp/Yarp.AppHost/Program.cs
+++ b/playground/yarp/Yarp.AppHost/Program.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.Yarp.Transforms;
 
 var builder = DistributedApplication.CreateBuilder(args);
+builder.Configuration["DcpPublisher:EnableAspireContainerTunnel"] = "true";
 
 var backendService = builder.AddProject<Projects.Yarp_Backend>("backend");
 

--- a/playground/yarp/Yarp.AppHost/appsettings.json
+++ b/playground/yarp/Yarp.AppHost/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "DcpPublisher": {
+    "EnableAspireContainerTunnel": true
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
@@ -68,7 +68,7 @@ public static class DistributedApplicationHostingTestingExtensions
         ArgumentNullException.ThrowIfNull(app);
         ArgumentException.ThrowIfNullOrEmpty(resourceName);
 
-        return GetEndpoint(app, resourceName, endpointName, networkIdentifier: null);
+        return GetEndpointForNetwork(app, resourceName, null, endpointName);
     }
 
     /// <summary>
@@ -76,12 +76,12 @@ public static class DistributedApplicationHostingTestingExtensions
     /// </summary>
     /// <param name="app">The application.</param>
     /// <param name="resourceName">The resource name.</param>
-    /// <param name="endpointName">The optional endpoint name. If none are specified, the single defined endpoint is returned.</param>
     /// <param name="networkIdentifier">The optional network identifier. If none is specified, the default network is used.</param>
+    /// <param name="endpointName">The optional endpoint name. If none are specified, the single defined endpoint is returned.</param>
     /// <returns>A URI representation of the endpoint.</returns>
     /// <exception cref="ArgumentException">The resource was not found, no matching endpoint was found, or multiple endpoints were found.</exception>
     /// <exception cref="InvalidOperationException">The resource has no endpoints.</exception>
-    public static Uri GetEndpoint(this DistributedApplication app, string resourceName, string? endpointName = default, NetworkIdentifier? networkIdentifier = default)
+    public static Uri GetEndpointForNetwork(this DistributedApplication app, string resourceName, NetworkIdentifier? networkIdentifier, string? endpointName = default)
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentException.ThrowIfNullOrEmpty(resourceName);

--- a/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
@@ -60,15 +60,16 @@ public static class DistributedApplicationHostingTestingExtensions
     /// <param name="app">The application.</param>
     /// <param name="resourceName">The resource name.</param>
     /// <param name="endpointName">The optional endpoint name. If none are specified, the single defined endpoint is returned.</param>
+    /// <param name="networkIdentifier">The optional network identifier. If none is specified, the default network is used.</param>
     /// <returns>A URI representation of the endpoint.</returns>
     /// <exception cref="ArgumentException">The resource was not found, no matching endpoint was found, or multiple endpoints were found.</exception>
     /// <exception cref="InvalidOperationException">The resource has no endpoints.</exception>
-    public static Uri GetEndpoint(this DistributedApplication app, string resourceName, string? endpointName = default)
+    public static Uri GetEndpoint(this DistributedApplication app, string resourceName, string? endpointName = default, NetworkIdentifier? networkIdentifier = default)
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentException.ThrowIfNullOrEmpty(resourceName);
 
-        return new(GetEndpointUriStringCore(app, resourceName, endpointName));
+        return new(GetEndpointUriStringCore(app, resourceName, endpointName, networkIdentifier));
     }
 
     static IResource GetResource(DistributedApplication app, string resourceName)
@@ -87,7 +88,7 @@ public static class DistributedApplicationHostingTestingExtensions
         return resource;
     }
 
-    static string GetEndpointUriStringCore(DistributedApplication app, string resourceName, string? endpointName = default)
+    static string GetEndpointUriStringCore(DistributedApplication app, string resourceName, string? endpointName = default, NetworkIdentifier? networkIdentifier = default)
     {
         var resource = GetResource(app, resourceName);
         if (resource is not IResourceWithEndpoints resourceWithEndpoints)
@@ -98,11 +99,11 @@ public static class DistributedApplicationHostingTestingExtensions
         EndpointReference? endpoint;
         if (!string.IsNullOrEmpty(endpointName))
         {
-            endpoint = GetEndpointOrDefault(resourceWithEndpoints, endpointName);
+            endpoint = GetEndpointOrDefault(resourceWithEndpoints, endpointName, networkIdentifier);
         }
         else
         {
-            endpoint = GetEndpointOrDefault(resourceWithEndpoints, "http") ?? GetEndpointOrDefault(resourceWithEndpoints, "https");
+            endpoint = GetEndpointOrDefault(resourceWithEndpoints, "http", networkIdentifier) ?? GetEndpointOrDefault(resourceWithEndpoints, "https", networkIdentifier);
         }
 
         if (endpoint is null)
@@ -122,9 +123,9 @@ public static class DistributedApplicationHostingTestingExtensions
         }
     }
 
-    static EndpointReference? GetEndpointOrDefault(IResourceWithEndpoints resourceWithEndpoints, string endpointName)
+    static EndpointReference? GetEndpointOrDefault(IResourceWithEndpoints resourceWithEndpoints, string endpointName, NetworkIdentifier? networkIdentifier = default)
     {
-        var reference = resourceWithEndpoints.GetEndpoint(endpointName);
+        var reference = resourceWithEndpoints.GetEndpoint(endpointName, networkIdentifier ?? KnownNetworkIdentifiers.LocalhostNetwork);
 
         return reference.IsAllocated ? reference : null;
     }

--- a/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
@@ -60,11 +60,28 @@ public static class DistributedApplicationHostingTestingExtensions
     /// <param name="app">The application.</param>
     /// <param name="resourceName">The resource name.</param>
     /// <param name="endpointName">The optional endpoint name. If none are specified, the single defined endpoint is returned.</param>
+    /// <returns>A URI representation of the endpoint.</returns>
+    /// <exception cref="ArgumentException">The resource was not found, no matching endpoint was found, or multiple endpoints were found.</exception>
+    /// <exception cref="InvalidOperationException">The resource has no endpoints.</exception>
+    public static Uri GetEndpoint(this DistributedApplication app, string resourceName, string? endpointName = default)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentException.ThrowIfNullOrEmpty(resourceName);
+
+        return GetEndpoint(app, resourceName, endpointName, networkIdentifier: null);
+    }
+
+    /// <summary>
+    /// Gets the endpoint for the specified resource.
+    /// </summary>
+    /// <param name="app">The application.</param>
+    /// <param name="resourceName">The resource name.</param>
+    /// <param name="endpointName">The optional endpoint name. If none are specified, the single defined endpoint is returned.</param>
     /// <param name="networkIdentifier">The optional network identifier. If none is specified, the default network is used.</param>
     /// <returns>A URI representation of the endpoint.</returns>
     /// <exception cref="ArgumentException">The resource was not found, no matching endpoint was found, or multiple endpoints were found.</exception>
     /// <exception cref="InvalidOperationException">The resource has no endpoints.</exception>
-    public static Uri GetEndpoint(this DistributedApplication app, string resourceName, string? endpointName = default, NetworkIdentifier? networkIdentifier = default)
+    public static Uri GetEndpoint(this DistributedApplication app, string resourceName, string? endpointName = default, NetworkIdentifier? networkIdentifier)
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentException.ThrowIfNullOrEmpty(resourceName);

--- a/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
@@ -81,7 +81,7 @@ public static class DistributedApplicationHostingTestingExtensions
     /// <returns>A URI representation of the endpoint.</returns>
     /// <exception cref="ArgumentException">The resource was not found, no matching endpoint was found, or multiple endpoints were found.</exception>
     /// <exception cref="InvalidOperationException">The resource has no endpoints.</exception>
-    public static Uri GetEndpoint(this DistributedApplication app, string resourceName, string? endpointName = default, NetworkIdentifier? networkIdentifier)
+    public static Uri GetEndpoint(this DistributedApplication app, string resourceName, string? endpointName = default, NetworkIdentifier? networkIdentifier = default)
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentException.ThrowIfNullOrEmpty(resourceName);

--- a/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
@@ -23,22 +23,12 @@ public class ConnectionStringReference(IResourceWithConnectionString resource, b
 
     ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken)
     {
-        return this.GetNetworkValueAsync(null, cancellationToken);
+        return Resource.GetValueAsync(cancellationToken);
     }
 
-    ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken)
+    async ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken)
     {
-        return context.Network switch
-        {
-            NetworkIdentifier networkContext => GetNetworkValueAsync(networkContext, cancellationToken),
-            _ => GetNetworkValueAsync(null, cancellationToken)
-        };
-    }
-
-    private async ValueTask<string?> GetNetworkValueAsync(NetworkIdentifier? networkContext, CancellationToken cancellationToken)
-    {
-        ValueProviderContext vpc = new() { Network = networkContext };
-        var value = await Resource.GetValueAsync(vpc, cancellationToken).ConfigureAwait(false);
+        var value = await Resource.GetValueAsync(context, cancellationToken).ConfigureAwait(false);
 
         if (string.IsNullOrEmpty(value) && !Optional)
         {

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -282,7 +282,7 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
         return Property switch
         {
             EndpointProperty.Scheme => new(Endpoint.Scheme),
-            EndpointProperty.IPV4Host when context is null || networkContext == KnownNetworkIdentifiers.LocalhostNetwork => "127.0.0.1",
+            EndpointProperty.IPV4Host when networkContext == KnownNetworkIdentifiers.LocalhostNetwork => "127.0.0.1",
             EndpointProperty.TargetPort when Endpoint.TargetPort is int port => new(port.ToString(CultureInfo.InvariantCulture)),
             _ => await ResolveValueWithAllocatedAddress().ConfigureAwait(false)
         };

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -156,7 +156,7 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
 
         foreach (var nes in endpointAnnotation.AllAllocatedEndpoints)
         {
-            if (StringComparers.NetworkID.Equals(nes.NetworkID, _contextNetworkID))
+            if (StringComparers.NetworkID.Equals(nes.NetworkID, _contextNetworkID ?? KnownNetworkIdentifiers.LocalhostNetwork))
             {
                 if (!nes.Snapshot.IsValueSet)
                 {

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -294,6 +294,11 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
             var nes = Endpoint.EndpointAnnotation.AllAllocatedEndpoints.Where(nes => nes.NetworkID == networkContext).FirstOrDefault();
             if (nes is null)
             {
+                nes = Endpoint.EndpointAnnotation.AllAllocatedEndpoints.Where(nes => nes.NetworkID == Endpoint.ContextNetworkID).FirstOrDefault();
+            }
+
+            if (nes is null)
+            {
                 return null;
             }
 

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -95,13 +95,14 @@ internal class ExpressionResolver(CancellationToken cancellationToken)
     /// </summary>
     async ValueTask<ResolvedValue> ResolveInternalAsync(object? value, ValueProviderContext context)
     {
+        var networkContext = context.GetNetworkIdentifier();
         return value switch
         {
             ConnectionStringReference cs => await ResolveConnectionStringReferenceAsync(cs, context).ConfigureAwait(false),
             IResourceWithConnectionString cs and not ConnectionStringParameterResource => await ResolveInternalAsync(cs.ConnectionStringExpression, context).ConfigureAwait(false),
             ReferenceExpression ex => await EvalExpressionAsync(ex, context).ConfigureAwait(false),
-            EndpointReference er when context.Network == KnownNetworkIdentifiers.DefaultAspireContainerNetwork => new ResolvedValue(await ResolveInContainerContextAsync(er, EndpointProperty.Url, context).ConfigureAwait(false), false),
-            EndpointReferenceExpression ep when context.Network == KnownNetworkIdentifiers.DefaultAspireContainerNetwork => new ResolvedValue(await ResolveInContainerContextAsync(ep.Endpoint, ep.Property, context).ConfigureAwait(false), false),
+            EndpointReference er when networkContext == KnownNetworkIdentifiers.DefaultAspireContainerNetwork => new ResolvedValue(await ResolveInContainerContextAsync(er, EndpointProperty.Url, context).ConfigureAwait(false), false),
+            EndpointReferenceExpression ep when networkContext == KnownNetworkIdentifiers.DefaultAspireContainerNetwork => new ResolvedValue(await ResolveInContainerContextAsync(ep.Endpoint, ep.Property, context).ConfigureAwait(false), false),
             IValueProvider vp => await EvalValueProvider(vp, context).ConfigureAwait(false),
             _ => throw new NotImplementedException()
         };

--- a/src/Aspire.Hosting/ApplicationModel/HostUrl.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HostUrl.cs
@@ -1,6 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Dcp;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -13,26 +17,19 @@ public record HostUrl(string Url) : IValueProvider, IManifestExpressionProvider
     string IManifestExpressionProvider.ValueExpression => Url;
 
     // Returns the url
-    ValueTask<string?> IValueProvider.GetValueAsync(System.Threading.CancellationToken _) => GetNetworkValueAsync(null);
+    ValueTask<string?> IValueProvider.GetValueAsync(System.Threading.CancellationToken cancellationToken) => ((IValueProvider)this).GetValueAsync(new(), cancellationToken);
 
     // Returns the url
-    ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken _)
+    async ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken)
     {
-        return context.Network switch
-        {
-            NetworkIdentifier networkContext => GetNetworkValueAsync(networkContext),
-            _ => GetNetworkValueAsync(null)
-        };
-    }
+        var networkContext = context.GetNetworkIdentifier();
 
-    private ValueTask<string?> GetNetworkValueAsync(NetworkIdentifier? context)
-    {
         // HostUrl is a bit of a hack that is not modeled as an expression
         // So in this one case, we need to fix up the container host name 'manually'
         // Internally, this is only used for OTEL_EXPORTER_OTLP_ENDPOINT, but HostUrl
         // is public, so we don't control how it is used
 
-        if (context is null || context == KnownNetworkIdentifiers.LocalhostNetwork)
+        if (networkContext == KnownNetworkIdentifiers.LocalhostNetwork)
         {
             return new(Url);
         }
@@ -44,14 +41,52 @@ public record HostUrl(string Url) : IValueProvider, IManifestExpressionProvider
             var uri = new UriBuilder(Url);
             if (uri.Host is "localhost" or "127.0.0.1" or "[::1]")
             {
-                var hasEndingSlash = Url.EndsWith('/');
-                uri.Host = KnownHostNames.DefaultContainerTunnelHostName;
-                retval = uri.ToString();
-
-                // Remove trailing slash if we didn't have one before (UriBuilder always adds one)
-                if (!hasEndingSlash && retval.EndsWith('/'))
+                if (context.ExecutionContext is { } && context.ExecutionContext.IsRunMode)
                 {
-                    retval = retval[..^1];
+                    var options = context.ExecutionContext.ServiceProvider.GetRequiredService<IOptions<DcpOptions>>();
+
+                    var infoService = context.ExecutionContext.ServiceProvider.GetRequiredService<IDcpDependencyCheckService>();
+                    var dcpInfo = await infoService.GetDcpInfoAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                    var hasEndingSlash = Url.EndsWith('/');
+                    uri.Host = options.Value.EnableAspireContainerTunnel == true ? KnownHostNames.DefaultContainerTunnelHostName : dcpInfo?.Containers?.ContainerHostName ?? KnownHostNames.DockerDesktopHostBridge;
+
+                    if (options.Value.EnableAspireContainerTunnel)
+                    {
+                        // We need to consider that both the host and port may need to be remapped
+                        var model = context.ExecutionContext.ServiceProvider.GetRequiredService<DistributedApplicationModel>();
+                        var targetResource = model.Resources.FirstOrDefault(r =>
+                        {
+                            // Find a non-container resource with an endpoint matching the original localhost:port
+                            return !r.IsContainer() &&
+                                r is IResourceWithEndpoints &&
+                                r.TryGetEndpoints(out var endpoints) &&
+                                endpoints.Any(ep => ep.DefaultNetworkID == KnownNetworkIdentifiers.LocalhostNetwork && ep.Port == uri.Port);
+                        });
+
+                        if (targetResource is IResourceWithEndpoints resourceWithEndpoints)
+                        {
+                            var originalEndpoint = resourceWithEndpoints.GetEndpoints().FirstOrDefault(ep => ep.ContextNetworkID == KnownNetworkIdentifiers.LocalhostNetwork && ep.Port == uri.Port);
+                            if (originalEndpoint is not null)
+                            {
+                                // Find the mapped endpoint for the target network context
+                                var mappedEndpoint = resourceWithEndpoints.GetEndpoint(originalEndpoint.EndpointName, networkContext);
+                                if (mappedEndpoint is not null)
+                                {
+                                    // Update the port to the mapped port
+                                    uri.Port = mappedEndpoint.Port;
+                                }
+                            }
+                        }
+                    }
+
+                    retval = uri.ToString();
+
+                    // Remove trailing slash if we didn't have one before (UriBuilder always adds one)
+                    if (!hasEndingSlash && retval.EndsWith('/'))
+                    {
+                        retval = retval[..^1];
+                    }
                 }
             }
         }

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
@@ -20,11 +20,8 @@ public interface IResourceWithConnectionString : IResource, IManifestExpressionP
 
     ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => GetConnectionStringAsync(cancellationToken);
 
-    ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken) => context.Network switch
-    {
-        NetworkIdentifier networkContext => ConnectionStringExpression.GetValueAsync(new ValueProviderContext { Network = networkContext }, cancellationToken),
-        _ => GetConnectionStringAsync(cancellationToken),
-    };
+    ValueTask<string?> IValueProvider.GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken) =>
+        ConnectionStringExpression.GetValueAsync(context, cancellationToken);
 
     /// <summary>
     /// Describes the connection string format string used for this resource.

--- a/src/Aspire.Hosting/ApplicationModel/IValueProvider.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IValueProvider.cs
@@ -9,9 +9,9 @@ namespace Aspire.Hosting.ApplicationModel;
 public class ValueProviderContext
 {
     /// <summary>
-    /// Additional services that can be used during value resolution.
+    /// The execution context for the distributed application.
     /// </summary>
-    public IServiceProvider? Services { get; init; }
+    public DistributedApplicationExecutionContext? ExecutionContext { get; init; }
 
     /// <summary>
     /// The resource that is requesting the value.

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -98,7 +98,7 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
     {
-        return this.GetValueAsync(new ValueProviderContext(), cancellationToken);
+        return this.GetValueAsync(new(), cancellationToken);
     }
 
     internal static ReferenceExpression Create(string format, IValueProvider[] valueProviders, string[] manifestExpressions, string?[] stringFormats)

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -271,7 +271,6 @@ public static class ResourceExtensions
     /// </param>
     /// <param name="logger">The logger used for logging information or errors during the argument processing.</param>
     /// <param name="cancellationToken">A token for cancelling the operation, if needed.</param>
-    /// <param name="networkContext">An optional network identifier providing context for resolving network-related values.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     public static async ValueTask ProcessArgumentValuesAsync(
         this IResource resource,
@@ -279,8 +278,7 @@ public static class ResourceExtensions
         // (unprocessed, processed, exception, isSensitive)
         Action<object?, string?, Exception?, bool> processValue,
         ILogger logger,
-        CancellationToken cancellationToken = default,
-        NetworkIdentifier? networkContext = null)
+        CancellationToken cancellationToken = default)
     {
         if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var callbacks))
         {
@@ -296,13 +294,11 @@ public static class ResourceExtensions
                 await callback.Callback(context).ConfigureAwait(false);
             }
 
-            networkContext ??= resource.GetDefaultResourceNetwork();
-
             foreach (var a in args)
             {
                 try
                 {
-                    var resolvedValue = await ResolveValueAsync(executionContext, logger, a, null, networkContext, cancellationToken).ConfigureAwait(false);
+                    var resolvedValue = await resource.ResolveValueAsync(executionContext, logger, a, null, cancellationToken).ConfigureAwait(false);
 
                     if (resolvedValue?.Value != null)
                     {
@@ -325,15 +321,13 @@ public static class ResourceExtensions
     /// <param name="processValue">An action delegate invoked for each environment variable, providing the key, the unprocessed value, the processed value (if available), and any exception encountered during processing.</param>
     /// <param name="logger">The logger used to log any information or errors during the environment variables processing.</param>
     /// <param name="cancellationToken">A cancellation token to observe during the asynchronous operation.</param>
-    /// <param name="networkContext">An optional network identifier providing context for resolving network-related values.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static async ValueTask ProcessEnvironmentVariableValuesAsync(
         this IResource resource,
         DistributedApplicationExecutionContext executionContext,
         Action<string, object?, string?, Exception?> processValue,
         ILogger logger,
-        CancellationToken cancellationToken = default,
-        NetworkIdentifier? networkContext = null)
+        CancellationToken cancellationToken = default)
     {
         if (resource.TryGetEnvironmentVariables(out var callbacks))
         {
@@ -348,13 +342,11 @@ public static class ResourceExtensions
                 await callback.Callback(context).ConfigureAwait(false);
             }
 
-            networkContext ??= resource.GetDefaultResourceNetwork();
-
             foreach (var (key, expr) in config)
             {
                 try
                 {
-                    var resolvedValue = await ResolveValueAsync(executionContext, logger, expr, key, networkContext, cancellationToken).ConfigureAwait(false);
+                    var resolvedValue = await resource.ResolveValueAsync(executionContext, logger, expr, key, cancellationToken).ConfigureAwait(false);
 
                     if (resolvedValue?.Value is not null)
                     {
@@ -378,8 +370,8 @@ public static class ResourceExtensions
     /// Processes trusted certificates configuration for the specified resource within the given execution context.
     /// This may produce additional <see cref="CommandLineArgsCallbackAnnotation"/> and <see cref="EnvironmentCallbackAnnotation"/>
     /// annotations on the resource to configure certificate trust as needed and therefore must be run before
-    /// <see cref="ProcessArgumentValuesAsync(IResource, DistributedApplicationExecutionContext, Action{object?, string?, Exception?, bool}, ILogger, CancellationToken, NetworkIdentifier?)"/>
-    /// and <see cref="ProcessEnvironmentVariableValuesAsync(IResource, DistributedApplicationExecutionContext, Action{string, object?, string?, Exception?}, ILogger, CancellationToken, NetworkIdentifier?)"/> are called.
+    /// <see cref="ProcessArgumentValuesAsync(IResource, DistributedApplicationExecutionContext, Action{object?, string?, Exception?, bool}, ILogger, CancellationToken)"/>
+    /// and <see cref="ProcessEnvironmentVariableValuesAsync(IResource, DistributedApplicationExecutionContext, Action{string, object?, string?, Exception?}, ILogger, CancellationToken)"/> are called.
     /// </summary>
     /// <param name="resource">The resource for which to process the certificate trust configuration.</param>
     /// <param name="executionContext">The execution context used during the processing.</param>
@@ -388,7 +380,6 @@ public static class ResourceExtensions
     /// <param name="logger">The logger used for logging information during the processing.</param>
     /// <param name="bundlePathFactory">A function that takes the active <see cref="CertificateTrustScope"/> and returns a <see cref="ReferenceExpression"/> representing the path to a custom certificate bundle for the resource.</param>
     /// <param name="certificateDirectoryPathsFactory">A function that takes the active <see cref="CertificateTrustScope"/> and returns a <see cref="ReferenceExpression"/> representing path(s) to a directory containing the custom certificates for the resource.</param>
-    /// <param name="networkContext">An optional network identifier providing context for resolving network-related values.</param>
     /// <param name="cancellationToken">A cancellation token to observe while processing.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public static async ValueTask<(CertificateTrustScope, X509Certificate2Collection?)> ProcessCertificateTrustConfigAsync(
@@ -401,7 +392,6 @@ public static class ResourceExtensions
         ILogger logger,
         Func<CertificateTrustScope, ReferenceExpression> bundlePathFactory,
         Func<CertificateTrustScope, ReferenceExpression> certificateDirectoryPathsFactory,
-        NetworkIdentifier? networkContext = null,
         CancellationToken cancellationToken = default)
     {
         var developerCertificateService = executionContext.ServiceProvider.GetRequiredService<IDeveloperCertificateService>();
@@ -494,7 +484,7 @@ public static class ResourceExtensions
         {
             try
             {
-                var resolvedValue = await ResolveValueAsync(executionContext, logger, a, null, networkContext, cancellationToken).ConfigureAwait(false);
+                var resolvedValue = await resource.ResolveValueAsync(executionContext, logger, a, null, cancellationToken).ConfigureAwait(false);
 
                 if (resolvedValue?.Value != null)
                 {
@@ -511,7 +501,7 @@ public static class ResourceExtensions
         {
             try
             {
-                var resolvedValue = await ResolveValueAsync(executionContext, logger, expr, key, networkContext, cancellationToken).ConfigureAwait(false);
+                var resolvedValue = await resource.ResolveValueAsync(executionContext, logger, expr, key, cancellationToken).ConfigureAwait(false);
 
                 if (resolvedValue?.Value is not null)
                 {
@@ -528,18 +518,18 @@ public static class ResourceExtensions
     }
 
     private static async ValueTask<ResolvedValue?> ResolveValueAsync(
+        this IResource resource,
         DistributedApplicationExecutionContext executionContext,
         ILogger logger,
-        object value,
+        object? value,
         string? key = null,
-        NetworkIdentifier? networkContext = null,
         CancellationToken cancellationToken = default)
     {
         return (executionContext.Operation, value) switch
         {
             (_, string s) => new(s, false),
-            (DistributedApplicationOperation.Run, IValueProvider provider) => await GetValue(key, provider, logger, networkContext, cancellationToken).ConfigureAwait(false),
-            (DistributedApplicationOperation.Run, IResourceBuilder<IResource> rb) when rb.Resource is IValueProvider provider => await GetValue(key, provider, logger, networkContext, cancellationToken).ConfigureAwait(false),
+            (DistributedApplicationOperation.Run, IValueProvider provider) => await resource.GetValue(executionContext, key, provider, logger, cancellationToken).ConfigureAwait(false),
+            (DistributedApplicationOperation.Run, IResourceBuilder<IResource> rb) when rb.Resource is IValueProvider provider => await resource.GetValue(executionContext, key, provider, logger, cancellationToken).ConfigureAwait(false),
             (DistributedApplicationOperation.Publish, IManifestExpressionProvider provider) => new(provider.ValueExpression, false),
             (DistributedApplicationOperation.Publish, IResourceBuilder<IResource> rb) when rb.Resource is IManifestExpressionProvider provider => new(provider.ValueExpression, false),
             (_, { } o) => new(o.ToString(), false),
@@ -556,10 +546,10 @@ public static class ResourceExtensions
 
     internal static async ValueTask ProcessContainerRuntimeArgValues(
         this IResource resource,
+        DistributedApplicationExecutionContext executionContext,
         Action<string?, Exception?> processValue,
         ILogger logger,
-        CancellationToken cancellationToken = default,
-        NetworkIdentifier? context = null)
+        CancellationToken cancellationToken = default)
     {
         // Apply optional extra arguments to the container run command.
         if (resource.TryGetAnnotationsOfType<ContainerRuntimeArgsCallbackAnnotation>(out var runArgsCallback))
@@ -580,7 +570,7 @@ public static class ResourceExtensions
                     var value = arg switch
                     {
                         string s => s,
-                        IValueProvider valueProvider => (await GetValue(key: null, valueProvider, logger, context, cancellationToken).ConfigureAwait(false))?.Value,
+                        IValueProvider valueProvider => (await resource.GetValue(executionContext, key: null, valueProvider, logger, cancellationToken).ConfigureAwait(false))?.Value,
                         { } obj => obj.ToString(),
                         null => null
                     };
@@ -598,21 +588,21 @@ public static class ResourceExtensions
         }
     }
 
-    private static async Task<ResolvedValue?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, NetworkIdentifier? networkContext, CancellationToken cancellationToken)
+    private static async Task<ResolvedValue?> GetValue(this IResource resource, DistributedApplicationExecutionContext executionContext, string? key, IValueProvider valueProvider, ILogger logger, CancellationToken cancellationToken)
     {
-        var task = ExpressionResolver.ResolveAsync(valueProvider, new ValueProviderContext() { Network = networkContext }, cancellationToken);
+        var task = ExpressionResolver.ResolveAsync(valueProvider, new ValueProviderContext() { ExecutionContext = executionContext, Caller = resource }, cancellationToken);
 
         if (!task.IsCompleted)
         {
-            if (valueProvider is IResource resource)
+            if (valueProvider is IResource providerResource)
             {
                 if (key is null)
                 {
-                    logger.LogInformation("Waiting for value from resource '{ResourceName}'", resource.Name);
+                    logger.LogInformation("Waiting for value from resource '{ResourceName}'", providerResource.Name);
                 }
                 else
                 {
-                    logger.LogInformation("Waiting for value for environment variable value '{Name}' from resource '{ResourceName}'", key, resource.Name);
+                    logger.LogInformation("Waiting for value for environment variable value '{Name}' from resource '{ResourceName}'", key, providerResource.Name);
                 }
             }
             else if (valueProvider is ConnectionStringReference { Resource: var cs })

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -366,6 +366,11 @@ public static class ResourceExtensions
         return resource.IsContainer() ? KnownNetworkIdentifiers.DefaultAspireContainerNetwork : KnownNetworkIdentifiers.LocalhostNetwork;
     }
 
+    internal static IEnumerable<NetworkIdentifier> GetSupportedNetworks(this IResource resource)
+    {
+        return resource.IsContainer() ? [KnownNetworkIdentifiers.DefaultAspireContainerNetwork, KnownNetworkIdentifiers.LocalhostNetwork] : [KnownNetworkIdentifiers.LocalhostNetwork];
+    }
+
     /// <summary>
     /// Processes trusted certificates configuration for the specified resource within the given execution context.
     /// This may produce additional <see cref="CommandLineArgsCallbackAnnotation"/> and <see cref="EnvironmentCallbackAnnotation"/>

--- a/src/Aspire.Hosting/ApplicationModel/ValueProviderExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ValueProviderExtensions.cs
@@ -9,4 +9,19 @@ internal static class ValueProviderExtensions
     {
         return context?.Network ?? context?.Caller?.GetDefaultResourceNetwork() ?? KnownNetworkIdentifiers.LocalhostNetwork;
     }
+
+    public static IEnumerable<NetworkIdentifier> GetSupportedNetworkIdentifiers(this ValueProviderContext context)
+    {
+        if (context?.Network is { } network)
+        {
+            return [network];
+        }
+
+        if (context?.Caller?.GetSupportedNetworks() is { } networks)
+        {
+            return networks;
+        }
+
+        return [KnownNetworkIdentifiers.LocalhostNetwork];
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ValueProviderExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ValueProviderExtensions.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+internal static class ValueProviderExtensions
+{
+    public static NetworkIdentifier GetNetworkIdentifier(this ValueProviderContext context)
+    {
+        return context?.Network ?? context?.Caller?.GetDefaultResourceNetwork() ?? KnownNetworkIdentifiers.LocalhostNetwork;
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ValueProviderExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ValueProviderExtensions.cs
@@ -9,19 +9,4 @@ internal static class ValueProviderExtensions
     {
         return context?.Network ?? context?.Caller?.GetDefaultResourceNetwork() ?? KnownNetworkIdentifiers.LocalhostNetwork;
     }
-
-    public static IEnumerable<NetworkIdentifier> GetSupportedNetworkIdentifiers(this ValueProviderContext context)
-    {
-        if (context?.Network is { } network)
-        {
-            return [network];
-        }
-
-        if (context?.Caller?.GetSupportedNetworks() is { } networks)
-        {
-            return networks;
-        }
-
-        return [KnownNetworkIdentifiers.LocalhostNetwork];
-    }
 }

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -105,6 +105,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Aspire.Hosting.Tests" />
+    <InternalsVisibleTo Include="Aspire.Hosting.Yarp.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Python.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Testing.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Containers.Tests" />

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -94,6 +94,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.ApplicationModel.ResourceExtensions.ProcessArgumentValuesAsync(Aspire.Hosting.ApplicationModel.IResource,Aspire.Hosting.DistributedApplicationExecutionContext,System.Action{System.Object,System.String,System.Exception,System.Boolean},Microsoft.Extensions.Logging.ILogger,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.ApplicationModel.ResourceExtensions.ProcessEnvironmentVariableValuesAsync(Aspire.Hosting.ApplicationModel.IResource,Aspire.Hosting.DistributedApplicationExecutionContext,System.Action{System.String,System.Object,System.String,System.Exception},Microsoft.Extensions.Logging.ILogger,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aspire.Hosting.IInteractionService.PromptInputsAsync(System.String,System.String,System.Collections.Generic.IReadOnlyList{Aspire.Hosting.InteractionInput},Aspire.Hosting.InputsDialogInteractionOptions,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
@@ -88,20 +88,6 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aspire.Hosting.ApplicationModel.EndpointReference.get_ContainerHost</Target>
-    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
-    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Aspire.Hosting.ApplicationModel.ResourceExtensions.ProcessArgumentValuesAsync(Aspire.Hosting.ApplicationModel.IResource,Aspire.Hosting.DistributedApplicationExecutionContext,System.Action{System.Object,System.String,System.Exception,System.Boolean},Microsoft.Extensions.Logging.ILogger,System.String,System.Threading.CancellationToken)</Target>
-    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
-    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Aspire.Hosting.ApplicationModel.ResourceExtensions.ProcessEnvironmentVariableValuesAsync(Aspire.Hosting.ApplicationModel.IResource,Aspire.Hosting.DistributedApplicationExecutionContext,System.Action{System.String,System.Object,System.String,System.Exception},Microsoft.Extensions.Logging.ILogger,System.String,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -612,26 +612,26 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         static ReferenceExpression GetTargetUrlExpression(EndpointReference e) =>
             ReferenceExpression.Create($"{e.Property(EndpointProperty.Scheme)}://{e.EndpointAnnotation.TargetHost}:{e.Property(EndpointProperty.TargetPort)}");
 
-        var otlpGrpc = dashboardResource.GetEndpoint(OtlpGrpcEndpointName);
+        var otlpGrpc = dashboardResource.GetEndpoint(OtlpGrpcEndpointName, KnownNetworkIdentifiers.LocalhostNetwork);
         if (otlpGrpc.Exists)
         {
             context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpGrpcUrlName.EnvVarName] = GetTargetUrlExpression(otlpGrpc);
         }
 
-        var otlpHttp = dashboardResource.GetEndpoint(OtlpHttpEndpointName);
+        var otlpHttp = dashboardResource.GetEndpoint(OtlpHttpEndpointName, KnownNetworkIdentifiers.LocalhostNetwork);
         if (otlpHttp.Exists)
         {
             context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpHttpUrlName.EnvVarName] = GetTargetUrlExpression(otlpHttp);
         }
 
-        var mcp = dashboardResource.GetEndpoint(McpEndpointName);
+        var mcp = dashboardResource.GetEndpoint(McpEndpointName, KnownNetworkIdentifiers.LocalhostNetwork);
         if (!mcp.Exists)
         {
             // Fallback to frontend https or http endpoint if not configured.
-            mcp = dashboardResource.GetEndpoint("https");
+            mcp = dashboardResource.GetEndpoint("https", KnownNetworkIdentifiers.LocalhostNetwork);
             if (!mcp.Exists)
             {
-                mcp = dashboardResource.GetEndpoint("http");
+                mcp = dashboardResource.GetEndpoint("http", KnownNetworkIdentifiers.LocalhostNetwork);
             }
         }
 
@@ -644,7 +644,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             context.EnvironmentVariables[DashboardConfigNames.DashboardMcpUrlName.EnvVarName] = GetTargetUrlExpression(mcp);
         }
 
-        var frontendEndpoints = dashboardResource.GetEndpoints().ToList();
+        var frontendEndpoints = dashboardResource.GetEndpoints(KnownNetworkIdentifiers.LocalhostNetwork).ToList();
         var aspnetCoreUrls = new ReferenceExpressionBuilder();
         var first = true;
 

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -168,7 +168,7 @@ public static class OtlpConfigurationExtensions
         ArgumentNullException.ThrowIfNull(builder);
 
         AddOtlpEnvironment(builder.Resource, builder.ApplicationBuilder.Configuration, builder.ApplicationBuilder.Environment);
-        
+
         return builder;
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -112,7 +112,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         Assert.Same(container.Resource, dashboard);
 
-        var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance, KnownNetworkIdentifiers.LocalhostNetwork).DefaultTimeout())
+        var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout())
             .OrderBy(c => c.Key)
             .ToList();
 
@@ -214,7 +214,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         Assert.Same(container.Resource, dashboard);
 
-        var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance, KnownNetworkIdentifiers.LocalhostNetwork).DefaultTimeout())
+        var config = (await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout())
             .OrderBy(c => c.Key)
             .ToList();
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -2035,6 +2035,7 @@ public class DcpExecutorTests
             {
                 ServiceProvider = new TestServiceProvider(configuration)
                     .AddService<IDeveloperCertificateService>(developerCertificateService)
+                    .AddService(Options.Create(dcpOptions))
             }),
             resourceLoggerService,
             new TestDcpDependencyCheckService(),

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -155,24 +155,12 @@ public class ExpressionResolverTests
     [InlineData(true, true, "http://127.0.0.1:18889", "http://aspire.dev.internal:18889")]
     [InlineData(false, true, "http://[::1]:18889", "http://[::1]:18889")]
     [InlineData(true, true, "http://[::1]:18889", "http://aspire.dev.internal:18889")]
-    [InlineData(false, true, "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy", "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(true, true, "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy", "Server=aspire.dev.internal,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(false, true, "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy", "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(true, true, "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy", "Server=aspire.dev.internal,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(false, true, "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy", "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(true, true, "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy", "Server=aspire.dev.internal,1433;User ID=sa;Password=xxx;Database=yyy")]
     [InlineData(false, false, "http://localhost:18889", "http://localhost:18889")]
     [InlineData(true, false, "http://localhost:18889", "http://host.docker.internal:18889")]
     [InlineData(false, false, "http://127.0.0.1:18889", "http://127.0.0.1:18889")]
     [InlineData(true, false, "http://127.0.0.1:18889", "http://host.docker.internal:18889")]
     [InlineData(false, false, "http://[::1]:18889", "http://[::1]:18889")]
     [InlineData(true, false, "http://[::1]:18889", "http://host.docker.internal:18889")]
-    [InlineData(false, false, "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy", "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(true, false, "Server=localhost,1433;User ID=sa;Password=xxx;Database=yyy", "Server=host.docker.internal,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(false, false, "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy", "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(true, false, "Server=127.0.0.1,1433;User ID=sa;Password=xxx;Database=yyy", "Server=host.docker.internal,1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(false, false, "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy", "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy")]
-    [InlineData(true, false, "Server=[::1],1433;User ID=sa;Password=xxx;Database=yyy", "Server=host.docker.internal,1433;User ID=sa;Password=xxx;Database=yyy")]
     public async Task HostUrlPropertyGetsResolved(bool targetIsContainer, bool withTunnel, string hostUrlVal, string expectedValue)
     {
         var builder = DistributedApplication.CreateBuilder();
@@ -270,9 +258,9 @@ sealed class TestValueProviderResource(string name) : Resource(name), IValueProv
 sealed class TestExpressionResolverResource : ContainerResource, IResourceWithEndpoints, IResourceWithConnectionString
 {
     readonly string _exprName;
-    EndpointReference Endpoint1 => new(this, "endpoint1", KnownNetworkIdentifiers.LocalhostNetwork);
-    EndpointReference Endpoint2 => new(this, "endpoint2", KnownNetworkIdentifiers.LocalhostNetwork);
-    EndpointReference Endpoint3 => new(this, "endpoint3", KnownNetworkIdentifiers.LocalhostNetwork);
+    EndpointReference Endpoint1 => new(this, "endpoint1");
+    EndpointReference Endpoint2 => new(this, "endpoint2");
+    EndpointReference Endpoint3 => new(this, "endpoint3");
     Dictionary<string, ReferenceExpression> Expressions { get; }
     public TestExpressionResolverResource(string exprName) : base("testresource")
     {

--- a/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
@@ -35,8 +35,7 @@ public static class EnvironmentVariableEvaluator
                 }
             },
             NullLogger.Instance,
-            CancellationToken.None,
-            networkContext);
+            CancellationToken.None);
 
         return environmentVariables;
     }

--- a/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
@@ -11,8 +11,7 @@ public static class EnvironmentVariableEvaluator
     public static async ValueTask<Dictionary<string, string>> GetEnvironmentVariablesAsync(
         IResource resource,
         DistributedApplicationOperation applicationOperation = DistributedApplicationOperation.Run,
-        IServiceProvider? serviceProvider = null,
-        NetworkIdentifier? networkContext = null)
+        IServiceProvider? serviceProvider = null)
     {
         var executionContext = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(applicationOperation)
         {

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -237,9 +237,6 @@ public class WithEnvironmentTests
                                 .WithEnvironment("TARGET_PORT", $"{endpoint.Property(EndpointProperty.TargetPort)}")
                                 .WithEnvironment("HOST", $"{test.Resource};name=1");
 
-        /*var testServiceProvider = new TestServiceProvider();
-        testServiceProvider.AddService<>*/
-
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerB.Resource).DefaultTimeout();
         var manifestConfig = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerB.Resource, DistributedApplicationOperation.Publish).DefaultTimeout();
 

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -237,6 +237,9 @@ public class WithEnvironmentTests
                                 .WithEnvironment("TARGET_PORT", $"{endpoint.Property(EndpointProperty.TargetPort)}")
                                 .WithEnvironment("HOST", $"{test.Resource};name=1");
 
+        /*var testServiceProvider = new TestServiceProvider();
+        testServiceProvider.AddService<>*/
+
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerB.Resource).DefaultTimeout();
         var manifestConfig = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerB.Resource, DistributedApplicationOperation.Publish).DefaultTimeout();
 

--- a/tests/Aspire.Hosting.Yarp.Tests/AddYarpTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/AddYarpTests.cs
@@ -3,8 +3,10 @@
 
 using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Yarp.Tests;
 
@@ -36,6 +38,7 @@ public class AddYarpTests(ITestOutputHelper testOutputHelper)
             new List<X509Certificate2>(),
             containerCertificateSupport,
             trustCertificate: true));
+        testProvider.AddService(Options.Create(new DcpOptions()));
 
         var yarp = builder.AddYarp("yarp");
 
@@ -83,6 +86,7 @@ public class AddYarpTests(ITestOutputHelper testOutputHelper)
             new List<X509Certificate2>(),
             supportsContainerTrust: false,
             trustCertificate: true));
+        testProvider.AddService(Options.Create(new DcpOptions()));
 
         var yarp = builder.AddYarp("yarp").WithStaticFiles();
 
@@ -123,6 +127,7 @@ public class AddYarpTests(ITestOutputHelper testOutputHelper)
             new List<X509Certificate2>(),
             supportsContainerTrust: false,
             trustCertificate: true));
+        testProvider.AddService(Options.Create(new DcpOptions()));
 
         using var tempDir = new TempDirectory();
 


### PR DESCRIPTION
When dealing with `HostUrl` values (such as for the otel endpoint references) we need to consider that we may have to remap both the address and port if in a tunnel scenario. This PR allows us to find a referenced by port and remap to the equivalent endpoint on a separate network context.