### PR TITLE
[release/13.0] EndpointReference evaluation should wait on missing AllocatedEndpoint (#13074)

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -293,10 +293,16 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
         {
             // We are going to take the first snapshot that matches the context network ID. In general there might be multiple endpoints for a single service,
             // and in future we might need some sort of policy to choose between them, but for now we just take the first one.
-            var nes = Endpoint.EndpointAnnotation.AllAllocatedEndpoints.Where(nes => nes.NetworkID == networkContext).FirstOrDefault();
+            var endpointSnapshots = Endpoint.EndpointAnnotation.AllAllocatedEndpoints;
+            var nes = endpointSnapshots.Where(nes => nes.NetworkID == networkContext).FirstOrDefault();
             if (nes is null)
             {
-                return null;
+                nes = new NetworkEndpointSnapshot(new ValueSnapshot<AllocatedEndpoint>(), networkContext);
+                if (!endpointSnapshots.TryAdd(networkContext, nes.Snapshot))
+                {
+                    // Someone else added it first, use theirs.
+                    nes = endpointSnapshots.Where(nes => nes.NetworkID == networkContext).First();
+                }
             }
 
             var allocatedEndpoint = await nes.Snapshot.GetValueAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Description

A fix to restore proper EndpointReference resolution behavior, which should wait on missing AllocatedEndpoint instead of resolving as empty value. This bug can break existing applications and tests.

Fixes https://github.com/dotnet/aspire/issues/12823

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
