### PR TITLE
Add menu to resource details to make it consistant with other details controls

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -20,6 +20,7 @@
                       slot="end" />
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
+                          ButtonClass="resource-details-actions"
                           Icon="@(new Icons.Regular.Size20.Options())"
                           Items="@_resourceActionsMenuItems"
                           Title="@Loc[nameof(ControlsStrings.ActionsButtonText)]"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -13,35 +13,17 @@
 <div class="resource-details-layout">
 
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(ResourceViewModel.GetResourceName(Resource, ResourceByName))" slot="end">@Loc[nameof(Resources.ResourceDetailsViewConsoleLogs)]</FluentAnchor>
-
-        @if (ShowSpecOnlyToggle)
-        {
-            <FluentIconSwitch Appearance="Appearance.Lightweight"
-                              Disabled="IsSpecOnlyToggleDisabled"
-                              CheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly)]"
-                              UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowAll)]"
-                              OnToggle="@(() => _showAll = !_showAll)"
-                              CheckedIcon="@(new Icons.Regular.Size16.DocumentHeader())"
-                              UncheckedIcon="@(new Icons.Regular.Size16.DocumentOnePage())"
-                              slot="end"/>
-        }
-
-        <FluentIconSwitch @bind-Value="@IsMaskAllChecked"
-                          Appearance="Appearance.Lightweight"
-                          CheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesShowVariableValues)]"
-                          UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)]"
-                          OnToggle="@OnMaskAllCheckedChanged"
-                          CheckedIcon="@(new Icons.Regular.Size16.Eye())"
-                          UncheckedIcon="@(new Icons.Regular.Size16.EyeOff())"
-                          class="mask-all-switch"
-                          slot="end" />
-
         <FluentSearch Placeholder="@ControlStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"
                       Autofocus="true"
                       @bind-Value="_filter"
                       slot="end" />
+        <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+        <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
+                          Icon="@(new Icons.Regular.Size20.Options())"
+                          Items="@_resourceActionsMenuItems"
+                          Title="@Loc[nameof(ControlsStrings.ActionsButtonText)]"
+                          slot="end" />
     </FluentToolbar>
     <div class="property-grid-container">
         <FluentAccordion>

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -210,7 +210,6 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
     {
         _resourceActionsMenuItems.Clear();
 
-        // Add "View structured logs" at the top
         _resourceActionsMenuItems.Add(new MenuButtonItem
         {
             Text = Loc[nameof(Resources.Resources.ResourceDetailsViewConsoleLogs)],

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -206,30 +206,6 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
         _aiContext = CreateAIContext();
     }
 
-        //<FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(ResourceViewModel.GetResourceName(Resource, ResourceByName))" slot="end">@Loc[nameof(Resources.ResourceDetailsViewConsoleLogs)]</FluentAnchor>
-
-        //@if (ShowSpecOnlyToggle)
-        //{
-        //    <FluentIconSwitch Appearance="Appearance.Lightweight"
-        //                      Disabled="IsSpecOnlyToggleDisabled"
-        //                      CheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly)]"
-        //                      UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowAll)]"
-        //                      OnToggle="@(() => _showAll = !_showAll)"
-        //                      CheckedIcon="@(new Icons.Regular.Size16.DocumentHeader())"
-        //                      UncheckedIcon="@(new Icons.Regular.Size16.DocumentOnePage())"
-        //                      slot="end"/>
-        //}
-
-        //<FluentIconSwitch @bind-Value="@IsMaskAllChecked"
-        //                  Appearance="Appearance.Lightweight"
-        //                  CheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesShowVariableValues)]"
-        //                  UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)]"
-        //                  OnToggle="@OnMaskAllCheckedChanged"
-        //                  CheckedIcon="@(new Icons.Regular.Size16.Eye())"
-        //                  UncheckedIcon="@(new Icons.Regular.Size16.EyeOff())"
-        //                  class="mask-all-switch"
-        //                  slot="end" />
-
     private void UpdateResourceActionsMenu()
     {
         _resourceActionsMenuItems.Clear();

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Google.Protobuf.WellKnownTypes;
@@ -15,6 +16,7 @@ using Humanizer;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -106,6 +108,7 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
     private bool _isBackRelationshipsExpanded;
 
     private string _filter = "";
+    private readonly List<MenuButtonItem> _resourceActionsMenuItems = [];
     private bool? _isMaskAllChecked;
     private bool _dataChanged;
     private AIContext? _aiContext;
@@ -176,6 +179,8 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
                     Parameters = { ["Resource"] = _resource }
                 },
             };
+
+            UpdateResourceActionsMenu();
         }
 
         UpdateTelemetryProperties();
@@ -199,6 +204,81 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
         TelemetryContextProvider.Initialize(TelemetryContext);
         (_resizeLabels, _sortLabels) = DashboardUIHelpers.CreateGridLabels(ControlStringsLoc);
         _aiContext = CreateAIContext();
+    }
+
+        //<FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(ResourceViewModel.GetResourceName(Resource, ResourceByName))" slot="end">@Loc[nameof(Resources.ResourceDetailsViewConsoleLogs)]</FluentAnchor>
+
+        //@if (ShowSpecOnlyToggle)
+        //{
+        //    <FluentIconSwitch Appearance="Appearance.Lightweight"
+        //                      Disabled="IsSpecOnlyToggleDisabled"
+        //                      CheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly)]"
+        //                      UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowAll)]"
+        //                      OnToggle="@(() => _showAll = !_showAll)"
+        //                      CheckedIcon="@(new Icons.Regular.Size16.DocumentHeader())"
+        //                      UncheckedIcon="@(new Icons.Regular.Size16.DocumentOnePage())"
+        //                      slot="end"/>
+        //}
+
+        //<FluentIconSwitch @bind-Value="@IsMaskAllChecked"
+        //                  Appearance="Appearance.Lightweight"
+        //                  CheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesShowVariableValues)]"
+        //                  UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)]"
+        //                  OnToggle="@OnMaskAllCheckedChanged"
+        //                  CheckedIcon="@(new Icons.Regular.Size16.Eye())"
+        //                  UncheckedIcon="@(new Icons.Regular.Size16.EyeOff())"
+        //                  class="mask-all-switch"
+        //                  slot="end" />
+
+    private void UpdateResourceActionsMenu()
+    {
+        _resourceActionsMenuItems.Clear();
+
+        // Add "View structured logs" at the top
+        _resourceActionsMenuItems.Add(new MenuButtonItem
+        {
+            Text = Loc[nameof(Resources.Resources.ResourceDetailsViewConsoleLogs)],
+            Icon = new Icons.Regular.Size16.SlideText(),
+            OnClick = () =>
+            {
+                NavigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(ResourceViewModel.GetResourceName(Resource, ResourceByName)));
+                return Task.CompletedTask;
+            }
+        });
+
+        if (ShowSpecOnlyToggle)
+        {
+            _resourceActionsMenuItems.Add(new MenuButtonItem
+            {
+                Text = _showAll ? ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly)] : ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowAll)],
+                Icon = _showAll ? new Icons.Regular.Size16.DocumentHeader() : new Icons.Regular.Size16.DocumentOnePage(),
+                OnClick = () =>
+                {
+                    _showAll = !_showAll;
+
+                    UpdateResourceActionsMenu();
+                    StateHasChanged();
+                    return Task.CompletedTask;
+                }
+            });
+        }
+
+        _resourceActionsMenuItems.Add(new MenuButtonItem
+        {
+            Text = IsMaskAllChecked ? ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesShowVariableValues)] : ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)],
+            Icon = IsMaskAllChecked ? new Icons.Regular.Size16.Eye() : new Icons.Regular.Size16.EyeOff(),
+            OnClick = () =>
+            {
+                IsMaskAllChecked = !IsMaskAllChecked;
+                OnMaskAllCheckedChanged();
+
+                UpdateResourceActionsMenu();
+                StateHasChanged();
+                return Task.CompletedTask;
+            },
+            Class = "mask-all-switch",
+            IsDisabled = IsSpecOnlyToggleDisabled
+        });
     }
 
     private IEnumerable<ResourceDetailRelationshipViewModel> GetRelationships()

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -286,7 +286,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show all.
+        ///   Looks up a localized string similar to Show all properties.
         /// </summary>
         public static string EnvironmentVariablesFilterToggleShowAll {
             get {
@@ -295,7 +295,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show spec only.
+        ///   Looks up a localized string similar to Show core properties.
         /// </summary>
         public static string EnvironmentVariablesFilterToggleShowSpecOnly {
             get {
@@ -304,7 +304,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hide values.
+        ///   Looks up a localized string similar to Hide sensitive values.
         /// </summary>
         public static string EnvironmentVariablesHideVariableValues {
             get {
@@ -313,7 +313,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show values.
+        ///   Looks up a localized string similar to Show sensitive values.
         /// </summary>
         public static string EnvironmentVariablesShowVariableValues {
             get {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -133,17 +133,16 @@
     <value>Graph. For an accessible view please navigate to the Table tab</value>
   </data>
   <data name="EnvironmentVariablesFilterToggleShowSpecOnly" xml:space="preserve">
-    <value>Show spec only</value>
-    <comment>Spec means from the resource specification</comment>
+    <value>Show core properties</value>
   </data>
   <data name="EnvironmentVariablesFilterToggleShowAll" xml:space="preserve">
-    <value>Show all</value>
+    <value>Show all properties</value>
   </data>
   <data name="EnvironmentVariablesShowVariableValues" xml:space="preserve">
-    <value>Show values</value>
+    <value>Show sensitive values</value>
   </data>
   <data name="EnvironmentVariablesHideVariableValues" xml:space="preserve">
-    <value>Hide values</value>
+    <value>Hide sensitive values</value>
   </data>
   <data name="FilterPlaceholder" xml:space="preserve">
     <value>Filter...</value>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">Zobrazit vše</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">Zobrazit vše</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">Zobrazit jen specifikaci</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">Zobrazit jen specifikaci</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">Skrýt hodnoty</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">Skrýt hodnoty</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">Zobrazit hodnoty</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">Zobrazit hodnoty</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">Alle anzeigen</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">Alle anzeigen</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">Nur Spezifikation anzeigen</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">Nur Spezifikation anzeigen</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">Werte ausblenden</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">Werte ausblenden</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">Werte anzeigen</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">Werte anzeigen</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">Mostrar todo</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">Mostrar todo</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">Mostrar solo especificación</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">Mostrar solo especificación</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">Ocultar los valores</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">Ocultar los valores</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">Mostrar valores</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">Mostrar valores</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">Tout afficher</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">Tout afficher</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">Afficher uniquement la spécification</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">Afficher uniquement la spécification</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">Masquer les valeurs</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">Masquer les valeurs</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">Afficher les valeurs</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">Afficher les valeurs</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">Mostra tutto</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">Mostra tutto</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">Mostra solo specifiche</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">Mostra solo specifiche</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">Nascondi valori</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">Nascondi valori</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">Mostra valori</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">Mostra valori</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">すべてを表示</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">すべてを表示</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">仕様のみを表示</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">仕様のみを表示</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">値を非表示にする</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">値を非表示にする</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">値を表示する</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">値を表示する</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">모두 표시</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">모두 표시</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">사양만 표시</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">사양만 표시</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">값 숨기기</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">값 숨기기</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">값 표시</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">값 표시</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">Pokaż wszystkie</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">Pokaż wszystkie</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">Pokaż tylko specyfikację</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">Pokaż tylko specyfikację</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">Ukryj wartości</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">Ukryj wartości</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">Pokaż wartości</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">Pokaż wartości</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">Mostrar tudo</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">Mostrar tudo</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">Mostrar somente especificação</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">Mostrar somente especificação</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">Ocultar valores</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">Ocultar valores</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">Mostrar valores</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">Mostrar valores</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">Показать все</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">Показать все</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">Показать только спецификацию</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">Показать только спецификацию</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">Скрыть значения</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">Скрыть значения</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">Показать значения</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">Показать значения</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">Tümünü göster</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">Tümünü göster</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">Yalnızca belirtimi göster</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">Yalnızca belirtimi göster</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">Değerleri gizle</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">Değerleri gizle</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">Değerleri göster</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">Değerleri göster</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">全部显示</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">全部显示</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">仅显示规范</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">仅显示规范</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">隐藏值</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">隐藏值</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">显示值</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">显示值</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -148,23 +148,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowAll">
-        <source>Show all</source>
-        <target state="translated">全部顯示</target>
+        <source>Show all properties</source>
+        <target state="needs-review-translation">全部顯示</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
-        <source>Show spec only</source>
-        <target state="translated">僅顯示規格</target>
-        <note>Spec means from the resource specification</note>
+        <source>Show core properties</source>
+        <target state="needs-review-translation">僅顯示規格</target>
+        <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
-        <source>Hide values</source>
-        <target state="translated">隱藏值</target>
+        <source>Hide sensitive values</source>
+        <target state="needs-review-translation">隱藏值</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariablesShowVariableValues">
-        <source>Show values</source>
-        <target state="translated">顯示值</target>
+        <source>Show sensitive values</source>
+        <target state="needs-review-translation">顯示值</target>
         <note />
       </trans-unit>
       <trans-unit id="FluentDataGridHeaderCellGrowAriaLabelText">

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
@@ -9,6 +9,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Tests.Shared.DashboardModel;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
 
 namespace Aspire.Dashboard.Components.Tests.Controls;
@@ -53,8 +54,14 @@ public class ResourceDetailsTests : DashboardTestContext
                 Assert.True(e.IsValueMasked);
             });
 
+        var actionsButton = cut.Find(".resource-details-actions");
+        await actionsButton.ClickAsync(new MouseEventArgs());
+
         var maskAllSwitch = cut.Find(".mask-all-switch");
-        await maskAllSwitch.ClickAsync(new MouseEventArgs());
+
+        // HACK. Calling OnClick on the element isn't triggering the event correctly. Instead, call OnClick on the component.
+        var item = cut.FindComponents<FluentMenuItem>().Single(s => s.Instance.Class == maskAllSwitch.Attributes["class"]!.Value);
+        await cut.InvokeAsync(() => item.Instance.OnClick.InvokeAsync(new MouseEventArgs()));
 
         Assert.Collection(cut.Instance.FilteredEnvironmentVariables,
             e =>
@@ -137,8 +144,14 @@ public class ResourceDetailsTests : DashboardTestContext
                 Assert.True(e.IsValueMasked);
             });
 
+        var actionsButton = cut.Find(".resource-details-actions");
+        await actionsButton.ClickAsync(new MouseEventArgs());
+
         var maskAllSwitch = cut.Find(".mask-all-switch");
-        await maskAllSwitch.ClickAsync(new MouseEventArgs());
+
+        // HACK. Calling OnClick on the element isn't triggering the event correctly. Instead, call OnClick on the component.
+        var item = cut.FindComponents<FluentMenuItem>().Single(s => s.Instance.Class == maskAllSwitch.Attributes["class"]!.Value);
+        await cut.InvokeAsync(() => item.Instance.OnClick.InvokeAsync(new MouseEventArgs()));
 
         Assert.Collection(cut.Instance.FilteredEnvironmentVariables,
             e =>

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -36,6 +36,7 @@ internal static class ResourceSetupHelpers
         context.Services.AddSingleton<DashboardTelemetryService>();
         context.Services.AddSingleton<ComponentTelemetryContextProvider>();
         context.Services.AddSingleton<IAIContextProvider, TestAIContextProvider>();
+        context.Services.AddSingleton<GlobalState>();
 
         var version = typeof(FluentMain).Assembly.GetName().Version!;
 


### PR DESCRIPTION
Details actions were added to a control in span details. This PR does the same thing for resource details.

![resource-details-menu](https://github.com/user-attachments/assets/8b4e0357-9b6d-40dc-b9dc-5b79cc4a4147)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
