### PR TITLE
Fix status code middleware from interfering with API calls

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Error.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Error.razor.cs
@@ -25,7 +25,7 @@ public partial class Error : IComponentWithTelemetry, IDisposable
     }
 
     [Inject]
-    public required ComponentTelemetryContextProvider TelemetryContextProvider { get; init;  }
+    public required ComponentTelemetryContextProvider TelemetryContextProvider { get; init; }
 
     // IComponentWithTelemetry impl
     public ComponentTelemetryContext TelemetryContext { get; } = new(ComponentType.Page, TelemetryComponentIds.Error);

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -473,6 +473,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         {
             // Don't run status code middleware for API requests. This is to avoid interfering with API requests.
             // We're using path segments to identify API requests instead of endpoint metadata because endpoints might be disabled based on configuration.
+            // If this approach has probems then we might be able to use endpoint metadata if we add hardcoded 404 endpoints when APIs are disabled.
+            // For example, if MCP is disabled, then add endpoints with skip status code metadata that return 404.
             if (context.Request.Path.StartsWithSegments("/api", StringComparisons.UrlPath) || // Dashboard minimal APIs
                 context.Request.Path.StartsWithSegments("/authentication", StringComparisons.UrlPath) || // Dashboard minimal APIs
                 context.Request.Path.StartsWithSegments("/mcp", StringComparisons.UrlPath) || // MCP API

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -472,7 +472,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         _app.Use((context, next) =>
         {
             // Don't run status code middleware for non-GET methods. This is to avoid interfering with API requests.
-            // There are some GET APIs so this isn't a perfect fix. Consider excluding all known API paths in the future if this causes issues.
+            // TODO: Exclude all known API paths from status code middleware. There are some GET APIs so this isn't a perfect fix. Consider excluding all known API paths in the future if this causes issues.
             if (context.Request.Method != HttpMethods.Get)
             {
                 // Must happen after UseStatusCodePagesWithReExecute so the feature is set.

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -471,9 +471,16 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
         _app.Use((context, next) =>
         {
-            // Don't run status code middleware for non-GET methods. This is to avoid interfering with API requests.
-            // TODO: Exclude all known API paths from status code middleware. There are some GET APIs so this isn't a perfect fix. Consider excluding all known API paths in the future if this causes issues.
-            if (context.Request.Method != HttpMethods.Get)
+            // Don't run status code middleware for API requests. This is to avoid interfering with API requests.
+            // We're using path segments to identify API requests instead of endpoint metadata because endpoints might be disabled based on configuration.
+            if (context.Request.Path.StartsWithSegments("/api", StringComparisons.UrlPath) || // Dashboard minimal APIs
+                context.Request.Path.StartsWithSegments("/authentication", StringComparisons.UrlPath) || // Dashboard minimal APIs
+                context.Request.Path.StartsWithSegments("/mcp", StringComparisons.UrlPath) || // MCP API
+                context.Request.Path.StartsWithSegments("/opentelemetry.proto.collector.trace.v1.TraceService", StringComparisons.UrlPath) || // OTLP gRPC API
+                context.Request.Path.StartsWithSegments("/opentelemetry.proto.collector.metrics.v1.MetricsService", StringComparisons.UrlPath) || // OTLP gRPC API
+                context.Request.Path.StartsWithSegments("/opentelemetry.proto.collector.logs.v1.LogsService", StringComparisons.UrlPath) || // OTLP gRPC API
+                context.Request.Path.StartsWithSegments("/v1", StringComparisons.UrlPath) // OTLP HTTP API
+            )
             {
                 // Must happen after UseStatusCodePagesWithReExecute so the feature is set.
                 if (context.Features.Get<IStatusCodePagesFeature>() is { } statusCodeFeature)

--- a/src/Aspire.Dashboard/Otlp/OtlpLogsService.cs
+++ b/src/Aspire.Dashboard/Otlp/OtlpLogsService.cs
@@ -3,10 +3,12 @@
 
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Microsoft.AspNetCore.Mvc;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 
 namespace Aspire.Dashboard.Otlp;
 
+[SkipStatusCodePages]
 public sealed class OtlpLogsService
 {
     private readonly ILogger<OtlpLogsService> _logger;

--- a/src/Aspire.Dashboard/Otlp/OtlpMetricsService.cs
+++ b/src/Aspire.Dashboard/Otlp/OtlpMetricsService.cs
@@ -3,10 +3,12 @@
 
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Microsoft.AspNetCore.Mvc;
 using OpenTelemetry.Proto.Collector.Metrics.V1;
 
 namespace Aspire.Dashboard.Otlp;
 
+[SkipStatusCodePages]
 public sealed class OtlpMetricsService
 {
     private readonly ILogger<OtlpMetricsService> _logger;

--- a/src/Aspire.Dashboard/Otlp/OtlpTraceService.cs
+++ b/src/Aspire.Dashboard/Otlp/OtlpTraceService.cs
@@ -3,10 +3,12 @@
 
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Microsoft.AspNetCore.Mvc;
 using OpenTelemetry.Proto.Collector.Trace.V1;
 
 namespace Aspire.Dashboard.Otlp;
 
+[SkipStatusCodePages]
 public sealed class OtlpTraceService
 {
     private readonly ILogger<OtlpTraceService> _logger;

--- a/src/Aspire.Dashboard/Utils/RoutingExtensions.cs
+++ b/src/Aspire.Dashboard/Utils/RoutingExtensions.cs
@@ -16,9 +16,9 @@ internal static class RoutingExtensions
         return builder;
     }
 
-    public static IEndpointConventionBuilder MapPostNotFound(this IEndpointRouteBuilder endpoints, string route)
+    public static IEndpointConventionBuilder MapPostNotFound(this IEndpointRouteBuilder endpoints, string pattern)
     {
-        return endpoints.MapPost(route, context =>
+        return endpoints.MapPost(pattern, context =>
         {
             context.Response.StatusCode = StatusCodes.Status404NotFound;
             return Task.CompletedTask;

--- a/src/Aspire.Dashboard/Utils/RoutingExtensions.cs
+++ b/src/Aspire.Dashboard/Utils/RoutingExtensions.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Aspire.Dashboard.Utils;
+
+internal static class RoutingExtensions
+{
+    public static TBuilder SkipStatusCodePages<TBuilder>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder
+    {
+        builder.Add(endpointBuilder =>
+        {
+            endpointBuilder.Metadata.Add(new SkipStatusCodePagesAttribute());
+        });
+        return builder;
+    }
+
+    public static IEndpointConventionBuilder MapPostNotFound(this IEndpointRouteBuilder endpoints, string route)
+    {
+        return endpoints.MapPost(route, context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -126,7 +126,7 @@ public class FrontendBrowserTokenAuthTests
     [Theory]
     [InlineData(FrontendAuthMode.BrowserToken, "TestKey123!", HttpStatusCode.OK, true)]
     [InlineData(FrontendAuthMode.BrowserToken, "Wrong!", HttpStatusCode.OK, false)]
-    [InlineData(FrontendAuthMode.Unsecured, "Wrong!", HttpStatusCode.BadRequest, null)]
+    [InlineData(FrontendAuthMode.Unsecured, "Wrong!", HttpStatusCode.NotFound, null)]
     public async Task Post_ValidateTokenApi_AvailableBasedOnOptions(FrontendAuthMode authMode, string requestToken, HttpStatusCode statusCode, bool? result)
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Integration/McpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/McpServiceTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using System.Text;
 using System.Text.Json.Nodes;
 using Aspire.Dashboard.Configuration;
@@ -62,7 +63,7 @@ public class McpServiceTests
         var responseMessage = await httpClient.SendAsync(request).DefaultTimeout(TestConstants.LongTimeoutDuration);
 
         // Assert
-        Assert.False(responseMessage.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, responseMessage.StatusCode);
     }
 
     [Fact]
@@ -85,7 +86,7 @@ public class McpServiceTests
         var responseMessage = await httpClient.SendAsync(requestMessage).DefaultTimeout(TestConstants.LongTimeoutDuration);
 
         // Assert
-        Assert.False(responseMessage.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, responseMessage.StatusCode);
     }
 
     [Fact]
@@ -201,7 +202,7 @@ public class McpServiceTests
         var responseMessage = await httpClient.SendAsync(request).DefaultTimeout(TestConstants.LongTimeoutDuration);
 
         // Assert
-        Assert.False(responseMessage.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, responseMessage.StatusCode);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
@@ -250,11 +250,11 @@ public class OtlpHttpServiceTests
     {
         // Arrange
         var testSink = new TestSink();
-        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, 
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper,
             dictionary =>
             {
                 dictionary[DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://127.0.0.1:0";
-            }, 
+            },
             testSink: testSink);
         await app.StartAsync().DefaultTimeout();
 
@@ -273,21 +273,21 @@ public class OtlpHttpServiceTests
         // Assert
         Assert.Equal(HttpStatusCode.UnsupportedMediaType, responseMessage.StatusCode);
         Assert.Equal("application/json", responseMessage.Content.Headers.ContentType?.MediaType);
-        
+
         // Verify JSON error response
         var responseBody = await responseMessage.Content.ReadAsStringAsync();
         var statusResponse = JsonSerializer.Deserialize<StatusResponse>(responseBody, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-        
+
         Assert.NotNull(statusResponse);
         Assert.Equal(15, statusResponse.Code); // UNIMPLEMENTED gRPC status code
         Assert.Contains("application/x-protobuf", statusResponse.Message);
         Assert.Contains("not supported", statusResponse.Message);
-        
+
         // Verify log
-        var logs = testSink.Writes.Where(w => 
+        var logs = testSink.Writes.Where(w =>
             w.LoggerName == "Aspire.Dashboard.Otlp.Http" &&
             w.Message!.Contains("OTLP HTTP request with unsupported content type")).ToList();
-        
+
         var log = Assert.Single(logs);
         Assert.Contains("application/x-protobuf", log.Message);
         Assert.Contains("unsupported content type", log.Message);


### PR DESCRIPTION
## Description

The MCP endpoint with a missing or incorrect API key was returning 404 instead of 401. This was caused by the status code middleware being executed for a 401 response, and incorrectly turning it into a 404.

The status code middleware is present for browsers and shouldn't run for APIs. The quick fix in this PR is to disable it for all non-GET requests, which prevents it from running for `/mcp` requests.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
