### PR TITLE
Workaround bug in interaction provider when displaying dialogs on load

### DIFF
--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -118,6 +118,12 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
 
         _watchInteractionsTask = Task.Run(async () =>
         {
+            // There is a bug in FluentDialogProvider that causes it to error if used immediately because it's still loading its own JavaScript.
+            // Wait a small amount of time for it to get ready.
+            //
+            // TODO: Remove when https://github.com/microsoft/fluentui-blazor/issues/4311 is fixed.
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
             try
             {
                 await WatchInteractionsAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/12858

Caused by regression in FluentUI - https://github.com/microsoft/fluentui-blazor/pull/4095

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
