### PR TITLE
Improve path validation for ExternalServiceResource to support reverse proxy scenarios

### DIFF
--- a/src/Aspire.Hosting/ExternalServiceResource.cs
+++ b/src/Aspire.Hosting/ExternalServiceResource.cs
@@ -21,6 +21,7 @@ public sealed class ExternalServiceResource : Resource
     /// <param name="uri">The URI for the external service.</param>
     /// <remarks>
     /// The URI must be an absolute URI with the absolute path ending with '/'.
+    /// The URI cannot contain a fragment or query string.
     /// </remarks>
     public ExternalServiceResource(string name, Uri uri) : base(name)
     {

--- a/src/Aspire.Hosting/ExternalServiceResource.cs
+++ b/src/Aspire.Hosting/ExternalServiceResource.cs
@@ -20,7 +20,7 @@ public sealed class ExternalServiceResource : Resource
     /// <param name="name">The name of the resource.</param>
     /// <param name="uri">The URI for the external service.</param>
     /// <remarks>
-    /// The URI must be an absolute URI with the absolute path set to "/".
+    /// The URI must be an absolute URI with the absolute path ending with '/'.
     /// </remarks>
     public ExternalServiceResource(string name, Uri uri) : base(name)
     {
@@ -85,13 +85,17 @@ public sealed class ExternalServiceResource : Resource
         {
             return new ArgumentException("The URI for the external service must be absolute.", nameof(uri));
         }
-        if (uri.AbsolutePath != "/")
+        if (!uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal))
         {
-            return new ArgumentException("The URI absolute path must be \"/\".", nameof(uri));
+            return new ArgumentException("The URI absolute path must end with '/'.", nameof(uri));
         }
         if (!string.IsNullOrEmpty(uri.Fragment))
         {
             return new ArgumentException("The URI cannot contain a fragment.", nameof(uri));
+        }
+        if (!string.IsNullOrEmpty(uri.Query))
+        {
+            return new ArgumentException("The URI cannot contain a query string.", nameof(uri));
         }
         return null;
     }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -591,9 +591,9 @@ public static class ResourceBuilderExtensions
             throw new InvalidOperationException("The uri for service reference must be absolute.");
         }
 
-        if (uri.AbsolutePath != "/")
+        if (!uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal))
         {
-            throw new InvalidOperationException("The uri absolute path must be \"/\".");
+            throw new InvalidOperationException("The uri absolute path must end with '/'.");
         }
 
         // Determine what to inject based on the annotation on the destination resource

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -596,6 +596,16 @@ public static class ResourceBuilderExtensions
             throw new InvalidOperationException("The uri absolute path must end with '/'.");
         }
 
+        if (!string.IsNullOrEmpty(uri.Fragment))
+        {
+            throw new InvalidOperationException("The URI cannot contain a fragment.");
+        }
+
+        if (!string.IsNullOrEmpty(uri.Query))
+        {
+            throw new InvalidOperationException("The URI cannot contain a query string.");
+        }
+
         // Determine what to inject based on the annotation on the destination resource
         builder.Resource.TryGetLastAnnotation<ReferenceEnvironmentInjectionAnnotation>(out var injectionAnnotation);
         var flags = injectionAnnotation?.Flags ?? ReferenceEnvironmentInjectionFlags.All;

--- a/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
@@ -53,9 +53,12 @@ public class ExternalServiceTests
     [Theory]
     [InlineData("not-a-url")]
     [InlineData("")]
-    [InlineData("https://example.com/path")]
-    [InlineData("https://example.com/path?query=value")]
-    [InlineData("https://example.com#fragment")]
+    [InlineData("https://example.com/path")]  // Invalid: missing trailing slash
+    [InlineData("https://example.com/path?query=value")]  // Invalid: has query string
+    [InlineData("https://example.com#fragment")]  // Invalid: has fragment
+    [InlineData("https://example.com/service")]  // Invalid: missing trailing slash
+    [InlineData("https://example.com/service/sub")]  // Invalid: missing trailing slash
+    [InlineData("https://example.com/?query=1")]  // Invalid: has query string
     public void AddExternalServiceThrowsWithInvalidUrl(string invalidUrl)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -75,19 +78,21 @@ public class ExternalServiceTests
     }
 
     [Fact]
-    public void AddExternalServiceThrowsWithUriWithPath()
+    public void AddExternalServiceThrowsWithUriWithoutTrailingSlash()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var uriWithPath = new Uri("https://api.example.com/api/v1");
         var ex = Assert.Throws<ArgumentException>(() => builder.AddExternalService("nuget", uriWithPath));
-        Assert.Contains("absolute path must be \"/\"", ex.Message);
+        Assert.Contains("absolute path must end with '/'", ex.Message);
     }
 
     [Theory]
     [InlineData("https://nuget.org/")]
     [InlineData("http://localhost/")]
     [InlineData("https://example.com:8080/")]
+    [InlineData("https://gateway/orders-service/")]  // Path with trailing slash
+    [InlineData("https://gateway/api/v1/")]  // Nested path with trailing slash
     public void AddExternalServiceAcceptsValidUrls(string validUrl)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -277,7 +282,24 @@ public class ExternalServiceTests
         Assert.False(ExternalServiceResource.UrlIsValidForExternalService("https://nuget.org/path", out var pathUri, out var pathMessage));
         Assert.Null(pathUri);
         Assert.NotNull(pathMessage);
-        Assert.Contains("absolute path must be \"/\"", pathMessage);
+        Assert.Contains("absolute path must end with '/'", pathMessage);
+
+        // Test valid paths with trailing slash
+        Assert.True(ExternalServiceResource.UrlIsValidForExternalService("https://gateway/orders-service/", out var validPathUri, out var validPathMessage));
+        Assert.Equal("https://gateway/orders-service/", validPathUri!.ToString());
+        Assert.Null(validPathMessage);
+
+        // Test fragment rejection
+        Assert.False(ExternalServiceResource.UrlIsValidForExternalService("https://nuget.org/#fragment", out var fragmentUri, out var fragmentMessage));
+        Assert.Null(fragmentUri);
+        Assert.NotNull(fragmentMessage);
+        Assert.Contains("fragment", fragmentMessage);
+
+        // Test query string rejection
+        Assert.False(ExternalServiceResource.UrlIsValidForExternalService("https://nuget.org/?query=1", out var queryUri, out var queryMessage));
+        Assert.Null(queryUri);
+        Assert.NotNull(queryMessage);
+        Assert.Contains("query", queryMessage);
     }
 
     [Fact]
@@ -448,6 +470,100 @@ public class ExternalServiceTests
         var manifest = await ManifestUtils.GetManifest(project.Resource);
 
         await Verify(manifest.ToString(), extension: "json");
+    }
+
+    [Theory]
+    [InlineData("https://host/")]
+    [InlineData("https://host/service/")]
+    [InlineData("https://host/service/sub/")]
+    [InlineData("https://host/service/sub/deep/")]
+    [InlineData("http://gateway:8080/api/v1/")]
+    public void ExternalServiceAcceptsPathsWithTrailingSlash(string validUrl)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var externalService = builder.AddExternalService("service", validUrl);
+
+        Assert.Equal("service", externalService.Resource.Name);
+        Assert.Equal(validUrl, externalService.Resource.Uri?.ToString());
+    }
+
+    [Theory]
+    [InlineData("https://host/service")]
+    [InlineData("https://host/service/sub")]
+    [InlineData("https://host/api")]
+    [InlineData("https://host/service?query=1")]
+    public void ExternalServiceRejectsPathsWithoutTrailingSlash(string invalidUrl)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var ex = Assert.Throws<ArgumentException>(() => builder.AddExternalService("service", invalidUrl));
+        Assert.Contains("absolute path must end with '/'", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("https://host/service/#frag")]
+    [InlineData("https://host/#fragment")]
+    [InlineData("https://host/service/#")]
+    public void ExternalServiceRejectsUrisWithFragment(string invalidUrl)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var ex = Assert.Throws<ArgumentException>(() => builder.AddExternalService("service", invalidUrl));
+        Assert.Contains("fragment", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("https://host/service/?query=1")]
+    [InlineData("https://host/?query=value")]
+    [InlineData("https://host/service/?key=value&other=data")]
+    public void ExternalServiceRejectsUrisWithQueryString(string invalidUrl)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var ex = Assert.Throws<ArgumentException>(() => builder.AddExternalService("service", invalidUrl));
+        Assert.Contains("query", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExternalServiceWithPathCanBeReferenced()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var externalService = builder.AddExternalService("gateway", "https://gateway.example.com/orders-service/");
+        var project = builder.AddProject<TestProject>("project")
+                             .WithReference(externalService);
+
+        // Call environment variable callbacks.
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(project.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
+
+        // Check that service discovery information was injected with the full URL including path
+        Assert.Contains(config, kvp => kvp.Key == "services__gateway__https__0" && kvp.Value == "https://gateway.example.com/orders-service/");
+        Assert.Contains(config, kvp => kvp.Key == "GATEWAY" && kvp.Value == "https://gateway.example.com/orders-service/");
+    }
+
+    [Fact]
+    public void WithReferenceThrowsForUriWithoutTrailingSlash()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var project = builder.AddProject<TestProject>("project");
+
+        var uri = new Uri("https://api.example.com/service");
+        var ex = Assert.Throws<InvalidOperationException>(() => project.WithReference("api", uri));
+        Assert.Contains("absolute path must end with '/'", ex.Message);
+    }
+
+    [Fact]
+    public void WithReferenceAcceptsUriWithPathAndTrailingSlash()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var project = builder.AddProject<TestProject>("project");
+
+        var uri = new Uri("https://api.example.com/service/");
+        // Should not throw
+        project.WithReference("api", uri);
     }
 
     private sealed class TestProject : IProjectMetadata


### PR DESCRIPTION
## Description

This PR improves URL validation for `ExternalServiceResource` and fixes an exception when the URL contains a base path:

1. Relax path validation to allow URLs with a base path like `https://api-gateway/orders-api/`
2. Invalidate URLs containing a query string (consistent with how URL fragments are invalidated)

Fixes #13025

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
