### PR TITLE
Check aspire exists on path before command or starting aspire debug session

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -204,3 +204,12 @@ These instructions are comprehensive and tested. Only search for additional info
 3. You need details about new features not yet documented
 
 For most development tasks, following these instructions should be sufficient to build, test, and validate changes successfully.
+
+## Typescript
+
+* When possible, you should create Typescript files instead of Javascript files.
+* You must not use dynamic imports unless absolutely necessary. Instead, use static imports.
+
+## Aspire VS Code Extension
+
+* When displaying text to the user, ensure that the strings are localized. New localized strings must be put both in the extension `package.nls.json` and also `src/loc/strings.ts`.

--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -10,6 +10,9 @@
     <trans-unit id="aspire-vscode.strings.aspireCliVersion">
       <source xml:lang="en">Aspire CLI Version: {0}.</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.cliNotAvailable">
+      <source xml:lang="en">Aspire CLI is not available on PATH. Please install it and restart VS Code.</source>
+    </trans-unit>
     <trans-unit id="aspire-vscode.strings.aspireOutputChannelName">
       <source xml:lang="en">Aspire Extension</source>
     </trans-unit>
@@ -84,6 +87,9 @@
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.disconnectingFromSession">
       <source xml:lang="en">Disconnecting from Aspire debug session... Child processes will be stopped.</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.dismissLabel">
+      <source xml:lang="en">Dismiss</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.doYouWantToSelectDefaultApphost">
       <source xml:lang="en">Do you want to select the default apphost for this workspace?</source>
@@ -240,6 +246,9 @@
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.runProject">
       <source xml:lang="en">Run {0}</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.openCliInstallInstructions">
+      <source xml:lang="en">See CLI installation instructions</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.selectDefaultLaunchApphost">
       <source xml:lang="en">Select the default apphost to launch when starting an Aspire debug session</source>

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Aspire",
   "description": "%extension.description%",
   "publisher": "microsoft-aspire",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "icon": "dotnet-aspire-logo-128.png",
   "license": "SEE LICENSE IN LICENSE.TXT",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -86,5 +86,8 @@
   "aspire-vscode.strings.authorizationAndDcpHeadersRequired": "Authorization and Microsoft-Developer-DCP-Instance-ID headers are required.",
   "aspire-vscode.strings.buildFailedForProjectWithError": "Build failed for project {0} with error: {1}.",
   "aspire-vscode.strings.lookingForDevkitBuildTask": "C# Dev Kit is installed, looking for C# Dev Kit build task...",
-  "aspire-vscode.strings.csharpDevKitNotInstalled": "C# Dev Kit is not installed, building using dotnet CLI..."
+  "aspire-vscode.strings.csharpDevKitNotInstalled": "C# Dev Kit is not installed, building using dotnet CLI...",
+  "aspire-vscode.strings.cliNotAvailable": "Aspire CLI is not available on PATH. Please install it and restart VS Code.",
+  "aspire-vscode.strings.openCliInstallInstructions": "See CLI installation instructions",
+  "aspire-vscode.strings.dismissLabel": "Dismiss"
 }

--- a/extension/src/debugger/AspireDebugConfigurationProvider.ts
+++ b/extension/src/debugger/AspireDebugConfigurationProvider.ts
@@ -28,12 +28,10 @@ export class AspireDebugConfigurationProvider implements vscode.DebugConfigurati
 
     async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined> {
          // Check if CLI is available before starting debug session
-        if (this._terminalProvider) {
-            const cliPath = this._terminalProvider.getAspireCliExecutablePath();
-            const isCliAvailable = await checkCliAvailableOrRedirect(cliPath);
-            if (!isCliAvailable) {
-                return undefined; // Cancel the debug session
-            }
+        const cliPath = this._terminalProvider.getAspireCliExecutablePath();
+        const isCliAvailable = await checkCliAvailableOrRedirect(cliPath);
+        if (!isCliAvailable) {
+            return undefined; // Cancel the debug session
         }
 
         if (!config.type) {

--- a/extension/src/debugger/AspireDebugConfigurationProvider.ts
+++ b/extension/src/debugger/AspireDebugConfigurationProvider.ts
@@ -1,7 +1,15 @@
 import * as vscode from 'vscode';
 import { defaultConfigurationName } from '../loc/strings';
+import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+import { checkCliAvailableOrRedirect } from '../utils/workspace';
 
 export class AspireDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+    private _terminalProvider: AspireTerminalProvider;
+
+    constructor(terminalProvider: AspireTerminalProvider) {
+        this._terminalProvider = terminalProvider;
+    }
+
     async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
         if (folder === undefined) {
             return [];
@@ -18,7 +26,16 @@ export class AspireDebugConfigurationProvider implements vscode.DebugConfigurati
         return configurations;
     }
 
-    async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> {
+    async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined> {
+         // Check if CLI is available before starting debug session
+        if (this._terminalProvider) {
+            const cliPath = this._terminalProvider.getAspireCliExecutablePath();
+            const isCliAvailable = await checkCliAvailableOrRedirect(cliPath);
+            if (!isCliAvailable) {
+                return undefined; // Cancel the debug session
+            }
+        }
+
         if (!config.type) {
             config.type = 'aspire';
         }

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -144,7 +144,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
 
     spawnCliProcess(
       this._terminalProvider,
-      this._terminalProvider.getAspireCliExecutablePath(false),
+      this._terminalProvider.getAspireCliExecutablePath(),
       args,
       {
         stdoutCallback: (data) => {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -95,7 +95,7 @@ async function tryExecuteCommand(commandName: string, terminalProvider: AspireTe
     sendTelemetryEvent(`${commandName}.invoked`);
 
     // TODO add walkthrough commands
-    const cliCheckExcludedCommands: string[] = [];
+    const cliCheckExcludedCommands: string[] = ["aspire-vscode.settings", "aspire-vscode.configureLaunchJson"];
 
     // Skip CLI check for walkthrough commands themselves
     if (!cliCheckExcludedCommands.includes(commandName)) {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -94,7 +94,6 @@ async function tryExecuteCommand(commandName: string, terminalProvider: AspireTe
   try {
     sendTelemetryEvent(`${commandName}.invoked`);
 
-    // TODO add walkthrough commands
     const cliCheckExcludedCommands: string[] = ["aspire-vscode.settings", "aspire-vscode.configureLaunchJson"];
 
     // Skip CLI check for walkthrough commands themselves

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -96,7 +96,6 @@ async function tryExecuteCommand(commandName: string, terminalProvider: AspireTe
 
     const cliCheckExcludedCommands: string[] = ["aspire-vscode.settings", "aspire-vscode.configureLaunchJson"];
 
-    // Skip CLI check for walkthrough commands themselves
     if (!cliCheckExcludedCommands.includes(commandName)) {
       const cliPath = terminalProvider.getAspireCliExecutablePath();
       const isCliAvailable = await checkCliAvailableOrRedirect(cliPath);

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -65,3 +65,6 @@ export const authorizationAndDcpHeadersRequired = vscode.l10n.t('Authorization a
 export const buildFailedForProjectWithError = (project: string, error: string) => vscode.l10n.t('Build failed for project {0} with error: {1}.', project, error);
 export const lookingForDevkitBuildTask = vscode.l10n.t('C# Dev Kit is installed, looking for C# Dev Kit build task...');
 export const csharpDevKitNotInstalled = vscode.l10n.t('C# Dev Kit is not installed, building using dotnet CLI...');
+export const dismissLabel = vscode.l10n.t('Dismiss');
+export const openCliInstallInstructions = vscode.l10n.t('See CLI installation instructions');
+export const cliNotAvailable = vscode.l10n.t('Aspire CLI is not available on PATH. Please install it and restart VS Code.');

--- a/extension/src/test/aspireTerminalProvider.test.ts
+++ b/extension/src/test/aspireTerminalProvider.test.ts
@@ -1,0 +1,95 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+
+suite('AspireTerminalProvider tests', () => {
+    let terminalProvider: AspireTerminalProvider;
+    let configStub: sinon.SinonStub;
+    let subscriptions: vscode.Disposable[];
+
+    setup(() => {
+        subscriptions = [];
+        terminalProvider = new AspireTerminalProvider(subscriptions);
+        configStub = sinon.stub(vscode.workspace, 'getConfiguration');
+    });
+
+    teardown(() => {
+        configStub.restore();
+        subscriptions.forEach(s => s.dispose());
+    });
+
+    suite('getAspireCliExecutablePath', () => {
+        test('returns "aspire" when no custom path is configured', () => {
+            configStub.returns({
+                get: sinon.stub().returns('')
+            });
+
+            const result = terminalProvider.getAspireCliExecutablePath();
+            assert.strictEqual(result, 'aspire');
+        });
+
+        test('returns custom path when configured', () => {
+            configStub.returns({
+                get: sinon.stub().returns('/usr/local/bin/aspire')
+            });
+
+            const result = terminalProvider.getAspireCliExecutablePath();
+            assert.strictEqual(result, '/usr/local/bin/aspire');
+        });
+
+        test('returns custom path with spaces', () => {
+            configStub.returns({
+                get: sinon.stub().returns('/my path/with spaces/aspire')
+            });
+
+            const result = terminalProvider.getAspireCliExecutablePath();
+            assert.strictEqual(result, '/my path/with spaces/aspire');
+        });
+
+        test('trims whitespace from configured path', () => {
+            configStub.returns({
+                get: sinon.stub().returns('  /usr/local/bin/aspire  ')
+            });
+
+            const result = terminalProvider.getAspireCliExecutablePath();
+            assert.strictEqual(result, '/usr/local/bin/aspire');
+        });
+
+        test('returns "aspire" when configured path is only whitespace', () => {
+            configStub.returns({
+                get: sinon.stub().returns('   ')
+            });
+
+            const result = terminalProvider.getAspireCliExecutablePath();
+            assert.strictEqual(result, 'aspire');
+        });
+
+        test('handles Windows-style paths', () => {
+            configStub.returns({
+                get: sinon.stub().returns('C:\\Program Files\\Aspire\\aspire.exe')
+            });
+
+            const result = terminalProvider.getAspireCliExecutablePath();
+            assert.strictEqual(result, 'C:\\Program Files\\Aspire\\aspire.exe');
+        });
+
+        test('handles Windows-style paths without spaces', () => {
+            configStub.returns({
+                get: sinon.stub().returns('C:\\aspire\\aspire.exe')
+            });
+
+            const result = terminalProvider.getAspireCliExecutablePath();
+            assert.strictEqual(result, 'C:\\aspire\\aspire.exe');
+        });
+
+        test('handles paths with special characters', () => {
+            configStub.returns({
+                get: sinon.stub().returns('/path/with$dollar/aspire')
+            });
+
+            const result = terminalProvider.getAspireCliExecutablePath();
+            assert.strictEqual(result, '/path/with$dollar/aspire');
+        });
+    });
+});

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -67,7 +67,7 @@ export class AspireTerminalProvider implements vscode.Disposable {
             command = `& "${cliPath}" ${subcommand}`;
         } else {
             // For Unix-like systems, quote only if needed
-            const quotedPath = /[\s"'`$!*?()&|<>;]/.test(cliPath) ? `'${cliPath.replace(/'/g, `'\\''`)}'` : cliPath;
+            const quotedPath = /[\s"'`$!*?()&|<>;]/.test(cliPath) ? `'${cliPath.replace(/'/g, `'\"'\"'`)}'` : cliPath;
             command = `${quotedPath} ${subcommand}`;
         }
 

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -57,7 +57,20 @@ export class AspireTerminalProvider implements vscode.Disposable {
     }
 
     sendAspireCommandToAspireTerminal(subcommand: string, showTerminal: boolean = true) {
-        let command = `${this.getAspireCliExecutablePath()} ${subcommand}`;
+        const cliPath = this.getAspireCliExecutablePath();
+
+        // On Windows, use & to execute paths, especially those with special characters
+        // On Unix, just use the path directly
+        let command: string;
+        if (process.platform === 'win32') {
+            // Use & call operator with quoted path for Windows
+            command = `& "${cliPath}" ${subcommand}`;
+        } else {
+            // For Unix-like systems, quote only if needed
+            const quotedPath = /[\s"'`$!*?()&|<>;]/.test(cliPath) ? `'${cliPath.replace(/'/g, `'\\''`)}'` : cliPath;
+            command = `${quotedPath} ${subcommand}`;
+        }
+
         if (this.isCliDebugLoggingEnabled()) {
             command += ' --debug';
         }
@@ -186,20 +199,15 @@ export class AspireTerminalProvider implements vscode.Disposable {
     }
 
 
-    getAspireCliExecutablePath(surroundWithQuotes: boolean = true): string {
+    getAspireCliExecutablePath(): string {
         const aspireCliPath = vscode.workspace.getConfiguration('aspire').get<string>('aspireCliExecutablePath', '');
         if (aspireCliPath && aspireCliPath.trim().length > 0) {
             extensionLogOutputChannel.debug(`Using user-configured Aspire CLI path: ${aspireCliPath}`);
-            const path = shellEscapeSingleQuotes(aspireCliPath.trim());
-            return surroundWithQuotes ? `'${path}'` : path;
+            return aspireCliPath.trim();
         }
 
         extensionLogOutputChannel.debug('No user-configured Aspire CLI path found');
         return "aspire";
-
-        function shellEscapeSingleQuotes(str: string): string {
-            return str.replace(/'/g, `'\\''`);
-        }
     }
 
     isCliDebugLoggingEnabled(): boolean {

--- a/extension/src/utils/workspace.ts
+++ b/extension/src/utils/workspace.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode';
-import { dontShowAgainLabel, doYouWantToSetDefaultApphost, noLabel, noWorkspaceOpen, selectDefaultLaunchApphost, yesLabel } from '../loc/strings';
+import { cliNotAvailable, dismissLabel, dontShowAgainLabel, doYouWantToSetDefaultApphost, noLabel, noWorkspaceOpen, openCliInstallInstructions, selectDefaultLaunchApphost, yesLabel } from '../loc/strings';
 import path from 'path';
 import { spawnCliProcess } from '../debugger/languages/cli';
 import { AspireTerminalProvider } from './AspireTerminalProvider';
-import { ChildProcessWithoutNullStreams } from 'child_process';
+import { ChildProcessWithoutNullStreams, execFile } from 'child_process';
 import { AspireSettingsFile } from './cliTypes';
 import { extensionLogOutputChannel } from './logging';
 import { EnvironmentVariables } from './environment';
+import { promisify } from 'util';
 
 export function isWorkspaceOpen(showErrorMessage: boolean = true): boolean {
     const isOpen = !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0;
@@ -99,7 +100,7 @@ export async function checkForExistingAppHostPathInWorkspace(terminalProvider: A
             args.push('--cli-wait-for-debugger');
         }
 
-        proc = spawnCliProcess(terminalProvider, terminalProvider.getAspireCliExecutablePath(false), args, {
+        proc = spawnCliProcess(terminalProvider, terminalProvider.getAspireCliExecutablePath(), args, {
             errorCallback: error => {
                 extensionLogOutputChannel.error(`Error executing get-apphosts command: ${error}`);
                 reject();
@@ -202,4 +203,37 @@ async function promptToAddAppHostPathToSettingsFile(result: AppHostProjectSearch
     await vscode.workspace.fs.writeFile(settingsFileLocation, updatedSettingsFileContent);
 
     extensionLogOutputChannel.info(`Successfully set appHostPath to: ${appHostToUse} in ${settingsFileLocation.fsPath}`);
+}
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Checks if the Aspire CLI is available. If not, shows a message prompting to open Aspire CLI installation steps on the repo.
+ * @param cliPath The path to the Aspire CLI executable
+ * @returns true if CLI is available, false otherwise
+ */
+export async function checkCliAvailableOrRedirect(cliPath: string): Promise<boolean> {
+    try {
+        // Remove surrounding quotes if present (both single and double quotes)
+        let cleanPath = cliPath.trim();
+        if ((cleanPath.startsWith("'") && cleanPath.endsWith("'")) ||
+            (cleanPath.startsWith('"') && cleanPath.endsWith('"'))) {
+            cleanPath = cleanPath.slice(1, -1);
+        }
+        await execFileAsync(cleanPath, ['--version'], { timeout: 5000 });
+        return true;
+    } catch (error) {
+        vscode.window.showErrorMessage(
+            cliNotAvailable,
+            openCliInstallInstructions,
+            dismissLabel
+        ).then(selection => {
+            if (selection === openCliInstallInstructions) {
+                // Go to Aspire README in external browser
+                vscode.env.openExternal(vscode.Uri.parse('https://aspire.dev/get-started/install-cli/'));
+            }
+        });
+
+        return false;
+    }
 }

--- a/extension/src/utils/workspace.ts
+++ b/extension/src/utils/workspace.ts
@@ -207,12 +207,19 @@ async function promptToAddAppHostPathToSettingsFile(result: AppHostProjectSearch
 
 const execFileAsync = promisify(execFile);
 
+let cliAvailableOnPath: boolean | undefined = undefined;
+
 /**
  * Checks if the Aspire CLI is available. If not, shows a message prompting to open Aspire CLI installation steps on the repo.
  * @param cliPath The path to the Aspire CLI executable
  * @returns true if CLI is available, false otherwise
  */
 export async function checkCliAvailableOrRedirect(cliPath: string): Promise<boolean> {
+    if (cliAvailableOnPath === true) {
+        // Assume, for now, that CLI availability does not change during the session if it was previously confirmed
+        return Promise.resolve(true);
+    }
+
     try {
         // Remove surrounding quotes if present (both single and double quotes)
         let cleanPath = cliPath.trim();
@@ -221,8 +228,10 @@ export async function checkCliAvailableOrRedirect(cliPath: string): Promise<bool
             cleanPath = cleanPath.slice(1, -1);
         }
         await execFileAsync(cleanPath, ['--version'], { timeout: 5000 });
+        cliAvailableOnPath = true;
         return true;
     } catch (error) {
+        cliAvailableOnPath = false;
         vscode.window.showErrorMessage(
             cliNotAvailable,
             openCliInstallInstructions,

--- a/extension/src/utils/workspace.ts
+++ b/extension/src/utils/workspace.ts
@@ -238,7 +238,7 @@ export async function checkCliAvailableOrRedirect(cliPath: string): Promise<bool
             dismissLabel
         ).then(selection => {
             if (selection === openCliInstallInstructions) {
-                // Go to Aspire README in external browser
+                // Go to Aspire CLI installation instruction page in external browser
                 vscode.env.openExternal(vscode.Uri.parse('https://aspire.dev/get-started/install-cli/'));
             }
         });


### PR DESCRIPTION
## Description

Fixes running a custom version of aspire cli on windows, and when aspire is not on the path, complains and bails with the following informational message:

<img width="826" height="202" alt="image" src="https://github.com/user-attachments/assets/37e21cbf-86b0-4954-bb91-cfefd78c24fb" />

It checks for CLI availability by running `aspire --version`. If that command succeeds, CLI is assumed to be available for the entire lifetime of the extension (in practice, until VS code is restarted or workspace is closed) and the command is not run anymore.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
