### PR TITLE
Fix MCP endpoint with redirect HTTPS

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -196,7 +196,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         ConfigureKestrelEndpoints(builder, dashboardOptions);
 
         var browserHttpsPort = dashboardOptions.Frontend.GetEndpointAddresses().FirstOrDefault(IsHttpsOrNull)?.Port;
-        var isAllHttps = browserHttpsPort is not null && IsHttpsOrNull(dashboardOptions.Otlp.GetGrpcEndpointAddress()) && IsHttpsOrNull(dashboardOptions.Otlp.GetHttpEndpointAddress());
+        var isAllHttps = browserHttpsPort is not null && IsHttpsOrNull(dashboardOptions.Otlp.GetGrpcEndpointAddress()) && IsHttpsOrNull(dashboardOptions.Otlp.GetHttpEndpointAddress()) && IsHttpsOrNull(dashboardOptions.Mcp.GetEndpointAddress());
         if (isAllHttps)
         {
             // Explicitly configure the HTTPS redirect port as we're possibly listening on multiple HTTPS addresses
@@ -619,8 +619,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
             var kestrelSection = context.Configuration.GetSection("Kestrel");
             var configurationLoader = serverOptions.Configure(kestrelSection);
+            var groupedEndpoints = EndpointInfo.GroupEndpointsByAddress(endpoints);
 
-            foreach (var (address, addressEndpoints) in EndpointInfo.GroupEndpointsByAddress(endpoints))
+            foreach (var (address, addressEndpoints) in groupedEndpoints)
             {
                 var name = string.Join("-", addressEndpoints.Select(m => m.Name));
                 var connectionTypes = addressEndpoints.Select(m => m.ConnectionType).ToList();

--- a/tests/Aspire.Dashboard.Tests/Integration/McpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/McpServiceTests.cs
@@ -211,7 +211,7 @@ public class McpServiceTests
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper,
             additionalConfiguration: data =>
             {
-                data[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0;";
+                data[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0";
                 data[DashboardConfigNames.DashboardOtlpGrpcUrlName.ConfigKey] = "https://127.0.0.1:0";
                 data[DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "https://127.0.0.1:0";
 


### PR DESCRIPTION
## Description

Fix dashboard configuration error when MCP endpoint is the only non-HTTPS endpoint.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
