### PR TITLE
Add icon & status to `CertificateAuthorityCollection` resource

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
@@ -81,7 +81,7 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
                 _ => (new Icons.Filled.Size16.Circle(), Color.Neutral)
             };
         }
-        else if (resource.HealthStatus is not HealthStatus.Healthy)
+        else if (resource.HealthStatus is HealthStatus.Unhealthy or HealthStatus.Degraded)
         {
             icon = new Icons.Filled.Size16.CheckmarkCircleWarning();
             color = Color.Warning;

--- a/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionResourceExtensions.cs
@@ -24,6 +24,7 @@ public static class CertificateAuthorityCollectionResourceExtensions
 
         var resource = new CertificateAuthorityCollection(name);
         return builder.AddResource(resource)
+            .WithIconName("Certificate")
             .ExcludeFromManifest()
             .WithInitialState(new CustomResourceSnapshot
             {

--- a/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateAuthorityCollectionResourceExtensions.cs
@@ -31,6 +31,7 @@ public static class CertificateAuthorityCollectionResourceExtensions
                 ResourceType = nameof(CertificateAuthorityCollection),
                 Properties = [],
                 IsHidden = true,
+                State = KnownResourceStates.Active
             });
     }
 


### PR DESCRIPTION
## Description

Adds a resource icon to certificate collection resources.  (Only visible if you show hidden resources)
<img width="693" height="316" alt="image" src="https://github.com/user-attachments/assets/78457567-e459-4331-99e0-df295d7a9df5" />


## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
