### PR TITLE
[release/13.0] Remove .py and .js files from being signed (#13005)

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -3,14 +3,15 @@
   <ItemGroup>
     <FileExtensionSignInfo Update=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Update=".zip" CertificateName="None" />
-    <FileExtensionSignInfo Update=".js" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Update=".vsix" CertificateName="VsixSHA2" />
 
     <!-- add missing entry for .msi, this can be removed once aspire uses arcade 10.0 -->
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" Condition="!@(FileExtensionSignInfo->AnyHaveMetadataValue('Identity', '.msi'))" />
 
+    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
+    <FileExtensionSignInfo Update=".js" CertificateName="None" />
     <!-- Remove .py files from being signed. See https://github.com/dotnet/aspire/issues/13004 -->
-    <FileExtensionSignInfo Remove=".py" />
+    <FileExtensionSignInfo Update=".py" CertificateName="None" />
   </ItemGroup>
 
   <ItemGroup>
@@ -50,10 +51,6 @@
     <!-- Sign the manifest catalog on Windows -->
     <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="manifest.cat" CertificateName="MicrosoftDotNet500" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <NoSignJS>true</NoSignJS>
-  </PropertyGroup>
 
   <ItemGroup>
     <ItemsToSign Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' != 'true'" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -8,6 +8,9 @@
 
     <!-- add missing entry for .msi, this can be removed once aspire uses arcade 10.0 -->
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" Condition="!@(FileExtensionSignInfo->AnyHaveMetadataValue('Identity', '.msi'))" />
+
+    <!-- Remove .py files from being signed. See https://github.com/dotnet/aspire/issues/13004 -->
+    <FileExtensionSignInfo Remove=".py" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of #13005 to release/13.0

## Customer Impact

Our python starter template has an Authenitcode signature block in its .py and .js files. These aren't wanted because users are meant to change these templates.

We were also signing .js files in our aspire-starter template as well. Removing that as dotnet/aspnetcore doesn't sign its .js files either. This is only needed in the Windows Script Host.

Fix #13004

## Testing

None yet. I need an official branch to test it, I guess.

## Risk

Low. We don't have other .py files in our product. And the .js files are only loaded in a browser which doesn't verify the signature.

## Regression?

No
