### PR TITLE
Add More information link to MCP Server dialog page

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/McpServerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/McpServerDialog.razor
@@ -67,7 +67,7 @@
                                 <br />
                                 <br />
                                 @((MarkupString)Loc[nameof(Resources.Dialogs.McpServerDialogVSCodeWarningInstructions)].ToString())
-                                <a href="https://aka.ms/aspire/mcp-vscode-limitations">@Loc[nameof(Resources.Dialogs.McpServerDialogVSCodeWarningMoreInfo)]</a>
+                                <a href="https://aka.ms/aspire/mcp-vscode-limitations" target="_blank">@Loc[nameof(Resources.Dialogs.McpServerDialogVSCodeWarningMoreInfo)]</a>
                             </div>
                         </div>
                     }

--- a/src/Aspire.Dashboard/Components/Dialogs/McpServerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/McpServerDialog.razor
@@ -67,7 +67,7 @@
                                 <br />
                                 <br />
                                 @((MarkupString)Loc[nameof(Resources.Dialogs.McpServerDialogVSCodeWarningInstructions)].ToString())
-                                <a href="">@Loc[nameof(Resources.Dialogs.McpServerDialogVSCodeWarningMoreInfo)]</a>
+                                <a href="https://aka.ms/aspire/mcp-vscode-limitations">@Loc[nameof(Resources.Dialogs.McpServerDialogVSCodeWarningMoreInfo)]</a>
                             </div>
                         </div>
                     }


### PR DESCRIPTION
This link currently doesn't go anywhere.

Fix #12717