### PR TITLE
Fix Azure Container App Environment to respect AsExisting and WithComputeEnvironment

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
@@ -3,7 +3,13 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-internal sealed class ComputeEnvironmentAnnotation(IComputeEnvironmentResource computeEnvironment) : IResourceAnnotation
+/// <summary>
+/// Annotation that specifies which compute environment a resource should be deployed to.
+/// </summary>
+public sealed class ComputeEnvironmentAnnotation(IComputeEnvironmentResource computeEnvironment) : IResourceAnnotation
 {
+    /// <summary>
+    /// Gets the compute environment that the resource should be deployed to.
+    /// </summary>
     public IComputeEnvironmentResource ComputeEnvironment { get; } = computeEnvironment;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ComputeEnvironmentAnnotation.cs
@@ -6,6 +6,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Annotation that specifies which compute environment a resource should be deployed to.
 /// </summary>
+/// <param name="computeEnvironment">The compute environment that the resource should be deployed to.</param>
 public sealed class ComputeEnvironmentAnnotation(IComputeEnvironmentResource computeEnvironment) : IResourceAnnotation
 {
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes two critical bugs preventing Azure Container App deployments from using existing Container App Environments, causing permission failures when the deployment attempted to create new infrastructure instead of referencing existing resources.

## Problems Fixed

Issue #12977

1. Infrastructure Generation Ignores `AsExisting` Annotation

When a Container App Environment was marked with `.AsExisting()`, the infrastructure callback still created a brand new environment with all child resources (Container Registry, Log Analytics Workspace, User Assigned Identity, Dashboard, etc.) instead of referencing the existing environment. This caused deployment failures due to ACR access permission issues.

Location: `src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs:60-324`

2. Resource Assignment Ignores `WithComputeEnvironment` Binding

When multiple Container App Environments existed, resources were assigned to ALL environments instead of only their specified environment via `WithComputeEnvironment()`. The last environment processed would win, causing resources to be deployed to the wrong environment.

Location: `src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs:39-52`

## Changes Made

1. `AzureContainerAppExtensions.cs` - Added early-return logic in the infrastructure callback to detect `ExistingAzureResourceAnnotation` and call `AddAsExistingResource()` instead of creating new infrastructure
2. `AzureContainerAppsInfrastructure.cs` - Added logic to check `ComputeEnvironmentAnnotation` and only assign resources to their matching environment
3. ComputeEnvironmentAnnotation.cs` - Made the class public (was internal) with XML documentation to allow access from the `AppContainers` package
4. `AzureContainerAppsTests.cs` - Added comprehensive tests:
  - `AsExistingEnvironmentWithWithComputeEnvironmentBindsCorrectly` - Validates single existing environment scenario
  - `MultipleEnvironmentsWithAsExistingAndWithComputeEnvironmentBindsCorrectly` - Validates multiple existing environments with correct binding

## Test Plan

- New tests added for both single and multiple existing environment scenarios
- Validates correct environment assignment in DeploymentTargetAnnotation
- Verifies Bicep output uses FromExisting references instead of creating new resources
- Existing Container Apps tests pass without regression (requires manual verification due to unrelated schema validation issues)

## Breaking Changes

None - this is a bug fix that makes existing functionality work as documented.

## Related Issues

Fixes scenarios where:
  - `.AsExisting(environmentName, sharedResourceGroupName)` creates new infrastructure
  - `.WithComputeEnvironment(env)` doesn't bind resources to the correct environment
  - Deployments fail with ACR permission errors when using existing infrastructure

---
Note: The `ComputeEnvironmentAnnotation` visibility change from internal to public is intentional and necessary for the fix to work across assembly boundaries.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No