### PR TITLE
Remove .py files from being signed

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -10,8 +10,7 @@
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" Condition="!@(FileExtensionSignInfo->AnyHaveMetadataValue('Identity', '.msi'))" />
 
     <!-- Remove .py files from being signed. See https://github.com/dotnet/aspire/issues/13004 -->
-    <FileExtensionSignInfo Remove=".ps1;.psd1;.psm1;.psc1;.py" />
-    <FileExtensionSignInfo Include=".ps1;.psd1;.psm1;.psc1" CertificateName="Microsoft400" />
+    <FileExtensionSignInfo Remove=".py" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -8,6 +8,10 @@
 
     <!-- add missing entry for .msi, this can be removed once aspire uses arcade 10.0 -->
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" Condition="!@(FileExtensionSignInfo->AnyHaveMetadataValue('Identity', '.msi'))" />
+
+    <!-- Remove .py files from being signed. See https://github.com/dotnet/aspire/issues/13004 -->
+    <FileExtensionSignInfo Remove=".ps1;.psd1;.psm1;.psc1;.py" />
+    <FileExtensionSignInfo Include=".ps1;.psd1;.psm1;.psc1" CertificateName="Microsoft400" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Our python starter template has an Authenitcode signature block in its .py files. These aren't wanted because users are meant to change these templates.

Fix #13004

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
