### PR TITLE
Fix Azure roles resources always redeploying

### DIFF
--- a/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
@@ -433,7 +433,6 @@ public class BicepUtilitiesTests
     /// This is important because if these known parameters are overwritten, it means the "roles"
     /// resources will be redeployed every time the app is run.
     /// </summary>
-    /// <returns></returns>
     [Fact]
     public async Task GetCurrentChecksumAsync_DoesNotOverwriteKnownParameters()
     {
@@ -445,8 +444,8 @@ public class BicepUtilitiesTests
 
         var parameters = new JsonObject
         {
-            [AzureBicepResource.KnownParameters.PrincipalType] = "User",
-            [AzureBicepResource.KnownParameters.PrincipalId] = "1234"
+            [AzureBicepResource.KnownParameters.PrincipalType] = new JsonObject { ["value"] = "User" },
+            [AzureBicepResource.KnownParameters.PrincipalId] = new JsonObject { ["value"] = "1234" },
         };
 
         var configurationBuilder = new ConfigurationBuilder();

--- a/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
@@ -428,6 +428,45 @@ public class BicepUtilitiesTests
         Assert.NotEmpty(result);
     }
 
+    /// <summary>
+    /// Ensures that known parameters are not overwritten when calculating the checksum.
+    /// This is important because if these known parameters are overwritten, it means the "roles"
+    /// resources will be redeployed every time the app is run.
+    /// </summary>
+    /// <returns></returns>
+    [Fact]
+    public async Task GetCurrentChecksumAsync_DoesNotOverwriteKnownParameters()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var bicep = builder.AddBicepTemplateString("test", "param name string").Resource;
+        bicep.Parameters[AzureBicepResource.KnownParameters.PrincipalType] = null;
+        bicep.Parameters[AzureBicepResource.KnownParameters.PrincipalId] = null;
+
+        var parameters = new JsonObject
+        {
+            [AzureBicepResource.KnownParameters.PrincipalType] = "User",
+            [AzureBicepResource.KnownParameters.PrincipalId] = "1234"
+        };
+
+        var configurationBuilder = new ConfigurationBuilder();
+        configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Parameters"] = parameters.ToJsonString()
+        });
+        var config = configurationBuilder.Build();
+
+        // Act
+        var result = await BicepUtilities.GetCurrentChecksumAsync(bicep, config);
+
+        // Assert
+        Assert.NotNull(result);
+
+        // verify the checksum is the same as using the config parameters directly
+        var expected = BicepUtilities.GetChecksum(bicep, parameters, scope: null);
+        Assert.Equal(expected, result);
+    }
+
     private sealed class ResourceWithConnectionString(string name, string connectionString) :
         Resource(name),
         IResourceWithConnectionString


### PR DESCRIPTION
## Description

Everytime we check if we need to redeploy an Azure "roles" resource in run mode, we are getting a different CheckSum. This is because we are overwriting the "known parameters" like PrincipalId and PrincipalType with 'null' values, because these values aren't available yet.

The fix is to skip setting those known parameters, like we did in previous versions.

Fix #12651

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
