### PR TITLE
[tests] Add logging to RemoteExecutor ConformanceTests

### DIFF
--- a/tests/Aspire.Azure.AI.OpenAI.Tests/Aspire.Azure.AI.OpenAI.Tests.csproj
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/Aspire.Azure.AI.OpenAI.Tests.csproj
@@ -9,10 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.AI.OpenAI\Aspire.Azure.AI.OpenAI.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.TestUtilities\Aspire.Components.Common.TestUtilities.csproj" />
   </ItemGroup>

--- a/tests/Aspire.Azure.AI.OpenAI.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/ConformanceTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Components.ConformanceTests;
 using Aspire.TestUtilities;
 using Azure.Identity;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -84,14 +83,18 @@ public class ConformanceTests : ConformanceTests<IChatClient, AzureOpenAISetting
         }
     }
 
+    public ConformanceTests(ITestOutputHelper? output = null) : base(output)
+    {
+    }
+
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: null), Output);
 
     [Fact]
     [QuarantinedTest("https://github.com/dotnet/aspire/issues/9916")]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: "key"), Output);
 
     protected override void SetHealthCheck(AzureOpenAISettings options, bool enabled)
         => throw new NotImplementedException();

--- a/tests/Aspire.Azure.Data.Tables.Tests/Aspire.Azure.Data.Tables.Tests.csproj
+++ b/tests/Aspire.Azure.Data.Tables.Tests/Aspire.Azure.Data.Tables.Tests.csproj
@@ -9,10 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Data.Tables\Aspire.Azure.Data.Tables.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.TestUtilities\Aspire.Components.Common.TestUtilities.csproj" />
   </ItemGroup>

--- a/tests/Aspire.Azure.Data.Tables.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Data.Tables.Tests/ConformanceTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Components.ConformanceTests;
 using Azure.Data.Tables;
 using Azure.Identity;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -94,6 +93,10 @@ public class ConformanceTests : ConformanceTests<TableServiceClient, AzureDataTa
         }
     }
 
+    public ConformanceTests(ITestOutputHelper? output = null) : base(output)
+    {
+    }
+
     protected override void SetHealthCheck(AzureDataTablesSettings options, bool enabled)
         => options.DisableHealthChecks = !enabled;
 
@@ -112,11 +115,11 @@ public class ConformanceTests : ConformanceTests<TableServiceClient, AzureDataTa
 
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: null), Output);
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: "key"), Output);
 
     private static bool GetCanConnect()
     {

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTests.EventHubProducerClient.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTests.EventHubProducerClient.cs
@@ -4,7 +4,6 @@
 using Azure.Identity;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 
@@ -12,6 +11,11 @@ namespace Aspire.Azure.Messaging.EventHubs.Tests;
 
 public class ConformanceTests_EventHubProducerClient : ConformanceTestsBase<EventHubProducerClient, AzureMessagingEventHubsProducerSettings>
 {
+    public ConformanceTests_EventHubProducerClient(ITestOutputHelper? output = null)
+        : base(output)
+    {
+    }
+
     protected override void SetHealthCheck(AzureMessagingEventHubsProducerSettings options, bool enabled)
         => options.DisableHealthChecks = !enabled;
 
@@ -60,9 +64,9 @@ public class ConformanceTests_EventHubProducerClient : ConformanceTestsBase<Even
 
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null), EnableTracingForAzureSdk()).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests_EventHubProducerClient().ActivitySourceTest(key: null), Output, EnableTracingForAzureSdk());
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key"), EnableTracingForAzureSdk()).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests_EventHubProducerClient().ActivitySourceTest(key: "key"), Output, EnableTracingForAzureSdk());
 }

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTestsBase.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/ConformanceTestsBase.cs
@@ -55,6 +55,10 @@ public abstract class ConformanceTestsBase<TService, TOptions> : ConformanceTest
              ($$"""{"Aspire": { "Azure": { "Messaging" :{ "EventHubs": { "{{typeof(TService).Name}}": { "DisableHealthChecks": "true" } } } } } }""", "Value is \"string\" but should be \"boolean\""),
         ];
 
+    public ConformanceTestsBase(ITestOutputHelper? output = null) : base(output)
+    {
+    }
+
     protected override void PopulateConfiguration(ConfigurationManager configuration, string? key = null)
     => configuration.AddInMemoryCollection(
     [

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests.cs
@@ -7,6 +7,7 @@ using Azure.Messaging.ServiceBus;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Xunit;
 
 namespace Aspire.Azure.Messaging.ServiceBus.Tests;
 
@@ -16,6 +17,10 @@ public abstract class ConformanceTests : ConformanceTests<ServiceBusClient, Azur
     public const string FullyQualifiedNamespace = "aspireservicebustests.servicebus.windows.net";
     // Fake connection string for cases when credentials are unavailable and need to switch to raw connection string
     protected const string ConnectionString = "Endpoint=sb://foo.servicebus.windows.net/;SharedAccessKeyName=fake;SharedAccessKey=fake";
+
+    public ConformanceTests(ITestOutputHelper? output = null) : base(output)
+    {
+    }
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests_Queue.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests_Queue.cs
@@ -3,7 +3,6 @@
 
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -26,6 +25,11 @@ public class ConformanceTests_Queue : ConformanceTests
             new(CreateConfigKey("Aspire:Azure:Messaging:ServiceBus", key, "ClientOptions:RetryOptions:MaxRetries"), "0")
         });
 
+    public ConformanceTests_Queue(ITestOutputHelper? output = null)
+        : base(output)
+    {
+    }
+
     protected override void SetHealthCheck(AzureMessagingServiceBusSettings options, bool enabled)
         => options.HealthCheckQueueName = enabled ? HealthCheckQueueName : default;
 
@@ -34,11 +38,11 @@ public class ConformanceTests_Queue : ConformanceTests
 
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null), EnableTracingForAzureSdk()).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests_Queue().ActivitySourceTest(key: null), Output, EnableTracingForAzureSdk());
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key"), EnableTracingForAzureSdk()).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests_Queue().ActivitySourceTest(key: "key"), Output, EnableTracingForAzureSdk());
 
     private static bool GetCanConnect()
     {

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests_Topic.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests_Topic.cs
@@ -3,7 +3,6 @@
 
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -33,14 +32,18 @@ public class ConformanceTests_Topic : ConformanceTests
     protected override void TriggerActivity(ServiceBusClient service)
         => _ = service.CreateReceiver(topicName: HealthCheckTopicName, subscriptionName: SubscriptionName).PeekMessageAsync().GetAwaiter().GetResult();
 
+    public ConformanceTests_Topic(ITestOutputHelper? output = null)
+        : base(output)
+    {
+    }
+
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null), EnableTracingForAzureSdk()).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests_Topic().ActivitySourceTest(key: null), Output, EnableTracingForAzureSdk());
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key"), EnableTracingForAzureSdk()).Dispose();
-
+        => RemoteInvokeWithLogging(() => new ConformanceTests_Topic().ActivitySourceTest(key: "key"), Output, EnableTracingForAzureSdk());
     private static bool GetCanConnect()
     {
         ServiceBusClientOptions clientOptions = new();

--- a/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests.csproj
+++ b/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests.csproj
@@ -18,7 +18,6 @@
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL\Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.TestUtilities\Aspire.Components.Common.TestUtilities.csproj" />
 
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Testcontainers.PostgreSQL" />
   </ItemGroup>
 

--- a/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Components.ConformanceTests;
 using Aspire.Npgsql.Tests;
 using Aspire.TestUtilities;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -76,7 +75,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, AzureNpgsqlEntit
             ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "DisableMetrics": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
         };
 
-    public ConformanceTests(PostgreSQLContainerFixture? containerFixture)
+    public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
         ConnectionString = (_containerFixture is not null && RequiresDockerAttribute.IsSupported)
@@ -134,8 +133,9 @@ public class ConformanceTests : ConformanceTests<TestDbContext, AzureNpgsqlEntit
     [Fact]
     [RequiresDocker]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(static connectionStringToUse => RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
-                                 ConnectionString).Dispose();
+        => RemoteInvokeWithLogging(static connectionStringToUse =>
+                RunWithConnectionString(connectionStringToUse, obj =>
+                    obj.ActivitySourceTest(key: null)), ConnectionString, Output);
 
     private static void RunWithConnectionString(string connectionString, Action<ConformanceTests> test)
         => test(new ConformanceTests(null) { ConnectionString = connectionString });

--- a/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests_TypeSpecificConfig.cs
+++ b/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests_TypeSpecificConfig.cs
@@ -4,12 +4,13 @@
 using Aspire.Npgsql.Tests;
 using Aspire.TestUtilities;
 using Microsoft.Extensions.Configuration;
+using Xunit;
 
 namespace Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests;
 
 public class ConformanceTests_TypeSpecificConfig : ConformanceTests
 {
-    public ConformanceTests_TypeSpecificConfig(PostgreSQLContainerFixture containerFixture) : base(containerFixture)
+    public ConformanceTests_TypeSpecificConfig(PostgreSQLContainerFixture containerFixture, ITestOutputHelper? output = null) : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/EnrichNpgsqlTests.cs
+++ b/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/EnrichNpgsqlTests.cs
@@ -19,7 +19,7 @@ namespace Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests;
 
 public class EnrichNpgsqlTests : ConformanceTests
 {
-    public EnrichNpgsqlTests(PostgreSQLContainerFixture containerFixture) : base(containerFixture)
+    public EnrichNpgsqlTests(PostgreSQLContainerFixture containerFixture, ITestOutputHelper output) : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.Azure.Npgsql.Tests/Aspire.Azure.Npgsql.Tests.csproj
+++ b/tests/Aspire.Azure.Npgsql.Tests/Aspire.Azure.Npgsql.Tests.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Testcontainers.PostgreSQL" />
   </ItemGroup>
 

--- a/tests/Aspire.Azure.Search.Documents.Tests/Aspire.Azure.Search.Documents.Tests.csproj
+++ b/tests/Aspire.Azure.Search.Documents.Tests/Aspire.Azure.Search.Documents.Tests.csproj
@@ -9,10 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Search.Documents\Aspire.Azure.Search.Documents.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.TestUtilities\Aspire.Components.Common.TestUtilities.csproj" />
   </ItemGroup>

--- a/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Components.ConformanceTests;
 using Azure.Identity;
 using Azure.Search.Documents.Indexes;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -36,7 +35,7 @@ public class ConformanceTests : ConformanceTests<SearchIndexClient, AzureSearchS
                   "ClientOptions": {
                     "Retry": {
                       "Mode": "Fixed",
-                      "MaxDelay": "00:00:03"  
+                      "MaxDelay": "00:00:03"
                     }
                   }
                 }
@@ -82,13 +81,17 @@ public class ConformanceTests : ConformanceTests<SearchIndexClient, AzureSearchS
         }
     }
 
+    public ConformanceTests(ITestOutputHelper? output = null) : base(output)
+    {
+    }
+
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
+        => RemoteInvokeWithLogging(static () => new ConformanceTests().ActivitySourceTest(key: null), Output);
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
+        => RemoteInvokeWithLogging(static () => new ConformanceTests().ActivitySourceTest(key: "key"), Output);
 
     protected override void SetHealthCheck(AzureSearchSettings options, bool enabled)
         => options.DisableHealthChecks = !enabled;

--- a/tests/Aspire.Azure.Storage.Blobs.Tests/Aspire.Azure.Storage.Blobs.Tests.csproj
+++ b/tests/Aspire.Azure.Storage.Blobs.Tests/Aspire.Azure.Storage.Blobs.Tests.csproj
@@ -9,10 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Storage.Blobs\Aspire.Azure.Storage.Blobs.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.TestUtilities\Aspire.Components.Common.TestUtilities.csproj" />
   </ItemGroup>

--- a/tests/Aspire.Azure.Storage.Blobs.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Blobs.Tests/ConformanceTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Components.ConformanceTests;
 using Azure.Identity;
 using Azure.Storage.Blobs;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -98,6 +97,10 @@ public class ConformanceTests : ConformanceTests<BlobServiceClient, AzureStorage
         }
     }
 
+    public ConformanceTests(ITestOutputHelper? output = null) : base(output)
+    {
+    }
+
     protected override void SetHealthCheck(AzureStorageBlobsSettings options, bool enabled)
         => options.DisableHealthChecks = !enabled;
 
@@ -116,11 +119,11 @@ public class ConformanceTests : ConformanceTests<BlobServiceClient, AzureStorage
 
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: null), Output);
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: "key"), Output);
 
     private static bool GetCanConnect()
     {

--- a/tests/Aspire.Azure.Storage.Queues.Tests/Aspire.Azure.Storage.Queues.Tests.csproj
+++ b/tests/Aspire.Azure.Storage.Queues.Tests/Aspire.Azure.Storage.Queues.Tests.csproj
@@ -9,10 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Storage.Queues\Aspire.Azure.Storage.Queues.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.TestUtilities\Aspire.Components.Common.TestUtilities.csproj" />
   </ItemGroup>

--- a/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
@@ -4,7 +4,6 @@
 using Aspire.Components.ConformanceTests;
 using Azure.Identity;
 using Azure.Storage.Queues;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -99,6 +98,10 @@ public class ConformanceTests : ConformanceTests<QueueServiceClient, AzureStorag
         }
     }
 
+    public ConformanceTests(ITestOutputHelper? output = null) : base(output)
+    {
+    }
+
     protected override void SetHealthCheck(AzureStorageQueuesSettings options, bool enabled)
         => options.DisableHealthChecks = !enabled;
 
@@ -117,11 +120,11 @@ public class ConformanceTests : ConformanceTests<QueueServiceClient, AzureStorag
 
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: null), Output);
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: "key"), Output);
 
     private static bool GetCanConnect()
     {

--- a/tests/Aspire.Components.Common.TestUtilities/Aspire.Components.Common.TestUtilities.csproj
+++ b/tests/Aspire.Components.Common.TestUtilities/Aspire.Components.Common.TestUtilities.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="JsonSchema.Net" />
+    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />

--- a/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
@@ -325,7 +325,7 @@ public abstract class ConformanceTests<TService, TOptions>
 
         // Output diagnostic information about which categories were actually logged
         // to help debug failures when expected categories are not found.
-        // if (Output is not null)
+        if (Output is not null)
         {
             Console.WriteLine("=== Logged Categories ===");
             foreach (var category in loggerFactory.Categories.OrderBy(c => c))

--- a/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
@@ -631,14 +631,14 @@ public abstract class ConformanceTests<TService, TOptions>
             {
                 if (e.Data is not null)
                 {
-                    testOutput.WriteLine(e.Data);
+                    testOutput.WriteLine($"[RemoteExecutor] {e.Data}");
                 }
             };
             handle.Process.ErrorDataReceived += (sender, e) =>
             {
                 if (e.Data is not null)
                 {
-                    testOutput.WriteLine($"ERROR: {e.Data}");
+                    testOutput.WriteLine($"[RemoteExecutor] ERROR: {e.Data}");
                 }
             };
         }

--- a/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
@@ -327,29 +327,29 @@ public abstract class ConformanceTests<TService, TOptions>
         // to help debug failures when expected categories are not found.
         if (Output is not null)
         {
-            Console.WriteLine("=== Logged Categories ===");
+            Output.WriteLine("=== Logged Categories ===");
             foreach (var category in loggerFactory.Categories.OrderBy(c => c))
             {
-                Console.WriteLine($"  - {category}");
+                Output.WriteLine($"  - {category}");
             }
-            Console.WriteLine("");
-            Console.WriteLine("=== Required Categories ===");
+            Output.WriteLine("");
+            Output.WriteLine("=== Required Categories ===");
             foreach (var category in RequiredLogCategories.OrderBy(c => c))
             {
                 var found = loggerFactory.Categories.Contains(category);
-                Console.WriteLine($"  {(found ? "✓" : "✗")} {category}");
+                Output.WriteLine($"  {(found ? "✓" : "✗")} {category}");
             }
             if (NotAcceptableLogCategories.Length > 0)
             {
-                Console.WriteLine("");
-                Console.WriteLine("=== Not Acceptable Categories (should not be present) ===");
+                Output.WriteLine("");
+                Output.WriteLine("=== Not Acceptable Categories (should not be present) ===");
                 foreach (var category in NotAcceptableLogCategories.OrderBy(c => c))
                 {
                     var found = loggerFactory.Categories.Contains(category);
-                    Console.WriteLine($"  {(found ? "✗ FOUND" : "✓ Not found")} {category}");
+                    Output.WriteLine($"  {(found ? "✗ FOUND" : "✓ Not found")} {category}");
                 }
             }
-            Console.WriteLine("");
+            Output.WriteLine("");
         }
 
         foreach (string logCategory in RequiredLogCategories)

--- a/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
@@ -13,6 +13,7 @@ using Json.Schema;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Xunit;
+using Microsoft.DotNet.RemoteExecutor;
 
 namespace Aspire.Components.ConformanceTests;
 
@@ -21,6 +22,25 @@ public abstract class ConformanceTests<TService, TOptions>
     where TOptions : class, new()
 {
     protected static readonly EvaluationOptions DefaultEvaluationOptions = new() { RequireFormatValidation = true, OutputFormat = OutputFormat.List };
+
+    /// <summary>
+    /// Optional ITestOutputHelper for capturing diagnostic logs during test execution.
+    /// When provided, all logs will be output to xUnit test results for easier debugging.
+    /// </summary>
+    protected ITestOutputHelper? Output { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the ConformanceTests base class.
+    /// </summary>
+    /// <param name="output">
+    /// Optional ITestOutputHelper for capturing diagnostic logs. When provided,
+    /// all logs from components under test will be written to xUnit output,
+    /// making test failures easier to diagnose.
+    /// </param>
+    protected ConformanceTests(ITestOutputHelper? output = null)
+    {
+        Output = output;
+    }
 
     protected abstract ServiceLifetime ServiceLifetime { get; }
 
@@ -303,6 +323,35 @@ public abstract class ConformanceTests<TService, TOptions>
         }
         catch (Exception) { }
 
+        // Output diagnostic information about which categories were actually logged
+        // to help debug failures when expected categories are not found.
+        // if (Output is not null)
+        {
+            Console.WriteLine("=== Logged Categories ===");
+            foreach (var category in loggerFactory.Categories.OrderBy(c => c))
+            {
+                Console.WriteLine($"  - {category}");
+            }
+            Console.WriteLine("");
+            Console.WriteLine("=== Required Categories ===");
+            foreach (var category in RequiredLogCategories.OrderBy(c => c))
+            {
+                var found = loggerFactory.Categories.Contains(category);
+                Console.WriteLine($"  {(found ? "✓" : "✗")} {category}");
+            }
+            if (NotAcceptableLogCategories.Length > 0)
+            {
+                Console.WriteLine("");
+                Console.WriteLine("=== Not Acceptable Categories (should not be present) ===");
+                foreach (var category in NotAcceptableLogCategories.OrderBy(c => c))
+                {
+                    var found = loggerFactory.Categories.Contains(category);
+                    Console.WriteLine($"  {(found ? "✗ FOUND" : "✓ Not found")} {category}");
+                }
+            }
+            Console.WriteLine("");
+        }
+
         foreach (string logCategory in RequiredLogCategories)
         {
             Assert.Contains(logCategory, loggerFactory.Categories);
@@ -444,6 +493,7 @@ public abstract class ConformanceTests<TService, TOptions>
     protected void ActivitySourceTest(string? key)
     {
         HostApplicationBuilder builder = CreateHostBuilder(key: key);
+        builder.Logging.AddConsole();
         RegisterComponent(builder, options => SetTracing(options, true), key);
 
         List<Activity> exportedActivities = new();
@@ -549,6 +599,56 @@ public abstract class ConformanceTests<TService, TOptions>
         if (!SupportsNamedConfig || ConfigurationSectionName is null)
         {
             Assert.Skip("Named configuration is not supported.");
+        }
+    }
+
+    protected static void RemoteInvokeWithLogging(Action action, ITestOutputHelper? testOutput, RemoteInvokeOptions? options = null)
+    {
+        using var handle = RemoteExecutor.Invoke(action, GetRemoteInvokeOptionsForLogging(options));
+        ConfigureLoggingAndStart(handle, testOutput);
+    }
+
+    protected static void RemoteInvokeWithLogging(Action<string> action, string arg, ITestOutputHelper? testOutput, RemoteInvokeOptions? options = null)
+    {
+        using var handle = RemoteExecutor.Invoke(action, arg, GetRemoteInvokeOptionsForLogging(options));
+        ConfigureLoggingAndStart(handle, testOutput);
+    }
+
+    private static RemoteInvokeOptions GetRemoteInvokeOptionsForLogging(RemoteInvokeOptions? options = null)
+    {
+        options ??= new RemoteInvokeOptions();
+        options.StartInfo.RedirectStandardError = true;
+        options.StartInfo.RedirectStandardOutput = true;
+        options.Start = false;
+        return options;
+    }
+
+    private static void ConfigureLoggingAndStart(RemoteInvokeHandle handle, ITestOutputHelper? testOutput)
+    {
+        if (testOutput is not null)
+        {
+            handle.Process.OutputDataReceived += (sender, e) =>
+            {
+                if (e.Data is not null)
+                {
+                    testOutput.WriteLine(e.Data);
+                }
+            };
+            handle.Process.ErrorDataReceived += (sender, e) =>
+            {
+                if (e.Data is not null)
+                {
+                    testOutput.WriteLine($"ERROR: {e.Data}");
+                }
+            };
+        }
+
+        handle.Process.Start();
+        // RemoveInvokeHandle Dispose will handle the wait for exit
+        if (testOutput is not null)
+        {
+            handle.Process.BeginErrorReadLine();
+            handle.Process.BeginOutputReadLine();
         }
     }
 

--- a/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
@@ -644,7 +644,7 @@ public abstract class ConformanceTests<TService, TOptions>
         }
 
         handle.Process.Start();
-        // RemoveInvokeHandle Dispose will handle the wait for exit
+        // RemoteInvokeHandle Dispose will handle the wait for exit
         if (testOutput is not null)
         {
             handle.Process.BeginErrorReadLine();

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/Aspire.Microsoft.Data.SqlClient.Tests.csproj
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/Aspire.Microsoft.Data.SqlClient.Tests.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.SqlServer\SqlServerContainerImageTags.cs" />
   </ItemGroup>
 

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/ConformanceTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.TestUtilities;
 using Aspire.Components.ConformanceTests;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -75,6 +74,10 @@ public class ConformanceTests : ConformanceTests<TestDbContext, EntityFrameworkC
         }
     }
 
+    public ConformanceTests(ITestOutputHelper? output = null) : base(output)
+    {
+    }
+
     [Fact]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "EF1001:Internal EF Core API usage.", Justification = "Required to verify pooling without touching DB")]
     public void DbContextPoolingRegistersIDbContextPool()
@@ -101,6 +104,6 @@ public class ConformanceTests : ConformanceTests<TestDbContext, EntityFrameworkC
     {
         SkipIfCanNotConnectToServer();
 
-        RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
+        RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: null), Output);
     }
 }

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Testcontainers.MsSql" />
   </ItemGroup>
 

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests_TypeSpecificConfig.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests_TypeSpecificConfig.cs
@@ -4,13 +4,14 @@
 using Aspire.TestUtilities;
 using Aspire.Microsoft.Data.SqlClient.Tests;
 using Microsoft.Extensions.Configuration;
+using Xunit;
 
 namespace Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests;
 
 public class ConformanceTests_TypeSpecificConfig : ConformanceTests
 {
-    public ConformanceTests_TypeSpecificConfig(SqlServerContainerFixture containerFixture)
-        : base(containerFixture)
+    public ConformanceTests_TypeSpecificConfig(SqlServerContainerFixture containerFixture, ITestOutputHelper? output = null)
+        : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/EnrichSqlServerTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/EnrichSqlServerTests.cs
@@ -16,8 +16,8 @@ namespace Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests;
 
 public class EnrichSqlServerTests : ConformanceTests
 {
-    public EnrichSqlServerTests(SqlServerContainerFixture containerFixture)
-        : base(containerFixture)
+    public EnrichSqlServerTests(SqlServerContainerFixture containerFixture, ITestOutputHelper output)
+        : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests.csproj
+++ b/tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests.csproj
@@ -10,10 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration\Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.TestUtilities\Aspire.Components.Common.TestUtilities.csproj" />
   </ItemGroup>

--- a/tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests/ConformanceTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Components.ConformanceTests;
 using Azure.Core;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.DependencyInjection;
@@ -99,9 +98,13 @@ public class ConformanceTests : ConformanceTests<IConfigurationRefresherProvider
         service.Refreshers.First().RefreshAsync().ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
+    public ConformanceTests(ITestOutputHelper? output = null) : base(output)
+    {
+    }
+
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: null), Output);
 
     internal sealed class EmptyTokenCredential : TokenCredential
     {

--- a/tests/Aspire.Milvus.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Milvus.Client.Tests/ConformanceTests.cs
@@ -16,7 +16,7 @@ public class ConformanceTests : ConformanceTests<MilvusClient, MilvusClientSetti
     private readonly MilvusContainerFixture? _containerFixture;
     private string ConnectionString { get; set; }
 
-    public ConformanceTests(MilvusContainerFixture? containerFixture)
+    public ConformanceTests(MilvusContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
         ConnectionString = (_containerFixture is not null && RequiresDockerAttribute.IsSupported)

--- a/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
@@ -40,7 +40,7 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
         }
         """;
 
-    public ConformanceTests(MongoDbContainerFixture containerFixture)
+    public ConformanceTests(MongoDbContainerFixture containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
     }

--- a/tests/Aspire.MySqlConnector.Tests/Aspire.MySqlConnector.Tests.csproj
+++ b/tests/Aspire.MySqlConnector.Tests/Aspire.MySqlConnector.Tests.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Testcontainers.MySql" />
   </ItemGroup>
 

--- a/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
@@ -15,7 +15,7 @@ public class ConformanceTests : ConformanceTests<INatsConnection, NatsClientSett
 {
     private readonly NatsContainerFixture _containerFixture;
     private readonly string _connectionString;
-    public ConformanceTests(NatsContainerFixture containerFixture)
+    public ConformanceTests(NatsContainerFixture containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
         _connectionString = RequiresDockerAttribute.IsSupported

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests.csproj
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Testcontainers.PostgreSQL" />
   </ItemGroup>
 

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -4,7 +4,6 @@
 using Aspire.TestUtilities;
 using Aspire.Components.ConformanceTests;
 using Aspire.Npgsql.Tests;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -79,7 +78,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
             ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "DisableMetrics": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
         };
 
-    public ConformanceTests(PostgreSQLContainerFixture? containerFixture)
+    public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
         ConnectionString = (_containerFixture is not null && RequiresDockerAttribute.IsSupported)
@@ -137,8 +136,9 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
     [Fact]
     [RequiresDocker]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(static connectionStringToUse => RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
-                                 ConnectionString).Dispose();
+        => RemoteInvokeWithLogging(static connectionStringToUse =>
+            RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
+            ConnectionString, Output);
 
     private static void RunWithConnectionString(string connectionString, Action<ConformanceTests> test)
         => test(new ConformanceTests(null) { ConnectionString = connectionString });

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests_TypeSpecificConfig.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests_TypeSpecificConfig.cs
@@ -4,12 +4,13 @@
 using Aspire.TestUtilities;
 using Aspire.Npgsql.Tests;
 using Microsoft.Extensions.Configuration;
+using Xunit;
 
 namespace Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests;
 
 public class ConformanceTests_TypeSpecificConfig : ConformanceTests
 {
-    public ConformanceTests_TypeSpecificConfig(PostgreSQLContainerFixture containerFixture) : base(containerFixture)
+    public ConformanceTests_TypeSpecificConfig(PostgreSQLContainerFixture containerFixture, ITestOutputHelper? output = null) : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/EnrichNpgsqlTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/EnrichNpgsqlTests.cs
@@ -18,7 +18,7 @@ namespace Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests;
 
 public class EnrichNpgsqlTests : ConformanceTests
 {
-    public EnrichNpgsqlTests(PostgreSQLContainerFixture containerFixture) : base(containerFixture)
+    public EnrichNpgsqlTests(PostgreSQLContainerFixture containerFixture, ITestOutputHelper output) : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.Npgsql.Tests/Aspire.Npgsql.Tests.csproj
+++ b/tests/Aspire.Npgsql.Tests/Aspire.Npgsql.Tests.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Testcontainers.PostgreSQL" />
   </ItemGroup>
 

--- a/tests/Aspire.OpenAI.Tests/Aspire.OpenAI.Tests.csproj
+++ b/tests/Aspire.OpenAI.Tests/Aspire.OpenAI.Tests.csproj
@@ -9,10 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.OpenAI\Aspire.OpenAI.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.TestUtilities\Aspire.Components.Common.TestUtilities.csproj" />
   </ItemGroup>

--- a/tests/Aspire.OpenAI.Tests/ConformanceTests.cs
+++ b/tests/Aspire.OpenAI.Tests/ConformanceTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.ConformanceTests;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -65,13 +64,17 @@ public class ConformanceTests : ConformanceTests<IChatClient, OpenAISettings>
         }
     }
 
+    public ConformanceTests(ITestOutputHelper? output = null) : base(output)
+    {
+    }
+
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: null), Output);
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
+        => RemoteInvokeWithLogging(() => new ConformanceTests().ActivitySourceTest(key: "key"), Output);
 
     protected override void SetHealthCheck(OpenAISettings options, bool enabled)
         => throw new NotImplementedException();

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/Aspire.Oracle.EntityFrameworkCore.Tests.csproj
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/Aspire.Oracle.EntityFrameworkCore.Tests.csproj
@@ -17,7 +17,6 @@
     <!-- Needed until Oracle supports net9.0 - https://github.com/dotnet/aspire/issues/7060 -->
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" VersionOverride="$(MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreLTSVersion)" />
 
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Testcontainers.Oracle" />
   </ItemGroup>
 </Project>

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests_TypeSpecificConfig.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests_TypeSpecificConfig.cs
@@ -9,7 +9,7 @@ namespace Aspire.Oracle.EntityFrameworkCore.Tests;
 
 public class ConformanceTests_TypeSpecificConfig : ConformanceTests
 {
-    public ConformanceTests_TypeSpecificConfig(OracleContainerFixture containerFixture, ITestOutputHelper testOutputHelper) : base(containerFixture, testOutputHelper)
+    public ConformanceTests_TypeSpecificConfig(OracleContainerFixture containerFixture, ITestOutputHelper? testOutputHelper = null) : base(containerFixture, testOutputHelper)
     {
     }
 

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests.csproj
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests.csproj
@@ -17,7 +17,6 @@
     <!-- Needed until Pomelo MySQL EF supports net9.0 - https://github.com/dotnet/aspire/pull/6948 -->
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" VersionOverride="$(MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreLTSVersion)" />
 
-    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Testcontainers.MySql" />
   </ItemGroup>
 

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests_TypeSpecificConfig.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests_TypeSpecificConfig.cs
@@ -4,12 +4,13 @@
 using Aspire.TestUtilities;
 using Aspire.MySqlConnector.Tests;
 using Microsoft.Extensions.Configuration;
+using Xunit;
 
 namespace Aspire.Pomelo.EntityFrameworkCore.MySql.Tests;
 
 public class ConformanceTests_TypeSpecificConfig : ConformanceTests
 {
-    public ConformanceTests_TypeSpecificConfig(MySqlContainerFixture containerFixture) : base(containerFixture)
+    public ConformanceTests_TypeSpecificConfig(MySqlContainerFixture containerFixture, ITestOutputHelper? output = null) : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/EnrichMySqlTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/EnrichMySqlTests.cs
@@ -22,7 +22,7 @@ public class EnrichMySqlTests : ConformanceTests
 {
     public static readonly MySqlServerVersion DefaultVersion = new(new Version(MySqlContainerImageTags.Tag));
 
-    public EnrichMySqlTests(MySqlContainerFixture containerFixture) : base(containerFixture)
+    public EnrichMySqlTests(MySqlContainerFixture containerFixture, ITestOutputHelper output) : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.Qdrant.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/ConformanceTests.cs
@@ -31,7 +31,7 @@ public class ConformanceTests : ConformanceTests<QdrantClient, QdrantClientSetti
 
     protected override string? ConfigurationSectionName => "Aspire:Qdrant:Client";
 
-    public ConformanceTests(QdrantContainerFixture containerFixture)
+    public ConformanceTests(QdrantContainerFixture containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
         _connectionString = RequiresDockerAttribute.IsSupported ?

--- a/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
@@ -15,7 +15,7 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
 {
     private readonly RabbitMQContainerFixture _containerFixture;
 
-    public ConformanceTests(RabbitMQContainerFixture containerFixture)
+    public ConformanceTests(RabbitMQContainerFixture containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
     }

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
@@ -33,7 +33,7 @@ public class DistributedCacheConformanceTests : ConformanceTests
         }
     }
 
-    public DistributedCacheConformanceTests(RedisContainerFixture containerFixture) : base(containerFixture)
+    public DistributedCacheConformanceTests(RedisContainerFixture containerFixture, ITestOutputHelper? output = null) : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
@@ -33,7 +33,7 @@ public class OutputCacheConformanceTests : ConformanceTests
         }
     }
 
-    public OutputCacheConformanceTests(RedisContainerFixture containerFixture) : base(containerFixture)
+    public OutputCacheConformanceTests(RedisContainerFixture containerFixture, ITestOutputHelper? output = null) : base(containerFixture, output)
     {
     }
 

--- a/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
@@ -59,7 +59,7 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
             ("""{"Aspire": { "StackExchange": { "Redis":{ "ConfigurationOptions": { "HeartbeatInterval": "3S"}}}}}""", "The string value is not a match for the indicated regular expression")
         };
 
-    public ConformanceTests(RedisContainerFixture containerFixture)
+    public ConformanceTests(RedisContainerFixture containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
     }

--- a/tests/Aspire.TestUtilities/Aspire.TestUtilities.csproj
+++ b/tests/Aspire.TestUtilities/Aspire.TestUtilities.csproj
@@ -13,5 +13,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
## Summary

Adds diagnostic logging infrastructure to conformance tests to improve debuggability when tests fail in CI or locally.

## Changes

### Infrastructure (Commit 1)
- Added `ITestOutputHelper` support to `ConformanceTests` base class
- Added `RemoteInvokeWithLogging` helper methods that capture stdout/stderr from remote executor processes
- Enhanced `LoggerFactoryIsUsedByRegisteredClient` test with diagnostic output showing which log categories were found/missing
- Added `Microsoft.DotNet.RemoteExecutor` package reference to test utilities

### Adoption (Commit 2)
- Updated all component conformance test constructors to accept and forward `ITestOutputHelper`
- Replaced `RemoteExecutor.Invoke` calls with `RemoteInvokeWithLogging` across all components
- Removed redundant `Microsoft.DotNet.RemoteExecutor` package references (now inherited from TestUtilities)

## Benefits

- Test failures now include full diagnostic output in xUnit test results
- Remote executor output is captured and visible in test logs
- Log category validation failures show exactly which categories were found vs. expected
- Easier to diagnose failures in CI without needing to reproduce locally