### PR TITLE
Fix dependency tracking of resources that write keyvault secrets

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -422,6 +422,8 @@ public static class AzureCosmosExtensions
 
         var azureResource = builder.Resource;
         azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecret($"connectionstrings--{azureResource.Name}");
+        // Set the secret owner to this resource
+        azureResource.ConnectionStringSecretOutput.SecretOwner = azureResource;
 
         // remove role assignment annotations when using access key authentication so an empty roles bicep module isn't generated
         var roleAssignmentAnnotations = azureResource.Annotations.OfType<DefaultRoleAssignmentsAnnotation>().ToArray();

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -167,7 +167,9 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
 
         if (UseAccessKeyAuthentication && !IsEmulator)
         {
-            builder.AppendFormatted(ConnectionStringSecretOutput.Resource.GetSecret(GetKeyValueSecretName(childResourceName)));
+            var dbSecret = ConnectionStringSecretOutput.Resource.GetSecret(GetKeyValueSecretName(childResourceName));
+            dbSecret.SecretOwner = ConnectionStringSecretOutput.SecretOwner;
+            builder.AppendFormatted(dbSecret);
         }
         else
         {

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
@@ -22,6 +22,16 @@ internal sealed class AzureKeyVaultSecretReference(string secretName, AzureKeyVa
     /// </summary>
     public IAzureKeyVaultResource Resource => azureKeyVaultResource;
 
+    /// <summary>
+    /// Gets or sets the resource that writes this secret to the Key Vault.
+    /// </summary>
+    public IResource? SecretOwner { get; set; }
+
+    /// <summary>
+    /// Gets the resources referenced by this secret.
+    /// </summary>
+    IEnumerable<object> IValueWithReferences.References => SecretOwner is null ? [Resource] : [Resource, SecretOwner];
+
     string IManifestExpressionProvider.ValueExpression => $"{{{azureKeyVaultResource.Name}.secrets.{SecretName}}}";
 
     async ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretReference.cs
@@ -27,11 +27,6 @@ internal sealed class AzureKeyVaultSecretReference(string secretName, AzureKeyVa
     /// </summary>
     public IResource? SecretOwner { get; set; }
 
-    /// <summary>
-    /// Gets the resources referenced by this secret.
-    /// </summary>
-    IEnumerable<object> IValueWithReferences.References => SecretOwner is null ? [Resource] : [Resource, SecretOwner];
-
     string IManifestExpressionProvider.ValueExpression => $"{{{azureKeyVaultResource.Name}.secrets.{SecretName}}}";
 
     async ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretResource.cs
@@ -37,6 +37,8 @@ public class AzureKeyVaultSecretResource(string name, string secretName, AzureKe
     /// </summary>
     IAzureKeyVaultResource IAzureKeyVaultSecretReference.Resource => Parent;
 
+    IResource? IAzureKeyVaultSecretReference.SecretOwner { get; set; }
+
     /// <summary>
     /// Gets the expression for the secret value in the manifest.
     /// </summary>

--- a/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -338,6 +338,8 @@ public static class AzurePostgresExtensions
         builder.WithParameter("administratorLoginPassword", azureResource.PasswordParameter);
 
         azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecret($"connectionstrings--{builder.Resource.Name}");
+        // Set the secret owner to this resource
+        azureResource.ConnectionStringSecretOutput.SecretOwner = azureResource;
 
         // If someone already called RunAsContainer - we need to reset the username/password parameters on the InnerResource
         var containerResource = azureResource.InnerResource;

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -147,7 +147,9 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
         // Note that the bicep template puts each database's connection string in a KeyVault secret.
         if (InnerResource is null && ConnectionStringSecretOutput is not null)
         {
-            return ReferenceExpression.Create($"{ConnectionStringSecretOutput.Resource.GetSecret(GetDatabaseKeyVaultSecretName(databaseResourceName))}");
+            var dbSecret = ConnectionStringSecretOutput.Resource.GetSecret(GetDatabaseKeyVaultSecretName(databaseResourceName));
+            dbSecret.SecretOwner = ConnectionStringSecretOutput.SecretOwner;
+            return ReferenceExpression.Create($"{dbSecret}");
         }
 
         return ReferenceExpression.Create($"{this};Database={databaseName}");

--- a/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
+++ b/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Redis\Aspire.Hosting.Redis.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Azure.KeyVault\Aspire.Hosting.Azure.KeyVault.csproj" />

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisEnterpriseExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisEnterpriseExtensions.cs
@@ -165,6 +165,8 @@ public static class AzureRedisEnterpriseExtensions
 
         var azureResource = builder.Resource;
         azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecret($"connectionstrings--{azureResource.Name}");
+        // Set the secret owner to this resource
+        azureResource.ConnectionStringSecretOutput.SecretOwner = azureResource;
 
         // remove role assignment annotations when using access key authentication so an empty roles bicep module isn't generated
         var roleAssignmentAnnotations = azureResource.Annotations.OfType<DefaultRoleAssignmentsAnnotation>().ToArray();

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -229,6 +229,8 @@ public static class AzureRedisExtensions
 
         var azureResource = builder.Resource;
         azureResource.ConnectionStringSecretOutput = keyVaultBuilder.Resource.GetSecret($"connectionstrings--{azureResource.Name}");
+        // Set the secret owner to this resource
+        azureResource.ConnectionStringSecretOutput.SecretOwner = azureResource;
 
         // remove role assignment annotations when using access key authentication so an empty roles bicep module isn't generated
         var roleAssignmentAnnotations = azureResource.Annotations.OfType<DefaultRoleAssignmentsAnnotation>().ToArray();

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -71,6 +71,11 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
                 ProcessAzureReferences(azureReferences, parameter.Value);
             }
 
+            foreach (var reference in References)
+            {
+                ProcessAzureReferences(azureReferences, reference);
+            }
+
             // Get the provision steps for this resource
             var provisionSteps = context.GetSteps(this, WellKnownPipelineTags.ProvisionInfrastructure);
 
@@ -93,6 +98,11 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
     /// Parameters that will be passed into the bicep template.
     /// </summary>
     public Dictionary<string, object?> Parameters { get; } = [];
+
+    /// <summary>
+    /// Resources that this resource depends on.
+    /// </summary>
+    public HashSet<object> References { get; } = [];
 
     IDictionary<string, object?> IResourceWithParameters.Parameters => Parameters;
 

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -100,7 +100,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
     public Dictionary<string, object?> Parameters { get; } = [];
 
     /// <summary>
-    /// Resources that this resource depends on.
+    /// References to other objects that may contain Azure resource references.
     /// </summary>
     public HashSet<object> References { get; } = [];
 

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
@@ -90,6 +90,9 @@ public static class AzureProvisioningResourceExtensions
 
         if (kvs is null)
         {
+            // Ensure the secret reference is tracked in the infrastructure for dependency discovery
+            infrastructure.AspireResource.References.Add(secretReference);
+
             kvs = KeyVaultSecret.FromExisting(kvsName);
             kvs.Name = secretReference.SecretName;
             kvs.Parent = kv;

--- a/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
@@ -20,5 +20,10 @@ public interface IAzureKeyVaultSecretReference : IValueProvider, IManifestExpres
     /// </summary>
     IAzureKeyVaultResource Resource { get; }
 
-    IEnumerable<object> IValueWithReferences.References => [Resource];
+    /// <summary>
+    /// The resource that writes this secret to the Key Vault.
+    /// </summary>
+    public IResource? SecretOwner { get => null; set { } }
+
+    IEnumerable<object> IValueWithReferences.References => SecretOwner is null ? [Resource] : [Resource, SecretOwner];
 }

--- a/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
@@ -27,7 +27,7 @@ public interface IAzureKeyVaultSecretReference : IValueProvider, IManifestExpres
     /// The <see cref="IResource"/> that is responsible for writing this secret to the Key Vault, or <c>null</c> if not set.
     /// </value>
     /// <remarks>
-    /// Implementers must provide both a getter and setter for this property. If not implemented, attempts to set <see cref="SecretOwner"/> will silently fail.
+    /// Implementers must provide both a getter and setter for this property. If not implemented, attempts to set <see cref="SecretOwner"/> will throw an exception.
     /// </remarks>
     public IResource? SecretOwner
     {

--- a/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
@@ -21,9 +21,19 @@ public interface IAzureKeyVaultSecretReference : IValueProvider, IManifestExpres
     IAzureKeyVaultResource Resource { get; }
 
     /// <summary>
-    /// The resource that writes this secret to the Key Vault.
+    /// Gets or sets the resource that writes this secret to the Key Vault.
     /// </summary>
-    public IResource? SecretOwner { get => null; set { } }
+    /// <value>
+    /// The <see cref="IResource"/> that is responsible for writing this secret to the Key Vault, or <c>null</c> if not set.
+    /// </value>
+    /// <remarks>
+    /// Implementers must provide both a getter and setter for this property. If not implemented, attempts to set <see cref="SecretOwner"/> will silently fail.
+    /// </remarks>
+    public IResource? SecretOwner
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
 
     IEnumerable<object> IValueWithReferences.References => SecretOwner is null ? [Resource] : [Resource, SecretOwner];
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1019,9 +1019,16 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         // and a compute resource that references the Redis cache
         builder.AddAzureAppServiceEnvironment("env");
 
-        var keyVault = builder.AddAzureKeyVault("kv");
         var cache = builder.AddAzureRedis("cache")
-            .WithAccessKeyAuthentication(keyVault);
+            .WithAccessKeyAuthentication();
+
+        var azpg = builder.AddAzurePostgresFlexibleServer("pg")
+                          .WithPasswordAuthentication()
+                          .AddDatabase("db");
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos")
+                            .WithAccessKeyAuthentication()
+                            .AddCosmosDatabase("cdb");
 
         // Add a compute resource that references the Redis cache
         // This creates dependencies: api -> cache secret -> keyVault
@@ -1029,7 +1036,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         builder.AddProject<Project>("api", launchProfileName: null)
             .WithHttpEndpoint()
             .WithExternalHttpEndpoints()
-            .WithReference(cache);
+            .WithReference(cache)
+            .WithReference(azpg)
+            .WithReference(cosmos);
 
         // Act
         using var app = builder.Build();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -300,6 +300,36 @@ public class AzureRedisExtensionsTests
              .AppendContentAsFile(bicep, "bicep");
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("mykeyvault")]
+    public void WithAccessKeyAuthentication_SetsSecretOwner(string? kvName)
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var redis = builder.AddAzureRedis("redis-cache");
+
+        // Act
+        if (kvName is null)
+        {
+            redis.WithAccessKeyAuthentication();
+        }
+        else
+        {
+            redis.WithAccessKeyAuthentication(builder.AddAzureKeyVault(kvName));
+        }
+
+        // Assert - Verify that the SecretOwner is set to the Redis resource
+        Assert.NotNull(redis.Resource.ConnectionStringSecretOutput);
+        Assert.Same(redis.Resource, redis.Resource.ConnectionStringSecretOutput.SecretOwner);
+        
+        // Also verify that References includes both the KeyVault and the Redis resource
+        var references = ((IValueWithReferences)redis.Resource.ConnectionStringSecretOutput).References.ToList();
+        Assert.Contains(redis.Resource, references);
+        Assert.Contains(redis.Resource.ConnectionStringSecretOutput.Resource, references);
+    }
+
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
     private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -1,0 +1,384 @@
+﻿[  
+PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
+=====================================
+
+This diagnostic output shows the complete pipeline dependency graph structure.
+Use this to understand step relationships and troubleshoot execution issues.
+
+Total steps defined: 24
+
+Analysis for full pipeline execution (showing all steps and their relationships)
+
+EXECUTION ORDER
+===============
+This shows the order in which steps would execute, respecting all dependencies.
+Steps with no dependencies run first, followed by steps that depend on them.
+
+  1. build-prereq
+  2. deploy-prereq
+  3. build-api
+  4. build
+  5. validate-azure-login
+  6. create-provisioning-context
+  7. provision-api-identity
+  8. provision-kv
+  9. provision-api-roles-kv
+ 10. provision-env
+ 11. login-to-acr-env
+ 12. push-api
+ 13. provision-api-website
+ 14. provision-cache
+ 15. provision-azure-bicep-resources
+ 16. print-dashboard-url-env
+ 17. deploy
+ 18. print-api-summary
+ 19. deploy-api
+ 20. diagnostics
+ 21. publish-prereq
+ 22. publish-azure634f9
+ 23. publish
+ 24. publish-manifest
+
+DETAILED STEP ANALYSIS
+======================
+Shows each step's dependencies, associated resources, and tags.
+✓ = dependency exists, ? = dependency missing
+
+Step: build
+    Dependencies: ✓ build-api
+
+Step: build-api
+    Dependencies: ✓ build-prereq, ✓ deploy-prereq
+    Resource: api (ProjectResource)
+    Tags: build-compute
+
+Step: build-prereq
+    Dependencies: none
+
+Step: create-provisioning-context
+    Dependencies: ✓ deploy-prereq, ✓ validate-azure-login
+    Resource: azure634f9 (AzureEnvironmentResource)
+
+Step: deploy
+    Dependencies: ✓ build-api, ✓ create-provisioning-context, ✓ print-dashboard-url-env, ✓ provision-azure-bicep-resources, ✓ validate-azure-login
+
+Step: deploy-api
+    Dependencies: ✓ print-api-summary
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: deploy-compute
+
+Step: deploy-prereq
+    Dependencies: none
+
+Step: diagnostics
+    Dependencies: none
+
+Step: login-to-acr-env
+    Dependencies: ✓ provision-env
+    Resource: env (AzureAppServiceEnvironmentResource)
+    Tags: acr-login
+
+Step: print-api-summary
+    Dependencies: ✓ provision-api-website
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: print-summary
+
+Step: print-dashboard-url-env
+    Dependencies: ✓ provision-azure-bicep-resources, ✓ provision-env
+    Resource: env (AzureAppServiceEnvironmentResource)
+    Tags: print-summary
+
+Step: provision-api-identity
+    Dependencies: ✓ create-provisioning-context
+    Resource: api-identity (AzureUserAssignedIdentityResource)
+    Tags: provision-infra
+
+Step: provision-api-roles-kv
+    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-kv
+    Resource: api-roles-kv (AzureProvisioningResource)
+    Tags: provision-infra
+
+Step: provision-api-website
+    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cache, ✓ provision-env, ✓ provision-kv, ✓ push-api
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: provision-infra
+
+Step: provision-azure-bicep-resources
+    Dependencies: ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-api-identity, ✓ provision-api-roles-kv, ✓ provision-api-website, ✓ provision-cache, ✓ provision-env, ✓ provision-kv
+    Resource: azure634f9 (AzureEnvironmentResource)
+    Tags: provision-infra
+
+Step: provision-cache
+    Dependencies: ✓ create-provisioning-context, ✓ provision-kv
+    Resource: cache (AzureRedisCacheResource)
+    Tags: provision-infra
+
+Step: provision-env
+    Dependencies: ✓ create-provisioning-context
+    Resource: env (AzureAppServiceEnvironmentResource)
+    Tags: provision-infra
+
+Step: provision-kv
+    Dependencies: ✓ create-provisioning-context
+    Resource: kv (AzureKeyVaultResource)
+    Tags: provision-infra
+
+Step: publish
+    Dependencies: ✓ publish-azure634f9
+
+Step: publish-azure634f9
+    Dependencies: ✓ publish-prereq
+    Resource: azure634f9 (AzureEnvironmentResource)
+
+Step: publish-manifest
+    Dependencies: none
+
+Step: publish-prereq
+    Dependencies: none
+
+Step: push-api
+    Dependencies: ✓ build-api, ✓ login-to-acr-env, ✓ provision-env
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: push-container-image
+
+Step: validate-azure-login
+    Dependencies: ✓ deploy-prereq
+    Resource: azure634f9 (AzureEnvironmentResource)
+
+POTENTIAL ISSUES:
+Identifies problems in the pipeline configuration that could prevent execution.
+─────────────────
+INFO: Orphaned steps (no dependencies, not required by others):
+   - diagnostics
+   - publish-manifest
+
+EXECUTION SIMULATION ("What If" Analysis):
+Shows what steps would run for each possible target step and in what order.
+Steps at the same level can run concurrently.
+─────────────────────────────────────────────────────────────────────────────
+If targeting 'build':
+  Direct dependencies: build-api
+  Total steps: 4
+  Execution order:
+    [0] build-prereq | deploy-prereq (parallel)
+    [1] build-api
+    [2] build
+
+If targeting 'build-api':
+  Direct dependencies: build-prereq, deploy-prereq
+  Total steps: 3
+  Execution order:
+    [0] build-prereq | deploy-prereq (parallel)
+    [1] build-api
+
+If targeting 'build-prereq':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] build-prereq
+
+If targeting 'create-provisioning-context':
+  Direct dependencies: deploy-prereq, validate-azure-login
+  Total steps: 3
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+
+If targeting 'deploy':
+  Direct dependencies: build-api, create-provisioning-context, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
+  Total steps: 16
+  Execution order:
+    [0] build-prereq | deploy-prereq (parallel)
+    [1] build-api | validate-azure-login (parallel)
+    [2] create-provisioning-context
+    [3] provision-api-identity | provision-env | provision-kv (parallel)
+    [4] login-to-acr-env | provision-api-roles-kv | provision-cache (parallel)
+    [5] push-api
+    [6] provision-api-website
+    [7] provision-azure-bicep-resources
+    [8] print-dashboard-url-env
+    [9] deploy
+
+If targeting 'deploy-api':
+  Direct dependencies: print-api-summary
+  Total steps: 13
+  Execution order:
+    [0] build-prereq | deploy-prereq (parallel)
+    [1] build-api | validate-azure-login (parallel)
+    [2] create-provisioning-context
+    [3] provision-api-identity | provision-env | provision-kv (parallel)
+    [4] login-to-acr-env
+    [5] push-api
+    [6] provision-api-website
+    [7] print-api-summary
+    [8] deploy-api
+
+If targeting 'deploy-prereq':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] deploy-prereq
+
+If targeting 'diagnostics':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] diagnostics
+
+If targeting 'login-to-acr-env':
+  Direct dependencies: provision-env
+  Total steps: 5
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-env
+    [4] login-to-acr-env
+
+If targeting 'print-api-summary':
+  Direct dependencies: provision-api-website
+  Total steps: 12
+  Execution order:
+    [0] build-prereq | deploy-prereq (parallel)
+    [1] build-api | validate-azure-login (parallel)
+    [2] create-provisioning-context
+    [3] provision-api-identity | provision-env | provision-kv (parallel)
+    [4] login-to-acr-env
+    [5] push-api
+    [6] provision-api-website
+    [7] print-api-summary
+
+If targeting 'print-dashboard-url-env':
+  Direct dependencies: provision-azure-bicep-resources, provision-env
+  Total steps: 15
+  Execution order:
+    [0] build-prereq | deploy-prereq (parallel)
+    [1] build-api | validate-azure-login (parallel)
+    [2] create-provisioning-context
+    [3] provision-api-identity | provision-env | provision-kv (parallel)
+    [4] login-to-acr-env | provision-api-roles-kv | provision-cache (parallel)
+    [5] push-api
+    [6] provision-api-website
+    [7] provision-azure-bicep-resources
+    [8] print-dashboard-url-env
+
+If targeting 'provision-api-identity':
+  Direct dependencies: create-provisioning-context
+  Total steps: 4
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-api-identity
+
+If targeting 'provision-api-roles-kv':
+  Direct dependencies: create-provisioning-context, provision-api-identity, provision-kv
+  Total steps: 6
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-api-identity | provision-kv (parallel)
+    [4] provision-api-roles-kv
+
+If targeting 'provision-api-website':
+  Direct dependencies: create-provisioning-context, provision-api-identity, provision-env, provision-kv, push-api
+  Total steps: 11
+  Execution order:
+    [0] build-prereq | deploy-prereq (parallel)
+    [1] build-api | validate-azure-login (parallel)
+    [2] create-provisioning-context
+    [3] provision-api-identity | provision-env | provision-kv (parallel)
+    [4] login-to-acr-env
+    [5] push-api
+    [6] provision-api-website
+
+If targeting 'provision-azure-bicep-resources':
+  Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-kv, provision-api-website, provision-cache, provision-env, provision-kv
+  Total steps: 14
+  Execution order:
+    [0] build-prereq | deploy-prereq (parallel)
+    [1] build-api | validate-azure-login (parallel)
+    [2] create-provisioning-context
+    [3] provision-api-identity | provision-env | provision-kv (parallel)
+    [4] login-to-acr-env | provision-api-roles-kv | provision-cache (parallel)
+    [5] push-api
+    [6] provision-api-website
+    [7] provision-azure-bicep-resources
+
+If targeting 'provision-cache':
+  Direct dependencies: create-provisioning-context, provision-kv
+  Total steps: 5
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-kv
+    [4] provision-cache
+
+If targeting 'provision-env':
+  Direct dependencies: create-provisioning-context
+  Total steps: 4
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-env
+
+If targeting 'provision-kv':
+  Direct dependencies: create-provisioning-context
+  Total steps: 4
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-kv
+
+If targeting 'publish':
+  Direct dependencies: publish-azure634f9
+  Total steps: 3
+  Execution order:
+    [0] publish-prereq
+    [1] publish-azure634f9
+    [2] publish
+
+If targeting 'publish-azure634f9':
+  Direct dependencies: publish-prereq
+  Total steps: 2
+  Execution order:
+    [0] publish-prereq
+    [1] publish-azure634f9
+
+If targeting 'publish-manifest':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] publish-manifest
+
+If targeting 'publish-prereq':
+  Direct dependencies: none
+  Total steps: 1
+  Execution order:
+    [0] publish-prereq
+
+If targeting 'push-api':
+  Direct dependencies: build-api, login-to-acr-env, provision-env
+  Total steps: 8
+  Execution order:
+    [0] build-prereq | deploy-prereq (parallel)
+    [1] build-api | validate-azure-login (parallel)
+    [2] create-provisioning-context
+    [3] provision-env
+    [4] login-to-acr-env
+    [5] push-api
+
+If targeting 'validate-azure-login':
+  Direct dependencies: deploy-prereq
+  Total steps: 2
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+
+
+]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -23,11 +23,11 @@ Steps with no dependencies run first, followed by steps that depend on them.
   7. provision-api-identity
   8. provision-kv
   9. provision-api-roles-kv
- 10. provision-env
- 11. login-to-acr-env
- 12. push-api
- 13. provision-api-website
- 14. provision-cache
+ 10. provision-cache
+ 11. provision-env
+ 12. login-to-acr-env
+ 13. push-api
+ 14. provision-api-website
  15. provision-azure-bicep-resources
  16. print-dashboard-url-env
  17. deploy
@@ -202,13 +202,13 @@ If targeting 'deploy':
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 13
+  Total steps: 14
   Execution order:
     [0] build-prereq | deploy-prereq (parallel)
     [1] build-api | validate-azure-login (parallel)
     [2] create-provisioning-context
     [3] provision-api-identity | provision-env | provision-kv (parallel)
-    [4] login-to-acr-env
+    [4] login-to-acr-env | provision-cache (parallel)
     [5] push-api
     [6] provision-api-website
     [7] print-api-summary
@@ -238,13 +238,13 @@ If targeting 'login-to-acr-env':
 
 If targeting 'print-api-summary':
   Direct dependencies: provision-api-website
-  Total steps: 12
+  Total steps: 13
   Execution order:
     [0] build-prereq | deploy-prereq (parallel)
     [1] build-api | validate-azure-login (parallel)
     [2] create-provisioning-context
     [3] provision-api-identity | provision-env | provision-kv (parallel)
-    [4] login-to-acr-env
+    [4] login-to-acr-env | provision-cache (parallel)
     [5] push-api
     [6] provision-api-website
     [7] print-api-summary
@@ -283,14 +283,14 @@ If targeting 'provision-api-roles-kv':
     [4] provision-api-roles-kv
 
 If targeting 'provision-api-website':
-  Direct dependencies: create-provisioning-context, provision-api-identity, provision-env, provision-kv, push-api
-  Total steps: 11
+  Direct dependencies: create-provisioning-context, provision-api-identity, provision-cache, provision-env, provision-kv, push-api
+  Total steps: 12
   Execution order:
     [0] build-prereq | deploy-prereq (parallel)
     [1] build-api | validate-azure-login (parallel)
     [2] create-provisioning-context
     [3] provision-api-identity | provision-env | provision-kv (parallel)
-    [4] login-to-acr-env
+    [4] login-to-acr-env | provision-cache (parallel)
     [5] push-api
     [6] provision-api-website
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 24
+Total steps defined: 30
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -21,23 +21,29 @@ Steps with no dependencies run first, followed by steps that depend on them.
   5. validate-azure-login
   6. create-provisioning-context
   7. provision-api-identity
-  8. provision-kv
-  9. provision-api-roles-kv
- 10. provision-cache
- 11. provision-env
- 12. login-to-acr-env
- 13. push-api
- 14. provision-api-website
- 15. provision-azure-bicep-resources
- 16. print-dashboard-url-env
- 17. deploy
- 18. print-api-summary
- 19. deploy-api
- 20. diagnostics
- 21. publish-prereq
- 22. publish-azure634f9
- 23. publish
- 24. publish-manifest
+  8. provision-cache-kv
+  9. provision-api-roles-cache-kv
+ 10. provision-cosmos-kv
+ 11. provision-api-roles-cosmos-kv
+ 12. provision-pg-kv
+ 13. provision-api-roles-pg-kv
+ 14. provision-cache
+ 15. provision-cosmos
+ 16. provision-env
+ 17. provision-pg
+ 18. login-to-acr-env
+ 19. push-api
+ 20. provision-api-website
+ 21. provision-azure-bicep-resources
+ 22. print-dashboard-url-env
+ 23. deploy
+ 24. print-api-summary
+ 25. deploy-api
+ 26. diagnostics
+ 27. publish-prereq
+ 28. publish-azure634f9
+ 29. publish
+ 30. publish-manifest
 
 DETAILED STEP ANALYSIS
 ======================
@@ -93,24 +99,49 @@ Step: provision-api-identity
     Resource: api-identity (AzureUserAssignedIdentityResource)
     Tags: provision-infra
 
-Step: provision-api-roles-kv
-    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-kv
-    Resource: api-roles-kv (AzureProvisioningResource)
+Step: provision-api-roles-cache-kv
+    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cache-kv
+    Resource: api-roles-cache-kv (AzureProvisioningResource)
+    Tags: provision-infra
+
+Step: provision-api-roles-cosmos-kv
+    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cosmos-kv
+    Resource: api-roles-cosmos-kv (AzureProvisioningResource)
+    Tags: provision-infra
+
+Step: provision-api-roles-pg-kv
+    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-pg-kv
+    Resource: api-roles-pg-kv (AzureProvisioningResource)
     Tags: provision-infra
 
 Step: provision-api-website
-    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cache, ✓ provision-env, ✓ provision-kv, ✓ push-api
+    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cache, ✓ provision-cache-kv, ✓ provision-cosmos, ✓ provision-cosmos-kv, ✓ provision-env, ✓ provision-pg, ✓ provision-pg-kv, ✓ push-api
     Resource: api-website (AzureAppServiceWebSiteResource)
     Tags: provision-infra
 
 Step: provision-azure-bicep-resources
-    Dependencies: ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-api-identity, ✓ provision-api-roles-kv, ✓ provision-api-website, ✓ provision-cache, ✓ provision-env, ✓ provision-kv
+    Dependencies: ✓ create-provisioning-context, ✓ deploy-prereq, ✓ provision-api-identity, ✓ provision-api-roles-cache-kv, ✓ provision-api-roles-cosmos-kv, ✓ provision-api-roles-pg-kv, ✓ provision-api-website, ✓ provision-cache, ✓ provision-cache-kv, ✓ provision-cosmos, ✓ provision-cosmos-kv, ✓ provision-env, ✓ provision-pg, ✓ provision-pg-kv
     Resource: azure634f9 (AzureEnvironmentResource)
     Tags: provision-infra
 
 Step: provision-cache
-    Dependencies: ✓ create-provisioning-context, ✓ provision-kv
+    Dependencies: ✓ create-provisioning-context, ✓ provision-cache-kv
     Resource: cache (AzureRedisCacheResource)
+    Tags: provision-infra
+
+Step: provision-cache-kv
+    Dependencies: ✓ create-provisioning-context
+    Resource: cache-kv (AzureKeyVaultResource)
+    Tags: provision-infra
+
+Step: provision-cosmos
+    Dependencies: ✓ create-provisioning-context, ✓ provision-cosmos-kv
+    Resource: cosmos (AzureCosmosDBResource)
+    Tags: provision-infra
+
+Step: provision-cosmos-kv
+    Dependencies: ✓ create-provisioning-context
+    Resource: cosmos-kv (AzureKeyVaultResource)
     Tags: provision-infra
 
 Step: provision-env
@@ -118,9 +149,14 @@ Step: provision-env
     Resource: env (AzureAppServiceEnvironmentResource)
     Tags: provision-infra
 
-Step: provision-kv
+Step: provision-pg
+    Dependencies: ✓ create-provisioning-context, ✓ provision-pg-kv
+    Resource: pg (AzurePostgresFlexibleServerResource)
+    Tags: provision-infra
+
+Step: provision-pg-kv
     Dependencies: ✓ create-provisioning-context
-    Resource: kv (AzureKeyVaultResource)
+    Resource: pg-kv (AzureKeyVaultResource)
     Tags: provision-infra
 
 Step: publish
@@ -187,13 +223,13 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api, create-provisioning-context, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 16
+  Total steps: 22
   Execution order:
     [0] build-prereq | deploy-prereq (parallel)
     [1] build-api | validate-azure-login (parallel)
     [2] create-provisioning-context
-    [3] provision-api-identity | provision-env | provision-kv (parallel)
-    [4] login-to-acr-env | provision-api-roles-kv | provision-cache (parallel)
+    [3] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env | provision-pg-kv (parallel)
+    [4] login-to-acr-env | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-pg (parallel)
     [5] push-api
     [6] provision-api-website
     [7] provision-azure-bicep-resources
@@ -202,13 +238,13 @@ If targeting 'deploy':
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 14
+  Total steps: 18
   Execution order:
     [0] build-prereq | deploy-prereq (parallel)
     [1] build-api | validate-azure-login (parallel)
     [2] create-provisioning-context
-    [3] provision-api-identity | provision-env | provision-kv (parallel)
-    [4] login-to-acr-env | provision-cache (parallel)
+    [3] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env | provision-pg-kv (parallel)
+    [4] login-to-acr-env | provision-cache | provision-cosmos | provision-pg (parallel)
     [5] push-api
     [6] provision-api-website
     [7] print-api-summary
@@ -238,26 +274,26 @@ If targeting 'login-to-acr-env':
 
 If targeting 'print-api-summary':
   Direct dependencies: provision-api-website
-  Total steps: 13
+  Total steps: 17
   Execution order:
     [0] build-prereq | deploy-prereq (parallel)
     [1] build-api | validate-azure-login (parallel)
     [2] create-provisioning-context
-    [3] provision-api-identity | provision-env | provision-kv (parallel)
-    [4] login-to-acr-env | provision-cache (parallel)
+    [3] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env | provision-pg-kv (parallel)
+    [4] login-to-acr-env | provision-cache | provision-cosmos | provision-pg (parallel)
     [5] push-api
     [6] provision-api-website
     [7] print-api-summary
 
 If targeting 'print-dashboard-url-env':
   Direct dependencies: provision-azure-bicep-resources, provision-env
-  Total steps: 15
+  Total steps: 21
   Execution order:
     [0] build-prereq | deploy-prereq (parallel)
     [1] build-api | validate-azure-login (parallel)
     [2] create-provisioning-context
-    [3] provision-api-identity | provision-env | provision-kv (parallel)
-    [4] login-to-acr-env | provision-api-roles-kv | provision-cache (parallel)
+    [3] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env | provision-pg-kv (parallel)
+    [4] login-to-acr-env | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-pg (parallel)
     [5] push-api
     [6] provision-api-website
     [7] provision-azure-bicep-resources
@@ -272,50 +308,98 @@ If targeting 'provision-api-identity':
     [2] create-provisioning-context
     [3] provision-api-identity
 
-If targeting 'provision-api-roles-kv':
-  Direct dependencies: create-provisioning-context, provision-api-identity, provision-kv
+If targeting 'provision-api-roles-cache-kv':
+  Direct dependencies: create-provisioning-context, provision-api-identity, provision-cache-kv
   Total steps: 6
   Execution order:
     [0] deploy-prereq
     [1] validate-azure-login
     [2] create-provisioning-context
-    [3] provision-api-identity | provision-kv (parallel)
-    [4] provision-api-roles-kv
+    [3] provision-api-identity | provision-cache-kv (parallel)
+    [4] provision-api-roles-cache-kv
+
+If targeting 'provision-api-roles-cosmos-kv':
+  Direct dependencies: create-provisioning-context, provision-api-identity, provision-cosmos-kv
+  Total steps: 6
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-api-identity | provision-cosmos-kv (parallel)
+    [4] provision-api-roles-cosmos-kv
+
+If targeting 'provision-api-roles-pg-kv':
+  Direct dependencies: create-provisioning-context, provision-api-identity, provision-pg-kv
+  Total steps: 6
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-api-identity | provision-pg-kv (parallel)
+    [4] provision-api-roles-pg-kv
 
 If targeting 'provision-api-website':
-  Direct dependencies: create-provisioning-context, provision-api-identity, provision-cache, provision-env, provision-kv, push-api
-  Total steps: 12
+  Direct dependencies: create-provisioning-context, provision-api-identity, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-pg, provision-pg-kv, push-api
+  Total steps: 16
   Execution order:
     [0] build-prereq | deploy-prereq (parallel)
     [1] build-api | validate-azure-login (parallel)
     [2] create-provisioning-context
-    [3] provision-api-identity | provision-env | provision-kv (parallel)
-    [4] login-to-acr-env | provision-cache (parallel)
+    [3] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env | provision-pg-kv (parallel)
+    [4] login-to-acr-env | provision-cache | provision-cosmos | provision-pg (parallel)
     [5] push-api
     [6] provision-api-website
 
 If targeting 'provision-azure-bicep-resources':
-  Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-kv, provision-api-website, provision-cache, provision-env, provision-kv
-  Total steps: 14
+  Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-cache-kv, provision-api-roles-cosmos-kv, provision-api-roles-pg-kv, provision-api-website, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-pg, provision-pg-kv
+  Total steps: 20
   Execution order:
     [0] build-prereq | deploy-prereq (parallel)
     [1] build-api | validate-azure-login (parallel)
     [2] create-provisioning-context
-    [3] provision-api-identity | provision-env | provision-kv (parallel)
-    [4] login-to-acr-env | provision-api-roles-kv | provision-cache (parallel)
+    [3] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env | provision-pg-kv (parallel)
+    [4] login-to-acr-env | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-pg (parallel)
     [5] push-api
     [6] provision-api-website
     [7] provision-azure-bicep-resources
 
 If targeting 'provision-cache':
-  Direct dependencies: create-provisioning-context, provision-kv
+  Direct dependencies: create-provisioning-context, provision-cache-kv
   Total steps: 5
   Execution order:
     [0] deploy-prereq
     [1] validate-azure-login
     [2] create-provisioning-context
-    [3] provision-kv
+    [3] provision-cache-kv
     [4] provision-cache
+
+If targeting 'provision-cache-kv':
+  Direct dependencies: create-provisioning-context
+  Total steps: 4
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-cache-kv
+
+If targeting 'provision-cosmos':
+  Direct dependencies: create-provisioning-context, provision-cosmos-kv
+  Total steps: 5
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-cosmos-kv
+    [4] provision-cosmos
+
+If targeting 'provision-cosmos-kv':
+  Direct dependencies: create-provisioning-context
+  Total steps: 4
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-cosmos-kv
 
 If targeting 'provision-env':
   Direct dependencies: create-provisioning-context
@@ -326,14 +410,24 @@ If targeting 'provision-env':
     [2] create-provisioning-context
     [3] provision-env
 
-If targeting 'provision-kv':
+If targeting 'provision-pg':
+  Direct dependencies: create-provisioning-context, provision-pg-kv
+  Total steps: 5
+  Execution order:
+    [0] deploy-prereq
+    [1] validate-azure-login
+    [2] create-provisioning-context
+    [3] provision-pg-kv
+    [4] provision-pg
+
+If targeting 'provision-pg-kv':
   Direct dependencies: create-provisioning-context
   Total steps: 4
   Execution order:
     [0] deploy-prereq
     [1] validate-azure-login
     [2] create-provisioning-context
-    [3] provision-kv
+    [3] provision-pg-kv
 
 If targeting 'publish':
   Direct dependencies: publish-azure634f9


### PR DESCRIPTION
## Description

Fix deployment dependency discovery for resources with AccessKeyAuthentication


### Problem

When deploying applications where a project references an Azure resource (Redis, CosmosDB, PostgreSQL) configured with `WithAccessKeyAuthentication()` or `WithPasswordAuthentication()`, deployments could fail. The dependency graph didn't recognize that the project transitively depends on the Azure resource being fully provisioned (including writing its access key secret to KeyVault), only on KeyVault itself.

This caused projects to start deploying before the Azure resource finished provisioning and writing secrets, leading to missing connection strings and deployment failures.

### Solution

1. Track Secret Ownership

Added `SecretOwner` property to `IAzureKeyVaultSecretReference` to track which resource writes each secret
Updated `References` to include both KeyVault and the SecretOwner resource
All resources using access key/password authentication now set `SecretOwner` when creating KeyVault secrets
This enables dependency discovery to walk the full chain: Project → ConnectionString → Secret → KeyVault + SecretOwner
2. Enhanced Dependency Discovery

AzureBicepResource` now processes both Bicep parameters AND its own `References` when discovering Azure dependencies
This catches dependencies expressed through connection string references in addition to direct parameter references

Result
The deployment pipeline now correctly identifies that projects depend on both KeyVault AND the resource that writes secrets (Redis/CosmosDB/PostgreSQL). This ensures proper provisioning order:

KeyVault provisions
- Azure resource (e.g., Redis) fully provisions and writes secret to KeyVault
- Project provisions with access to the secret

Fixes #12801

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
