### PR TITLE
Simplify installation command for PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install the latest released version of the Aspire CLI:
 On Windows:
 
 ```powershell
-iex "& { $(irm https://aspire.dev/install.ps1) }"
+irm https://aspire.dev/install.ps1 | iex
 ```
 
 On Linux or macOS:

--- a/extension/README.md
+++ b/extension/README.md
@@ -49,7 +49,7 @@ The [Aspire CLI](https://learn.microsoft.com/dotnet/aspire/cli/install) must be 
 On Windows:
 
 ```powershell
-iex "& { $(irm https://aspire.dev/install.ps1) }"
+irm https://aspire.dev/install.ps1 | iex
 ```
 
 On Linux or macOS:


### PR DESCRIPTION
## Description

Simplifies the command for installation in powershell by removing the sub-expression and invocation operator in new scriptblock, to make look more like the bash command.

Works for both Windows Powershell and modern PowerShell.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [z] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No - there were none
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No - it does not add any additional security concerns that were not there before
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No - but there are additional mentions of it in https://github.com/dotnet-presentations/dotnet-aspire-workshop will make separate PR if this one is accepted.
