### PR TITLE
Improve cancellation.

### DIFF
--- a/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
+++ b/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
@@ -119,7 +119,7 @@ internal sealed class DotNetSdkInstaller(IFeatures features, IConfiguration conf
 
             return (meetsMinimum, highestVersion?.ToString(), minimumVersion, forceInstall);
         }
-        catch
+        catch (Exception ex) when (ex is not OperationCanceledException) // If cancellation is requested let that bubble up.
         {
             // If we can't start the process, the SDK is not available
             return (false, null, minimumVersion, forceInstall);

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -257,6 +257,16 @@ public class Program
 
     public static async Task<int> Main(string[] args)
     {
+        // Setup handling of CTRL-C as early as possible so that if
+        // we get a CTRL-C anywhere that is not handled by Spectre Console
+        // already that we know to trigger cancellation.
+        var cts = new CancellationTokenSource();
+        Console.CancelKeyPress += (sender, eventArgs) =>
+        {
+            cts.Cancel();
+            eventArgs.Cancel = true;
+        };
+
         Console.OutputEncoding = Encoding.UTF8;
 
         using var app = await BuildApplicationAsync(args);
@@ -272,7 +282,7 @@ public class Program
 
         var telemetry = app.Services.GetRequiredService<AspireCliTelemetry>();
         using var activity = telemetry.ActivitySource.StartActivity();
-        var exitCode = await rootCommand.Parse(args).InvokeAsync(invokeConfig);
+        var exitCode = await rootCommand.Parse(args).InvokeAsync(invokeConfig, cts.Token);
 
         await app.StopAsync().ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -260,7 +260,7 @@ public class Program
         // Setup handling of CTRL-C as early as possible so that if
         // we get a CTRL-C anywhere that is not handled by Spectre Console
         // already that we know to trigger cancellation.
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         Console.CancelKeyPress += (sender, eventArgs) =>
         {
             cts.Cancel();


### PR DESCRIPTION
Should fix #11386

It is extremely tight timing but with this change I am no longer able to reproduce the issue. It highlighted another timing dependent bug on SDK detection that might make the report that the SDK is not installed.

We should not put this into 13.0.1 as I will want it to exist in `main` for a while since it might surface other bugs around cancellation handling like it did with the SDK install.