### PR TITLE
Update VS Code settings to new C#DK Settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "dotnet.defaultSolution": "./Aspire.slnx",
     "dotnet.solution.autoOpen": "./Aspire.slnx",
     "dotnet.preview.enableSupportForSlnx": true,
     "dotnet.testWindow.useTestingPlatformProtocol": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
-    "dotnet.previewSolution-freeWorkspaceMode": true,
-    "dotnet.testWindow.useTestingPlatformProtocol": true,
-    "dotnet.defaultSolution": "./Aspire.slnx",
+    "dotnet.solution.autoOpen": "./Aspire.slnx",
     "dotnet.preview.enableSupportForSlnx": true,
+    "dotnet.testWindow.useTestingPlatformProtocol": true,
     "aspire.enableSettingsFileCreationPromptOnStartup": false
 }


### PR DESCRIPTION
Updates VS Code settings to support both legacy and current C# extension solution handling.

Adds dotnet.solution.autoOpen while keeping dotnet.defaultSolution for backward compatibility with stable VS Code versions.

This is needed because Aspire repo isn't compatible with WorkspaceBasedDevelopment yet ...