### PR TITLE
Exclude localhost certificates without a subject key identifier extension

### DIFF
--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -365,8 +365,8 @@ public static class PythonAppResourceBuilderExtensions
         });
 
         // Configure required environment variables for custom certificate trust when running as an executable.
-        // TODO: Make CertificateTrustScope.System the default once we're able to validate that certificates are valid for OpenSSL. Otherwise we potentially add invalid certificates to the bundle which causes OpenSSL to error.
         resourceBuilder
+            .WithCertificateTrustScope(CertificateTrustScope.System)
             .WithCertificateTrustConfiguration(ctx =>
             {
                 if (ctx.Scope == CertificateTrustScope.Append)
@@ -787,7 +787,7 @@ public static class PythonAppResourceBuilderExtensions
     /// <code lang="csharp">
     /// var python = builder.AddPythonApp("api", "../python-api", "main.py")
     ///     .WithVirtualEnvironment("myenv");
-    /// 
+    ///
     /// // Disable automatic venv creation (require venv to exist)
     /// var python2 = builder.AddPythonApp("api2", "../python-api2", "main.py")
     ///     .WithVirtualEnvironment("myenv", createIfNotExists: false);

--- a/src/Aspire.Hosting/Utils/X509Certificate2Extensions.cs
+++ b/src/Aspire.Hosting/Utils/X509Certificate2Extensions.cs
@@ -109,8 +109,8 @@ internal static class X509Certificate2Extensions
     /// <summary>
     /// A Subject Key Identifier is used to identify certificate trust chains: https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.2
     /// </summary>
-    /// <param name="certificate"></param>
-    /// <returns></returns>
+    /// <param name="certificate">The certificate to check for a Subject Key Identifier extension.</param>
+    /// <returns>True if the certificate contains a non-empty Subject Key Identifier extension; otherwise, false.</returns>
     public static bool HasSubjectKeyIdentifier(this X509Certificate2 certificate)
     {
         ArgumentNullException.ThrowIfNull(certificate);

--- a/src/Aspire.Hosting/Utils/X509Certificate2Extensions.cs
+++ b/src/Aspire.Hosting/Utils/X509Certificate2Extensions.cs
@@ -98,7 +98,7 @@ internal static class X509Certificate2Extensions
             using var store = new X509Store(storeName, storeLocation);
             store.Open(OpenFlags.ReadOnly);
             // Add all root certificates, excluding any localhost certificates without a Subject Key Identifier.
-            // This avoid conflicts between legacy self-signed localhost certificates and the ASP.NET Core development certificate in OpenSSL.
+            // This avoids conflicts between legacy self-signed localhost certificates and the ASP.NET Core development certificate in OpenSSL.
             foreach (var certificate in store.Certificates.Where(c => !string.Equals(c.Subject, "localhost", StringComparison.OrdinalIgnoreCase) || c.HasSubjectKeyIdentifier()))
             {
                 collection.Add(certificate);


### PR DESCRIPTION
## Description

OpenSSL considers the subject name and the subject/authority key identifier extensions when considering what trusted certificates to validate a TLS connection against. The ASP.NET dev cert doesn't include a subject key identifier extension, but neither do the legacy IIS certificates. This can lead to conflicts when adding multiple certificates into an OpenSSL trust bundle.

This PR filters out `localhost` certificates without a subject key identifier from the store when adding system trust to a child resource. This ensures the ASP.NET developer certificate works, but does have the trade-off of prevent resources from trusting local IIS development endpoints.