### PR TITLE
[release/13.0] Update DCP to version 0.18.12

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.18.9">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.18.12">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>3e009e00b4274502c371e59322ac2dd91c634a17</Sha>
+      <Sha>17092f1262293c5d5a7848db59e43ae9cb295b44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.18.9">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.18.12">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>3e009e00b4274502c371e59322ac2dd91c634a17</Sha>
+      <Sha>17092f1262293c5d5a7848db59e43ae9cb295b44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.18.9">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.18.12">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>3e009e00b4274502c371e59322ac2dd91c634a17</Sha>
+      <Sha>17092f1262293c5d5a7848db59e43ae9cb295b44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.18.9">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.18.12">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>3e009e00b4274502c371e59322ac2dd91c634a17</Sha>
+      <Sha>17092f1262293c5d5a7848db59e43ae9cb295b44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.18.9">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.18.12">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>3e009e00b4274502c371e59322ac2dd91c634a17</Sha>
+      <Sha>17092f1262293c5d5a7848db59e43ae9cb295b44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.18.9">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.18.12">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>3e009e00b4274502c371e59322ac2dd91c634a17</Sha>
+      <Sha>17092f1262293c5d5a7848db59e43ae9cb295b44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.18.9">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.18.12">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>3e009e00b4274502c371e59322ac2dd91c634a17</Sha>
+      <Sha>17092f1262293c5d5a7848db59e43ae9cb295b44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.18.9">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.18.12">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>3e009e00b4274502c371e59322ac2dd91c634a17</Sha>
+      <Sha>17092f1262293c5d5a7848db59e43ae9cb295b44</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="9.10.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,14 +28,14 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.18.9</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.18.9</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.18.9</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.18.9</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.18.9</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindows386Version>0.18.9</MicrosoftDeveloperControlPlanewindows386Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.18.9</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.18.9</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.18.12</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.18.12</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.18.12</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.18.12</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.18.12</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindows386Version>0.18.12</MicrosoftDeveloperControlPlanewindows386Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.18.12</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.18.12</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>11.0.0-beta.25509.1</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>11.0.0-beta.25509.1</MicrosoftDotNetXUnitV3ExtensionsVersion>


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspire/pull/12610 to release/13.0 to fix the Python startup failure.
