### PR TITLE
Remove serverReadyAction for apphost, manually open the dashboard URL using vs code APIs

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Aspire",
   "description": "%extension.description%",
   "publisher": "microsoft-aspire",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "icon": "dotnet-aspire-logo-128.png",
   "license": "SEE LICENSE IN LICENSE.TXT",

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -288,15 +288,9 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
             debugConfiguration.executablePath = baseProfile?.executablePath;
             debugConfiguration.checkForDevCert = baseProfile?.useSSL;
 
-            if (launchOptions.isApphost) {
-                // The Aspire dashboard URL will be set as the apphost's application URL. Check if auto-launch is enabled
-                const enableDashboardAutoLaunch = vscode.workspace.getConfiguration('aspire').get<boolean>('enableAspireDashboardAutoLaunch', true);
-
-                if (enableDashboardAutoLaunch) {
-                    debugConfiguration.serverReadyAction = determineServerReadyAction(baseProfile?.launchBrowser, baseProfile?.applicationUrl);
-                }
-            }
-            else {
+            // The apphost's application URL is the Aspire dashboard URL. We already get the dashboard login URL later on,
+            // so we should just avoid setting up serverReadyAction and manually open the browser ourselves.
+            if (!launchOptions.isApphost) {
                 debugConfiguration.serverReadyAction = determineServerReadyAction(baseProfile?.launchBrowser, baseProfile?.applicationUrl);
             }
 

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -261,6 +261,9 @@ export class InteractionService implements IInteractionService {
         // to show an information message.
         const enableDashboardAutoLaunch = vscode.workspace.getConfiguration('aspire').get<boolean>('enableAspireDashboardAutoLaunch', true);
         if (enableDashboardAutoLaunch) {
+            // Open the dashboard URL in an external browser. Prefer codespaces URL if available.
+            const urlToOpen = dashboardUrls.CodespacesUrlWithLoginToken ?? dashboardUrls.BaseUrlWithLoginToken;
+            vscode.env.openExternal(vscode.Uri.parse(urlToOpen));
             return;
         }
 


### PR DESCRIPTION
## Description

We already have access to the proper dashboard login URL later in the apphost startup process, when the CLI tells the extension that it has dashboard URLs available.

Instead of setting a serverReadyAction for the apphost, we can use VS Code's openExternal API to open the dashboard URL we get from the CLI (which already includes the token) in the user's browser.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
