### PR TITLE
Detect which version of yarn is being used

### DIFF
--- a/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
+++ b/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
@@ -491,7 +491,7 @@ public static class NodeAppHostingExtension
 
         if (hasYarnBerry)
         {
-            // Yarn 2+ detected
+            // Yarn 2+ detected, --frozen-lockfile is deprecated in v2+, use --immutable instead
             return ["--immutable"];
         }
 

--- a/tests/Aspire.Hosting.NodeJs.Tests/PackageInstallationTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/PackageInstallationTests.cs
@@ -490,7 +490,7 @@ public class PackageInstallationTests
     {
         using var tempDir = new TempDirectory();
         File.WriteAllText(Path.Combine(tempDir.Path, "yarn.lock"), "empty");
-        File.WriteAllText(Path.Combine(tempDir.Path, ".yarnrc.yml"), "empty"); // .yarnrc.yml present
+        File.WriteAllText(Path.Combine(tempDir.Path, ".yarnrc.yml"), "empty");
 
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 

--- a/tests/Aspire.Hosting.NodeJs.Tests/PackageInstallationTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/PackageInstallationTests.cs
@@ -476,13 +476,45 @@ public class PackageInstallationTests
             .WithYarn();
 
         Assert.True(app.Resource.TryGetLastAnnotation<JavaScriptInstallCommandAnnotation>(out var installCommand));
-        Assert.Equal(["install", "--immutable"], installCommand.Args);
+        Assert.Equal(["install", "--frozen-lockfile"], installCommand.Args);
 
         var app2 = builder.AddViteApp("test-app2", tempDir.Path)
             .WithYarn(installArgs: ["--immutable-cache"]);
 
         Assert.True(app2.Resource.TryGetLastAnnotation<JavaScriptInstallCommandAnnotation>(out installCommand));
         Assert.Equal(["install", "--immutable-cache"], installCommand.Args);
+    }
+
+    [Fact]
+    public void WithYarn_ReturnsImmutable_WhenYarnRcYmlExists()
+    {
+        using var tempDir = new TempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "yarn.lock"), "empty");
+        File.WriteAllText(Path.Combine(tempDir.Path, ".yarnrc.yml"), "empty"); // .yarnrc.yml present
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var app = builder.AddViteApp("test-app", tempDir.Path)
+            .WithYarn();
+
+        Assert.True(app.Resource.TryGetLastAnnotation<JavaScriptInstallCommandAnnotation>(out var installCommand));
+        Assert.Equal(["install", "--immutable"], installCommand.Args);
+    }
+
+    [Fact]
+    public void WithYarn_ReturnsImmutable_WhenYarnReleasesDirExists()
+    {
+        using var tempDir = new TempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "yarn.lock"), "empty");
+        Directory.CreateDirectory(Path.Combine(tempDir.Path, ".yarn", "releases"));
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var app = builder.AddViteApp("test-app", tempDir.Path)
+            .WithYarn();
+
+        Assert.True(app.Resource.TryGetLastAnnotation<JavaScriptInstallCommandAnnotation>(out var installCommand));
+        Assert.Equal(["install", "--immutable"], installCommand.Args);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Change the install args based on yarn 1.x or 2+

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
