### PR TITLE
Fix Azure cross-tenant authentication by using lazy credential creation

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultTokenCredentialProvider.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Internal/DefaultTokenCredentialProvider.cs
@@ -11,7 +11,11 @@ namespace Aspire.Hosting.Azure.Provisioning.Internal;
 internal class DefaultTokenCredentialProvider : ITokenCredentialProvider
 {
     private readonly ILogger<DefaultTokenCredentialProvider> _logger;
-    private readonly TokenCredential _credential;
+    private readonly IOptions<AzureProvisionerOptions> _options;
+    private readonly DistributedApplicationExecutionContext _distributedApplicationExecutionContext;
+    private TokenCredential? _credential;
+    private string? _lastTenantId;
+    private readonly object _lock = new();
 
     public DefaultTokenCredentialProvider(
         ILogger<DefaultTokenCredentialProvider> logger,
@@ -19,36 +23,69 @@ internal class DefaultTokenCredentialProvider : ITokenCredentialProvider
         DistributedApplicationExecutionContext distributedApplicationExecutionContext)
     {
         _logger = logger;
+        _options = options;
+        _distributedApplicationExecutionContext = distributedApplicationExecutionContext;
+    }
 
-        // Optionally configured in AppHost appSettings under "Azure" : { "CredentialSource": "AzureCli" }
-        var credentialSetting = options.Value.CredentialSource;
+    public TokenCredential TokenCredential
+    {
+        get
+        {
+            lock (_lock)
+            {
+                var currentTenantId = _options.Value.TenantId;
+
+                // Recreate credential if tenant ID has changed or credential doesn't exist
+                if (_credential == null || _lastTenantId != currentTenantId)
+                {
+                    _credential = CreateCredential(currentTenantId);
+                    _lastTenantId = currentTenantId;
+                }
+
+                return _credential;
+            }
+        }
+    }
+
+    private TokenCredential CreateCredential(string? tenantId)
+    {
+        var credentialSetting = _options.Value.CredentialSource;
 
         TokenCredential credential = credentialSetting switch
         {
             "AzureCli" => new AzureCliCredential(new()
             {
+                TenantId = tenantId,
                 AdditionallyAllowedTenants = { "*" }
             }),
             "AzurePowerShell" => new AzurePowerShellCredential(new()
             {
+                TenantId = tenantId,
                 AdditionallyAllowedTenants = { "*" }
             }),
             "VisualStudio" => new VisualStudioCredential(new()
             {
+                TenantId = tenantId,
                 AdditionallyAllowedTenants = { "*" }
             }),
             "AzureDeveloperCli" => new AzureDeveloperCliCredential(new()
             {
+                TenantId = tenantId,
                 AdditionallyAllowedTenants = { "*" }
             }),
-            "InteractiveBrowser" => new InteractiveBrowserCredential(),
-            // Use AzureCli as default for publish mode when no explicit credential source is set
-            null or "Default" when distributedApplicationExecutionContext.IsPublishMode => new AzureCliCredential(new()
+            "InteractiveBrowser" => new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions()
             {
+                TenantId = tenantId
+            }),
+            // Use AzureCli as default for publish mode when no explicit credential source is set
+            null or "Default" when _distributedApplicationExecutionContext.IsPublishMode => new AzureCliCredential(new()
+            {
+                TenantId = tenantId,
                 AdditionallyAllowedTenants = { "*" }
             }),
             _ => new DefaultAzureCredential(new DefaultAzureCredentialOptions()
             {
+                TenantId = tenantId,
                 ExcludeManagedIdentityCredential = true,
                 ExcludeWorkloadIdentityCredential = true,
                 ExcludeAzurePowerShellCredential = true,
@@ -57,13 +94,12 @@ internal class DefaultTokenCredentialProvider : ITokenCredentialProvider
             })
         };
 
-        _credential = credential;
+        return credential;
     }
-
-    public TokenCredential TokenCredential => _credential;
 
     internal void LogCredentialType()
     {
-        _logger.LogInformation("Using {credentialType} for provisioning.", _credential.GetType().Name);
+        var credential = TokenCredential;
+        _logger.LogInformation("Using {credentialType} for provisioning.", credential.GetType().Name);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #13088

Changes `DefaultTokenCredentialProvider` to use lazy credential initialization, allowing credentials to be recreated when the tenant ID changes during the interactive `aspire deploy` workflow.

## Problem

Users could not authenticate to Azure subscriptions in non-default tenants when using `aspire deploy`. The token credential was created at service instantiation time with the initial (null) tenant ID. When users later selected a different tenant via the interactive prompt, the credential was never recreated, causing "wrong issuer" authentication errors.

## Solution

### Key Changes

1. **Lazy Credential Creation**: Credentials are now created on first access, not in the constructor
2. **Tenant ID Change Detection**: Credentials are recreated when tenant ID changes
3. **Thread Safety**: Added lock for thread-safe credential creation
4. **Efficient Reuse**: Credentials are reused when tenant ID remains unchanged

### Implementation Details

```csharp
// Before: Eager creation in constructor
public DefaultTokenCredentialProvider(...)
{
    _credential = CreateCredential(options.Value.TenantId); // Fixed at construction
}

// After: Lazy creation with change detection
public TokenCredential TokenCredential
{
    get
    {
        lock (_lock)
        {
            var currentTenantId = _options.Value.TenantId;
            if (_credential == null || _lastTenantId != currentTenantId)
            {
                _credential = CreateCredential(currentTenantId);
                _lastTenantId = currentTenantId;
            }
            return _credential;
        }
    }
}
```

### Workflow Impact

This fix enables the following workflow:
1. App starts, provider is instantiated (no credential created yet)
2. User runs `aspire deploy`
3. User selects tenant from interactive prompt
4. `_options.TenantId` is set to selected tenant
5. Credential is created with correct tenant ID on first access
6. Authentication succeeds for non-default tenants

## Testing

Added 5 new test cases:
- `TokenCredential_TenantIdChanges_RecreatesCredential` - Verifies credential recreation on tenant change
- `TokenCredential_TenantIdUnchanged_ReturnsSameCredential` - Verifies efficient reuse
- `TokenCredential_TenantIdSetFromNull_RecreatesCredential` - Tests initial null → value scenario
- `TokenCredential_MultipleCredentialTypes_RespectsCurrentTenantId` - Tests with different credential sources
- `TokenCredential_LazyInitialization_DoesNotCreateUntilAccessed` - Verifies lazy creation

All 15 tests in `DefaultTokenCredentialProviderTests` pass.

## Breaking Changes

None. This is a transparent implementation change that maintains backward compatibility.

## Related

- Affects all credential types: AzureCli, AzureDeveloperCli, AzurePowerShell, VisualStudio, InteractiveBrowser, DefaultAzureCredential
- Enables cross-tenant scenarios for Azure deployment
- No changes required to user code or configuration