### PR TITLE
Disable Sizes in Icon for copilot-cli compatibility

### DIFF
--- a/src/Aspire.Dashboard/Mcp/McpExtensions.cs
+++ b/src/Aspire.Dashboard/Mcp/McpExtensions.cs
@@ -23,7 +23,8 @@ public static class McpExtensions
                 stream.CopyTo(memoryStream);
                 var data = memoryStream.ToArray();
 
-                return new Icon { Source = $"data:image/png;base64,{Convert.ToBase64String(data)}", MimeType = "image/png", Sizes = [s] };
+                // TODO: Re-enable Sizes once https://github.com/github/copilot-cli/issues/486 is fixed
+                return new Icon { Source = $"data:image/png;base64,{Convert.ToBase64String(data)}", MimeType = "image/png" /*, Sizes = [s]*/ };
             }).ToList();
 
             options.ServerInfo = new Implementation


### PR DESCRIPTION
## Description

Commented out the Sizes property in the Icon return statement due to a bug in copilot-cli

https://github.com/github/copilot-cli/issues/486

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
