### PR TITLE
Fix generating random MCP endpoint URL in templates

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/dotnetcli.host.json
@@ -20,6 +20,12 @@
       "appHostOtlpHttpsPort": {
         "isHidden": true
       },
+      "appHostMcpHttpPort": {
+        "isHidden": true
+      },
+      "appHostMcpHttpsPort": {
+        "isHidden": true
+      },
       "appHostResourceHttpPort": {
         "isHidden": true
       },

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/template.json
@@ -134,6 +134,28 @@
       },
       "replaces": "19000"
     },
+    "appHostMcpHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTP endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 18000,
+        "high": 18300
+      }
+    },
+    "appHostMcpHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpPort",
+        "fallbackVariableName": "appHostMcpHttpPortGenerated"
+      },
+      "replaces": "18000"
+    },
     "appHostResourceHttpPort": {
       "type": "parameter",
       "datatype": "integer",
@@ -199,6 +221,28 @@
         "fallbackVariableName": "appHostOtlpHttpsPortGenerated"
       },
       "replaces": "21000"
+    },
+    "appHostMcpHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTPS endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 23000,
+        "high": 23300
+      }
+    },
+    "appHostMcpHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpsPort",
+        "fallbackVariableName": "appHostMcpHttpsPortGenerated"
+      },
+      "replaces": "23000"
     },
     "appHostResourceHttpsPort": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/dotnetcli.host.json
@@ -24,6 +24,12 @@
       "appHostOtlpHttpsPort": {
         "isHidden": true
       },
+      "appHostMcpHttpPort": {
+        "isHidden": true
+      },
+      "appHostMcpHttpsPort": {
+        "isHidden": true
+      },
       "appHostResourceHttpPort": {
         "isHidden": true
       },

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
@@ -141,6 +141,28 @@
       },
       "replaces": "19000"
     },
+    "appHostMcpHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTP endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 18000,
+        "high": 18300
+      }
+    },
+    "appHostMcpHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpPort",
+        "fallbackVariableName": "appHostMcpHttpPortGenerated"
+      },
+      "replaces": "18000"
+    },
     "appHostResourceHttpPort": {
       "type": "parameter",
       "datatype": "integer",
@@ -206,6 +228,28 @@
         "fallbackVariableName": "appHostOtlpHttpsPortGenerated"
       },
       "replaces": "21000"
+    },
+    "appHostMcpHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTPS endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 23000,
+        "high": 23300
+      }
+    },
+    "appHostMcpHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpsPort",
+        "fallbackVariableName": "appHostMcpHttpsPortGenerated"
+      },
+      "replaces": "23000"
     },
     "appHostResourceHttpsPort": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/dotnetcli.host.json
@@ -24,6 +24,12 @@
       "appHostOtlpHttpsPort": {
         "isHidden": true
       },
+      "appHostMcpHttpPort": {
+        "isHidden": true
+      },
+      "appHostMcpHttpsPort": {
+        "isHidden": true
+      },
       "appHostResourceHttpPort": {
         "isHidden": true
       },

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -169,6 +169,28 @@
       },
       "replaces": "19000"
     },
+    "appHostMcpHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTP endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 18000,
+        "high": 18300
+      }
+    },
+    "appHostMcpHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpPort",
+        "fallbackVariableName": "appHostMcpHttpPortGenerated"
+      },
+      "replaces": "18000"
+    },
     "appHostResourceHttpPort": {
       "type": "parameter",
       "datatype": "integer",
@@ -234,6 +256,28 @@
         "fallbackVariableName": "appHostOtlpHttpsPortGenerated"
       },
       "replaces": "21000"
+    },
+    "appHostMcpHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTPS endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 23000,
+        "high": 23300
+      }
+    },
+    "appHostMcpHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpsPort",
+        "fallbackVariableName": "appHostMcpHttpsPortGenerated"
+      },
+      "replaces": "23000"
     },
     "appHostResourceHttpsPort": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-py-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-py-starter/.template.config/template.json
@@ -88,6 +88,28 @@
       },
       "replaces": "19000"
     },
+    "appHostMcpHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTP endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 18000,
+        "high": 18300
+      }
+    },
+    "appHostMcpHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpPort",
+        "fallbackVariableName": "appHostMcpHttpPortGenerated"
+      },
+      "replaces": "18000"
+    },
     "appHostResourceHttpPort": {
       "type": "parameter",
       "datatype": "integer",
@@ -153,6 +175,28 @@
         "fallbackVariableName": "appHostOtlpHttpsPortGenerated"
       },
       "replaces": "21000"
+    },
+    "appHostMcpHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTPS endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 23000,
+        "high": 23300
+      }
+    },
+    "appHostMcpHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpsPort",
+        "fallbackVariableName": "appHostMcpHttpsPortGenerated"
+      },
+      "replaces": "23000"
     },
     "appHostResourceHttpsPort": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-py-starter/13.0/apphost.run.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-py-starter/13.0/apphost.run.json
@@ -15,6 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21000",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:23000",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22000"
       }
     },
@@ -32,6 +33,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19000",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18000",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20000"
       }
     }

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/dotnetcli.host.json
@@ -25,6 +25,12 @@
       "appHostOtlpHttpsPort": {
         "isHidden": true
       },
+      "appHostMcpHttpPort": {
+        "isHidden": true
+      },
+      "appHostMcpHttpsPort": {
+        "isHidden": true
+      },
       "appHostResourceHttpPort": {
         "isHidden": true
       },

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -259,6 +259,28 @@
       },
       "replaces": "19000"
     },
+    "appHostMcpHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTP endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 18000,
+        "high": 18300
+      }
+    },
+    "appHostMcpHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpPort",
+        "fallbackVariableName": "appHostMcpHttpPortGenerated"
+      },
+      "replaces": "18000"
+    },
     "appHostResourceHttpPort": {
       "type": "parameter",
       "datatype": "integer",
@@ -324,6 +346,28 @@
         "fallbackVariableName": "appHostOtlpHttpsPortGenerated"
       },
       "replaces": "21000"
+    },
+    "appHostMcpHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the MCP HTTPS endpoint in launchSettings.json of the AppHost project."
+    },
+    "appHostMcpHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 23000,
+        "high": 23300
+      }
+    },
+    "appHostMcpHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "appHostMcpHttpsPort",
+        "fallbackVariableName": "appHostMcpHttpsPortGenerated"
+      },
+      "replaces": "23000"
     },
     "appHostResourceHttpsPort": {
       "type": "parameter",


### PR DESCRIPTION
## Description

`ASPIRE_DASHBOARD_MCP_ENDPOINT_URL` values had previously been added to template's `launchSettings.json`. However config wasn't added to templates to generate a random value for the endpoint when a template was created.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
