### PR TITLE
Add missing namespace to `CertificateAuthorityCollectionResource`

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionAnnotation.cs
@@ -40,7 +40,7 @@ public enum CertificateTrustScope
 public sealed class CertificateAuthorityCollectionAnnotation : IResourceAnnotation
 {
     /// <summary>
-    /// Gets the <see cref="global::CertificateAuthorityCollection"/> that is being referenced.
+    /// Gets the <see cref="CertificateAuthorityCollection"/> that is being referenced.
     /// </summary>
     public List<CertificateAuthorityCollection> CertificateAuthorityCollections { get; internal set; } = new List<CertificateAuthorityCollection>();
 

--- a/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionResource.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography.X509Certificates;
-using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
 /// Represents a collection of certificate authorities within the application model.


### PR DESCRIPTION
## Description

`CertificateAuthorityCollectionResource` was missing a namespace.