### PR TITLE
[release/13.0] Use DateTimeOffset.Now for checking certificate validity

### DIFF
--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -364,18 +364,16 @@ public static class PythonAppResourceBuilderExtensions
             }
         });
 
-        // Configure required environment variables for custom certificate trust when running as an executable
-        // Python defaults to using System scope to allow combining custom CAs with system CAs as there's no clean
-        // way to simply append additional certificates to default Python trust stores such as certifi.
+        // Configure required environment variables for custom certificate trust when running as an executable.
+        // TODO: Make CertificateTrustScope.System the default once we're able to validate that certificates are valid for OpenSSL. Otherwise we potentially add invalid certificates to the bundle which causes OpenSSL to error.
         resourceBuilder
-            .WithCertificateTrustScope(CertificateTrustScope.System)
             .WithCertificateTrustConfiguration(ctx =>
             {
                 if (ctx.Scope == CertificateTrustScope.Append)
                 {
                     var resourceLogger = ctx.ExecutionContext.ServiceProvider.GetRequiredService<ResourceLoggerService>();
                     var logger = resourceLogger.GetLogger(ctx.Resource);
-                    logger.LogWarning("Certificate trust scope is set to 'Append', but Python resources do not support appending to the default certificate authorities; only OTLP certificate trust will be applied. Consider using 'System' or 'Override' certificate trust scopes instead.");
+                    logger.LogInformation("Certificate trust scope is set to 'Append', but Python resources do not support appending to the default certificate authorities; only OTLP certificate trust will be applied.");
                 }
                 else
                 {


### PR DESCRIPTION
Backport of #12680 to release/13.0

## Customer Impact

This fixes a time zone bug checking for dev cert validity and makes Python apps default to only trusting the dev cert for OTEL (instead of trusting the dev cert for all http clients) to avoid a potential issue with the Windows cert store being more permissive with certificates than OpenSSL is.

## Testing

Manual testing with users in different time zones generating dev certs as well as a user with a problematic certificate validating that the python certificate set change unblocked them.

## Risk

Low. We're matching the behavior of ASP.NET for developer certificate validation and limiting the default certificate set for Python to the dev cert for OTEL only.

## Regression?

No