### PR TITLE
Fix subscription ID not being disabled on Azure provisioning dialog

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.css
@@ -8,7 +8,8 @@
 
 .interaction-input-dialog .interaction-input ::deep fluent-text-field,
 .interaction-input-dialog .interaction-input ::deep fluent-select,
-.interaction-input-dialog .interaction-input ::deep fluent-combobox {
+.interaction-input-dialog .interaction-input ::deep fluent-combobox,
+.interaction-input-dialog .interaction-input ::deep label {
     width: 75%;
     /* Prevent long select/combox controls from extending outside the dialog. This can happen when there is very long placeholder text */
     max-width: 500px;

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -197,7 +197,7 @@ internal sealed class RunModeProvisioningContextProvider(
                     Label = AzureProvisioningStrings.LocationLabel,
                     Placeholder = AzureProvisioningStrings.LocationPlaceholder,
                     Required = true,
-                    Disabled = true,
+                    Disabled = string.IsNullOrEmpty(_options.SubscriptionId),
                     DynamicLoading = new InputLoadOptions
                     {
                         LoadCallback = async (context) =>
@@ -209,7 +209,7 @@ internal sealed class RunModeProvisioningContextProvider(
                             context.Input.Options = locationOptions;
                             context.Input.Disabled = false;
                         },
-                        DependsOnInputs = [SubscriptionIdName]
+                        DependsOnInputs = string.IsNullOrEmpty(_options.SubscriptionId) ? [SubscriptionIdName] : []
                     }
                 });
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/RunModeProvisioningContextProvider.cs
@@ -155,26 +155,13 @@ internal sealed class RunModeProvisioningContextProvider(
                 // show the value as from the configuration and disable the input
                 // there should be no option to change it
 
-                inputs.Add(new InteractionInput
+                InputLoadOptions? subscriptionLoadOptions = null;
+                if (string.IsNullOrEmpty(_options.SubscriptionId))
                 {
-                    Name = SubscriptionIdName,
-                    InputType = string.IsNullOrEmpty(_options.SubscriptionId) ? InputType.Choice : InputType.Text,
-                    Label = AzureProvisioningStrings.SubscriptionIdLabel,
-                    Required = true,
-                    AllowCustomChoice = true,
-                    Placeholder = AzureProvisioningStrings.SubscriptionIdPlaceholder,
-                    Disabled = !string.IsNullOrEmpty(_options.SubscriptionId),
-                    Value = _options.SubscriptionId,
-                    DynamicLoading = new InputLoadOptions
+                    subscriptionLoadOptions = new InputLoadOptions
                     {
                         LoadCallback = async (context) =>
                         {
-                            if (!string.IsNullOrEmpty(_options.SubscriptionId))
-                            {
-                                // If subscription ID is not set, we don't need to load options
-                                return;
-                            }
-
                             // Get tenant ID from input if tenant selection is enabled, otherwise use configured value
                             var tenantId = context.AllInputs[TenantName].Value ?? string.Empty;
 
@@ -186,8 +173,21 @@ internal sealed class RunModeProvisioningContextProvider(
                                 : [];
                             context.Input.Disabled = false;
                         },
-                        DependsOnInputs = string.IsNullOrEmpty(_options.SubscriptionId) ? [TenantName] : []
-                    }
+                        DependsOnInputs = [TenantName]
+                    };
+                }
+
+                inputs.Add(new InteractionInput
+                {
+                    Name = SubscriptionIdName,
+                    InputType = string.IsNullOrEmpty(_options.SubscriptionId) ? InputType.Choice : InputType.Text,
+                    Label = AzureProvisioningStrings.SubscriptionIdLabel,
+                    Required = true,
+                    AllowCustomChoice = true,
+                    Placeholder = AzureProvisioningStrings.SubscriptionIdPlaceholder,
+                    Disabled = true,
+                    Value = _options.SubscriptionId,
+                    DynamicLoading = subscriptionLoadOptions
                 });
 
                 inputs.Add(new InteractionInput


### PR DESCRIPTION
## Description

PR https://github.com/dotnet/aspire/pull/12172 added a new tenant ID option. However, if there is no subscription ID then the choice input is left enabled.

PR changes:

- Subscription ID is disabled until a tenant is selected
- Removes unnessessary dynamic load options whe subscription ID is a disabled textbox

Fixes https://github.com/dotnet/aspire/issues/12882

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
