### PR TITLE
Support a docker build arg to specify the source image in PublishWithContainerFiles

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -130,13 +130,16 @@ public static class JavaScriptHostingExtensions
                         }
                     }
 
+                    var logger = dockerfileContext.Services.GetService<ILogger<JavaScriptAppResource>>();
+                    dockerfileContext.Builder.AddContainerFilesStages(dockerfileContext.Resource, logger);
+
                     var baseRuntimeImage = baseImageAnnotation?.RuntimeImage ?? defaultBaseImage.Value;
                     var runtimeBuilder = dockerfileContext.Builder
                         .From(baseRuntimeImage, "runtime")
                             .EmptyLine()
                             .WorkDir("/app")
                             .CopyFrom("build", "/app", "/app")
-                            .AddContainerFiles(dockerfileContext.Resource, "/app", dockerfileContext.Services.GetService<ILogger<JavaScriptAppResource>>())
+                            .AddContainerFiles(dockerfileContext.Resource, "/app", logger)
                             .EmptyLine()
                             .Env("NODE_ENV", "production")
                             .Expose(3000)

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -550,10 +550,13 @@ public static class PythonAppResourceBuilderExtensions
                     "type=cache,target=/root/.cache/uv");
         }
 
+        var logger = context.Services.GetService<ILogger<PythonAppResource>>();
+        context.Builder.AddContainerFilesStages(context.Resource, logger);
+
         var runtimeBuilder = context.Builder
             .From(runtimeImage, "app")
             .EmptyLine()
-            .AddContainerFiles(context.Resource, "/app", context.Services.GetService<ILogger<PythonAppResource>>())
+            .AddContainerFiles(context.Resource, "/app", logger)
             .Comment("------------------------------")
             .Comment("🚀 Runtime stage")
             .Comment("------------------------------")
@@ -603,10 +606,13 @@ public static class PythonAppResourceBuilderExtensions
         var requirementsTxtPath = Path.Combine(resource.WorkingDirectory, "requirements.txt");
         var hasRequirementsTxt = File.Exists(requirementsTxtPath);
 
+        var logger = context.Services.GetService<ILogger<PythonAppResource>>();
+        context.Builder.AddContainerFilesStages(context.Resource, logger);
+
         var stage = context.Builder
             .From(runtimeImage)
             .EmptyLine()
-            .AddContainerFiles(context.Resource, "/app", context.Services.GetService<ILogger<PythonAppResource>>())
+            .AddContainerFiles(context.Resource, "/app", logger)
             .Comment("------------------------------")
             .Comment("🚀 Python Application")
             .Comment("------------------------------")

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -172,10 +172,14 @@ public static class YarpResourceExtensions
 
         return builder.WithDockerfileBuilder(".", ctx =>
         {
+            var logger = ctx.Services.GetService<ILogger<YarpResource>>();
             var imageName = GetYarpImageName(ctx.Resource);
+
+            ctx.Builder.AddContainerFilesStages(ctx.Resource, logger);
+
             ctx.Builder.From(imageName)
                 .WorkDir("/app")
-                .AddContainerFiles(ctx.Resource, "/app/wwwroot", ctx.Services.GetService<ILogger<YarpResource>>());
+                .AddContainerFiles(ctx.Resource, "/app/wwwroot", logger);
         });
     }
 

--- a/src/Aspire.Hosting/ApplicationModel/Docker/ContainerFilesExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Docker/ContainerFilesExtensions.cs
@@ -7,10 +7,50 @@ using Microsoft.Extensions.Logging;
 namespace Aspire.Hosting.ApplicationModel.Docker;
 
 /// <summary>
-/// Provides extension methods for <see cref="DockerfileStage"/>.
+/// Provides Dockerfile builder extension methods for supporting <see cref="ResourceBuilderExtensions.PublishWithContainerFiles" />.
 /// </summary>
-public static class DockerfileStageExtensions
+public static class ContainerFilesExtensions
 {
+    /// <summary>
+    /// Adds Dockerfile instructions to include container files from the specified resource into the Dockerfile build
+    /// process.
+    /// </summary>
+    /// <remarks>If the resource does not provide valid container image names for its sources, those sources
+    /// are skipped and a warning is logged if a logger is provided. This method is experimental and its behavior may
+    /// change in future releases.</remarks>
+    /// <param name="builder">The Dockerfile builder to which container file instructions will be added. Cannot be null.</param>
+    /// <param name="resource">The resource containing container files to be added to the Dockerfile. Cannot be null.</param>
+    /// <param name="logger">An optional logger used to record warnings if container image names cannot be determined for source resources.</param>
+    /// <returns>The same DockerfileBuilder instance with additional instructions for container files, enabling method chaining.</returns>
+    [Experimental("ASPIREDOCKERFILEBUILDER001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public static DockerfileBuilder AddContainerFilesStages(this DockerfileBuilder builder, IResource resource, ILogger? logger)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(resource);
+
+        if (resource.TryGetAnnotationsOfType<ContainerFilesDestinationAnnotation>(out var containerFilesDestinationAnnotations))
+        {
+            foreach (var containerFileDestination in containerFilesDestinationAnnotations)
+            {
+                var source = containerFileDestination.Source;
+
+                // get image name - skip this source if it doesn't have an image name
+                if (!source.TryGetContainerImageName(out var sourceImageName))
+                {
+                    logger?.LogWarning("Cannot get container image name for source resource {SourceName}, skipping", source.Name);
+                    continue;
+                }
+
+                var sourceImageArgName = GetSourceImageArgName(source);
+                builder.Arg(sourceImageArgName, sourceImageName);
+
+                var sourceImageStageName = GetSourceStageName(source);
+                builder.From("${" + sourceImageArgName + "}", sourceImageStageName);
+            }
+        }
+        return builder;
+    }
+
     /// <summary>
     /// Adds COPY --from statements to the Dockerfile stage for container files from resources referenced by <see cref="ContainerFilesDestinationAnnotation"/>.
     /// </summary>
@@ -53,11 +93,13 @@ public static class DockerfileStageExtensions
                 var source = containerFileDestination.Source;
 
                 // get image name - skip this source if it doesn't have an image name
-                if (!source.TryGetContainerImageName(out var sourceImageName))
+                if (!source.TryGetContainerImageName(out var _))
                 {
                     logger?.LogWarning("Cannot get container image name for source resource {SourceName}, skipping", source.Name);
                     continue;
                 }
+
+                var sourceImageStageName = GetSourceStageName(source);
 
                 var destinationPath = containerFileDestination.DestinationPath;
                 if (!destinationPath.StartsWith('/'))
@@ -68,8 +110,8 @@ public static class DockerfileStageExtensions
                 foreach (var containerFilesSource in source.Annotations.OfType<ContainerFilesSourceAnnotation>())
                 {
                     logger?.LogDebug("Adding COPY --from={SourceImage} {SourcePath} {DestinationPath}",
-                        sourceImageName, containerFilesSource.SourcePath, destinationPath);
-                    stage.CopyFrom(sourceImageName, containerFilesSource.SourcePath, destinationPath);
+                        sourceImageStageName, containerFilesSource.SourcePath, destinationPath);
+                    stage.CopyFrom(sourceImageStageName, containerFilesSource.SourcePath, destinationPath);
                 }
             }
 
@@ -77,4 +119,8 @@ public static class DockerfileStageExtensions
         }
         return stage;
     }
+
+    private static string GetSourceImageArgName(IResource source) => $"{source.Name}_IMAGENAME";
+
+    private static string GetSourceStageName(IResource source) => $"{source.Name}_stage";
 }

--- a/src/Aspire.Hosting/ApplicationModel/Docker/ContainerFilesExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Docker/ContainerFilesExtensions.cs
@@ -15,9 +15,6 @@ public static class ContainerFilesExtensions
     /// Adds Dockerfile instructions to include container files from the specified resource into the Dockerfile build
     /// process.
     /// </summary>
-    /// <remarks>If the resource does not provide valid container image names for its sources, those sources
-    /// are skipped and a warning is logged if a logger is provided. This method is experimental and its behavior may
-    /// change in future releases.</remarks>
     /// <param name="builder">The Dockerfile builder to which container file instructions will be added. Cannot be null.</param>
     /// <param name="resource">The resource containing container files to be added to the Dockerfile. Cannot be null.</param>
     /// <param name="logger">An optional logger used to record warnings if container image names cannot be determined for source resources.</param>
@@ -68,7 +65,7 @@ public static class ContainerFilesExtensions
     /// For each annotation:
     /// <list type="bullet">
     /// <item>If the source resource has a container image name (via <c>TryGetContainerImageName</c>), COPY statements are generated</item>
-    /// <item>If the source resource does not have a container image name, it is silently skipped</item>
+    /// <item>If the source resource does not have a container image name, it is skipped</item>
     /// <item>Relative destination paths are combined with <paramref name="rootDestinationPath"/></item>
     /// <item>Absolute destination paths are used as-is</item>
     /// <item>Each <see cref="ContainerFilesSourceAnnotation"/> on the source resource generates a COPY statement</item>
@@ -120,7 +117,7 @@ public static class ContainerFilesExtensions
         return stage;
     }
 
-    private static string GetSourceImageArgName(IResource source) => $"{source.Name}_IMAGENAME";
+    private static string GetSourceImageArgName(IResource source) => $"{source.Name.ToUpperInvariant()}_IMAGENAME";
 
     private static string GetSourceStageName(IResource source) => $"{source.Name}_stage";
 }

--- a/src/Aspire.Hosting/ApplicationModel/Docker/DockerfileBuilder.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Docker/DockerfileBuilder.cs
@@ -12,6 +12,7 @@ namespace Aspire.Hosting.ApplicationModel.Docker;
 public class DockerfileBuilder
 {
     private readonly List<DockerfileStage> _stages = [];
+    private readonly List<DockerfileArgStatement> _globalArgs = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerfileBuilder"/> class.
@@ -24,6 +25,44 @@ public class DockerfileBuilder
     /// Gets the stages in this Dockerfile.
     /// </summary>
     public IReadOnlyList<DockerfileStage> Stages => _stages.AsReadOnly();
+
+    /// <summary>
+    /// Adds a global ARG statement to define a build-time variable before any stages.
+    /// </summary>
+    /// <param name="name">The name of the build argument.</param>
+    /// <returns>The current DockerfileBuilder instance for method chaining.</returns>
+    /// <remarks>
+    /// Global ARG statements appear before the first FROM statement and can be used
+    /// to parameterize the base image selection.
+    /// </remarks>
+    [Experimental("ASPIREDOCKERFILEBUILDER001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public DockerfileBuilder Arg(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        _globalArgs.Add(new DockerfileArgStatement(name));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a global ARG statement to define a build-time variable with a default value before any stages.
+    /// </summary>
+    /// <param name="name">The name of the build argument.</param>
+    /// <param name="defaultValue">The default value for the build argument.</param>
+    /// <returns>The current DockerfileBuilder instance for method chaining.</returns>
+    /// <remarks>
+    /// Global ARG statements appear before the first FROM statement and can be used
+    /// to parameterize the base image selection.
+    /// </remarks>
+    [Experimental("ASPIREDOCKERFILEBUILDER001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public DockerfileBuilder Arg(string name, string defaultValue)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(defaultValue);
+
+        _globalArgs.Add(new DockerfileArgStatement(name, defaultValue));
+        return this;
+    }
 
     /// <summary>
     /// Adds a FROM statement to start a new named stage.
@@ -66,6 +105,18 @@ public class DockerfileBuilder
     public async Task WriteAsync(StreamWriter writer, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(writer);
+
+        // Write global ARG statements first
+        if (_globalArgs.Count > 0)
+        {
+            foreach (var arg in _globalArgs)
+            {
+                await arg.WriteStatementAsync(writer, cancellationToken).ConfigureAwait(false);
+            }
+
+            // Add a blank line after global args
+            await writer.WriteLineAsync().ConfigureAwait(false);
+        }
         
         foreach (var stage in _stages)
         {

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -121,6 +121,8 @@ public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWith
 
         // Generate a Dockerfile that layers the container files on top
         var dockerfileBuilder = new DockerfileBuilder();
+        dockerfileBuilder.AddContainerFilesStages(this, logger);
+
         var stage = dockerfileBuilder.From(tempImageName);
 
         var projectMetadata = this.GetProjectMetadata();

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddNodeAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddNodeAppTests.cs
@@ -335,9 +335,7 @@ public class AddNodeAppTests
 
         var dockerfileContent = File.ReadAllText(nodeDockerfilePath);
 
-        // Verify that the Dockerfile includes the COPY --from statement for container files
-        // Note: The image name is prefixed with the resource name, so it's "source:source-tag"
-        Assert.Contains("COPY --from=source:source-tag /app/dist /app/./static", dockerfileContent);
+        await Verify(dockerfileContent);
     }
 
     private sealed class MyFilesContainer(string name, string command, string workingDirectory)

--- a/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddNodeAppTests.VerifyNodeAppWithContainerFilesGeneratesCorrectDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddNodeAppTests.VerifyNodeAppWithContainerFilesGeneratesCorrectDockerfile.verified.txt
@@ -1,4 +1,4 @@
-﻿ARG source_IMAGENAME=source:source-tag
+﻿ARG SOURCE_IMAGENAME=source:source-tag
 
 FROM node:22-alpine AS build
 
@@ -7,7 +7,7 @@ COPY . .
 
 RUN npm install
 
-FROM ${source_IMAGENAME} AS source_stage
+FROM ${SOURCE_IMAGENAME} AS source_stage
 
 FROM node:22-alpine AS runtime
 

--- a/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddNodeAppTests.VerifyNodeAppWithContainerFilesGeneratesCorrectDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.JavaScript.Tests/Snapshots/AddNodeAppTests.VerifyNodeAppWithContainerFilesGeneratesCorrectDockerfile.verified.txt
@@ -1,0 +1,24 @@
+﻿ARG source_IMAGENAME=source:source-tag
+
+FROM node:22-alpine AS build
+
+WORKDIR /app
+COPY . .
+
+RUN npm install
+
+FROM ${source_IMAGENAME} AS source_stage
+
+FROM node:22-alpine AS runtime
+
+WORKDIR /app
+COPY --from=build /app /app
+COPY --from=source_stage /app/dist /app/./static
+
+
+ENV NODE_ENV=production
+EXPOSE 3000
+
+USER node
+
+ENTRYPOINT ["node","app.js"]

--- a/tests/Aspire.Hosting.Python.Tests/Snapshots/AddUvicornAppTests.WithUv_GeneratesDockerfileInPublishMode.verified.txt
+++ b/tests/Aspire.Hosting.Python.Tests/Snapshots/AddUvicornAppTests.WithUv_GeneratesDockerfileInPublishMode.verified.txt
@@ -1,4 +1,4 @@
-﻿ARG exe_IMAGENAME=exe:deterministc-tag
+﻿ARG EXE_IMAGENAME=exe:deterministc-tag
 
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
 
@@ -18,7 +18,7 @@ COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev
 
-FROM ${exe_IMAGENAME} AS exe_stage
+FROM ${EXE_IMAGENAME} AS exe_stage
 
 FROM python:3.12-slim-bookworm AS app
 

--- a/tests/Aspire.Hosting.Python.Tests/Snapshots/AddUvicornAppTests.WithUv_GeneratesDockerfileInPublishMode.verified.txt
+++ b/tests/Aspire.Hosting.Python.Tests/Snapshots/AddUvicornAppTests.WithUv_GeneratesDockerfileInPublishMode.verified.txt
@@ -1,4 +1,6 @@
-﻿FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+﻿ARG exe_IMAGENAME=exe:deterministc-tag
+
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
 
 # Enable bytecode compilation and copy mode for the virtual environment
 ENV UV_COMPILE_BYTECODE=1
@@ -16,9 +18,11 @@ COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev
 
+FROM ${exe_IMAGENAME} AS exe_stage
+
 FROM python:3.12-slim-bookworm AS app
 
-COPY --from=exe:deterministc-tag /app/dist /app/./static
+COPY --from=exe_stage /app/dist /app/./static
 
 # ------------------------------
 # 🚀 Runtime stage

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -7,6 +7,7 @@
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
 using System.Text;
+using System.Text.RegularExpressions;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Testing;
@@ -819,7 +820,21 @@ public class ProjectResourceTests
         builder.AddProject<TestProject>("projectName", launchProfileName: null)
             .PublishWithContainerFiles(sourceContainer, "./wwwroot");
 
+        var dockerfileVerified = false;
+
         using var app = builder.Build();
+        var fakeContainerRuntime = (FakeContainerRuntime)app.Services.GetRequiredService<IContainerRuntime>();
+
+        fakeContainerRuntime.BuildImageAsyncCallback = async (contextPath, dockerfilePath, imageName, options, buildArgs, buildSecrets, stage, cancellationToken) =>
+        {
+            // Verify that the Dockerfile contains the expected COPY command
+            var dockerFileContent = File.ReadAllText(dockerfilePath);
+            await Verify(dockerFileContent)
+                .ScrubLinesWithReplace(s => Regex.Replace(s, "FROM projectname:temp-.*", "FROM projectname:temp-"));
+
+            dockerfileVerified = true;
+        };
+
         await app.StartAsync();
         await app.WaitForShutdownAsync();
 
@@ -829,7 +844,6 @@ public class ProjectResourceTests
         Assert.Equal("projectName", builtImage.Name);
         Assert.False(mockImageBuilder.PushImageCalled);
 
-        var fakeContainerRuntime = (FakeContainerRuntime)app.Services.GetRequiredService<IContainerRuntime>();
         Assert.True(fakeContainerRuntime.WasTagImageCalled);
         var tagCall = Assert.Single(fakeContainerRuntime.TagImageCalls);
         Assert.Equal("projectname", tagCall.localImageName);
@@ -840,6 +854,8 @@ public class ProjectResourceTests
         Assert.Equal("projectname", buildCall.imageName);
         Assert.Empty(buildCall.contextPath);
         Assert.NotEmpty(buildCall.dockerfilePath);
+
+        Assert.True(dockerfileVerified);
 
         Assert.True(fakeContainerRuntime.WasRemoveImageCalled);
         var removeCall = Assert.Single(fakeContainerRuntime.RemoveImageCalls);

--- a/tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs
@@ -25,6 +25,7 @@ public sealed class FakeContainerRuntime(bool shouldFail = false) : IContainerRu
     public Dictionary<string, string?>? CapturedBuildArguments { get; private set; }
     public Dictionary<string, string?>? CapturedBuildSecrets { get; private set; }
     public string? CapturedStage { get; private set; }
+    public Func<string, string, string, ContainerBuildOptions?, Dictionary<string, string?>, Dictionary<string, string?>, string?, CancellationToken, Task>? BuildImageAsyncCallback { get; set; }
 
     public Task<bool> CheckIfRunningAsync(CancellationToken cancellationToken)
     {
@@ -65,7 +66,7 @@ public sealed class FakeContainerRuntime(bool shouldFail = false) : IContainerRu
         return Task.CompletedTask;
     }
 
-    public Task BuildImageAsync(string contextPath, string dockerfilePath, string imageName, ContainerBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, string?> buildSecrets, string? stage, CancellationToken cancellationToken)
+    public async Task BuildImageAsync(string contextPath, string dockerfilePath, string imageName, ContainerBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, string?> buildSecrets, string? stage, CancellationToken cancellationToken)
     {
         // Capture the arguments for verification in tests
         CapturedBuildArguments = buildArguments;
@@ -79,8 +80,12 @@ public sealed class FakeContainerRuntime(bool shouldFail = false) : IContainerRu
             throw new InvalidOperationException("Fake container runtime is configured to fail");
         }
 
+        if (BuildImageAsyncCallback is not null)
+        {
+            await BuildImageAsyncCallback(contextPath, dockerfilePath, imageName, options, buildArguments, buildSecrets, stage, cancellationToken);
+        }
+
         // For testing, we don't need to actually build anything
-        return Task.CompletedTask;
     }
 
     public Task LoginToRegistryAsync(string registryServer, string username, string password, CancellationToken cancellationToken)

--- a/tests/Aspire.Hosting.Tests/Snapshots/ProjectResourceTests.ProjectResourceWithContainerFilesDestinationAnnotationWorks.verified.txt
+++ b/tests/Aspire.Hosting.Tests/Snapshots/ProjectResourceTests.ProjectResourceWithContainerFilesDestinationAnnotationWorks.verified.txt
@@ -1,0 +1,7 @@
+﻿ARG source_IMAGENAME=myimage:latest
+
+FROM ${source_IMAGENAME} AS source_stage
+
+FROM projectname:temp-
+COPY --from=source_stage /app/dist /app/./wwwroot
+

--- a/tests/Aspire.Hosting.Tests/Snapshots/ProjectResourceTests.ProjectResourceWithContainerFilesDestinationAnnotationWorks.verified.txt
+++ b/tests/Aspire.Hosting.Tests/Snapshots/ProjectResourceTests.ProjectResourceWithContainerFilesDestinationAnnotationWorks.verified.txt
@@ -1,6 +1,6 @@
-﻿ARG source_IMAGENAME=myimage:latest
+﻿ARG SOURCE_IMAGENAME=myimage:latest
 
-FROM ${source_IMAGENAME} AS source_stage
+FROM ${SOURCE_IMAGENAME} AS source_stage
 
 FROM projectname:temp-
 COPY --from=source_stage /app/dist /app/./wwwroot

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfile.verified.txt
@@ -1,4 +1,8 @@
-﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
+﻿ARG source_IMAGENAME=sourceimage:latest
+
+FROM ${source_IMAGENAME} AS source_stage
+
+FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
 WORKDIR /app
-COPY --from=sourceimage:latest /app/dist /app/wwwroot
+COPY --from=source_stage /app/dist /app/wwwroot
 

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfile.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfile.verified.txt
@@ -1,6 +1,6 @@
-﻿ARG source_IMAGENAME=sourceimage:latest
+﻿ARG SOURCE_IMAGENAME=sourceimage:latest
 
-FROM ${source_IMAGENAME} AS source_stage
+FROM ${SOURCE_IMAGENAME} AS source_stage
 
 FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
 WORKDIR /app

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleContainerFiles.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleContainerFiles.verified.txt
@@ -1,5 +1,9 @@
-﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
+﻿ARG source_IMAGENAME=sourceimage:latest
+
+FROM ${source_IMAGENAME} AS source_stage
+
+FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
 WORKDIR /app
-COPY --from=sourceimage:latest /app/dist /app/wwwroot
-COPY --from=sourceimage:latest /app/assets /app/wwwroot
+COPY --from=source_stage /app/dist /app/wwwroot
+COPY --from=source_stage /app/assets /app/wwwroot
 

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleContainerFiles.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleContainerFiles.verified.txt
@@ -1,6 +1,6 @@
-﻿ARG source_IMAGENAME=sourceimage:latest
+﻿ARG SOURCE_IMAGENAME=sourceimage:latest
 
-FROM ${source_IMAGENAME} AS source_stage
+FROM ${SOURCE_IMAGENAME} AS source_stage
 
 FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
 WORKDIR /app

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleSourceContainerFiles.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleSourceContainerFiles.verified.txt
@@ -1,7 +1,14 @@
-﻿FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
+﻿ARG source1_IMAGENAME=sourceimage:latest
+ARG source2_IMAGENAME=sourceimage2:latest
+
+FROM ${source1_IMAGENAME} AS source1_stage
+
+FROM ${source2_IMAGENAME} AS source2_stage
+
+FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
 WORKDIR /app
-COPY --from=sourceimage:latest /app/dist /app/wwwroot
-COPY --from=sourceimage:latest /app/assets /app/wwwroot
-COPY --from=sourceimage2:latest /app/dist2 /app/wwwroot
-COPY --from=sourceimage2:latest /app/assets2 /app/wwwroot
+COPY --from=source1_stage /app/dist /app/wwwroot
+COPY --from=source1_stage /app/assets /app/wwwroot
+COPY --from=source2_stage /app/dist2 /app/wwwroot
+COPY --from=source2_stage /app/assets2 /app/wwwroot
 

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleSourceContainerFiles.verified.txt
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/AddYarpTests.VerifyPublishWithStaticFilesGeneratesCorrectDockerfileWithMultipleSourceContainerFiles.verified.txt
@@ -1,9 +1,9 @@
-﻿ARG source1_IMAGENAME=sourceimage:latest
-ARG source2_IMAGENAME=sourceimage2:latest
+﻿ARG SOURCE1_IMAGENAME=sourceimage:latest
+ARG SOURCE2_IMAGENAME=sourceimage2:latest
 
-FROM ${source1_IMAGENAME} AS source1_stage
+FROM ${SOURCE1_IMAGENAME} AS source1_stage
 
-FROM ${source2_IMAGENAME} AS source2_stage
+FROM ${SOURCE2_IMAGENAME} AS source2_stage
 
 FROM mcr.microsoft.com/dotnet/nightly/yarp:2.3.0-preview.4
 WORKDIR /app


### PR DESCRIPTION
## Description

This allows an external system, like azd, to provide the image name for the source image to copy the files from instead of always hard coding the image tag inline.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
