### PR TITLE
Don't update genai dialog if the currently view data hasn't changed

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -20,11 +20,11 @@
             <div Style="grid-area: dialog-format;">
                 <FluentButton IconStart="new Icons.Regular.Size16.ArrowUp()"
                               Appearance="Appearance.Stealth"
-                              Disabled="@(_currentSpanContextIndex == 0)"
+                              Disabled="@NoPreviousGenAISpan"
                               OnClick="OnPreviousGenAISpan">@Loc[nameof(Dialogs.GenAIPreviousButtonText)]</FluentButton>
                 <FluentButton IconStart="new Icons.Regular.Size16.ArrowDown()"
                               Appearance="Appearance.Stealth"
-                              Disabled="@(_currentSpanContextIndex >= _contextSpans.Count - 1)"
+                              Disabled="@NoNextGenAISpan"
                               OnClick="OnNextGenAISpan">@Loc[nameof(Dialogs.GenAINextButtonText)]</FluentButton>
             </div>
         }

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -87,7 +87,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
 
             // Only update dialog data if the current trace has been updated,
             // or if there are new context spans (for the next/previous buttons).
-            var newData = (newContextSpans.Count > _contextSpans.Count || hasUpdatedTrace);
+            var newData = (hasUpdatedTrace || newContextSpans.Count > _contextSpans.Count);
             if (newData)
             {
                 var span = newContextSpans.Find(s => s.SpanId == Content.Span.SpanId)!;

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -82,12 +82,22 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
     {
         await InvokeAsync(() =>
         {
-            _contextSpans = Content.GetContextGenAISpans();
-            var span = _contextSpans.Find(s => s.SpanId == Content.Span.SpanId)!;
-            _currentSpanContextIndex = _contextSpans.IndexOf(span);
+            var hasUpdatedTrace = TelemetryRepository.HasUpdatedTrace(Content.Span.Trace);
+            var newContextSpans = Content.GetContextGenAISpans();
 
-            TryUpdateViewedGenAISpan(span);
-            StateHasChanged();
+            // Only update dialog data if the current trace has been updated,
+            // or if there are new context spans (for the next/previous buttons).
+            var newData = (newContextSpans.Count > _contextSpans.Count || hasUpdatedTrace);
+            if (newData)
+            {
+                var span = newContextSpans.Find(s => s.SpanId == Content.Span.SpanId)!;
+
+                _contextSpans = Content.GetContextGenAISpans();
+                _currentSpanContextIndex = _contextSpans.IndexOf(span);
+
+                TryUpdateViewedGenAISpan(span);
+                StateHasChanged();
+            }
         });
     }
 

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -80,25 +80,25 @@ public partial class GenAIVisualizerDialog : ComponentBase, IDisposable
 
     private async Task UpdateDialogData()
     {
-        await InvokeAsync(() =>
-        {
-            var hasUpdatedTrace = TelemetryRepository.HasUpdatedTrace(Content.Span.Trace);
-            var newContextSpans = Content.GetContextGenAISpans();
+        var hasUpdatedTrace = TelemetryRepository.HasUpdatedTrace(Content.Span.Trace);
+        var newContextSpans = Content.GetContextGenAISpans();
 
-            // Only update dialog data if the current trace has been updated,
-            // or if there are new context spans (for the next/previous buttons).
-            var newData = (hasUpdatedTrace || newContextSpans.Count > _contextSpans.Count);
-            if (newData)
+        // Only update dialog data if the current trace has been updated,
+        // or if there are new context spans (for the next/previous buttons).
+        var newData = (hasUpdatedTrace || newContextSpans.Count > _contextSpans.Count);
+        if (newData)
+        {
+            await InvokeAsync(() =>
             {
                 var span = newContextSpans.Find(s => s.SpanId == Content.Span.SpanId)!;
 
-                _contextSpans = Content.GetContextGenAISpans();
+                _contextSpans = newContextSpans;
                 _currentSpanContextIndex = _contextSpans.IndexOf(span);
 
                 TryUpdateViewedGenAISpan(span);
                 StateHasChanged();
-            }
-        });
+            });
+        }
     }
 
     private void OnViewItem(GenAIItemViewModel viewModel)

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
@@ -95,6 +95,12 @@ internal static class FluentUISetupHelpers
         context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/List/ListComponentBase.razor.js"));
     }
 
+    public static void SetupFluentTab(TestContext context)
+    {
+        var tabModule = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Tabs/FluentTab.razor.js"));
+        tabModule.SetupVoid("TabEditable_Changed", _ => true);
+    }
+
     public static void AddCommonDashboardServices(
         TestContext context,
         ILocalStorage? localStorage = null,


### PR DESCRIPTION
## Description

The GenAI dialog watches for resource, traces and log entry changes. Currently the UI updates itself whenever any of these change which could be often.

PR adds some checks to see if the underlying data has changed. If it hasn't then dialog is left upchanged. Should offer a small perf improvement and avoid potential issues with the user interacting with the dialog as it updates.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
