### PR TITLE
Add env vars to resource MCP

### DIFF
--- a/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
+++ b/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
@@ -51,6 +51,7 @@ internal sealed class AspireResourceMcpTools
 
             var response = $"""
             resource_name is the identifier of resources. Use the dashboard_link when displaying resource_name. For example: [`frontend-abcxyz`](https://localhost:1234/resource?name=frontend-abcxyz)
+            environment_variables is a list of environment variables configured for the resource. Environment variable values aren't provided because they could contain sensitive information.
             Console logs for a resource can provide more information about why a resource is not in a running state.
 
             # RESOURCE DATA

--- a/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
+++ b/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
@@ -32,7 +32,7 @@ internal sealed class AspireResourceMcpTools
     }
 
     [McpServerTool(Name = "list_resources")]
-    [Description("List the application resources. Includes information about their type (.NET project, container, executable), running state, source, HTTP endpoints, health status, commands, and relationships.")]
+    [Description("List the application resources. Includes information about their type (.NET project, container, executable), running state, source, HTTP endpoints, health status, commands, configured environment variables, and relationships.")]
     public string ListResources()
     {
         _logger.LogDebug("MCP tool list_resources called");
@@ -46,6 +46,7 @@ internal sealed class AspireResourceMcpTools
                 filteredResources,
                 _dashboardOptions.CurrentValue,
                 includeDashboardUrl: true,
+                includeEnvironmentVariables: true,
                 getResourceName: r => ResourceViewModel.GetResourceName(r, resources));
 
             var response = $"""

--- a/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
@@ -192,7 +192,7 @@ internal static class AIHelpers
                 {
                     name = cmd.Name,
                     description = cmd.GetDisplayDescription(s_commandsLoc)
-                }).ToList(),
+                }).ToList()
             };
 
             if (includeDashboardUrl)
@@ -202,7 +202,7 @@ internal static class AIHelpers
 
             if (includeEnvironmentVariables)
             {
-                resourceObj["environment_variables"] = resource.Environment.Where(e => e.FromSpec).ToDictionary(e => e.Name, e => e.Value);
+                resourceObj["environment_variables"] = resource.Environment.Where(e => e.FromSpec).Select(e => e.Name).ToList();
             }
 
             return resourceObj;

--- a/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
@@ -158,7 +158,7 @@ internal static class AIHelpers
         return span.Attributes.GetPeerAddress();
     }
 
-    internal static string GetResponseGraphJson(List<ResourceViewModel> resources, DashboardOptions options, bool includeDashboardUrl = false, Func<ResourceViewModel, string>? getResourceName = null)
+    internal static string GetResponseGraphJson(List<ResourceViewModel> resources, DashboardOptions options, bool includeDashboardUrl = false, Func<ResourceViewModel, string>? getResourceName = null, bool includeEnvironmentVariables = false)
     {
         var data = resources.Where(resource => !resource.IsResourceHidden(false)).Select(resource =>
         {
@@ -192,12 +192,17 @@ internal static class AIHelpers
                 {
                     name = cmd.Name,
                     description = cmd.GetDisplayDescription(s_commandsLoc)
-                }).ToList()
+                }).ToList(),
             };
 
             if (includeDashboardUrl)
             {
                 resourceObj["dashboard_link"] = GetDashboardLink(options, DashboardUrls.ResourcesUrl(resource: resource.Name), resourceName);
+            }
+
+            if (includeEnvironmentVariables)
+            {
+                resourceObj["environment_variables"] = resource.Environment.Where(e => e.FromSpec).ToDictionary(e => e.Name, e => e.Value);
             }
 
             return resourceObj;


### PR DESCRIPTION
## Description

Make resource env vars available in `list_resources`.

Example of env var values:
<img width="917" height="473" alt="image" src="https://github.com/user-attachments/assets/21f172c5-e899-4141-9250-da800d5f2439" />

Alternative ideas:
- Only include env var names and not values
- Only include env var names and not values, and add a `get_resource_env_var` tool call that takes a resource name and env var name, and returns the value.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
