### PR TITLE
Add custom commands to open Kusto servers in Kusto Explorer

### DIFF
--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -392,7 +392,7 @@ public static class AzureKustoBuilderExtensions
                 {
                     _ = await interactionService.PromptMessageBoxAsync(
                         title: "Kusto Web Explorer",
-                        message: $"Could not automatically open Kusto Web Explorer for resource '{resourceBuilder.Resource.Name}'. Click {connectionString} to manually open the Web Explorer.",
+                        message: $"Could not automatically open Kusto Web Explorer for resource '{resourceBuilder.Resource.Name}'. Click [{connectionString}]({connectionString}) to manually open the Web Explorer.",
                         new MessageBoxInteractionOptions
                         {
                             Intent = MessageIntent.Information,

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -14,7 +14,6 @@ using Kusto.Data.Common;
 using Kusto.Data.Net.Client;
 using Kusto.Data.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
@@ -342,7 +341,7 @@ public static class AzureKustoBuilderExtensions
                 return ResourceCommandState.Hidden;
             }
 
-            return context.ResourceSnapshot.HealthStatus is HealthStatus.Healthy ? ResourceCommandState.Enabled : ResourceCommandState.Disabled;
+            return context.ResourceSnapshot.State?.Text == KnownResourceStates.Running ? ResourceCommandState.Enabled : ResourceCommandState.Disabled;
         }
 
         static ResourceCommandState UpdateStateWeb(IResourceBuilder<AzureKustoClusterResource> resourceBuilder, UpdateCommandStateContext context)
@@ -353,7 +352,7 @@ public static class AzureKustoBuilderExtensions
                 return ResourceCommandState.Hidden;
             }
 
-            return context.ResourceSnapshot.HealthStatus is HealthStatus.Healthy ? ResourceCommandState.Enabled : ResourceCommandState.Disabled;
+            return context.ResourceSnapshot.State?.Text == KnownResourceStates.Running ? ResourceCommandState.Enabled : ResourceCommandState.Disabled;
         }
 
         static async Task<ExecuteCommandResult> OnOpenInKustoExplorerDesktop(IResourceBuilder<AzureKustoClusterResource> resourceBuilder, ExecuteCommandContext context)

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -321,7 +321,7 @@ public static class AzureKustoBuilderExtensions
             commandOptions: new CommandOptions
             {
                 UpdateState = UpdateStateDesktop,
-                IconName = "ServerLink"
+                IconName = "DatabaseSearch"
             });
 
         resourceBuilder.WithCommand(
@@ -331,7 +331,7 @@ public static class AzureKustoBuilderExtensions
             commandOptions: new CommandOptions
             {
                 UpdateState = context => UpdateStateWeb(resourceBuilder, context),
-                IconName = "ServerLink"
+                IconName = "DatabaseSearch"
             });
 
         static ResourceCommandState UpdateStateDesktop(UpdateCommandStateContext context)

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -347,7 +347,7 @@ public static class AzureKustoBuilderExtensions
 
         static ResourceCommandState UpdateStateWeb(IResourceBuilder<AzureKustoClusterResource> resourceBuilder, UpdateCommandStateContext context)
         {
-            // The web explorer will only auto-connect to allowlisted domains, so do not show the command when running as an emulator.
+            // The web explorer will only auto-connect to allowed domains, so do not show the command when running as an emulator.
             if (resourceBuilder.Resource.IsEmulator)
             {
                 return ResourceCommandState.Hidden;

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -319,9 +319,8 @@ public static class AzureKustoBuilderExtensions
             IconName = "ServerLink"
         };
 
-        // TODO: What to do for remote deployment / SSH scenarios?
-
-        // Only add desktop command on Windows
+        // The Desktop Kusto.Explorer is a ClickOnce app that's only available on Windows, so don't add the command
+        // on other platforms.
         if (OperatingSystem.IsWindows())
         {
             resourceBuilder.WithCommand(
@@ -331,11 +330,15 @@ public static class AzureKustoBuilderExtensions
                 commandOptions: options);
         }
 
-        resourceBuilder.WithCommand(
-            name: "open-kusto-explorer-web",
-            displayName: "Open in Kusto Explorer (Web)",
-            executeCommand: context => OnOpenInKustoExplorerWeb(resourceBuilder, context),
-            commandOptions: options);
+        // The web explorer will only auto-connect to allowlisted domains, so do not show this command when running as an emulator.
+        if (!resourceBuilder.Resource.IsEmulator)
+        {
+            resourceBuilder.WithCommand(
+                name: "open-kusto-explorer-web",
+                displayName: "Open in Kusto Explorer (Web)",
+                executeCommand: context => OnOpenInKustoExplorerWeb(resourceBuilder, context),
+                commandOptions: options);
+        }
 
         static ResourceCommandState UpdateState(UpdateCommandStateContext context)
         {

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -321,11 +321,15 @@ public static class AzureKustoBuilderExtensions
 
         // TODO: What to do for remote deployment / SSH scenarios?
 
-        resourceBuilder.WithCommand(
-            name: "open-kusto-explorer-desktop",
-            displayName: "Open in Kusto Explorer (Desktop)",
-            executeCommand: context => OnOpenInKustoExplorerDesktop(resourceBuilder, context),
-            commandOptions: options);
+        // Only add desktop command on Windows
+        if (OperatingSystem.IsWindows())
+        {
+            resourceBuilder.WithCommand(
+                name: "open-kusto-explorer-desktop",
+                displayName: "Open in Kusto Explorer (Desktop)",
+                executeCommand: context => OnOpenInKustoExplorerDesktop(resourceBuilder, context),
+                commandOptions: options);
+        }
 
         resourceBuilder.WithCommand(
             name: "open-kusto-explorer-web",


### PR DESCRIPTION
## Description

Kusto has two "Kusto Explorer" apps for viewing and querying data:

- One is a Windows-only ClickOnce app
- One is a web-based client

Both are popular with different audiences. This change adds both to the actions list for the cluster resource. I can also add the commands to database resources, but I thought that might be cluttering for most users.

Contributes to #8233 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
