### PR TITLE
Update AzureAppService integration to set new suppress configuration name

### DIFF
--- a/playground/AzureAppService/AzureAppService.AppHost/infra.module.bicep
+++ b/playground/AzureAppService/AzureAppService.AppHost/infra.module.bicep
@@ -80,7 +80,7 @@ resource dashboard 'Microsoft.Web/sites@2024-11-01' = {
           value: 'Unsecured'
         }
         {
-          name: 'Dashboard__Otlp__SuppressUnsecuredTelemetryMessage'
+          name: 'Dashboard__Otlp__SuppressUnsecuredMessage'
           value: 'true'
         }
         {

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -83,7 +83,7 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
 
         options.AI.Disabled = _configuration.GetBool(DashboardConfigNames.DashboardAIDisabledName.ConfigKey);
 
-        if (_configuration.GetBool(DashboardConfigNames.Legacy.DashboardOtlpSuppressUnsecuredTelemetryMessage.ConfigKey) is { } suppressUnsecuredTelemetryMessage)
+        if (_configuration.GetBool(DashboardConfigNames.Legacy.DashboardOtlpSuppressUnsecuredTelemetryMessageName.ConfigKey) is { } suppressUnsecuredTelemetryMessage)
         {
             options.Otlp.SuppressUnsecuredMessage = suppressUnsecuredTelemetryMessage;
         }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
@@ -83,7 +83,7 @@ internal static class AzureAppServiceEnvironmentUtility
         // Security is handled by app service platform
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "Dashboard__Frontend__AuthMode", Value = "Unsecured" });
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "Dashboard__Otlp__AuthMode", Value = "Unsecured" });
-        dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "Dashboard__Otlp__SuppressUnsecuredTelemetryMessage", Value = "true" });
+        dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "Dashboard__Otlp__SuppressUnsecuredMessage", Value = "true" });
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "Dashboard__ResourceServiceClient__AuthMode", Value = "Unsecured" });
         // Dashboard ports
         dashboard.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITES_PORT", Value = "5000" });

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -52,7 +52,7 @@ internal static class DashboardConfigNames
         public static readonly ConfigName DashboardConfigFilePathName = new(KnownConfigNames.Legacy.DashboardConfigFilePath);
         public static readonly ConfigName DashboardFileConfigDirectoryName = new(KnownConfigNames.Legacy.DashboardFileConfigDirectory);
         public static readonly ConfigName ResourceServiceUrlName = new(KnownConfigNames.Legacy.ResourceServiceEndpointUrl);
-        public static readonly ConfigName DashboardOtlpSuppressUnsecuredTelemetryMessage = new("Dashboard:Otlp:SuppressUnsecuredTelemetryMessage", "Dashboard__Otlp__SuppressUnsecuredTelemetryMessage");
+        public static readonly ConfigName DashboardOtlpSuppressUnsecuredTelemetryMessageName = new("Dashboard:Otlp:SuppressUnsecuredTelemetryMessage", "DASHBOARD__OTLP__SUPPRESSUNSECUREDTELEMETRYMESSAGE");
     }
 }
 

--- a/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
@@ -259,7 +259,7 @@ public sealed class DashboardOptionsTests
         [
             new("ASPNETCORE_URLS", "http://localhost:8000/"),
             new("ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL", "http://localhost:4319/"),
-            new(DashboardConfigNames.Legacy.DashboardOtlpSuppressUnsecuredTelemetryMessage.ConfigKey, "true"),
+            new(DashboardConfigNames.Legacy.DashboardOtlpSuppressUnsecuredTelemetryMessageName.ConfigKey, "true"),
         ]));
         var options = app.Services.GetService<IOptionsMonitor<DashboardOptions>>()!;
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithAutomaticScaling.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithAutomaticScaling.verified.bicep
@@ -77,7 +77,7 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
           value: 'Unsecured'
         }
         {
-          name: 'Dashboard__Otlp__SuppressUnsecuredTelemetryMessage'
+          name: 'Dashboard__Otlp__SuppressUnsecuredMessage'
           value: 'true'
         }
         {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutAutoScale.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutAutoScale.verified.bicep
@@ -80,7 +80,7 @@ resource dashboard 'Microsoft.Web/sites@2024-11-01' = {
           value: 'Unsecured'
         }
         {
-          name: 'Dashboard__Otlp__SuppressUnsecuredTelemetryMessage'
+          name: 'Dashboard__Otlp__SuppressUnsecuredMessage'
           value: 'true'
         }
         {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsDefaultLocation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsDefaultLocation.verified.bicep
@@ -75,7 +75,7 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
           value: 'Unsecured'
         }
         {
-          name: 'Dashboard__Otlp__SuppressUnsecuredTelemetryMessage'
+          name: 'Dashboard__Otlp__SuppressUnsecuredMessage'
           value: 'true'
         }
         {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocation.verified.bicep
@@ -75,7 +75,7 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
           value: 'Unsecured'
         }
         {
-          name: 'Dashboard__Otlp__SuppressUnsecuredTelemetryMessage'
+          name: 'Dashboard__Otlp__SuppressUnsecuredMessage'
           value: 'true'
         }
         {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocationParam.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocationParam.verified.bicep
@@ -77,7 +77,7 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
           value: 'Unsecured'
         }
         {
-          name: 'Dashboard__Otlp__SuppressUnsecuredTelemetryMessage'
+          name: 'Dashboard__Otlp__SuppressUnsecuredMessage'
           value: 'true'
         }
         {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithExistingApplicationInsights.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithExistingApplicationInsights.verified.bicep
@@ -77,7 +77,7 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
           value: 'Unsecured'
         }
         {
-          name: 'Dashboard__Otlp__SuppressUnsecuredTelemetryMessage'
+          name: 'Dashboard__Otlp__SuppressUnsecuredMessage'
           value: 'true'
         }
         {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsEnvironmentResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsEnvironmentResource.verified.bicep
@@ -75,7 +75,7 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
           value: 'Unsecured'
         }
         {
-          name: 'Dashboard__Otlp__SuppressUnsecuredTelemetryMessage'
+          name: 'Dashboard__Otlp__SuppressUnsecuredMessage'
           value: 'true'
         }
         {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanReferenceExistingAppServicePlan.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanReferenceExistingAppServicePlan.verified.bicep
@@ -75,7 +75,7 @@ resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
           value: 'Unsecured'
         }
         {
-          name: 'Dashboard__Otlp__SuppressUnsecuredTelemetryMessage'
+          name: 'Dashboard__Otlp__SuppressUnsecuredMessage'
           value: 'true'
         }
         {


### PR DESCRIPTION
## Description

`Dashboard__Otlp__SuppressUnsecuredTelemetryMessage` was added in 9.5.1(?)

`Dashboard__Otlp__SuppressUnsecuredMessage` is the new name in v13 (old name still works!) to be consistent with `Dashboard__Mcp__SuppressUnsecuredMessage`

This PR changes AzureAppService intergration to use the new config name.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
