### PR TITLE
Improve flaky dashboard integration test

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -378,6 +378,11 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 // This isn't used by dotnet watch but still useful to have for debugging
                 _logger.LogInformation("OTLP/HTTP listening on: {OtlpEndpointUri}", _otlpServiceHttpEndPointAccessor().GetResolvedAddress());
             }
+            if (_mcpEndPointAccessor != null)
+            {
+                // This isn't used by dotnet watch but still useful to have for debugging
+                _logger.LogInformation("MCP listening on: {McpEndpointUri}", _mcpEndPointAccessor().GetResolvedAddress());
+            }
 
             if (_dashboardOptionsMonitor.CurrentValue.Otlp.AuthMode == OtlpAuthMode.Unsecured)
             {

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -196,6 +196,13 @@ public class FrontendBrowserTokenAuthTests
             },
             w =>
             {
+                Assert.Equal("MCP listening on: {McpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+
+                var uri = new Uri((string)GetValue(w.State, "McpEndpointUri")!);
+                Assert.NotEqual(0, uri.Port);
+            },
+            w =>
+            {
                 Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             },

--- a/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
@@ -39,6 +39,9 @@ public static class ServerRetryHelper
                 var port = GetAvailablePort(nextPortAttempt, logger);
                 ports.Add(port);
 
+                // Use a minimum gap of 10 between port allocations to reduce the risk of port collisions.
+                // Allocating consecutive ports (gap of 0) can lead to conflicts if the OS or other processes
+                // allocate ports in the same range. The random gap further reduces the chance of collision.
                 nextPortAttempt = port + Random.Shared.Next(10, 100);
             }
 

--- a/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
@@ -39,7 +39,12 @@ public static class ServerRetryHelper
                 var port = GetAvailablePort(nextPortAttempt, logger);
                 ports.Add(port);
 
-                nextPortAttempt = port + Random.Shared.Next(100);
+                nextPortAttempt = port + Random.Shared.Next(10, 100);
+            }
+
+            if (ports.Count != ports.Distinct().Count())
+            {
+                throw new InvalidOperationException($"Generated ports list contains duplicate numbers: {string.Join(", ", ports)}");
             }
 
             try

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -710,6 +710,13 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             },
             w =>
             {
+                Assert.Equal("MCP listening on: {McpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+
+                var uri = new Uri((string)GetValue(w.State, "McpEndpointUri")!);
+                Assert.NotEqual(0, uri.Port);
+            },
+            w =>
+            {
                 Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             },

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -756,6 +756,8 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
                 otlpHttpPort = ports[3];
 
                 // Reset sink writes. Required to clear out data from a previous failed retry.
+                // The following cast relies on the internal implementation detail that TestSink.Writes is a ConcurrentQueue<WriteContext>.
+                // If the implementation of TestSink changes, this may break. There is no public API to clear the writes.
                 var writes = (ConcurrentQueue<Microsoft.Extensions.Logging.Testing.WriteContext>)testSink.Writes;
                 writes.Clear();
 


### PR DESCRIPTION
## Description

I think some dashboard tests have been flaky because the next random port logic doesn't provide a min random number. A random increase of 0 could be used which would generate unexpected test results.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
