### PR TITLE
Add, respect auto-open aspire dashboard setting. Open the first application url in dotnet projects if multiple are provided

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -100,6 +100,9 @@
     <trans-unit id="configuration.aspire.enableSettingsFileCreationPromptOnStartup">
       <source xml:lang="en">Enable apphost discovery on extension activation and prompt to setup .aspire/settings.json.appHostPath if it does not exist in the workspace.</source>
     </trans-unit>
+    <trans-unit id="configuration.aspire.enableAspireDashboardAutoLaunch">
+      <source xml:lang="en">Enable automatic launch of the Aspire Dashboard when using the Aspire debugger.</source>
+    </trans-unit>
     <trans-unit id="configuration.aspire.enableAspireCliDebugLogging">
       <source xml:lang="en">Enable console debug logging for Aspire CLI commands executed by the extension.</source>
     </trans-unit>

--- a/extension/package.json
+++ b/extension/package.json
@@ -205,6 +205,12 @@
           "default": false,
           "description": "%configuration.aspire.enableAspireDcpDebugLogging%",
           "scope": "window"
+        },
+        "aspire.enableAspireDashboardAutoLaunch": {
+          "type": "boolean",
+          "default": true,
+          "description": "%configuration.aspire.enableAspireDashboardAutoLaunch%",
+          "scope": "window"
         }
       }
     }

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -19,6 +19,7 @@
   "configuration.aspire.aspireCliExecutablePath": "The path to the Aspire CLI executable. If not set, the extension will attempt to use 'aspire' from the system PATH.",
   "configuration.aspire.enableAspireCliDebugLogging": "Enable console debug logging for Aspire CLI commands executed by the extension.",
   "configuration.aspire.enableAspireDcpDebugLogging": "Enable Developer Control Plane (DCP) debug logging for Aspire applications. Logs will be stored in the workspace's .aspire/dcp/logs-{debugSessionId} folder.",
+  "configuration.aspire.enableAspireDashboardAutoLaunch": "Enable automatic launch of the Aspire Dashboard when using the Aspire debugger.",
   "command.runAppHost": "Run Aspire apphost",
 	"command.debugAppHost": "Debug Aspire apphost",
 	"aspire-vscode.strings.noCsprojFound": "No apphost found in the current workspace.",

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -287,7 +287,18 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
             debugConfiguration.args = determineArguments(baseProfile?.commandLineArgs, args);
             debugConfiguration.executablePath = baseProfile?.executablePath;
             debugConfiguration.checkForDevCert = baseProfile?.useSSL;
-            debugConfiguration.serverReadyAction = determineServerReadyAction(baseProfile?.launchBrowser, baseProfile?.applicationUrl);
+
+            if (launchOptions.isApphost) {
+                // The Aspire dashboard URL will be set as the apphost's application URL. Check if the user has disabled this behavior
+                const enableDashboardAutoLaunch = vscode.workspace.getConfiguration('aspire').get<boolean>('enableAspireDashboardAutoLaunch', true);
+
+                if (enableDashboardAutoLaunch) {
+                    debugConfiguration.serverReadyAction = determineServerReadyAction(baseProfile?.launchBrowser, baseProfile?.applicationUrl);
+                }
+            }
+            else {
+                debugConfiguration.serverReadyAction = determineServerReadyAction(baseProfile?.launchBrowser, baseProfile?.applicationUrl);
+            }
 
             if (!isSingleFileApp(projectPath)) {
                 const outputPath = await dotNetService.getDotNetTargetPath(projectPath);

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -289,7 +289,7 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
             debugConfiguration.checkForDevCert = baseProfile?.useSSL;
 
             if (launchOptions.isApphost) {
-                // The Aspire dashboard URL will be set as the apphost's application URL. Check if the user has disabled this behavior
+                // The Aspire dashboard URL will be set as the apphost's application URL. Check if auto-launch is enabled
                 const enableDashboardAutoLaunch = vscode.workspace.getConfiguration('aspire').get<boolean>('enableAspireDashboardAutoLaunch', true);
 
                 if (enableDashboardAutoLaunch) {

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -203,7 +203,7 @@ export function determineServerReadyAction(launchBrowser?: boolean, applicationU
         return undefined;
     }
 
-    let uriFormat = applicationUrl && applicationUrl.includes(';') ? applicationUrl.split(';')[0] : applicationUrl;
+    let uriFormat = applicationUrl.includes(';') ? applicationUrl.split(';')[0] : applicationUrl;
 
     return {
         action: "openExternally",

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -203,9 +203,11 @@ export function determineServerReadyAction(launchBrowser?: boolean, applicationU
         return undefined;
     }
 
+    let uriFormat = applicationUrl && applicationUrl.includes(';') ? applicationUrl.split(';')[0] : applicationUrl;
+
     return {
         action: "openExternally",
         pattern: "\\bNow listening on:\\s+https?://\\S+",
-        uriFormat: applicationUrl
+        uriFormat: uriFormat
     };
 }

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -257,7 +257,7 @@ export class InteractionService implements IInteractionService {
             this.writeDebugSessionMessage(codespaces + ': ' + dashboardUrls.CodespacesUrlWithLoginToken, true, AnsiColors.Green);
         }
 
-        // If aspire.enableAspireDashboardAutoLaunch is false, the dashboard will be launched automatically and we do not need
+        //  If aspire.enableAspireDashboardAutoLaunch is true, the dashboard will be launched automatically and we do not need
         // to show an information message.
         const enableDashboardAutoLaunch = vscode.workspace.getConfiguration('aspire').get<boolean>('enableAspireDashboardAutoLaunch', true);
         if (enableDashboardAutoLaunch) {

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -257,6 +257,13 @@ export class InteractionService implements IInteractionService {
             this.writeDebugSessionMessage(codespaces + ': ' + dashboardUrls.CodespacesUrlWithLoginToken, true, AnsiColors.Green);
         }
 
+        // If aspire.enableAspireDashboardAutoLaunch is false, the dashboard will be started automatically and we do not need
+        // to show an information message.
+        const enableDashboardAutoLaunch = vscode.workspace.getConfiguration('aspire').get<boolean>('enableAspireDashboardAutoLaunch', true);
+        if (enableDashboardAutoLaunch) {
+            return;
+        }
+
         const actions: vscode.MessageItem[] = [
             { title: directLink }
         ];

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -257,7 +257,7 @@ export class InteractionService implements IInteractionService {
             this.writeDebugSessionMessage(codespaces + ': ' + dashboardUrls.CodespacesUrlWithLoginToken, true, AnsiColors.Green);
         }
 
-        // If aspire.enableAspireDashboardAutoLaunch is false, the dashboard will be started automatically and we do not need
+        // If aspire.enableAspireDashboardAutoLaunch is false, the dashboard will be launched automatically and we do not need
         // to show an information message.
         const enableDashboardAutoLaunch = vscode.workspace.getConfiguration('aspire').get<boolean>('enableAspireDashboardAutoLaunch', true);
         if (enableDashboardAutoLaunch) {

--- a/extension/src/test/launchProfiles.test.ts
+++ b/extension/src/test/launchProfiles.test.ts
@@ -396,6 +396,16 @@ suite('Launch Profile Tests', () => {
             assert.strictEqual(result?.uriFormat, applicationUrl);
             assert.strictEqual(result?.pattern, '\\bNow listening on:\\s+https?://\\S+');
         });
+
+        test('returns serverReadyAction with first URL when multiple URLs separated by semicolon', () => {
+            const applicationUrl = 'https://localhost:5001;http://localhost:5000';
+            const result = determineServerReadyAction(true, applicationUrl);
+
+            assert.notStrictEqual(result, undefined);
+            assert.strictEqual(result?.action, 'openExternally');
+            assert.strictEqual(result?.uriFormat, 'https://localhost:5001');
+            assert.strictEqual(result?.pattern, '\\bNow listening on:\\s+https?://\\S+');
+        });
     });
 
     suite('readLaunchSettings', () => {


### PR DESCRIPTION
## Description

I noticed yesterday that server ready actions weren't working as I'd expect when there are multiple URLs in the `applicationUrls` property. The first should be opened. After a question from Tommaso, I also investigated and found that the dashboard was not auto-opening because of the same issue.

To allow opting out of launching the dashboard, I added a new VS Code setting (`aspire.enableAspireDashboardAutoLaunch`), which is `true` by default. If `true`, the launch aspire dashboard informational message no longer appears, as it would be redundant.

cc @tommasodotNET 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
