### PR TITLE
Set RuntimeIdentifier when building dotnet containers

### DIFF
--- a/playground/TestShop/BasketService/BasketService.csproj
+++ b/playground/TestShop/BasketService/BasketService.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <UserSecretsId>f0611710-1eab-4ff6-a476-9610bb7a8416</UserSecretsId>
-    <ContainerRegistry>localhost:5001</ContainerRegistry>
     <ContainerRepository>basket-service</ContainerRepository>
     <ContainerBaseImage>mcr.microsoft.com/dotnet/aspnet:8.0</ContainerBaseImage>
   </PropertyGroup>

--- a/playground/TestShop/CatalogService/CatalogService.csproj
+++ b/playground/TestShop/CatalogService/CatalogService.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <UserSecretsId>16965dbf-c1f8-4682-b7d8-e250ac520544</UserSecretsId>
     <LangVersion>preview</LangVersion>
-    <ContainerRegistry>localhost:5001</ContainerRegistry>
     <ContainerRepository>catalog-service</ContainerRepository>
     <ContainerBaseImage>mcr.microsoft.com/dotnet/aspnet:8.0</ContainerBaseImage>
   </PropertyGroup>

--- a/playground/TestShop/MyFrontend/MyFrontend.csproj
+++ b/playground/TestShop/MyFrontend/MyFrontend.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
-    <ContainerRegistry>localhost:5001</ContainerRegistry>
     <ContainerRepository>my-frontend</ContainerRepository>
     <ContainerBaseImage>mcr.microsoft.com/dotnet/aspnet:8.0</ContainerBaseImage>
     <!-- Razor tooling sometimes raises this warning. Don't make it an error. -->

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -286,8 +286,9 @@ internal sealed class ResourceContainerImageBuilder(
                 else
                 {
                     // Multiple platforms - use RuntimeIdentifiers/ContainerRuntimeIdentifiers
-                    arguments += $" /p:RuntimeIdentifiers=\"{runtimeIds}\"";
-                    arguments += $" /p:ContainerRuntimeIdentifiers=\"{runtimeIds}\"";
+                    // MSBuild doesn't handle ';' in parameters well, need to escape the double quote. See https://github.com/dotnet/msbuild/issues/471
+                    arguments += $" /p:RuntimeIdentifiers=\\\"{runtimeIds}\\\"";
+                    arguments += $" /p:ContainerRuntimeIdentifiers=\\\"{runtimeIds}\\\"";
                 }
             }
         }

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageBuilder.cs
@@ -273,19 +273,21 @@ internal sealed class ResourceContainerImageBuilder(
 
             if (options.TargetPlatform is not null)
             {
-                // Use the appropriate MSBuild property based on the number of RIDs
+                // Use the appropriate MSBuild properties based on the number of RIDs
                 var runtimeIds = options.TargetPlatform.Value.ToMSBuildRuntimeIdentifierString();
                 var ridArray = runtimeIds.Split(';');
 
                 if (ridArray.Length == 1)
                 {
-                    // Single platform - use ContainerRuntimeIdentifier
+                    // Single platform - use RuntimeIdentifier/ContainerRuntimeIdentifier
+                    arguments += $" /p:RuntimeIdentifier=\"{ridArray[0]}\"";
                     arguments += $" /p:ContainerRuntimeIdentifier=\"{ridArray[0]}\"";
                 }
                 else
                 {
-                    // Multiple platforms - use RuntimeIdentifiers
+                    // Multiple platforms - use RuntimeIdentifiers/ContainerRuntimeIdentifiers
                     arguments += $" /p:RuntimeIdentifiers=\"{runtimeIds}\"";
+                    arguments += $" /p:ContainerRuntimeIdentifiers=\"{runtimeIds}\"";
                 }
             }
         }


### PR DESCRIPTION
## Description

Set both RuntimeIdentifier/ContainerRuntimeIdentifier or RuntimeIdentifiers/ContainerRuntimeIdentifiers when building dotnet containers. This way the application is published correctly - for example for native AOT.