### PR TITLE
Add ModelContextProtocol assemblies to signing list

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -28,6 +28,9 @@
     <FileSignInfo Include="Markdig.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="MessagePack.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="MessagePack.Annotations.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="ModelContextProtocol.AspNetCore.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="ModelContextProtocol.Core.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="ModelContextProtocol.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenAI.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Spectre.Console.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.dll" CertificateName="3PartySHA2" />


### PR DESCRIPTION
## Description

The official build is currently failing with:

```
##[error].packages\microsoft.dotnet.arcade.sdk\11.0.0-beta.25509.1\tools\Sign.proj(76,5): error SIGN004: Signing 3rd party library 'D:\a\_work\1\s\artifacts\tmp\Release\ContainerSigning\369\tools/ModelContextProtocol.AspNetCore.dll' with Microsoft certificate 'Microsoft400'. The library is considered 3rd party library due to its copyright: '© Anthropic and Contributors.'.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\11.0.0-beta.25509.1\tools\Sign.proj(76,5): error SIGN004: Signing 3rd party library 'D:\a\_work\1\s\artifacts\tmp\Release\ContainerSigning\369\tools/ModelContextProtocol.AspNetCore.dll' with Microsoft certificate 'Microsoft400'. The library is considered 3rd party library due to its copyright: '© Anthropic and Contributors.'.
##[error].packages\microsoft.dotnet.arcade.sdk\11.0.0-beta.25509.1\tools\Sign.proj(76,5): error SIGN004: Signing 3rd party library 'D:\a\_work\1\s\artifacts\tmp\Release\ContainerSigning\370\tools/ModelContextProtocol.Core.dll' with Microsoft certificate 'Microsoft400'. The library is considered 3rd party library due to its copyright: '© Anthropic and Contributors.'.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\11.0.0-beta.25509.1\tools\Sign.proj(76,5): error SIGN004: Signing 3rd party library 'D:\a\_work\1\s\artifacts\tmp\Release\ContainerSigning\370\tools/ModelContextProtocol.Core.dll' with Microsoft certificate 'Microsoft400'. The library is considered 3rd party library due to its copyright: '© Anthropic and Contributors.'.
##[error].packages\microsoft.dotnet.arcade.sdk\11.0.0-beta.25509.1\tools\Sign.proj(76,5): error SIGN004: Signing 3rd party library 'D:\a\_work\1\s\artifacts\tmp\Release\ContainerSigning\371\tools/ModelContextProtocol.dll' with Microsoft certificate 'Microsoft400'. The library is considered 3rd party library due to its copyright: '© Anthropic and Contributors.'.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\11.0.0-beta.25509.1\tools\Sign.proj(76,5): error SIGN004: Signing 3rd party library 'D:\a\_work\1\s\artifacts\tmp\Release\ContainerSigning\371\tools/ModelContextProtocol.dll' with Microsoft certificate 'Microsoft400'. The library is considered 3rd party library due to its copyright: '© Anthropic and Contributors.'.
```

These changes should fix that. (No real way to validate until we do an actual full build.

cc: @radical @JamesNK @halter73 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
