### PR TITLE
Removing preview qualifiers from Functions readme

### DIFF
--- a/src/Aspire.Hosting.Azure.Functions/README.md
+++ b/src/Aspire.Hosting.Azure.Functions/README.md
@@ -1,4 +1,4 @@
-# Aspire.Hosting.Azure.Functions library (Preview)
+# Aspire.Hosting.Azure.Functions library
 
 Provides methods to the Aspire hosting model for Azure functions.
 
@@ -14,7 +14,7 @@ Provides methods to the Aspire hosting model for Azure functions.
 In your AppHost project, install the Aspire Azure Functions Hosting library with [NuGet](https://www.nuget.org):
 
 ```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Functions --prerelease
+dotnet add package Aspire.Hosting.Azure.Functions
 ```
 
 ## Usage example


### PR DESCRIPTION
## Description

Since 13.1 will move the package to GA, removing:

- preview tag in README title
- prerelease flag in NuGet command

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
