### PR TITLE
Add 'do' command to runtime-only check

### DIFF
--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -126,6 +126,6 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
     private static bool IsRuntimeOnlyCommand(BaseCommand command)
     {
         var commandName = command.Name;
-        return commandName is "run" or "publish" or "deploy";
+        return commandName is "run" or "publish" or "deploy" or "do";
     }
 }


### PR DESCRIPTION
Avoid doing NuGet package prefetching when the `do` command is called.

Note: we're still doing the prefetch to check for CLI updates on every command ([ref](https://source.dot.net/#aspire/NuGet/NuGetPackagePrefetcher.cs,114)). We could probably avoid doing a NuGet call on every invocation to the CLI here.