### PR TITLE
Add Schema Registry option to the Kafka hosting package.

### DIFF
--- a/playground/kafka/KafkaBasic.AppHost/AppHost.cs
+++ b/playground/kafka/KafkaBasic.AppHost/AppHost.cs
@@ -5,7 +5,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var kafka = builder.AddKafka("kafka")
     .WithKafkaUI(kafkaUi => kafkaUi.WithHostPort(8080))
-    .WithKafkaSchemaRegistry(registry => registry.WithHostPort(7000));
+    .WithKafkaSchemaRegistry("schema-registry",registry => registry.WithHostPort(7000));
 
 builder.AddProject<Projects.Producer>("producer")
     .WithReference(kafka).WaitFor(kafka)

--- a/playground/kafka/KafkaBasic.AppHost/AppHost.cs
+++ b/playground/kafka/KafkaBasic.AppHost/AppHost.cs
@@ -18,7 +18,19 @@ builder.AddProject<Projects.Consumer>("consumer")
     .WithReference(kafka).WaitFor(kafka)
     .WithArgs(kafka.Resource.Name);
 
-builder.AddKafka("kafka2").WithKafkaUI();
+var kafka2 = builder.AddKafka("kafka2").WithKafkaUI();
+var schemaRegistry2 =
+    kafka2.WithKafkaSchemaRegistry(registry => registry.WithHostPort(7001),"schema-registry-2");
+
+builder.AddProject<Projects.Producer>("producer-2")
+    .WithReference(schemaRegistry2)
+    .WithReference(kafka2).WaitFor(kafka2)
+    .WithArgs(kafka.Resource.Name);
+
+builder.AddProject<Projects.Consumer>("consumer-2")
+    .WithReference(kafka2).WaitFor(kafka2)
+    .WithArgs(kafka.Resource.Name);
+
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
 // or build with `/p:SkipDashboardReference=true`, to test end developer

--- a/playground/kafka/KafkaBasic.AppHost/AppHost.cs
+++ b/playground/kafka/KafkaBasic.AppHost/AppHost.cs
@@ -4,10 +4,13 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kafka = builder.AddKafka("kafka")
-    .WithKafkaUI(kafkaUi => kafkaUi.WithHostPort(8080))
-    .WithKafkaSchemaRegistry("schema-registry",registry => registry.WithHostPort(7000));
+    .WithKafkaUI(kafkaUi => kafkaUi.WithHostPort(8080));
+
+var schemaRegistry =
+    kafka.WithKafkaSchemaRegistry("schema-registry", registry => registry.WithHostPort(7000));
 
 builder.AddProject<Projects.Producer>("producer")
+    .WithReference(schemaRegistry)
     .WithReference(kafka).WaitFor(kafka)
     .WithArgs(kafka.Resource.Name);
 
@@ -22,8 +25,8 @@ builder.AddKafka("kafka2").WithKafkaUI();
 // dashboard launch experience, Refer to Directory.Build.props for the path to
 // the dashboard binary (defaults to the Aspire.Dashboard bin output in the
 // artifacts dir).
-//#if !SKIP_DASHBOARD_REFERENCE
+#if !SKIP_DASHBOARD_REFERENCE
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
-//#endif
+#endif
 
 builder.Build().Run();

--- a/playground/kafka/KafkaBasic.AppHost/AppHost.cs
+++ b/playground/kafka/KafkaBasic.AppHost/AppHost.cs
@@ -7,7 +7,7 @@ var kafka = builder.AddKafka("kafka")
     .WithKafkaUI(kafkaUi => kafkaUi.WithHostPort(8080));
 
 var schemaRegistry =
-    kafka.WithKafkaSchemaRegistry("schema-registry", registry => registry.WithHostPort(7000));
+    kafka.WithKafkaSchemaRegistry(registry => registry.WithHostPort(7000),"schema-registry");
 
 builder.AddProject<Projects.Producer>("producer")
     .WithReference(schemaRegistry)

--- a/playground/kafka/KafkaBasic.AppHost/AppHost.cs
+++ b/playground/kafka/KafkaBasic.AppHost/AppHost.cs
@@ -4,7 +4,8 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kafka = builder.AddKafka("kafka")
-    .WithKafkaUI(kafkaUi => kafkaUi.WithHostPort(8080));
+    .WithKafkaUI(kafkaUi => kafkaUi.WithHostPort(8080))
+    .WithKafkaSchemaRegistry(registry => registry.WithHostPort(7000));
 
 builder.AddProject<Projects.Producer>("producer")
     .WithReference(kafka).WaitFor(kafka)
@@ -15,15 +16,14 @@ builder.AddProject<Projects.Consumer>("consumer")
     .WithArgs(kafka.Resource.Name);
 
 builder.AddKafka("kafka2").WithKafkaUI();
-
-#if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
 // or build with `/p:SkipDashboardReference=true`, to test end developer
 // dashboard launch experience, Refer to Directory.Build.props for the path to
 // the dashboard binary (defaults to the Aspire.Dashboard bin output in the
 // artifacts dir).
+//#if !SKIP_DASHBOARD_REFERENCE
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
-#endif
+//#endif
 
 builder.Build().Run();

--- a/playground/kafka/KafkaBasic.AppHost/AppHost.cs
+++ b/playground/kafka/KafkaBasic.AppHost/AppHost.cs
@@ -7,7 +7,7 @@ var kafka = builder.AddKafka("kafka")
     .WithKafkaUI(kafkaUi => kafkaUi.WithHostPort(8080));
 
 var schemaRegistry =
-    kafka.WithKafkaSchemaRegistry(registry => registry.WithHostPort(7000),"schema-registry");
+    kafka.WithKafkaSchemaRegistry(registry => registry.WithHostPort(7000), "schema-registry");
 
 builder.AddProject<Projects.Producer>("producer")
     .WithReference(schemaRegistry)
@@ -20,16 +20,16 @@ builder.AddProject<Projects.Consumer>("consumer")
 
 var kafka2 = builder.AddKafka("kafka2").WithKafkaUI();
 var schemaRegistry2 =
-    kafka2.WithKafkaSchemaRegistry(registry => registry.WithHostPort(7001),"schema-registry-2");
+    kafka2.WithKafkaSchemaRegistry(registry => registry.WithHostPort(7001), "schema-registry-2");
 
 builder.AddProject<Projects.Producer>("producer-2")
     .WithReference(schemaRegistry2)
     .WithReference(kafka2).WaitFor(kafka2)
-    .WithArgs(kafka.Resource.Name);
+    .WithArgs(kafka2.Resource.Name);
 
 builder.AddProject<Projects.Consumer>("consumer-2")
     .WithReference(kafka2).WaitFor(kafka2)
-    .WithArgs(kafka.Resource.Name);
+    .WithArgs(kafka2.Resource.Name);
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -161,7 +161,7 @@ public static class KafkaBuilderExtensions
     /// <param name="configureContainer">Configuration callback for KafkaUI container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KafkaServerResource}"/>.</returns>
-    public static IResourceBuilder<KafkaServerResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, string? containerName = null, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null)
+    public static IResourceBuilder<KafkaSchemaRegistryResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, string? containerName = null, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -169,7 +169,7 @@ public static class KafkaBuilderExtensions
         {
             var builderForExistingResource = builder.ApplicationBuilder.CreateResourceBuilder(existingKafkaSchemaRegistryResource);
             configureContainer?.Invoke(builderForExistingResource);
-            return builder;
+            return builderForExistingResource;
         }
 
         containerName ??= "kafka-schema-registry";
@@ -189,7 +189,7 @@ public static class KafkaBuilderExtensions
 
         configureContainer?.Invoke(kafkaSchemaRegistryBuilder);
 
-        return builder;
+        return kafkaSchemaRegistryBuilder;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -152,15 +152,15 @@ public static class KafkaBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a Kafka UI container to the application.
+    /// Adds a Kafka Schema Registry container to the application.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.KafkaUiTag"/> tag of the <inheritdoc cref="KafkaContainerImageTags.KafkaUiImage"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.KafkaSchemaRegistryTag"/> tag of the <inheritdoc cref="KafkaContainerImageTags.KafkaSchemaRegistryImage"/> container image.
     /// </remarks>
     /// <param name="builder">The Kafka server resource builder.</param>
     /// <param name="configureContainer">Configuration callback for KafkaUI container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{KafkaServerResource}"/>.</returns>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KafkaSchemaRegistryResource}"/>.</returns>
     public static IResourceBuilder<KafkaSchemaRegistryResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, string? containerName = null, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -210,11 +210,11 @@ public static class KafkaBuilderExtensions
     }
 
     /// <summary>
-    /// Configures the host port that the Kakfa Schema Registry resource is exposed on instead of using randomly assigned port.
+    /// Configures the host port that the Kafka Schema Registry resource is exposed on instead of using randomly assigned port.
     /// </summary>
-    /// <param name="builder">The resource builder for Kakfa Schema Registry.</param>
+    /// <param name="builder">The resource builder for Kafka Schema Registry.</param>
     /// <param name="port">The port to bind on the host. If <see langword="null"/> is used random port will be assigned.</param>
-    /// <returns>The resource builder for Kakfa Schema Registry.</returns>
+    /// <returns>The resource builder for Kafka Schema Registry.</returns>
     public static IResourceBuilder<KafkaSchemaRegistryResource> WithHostPort(this IResourceBuilder<KafkaSchemaRegistryResource> builder, int? port)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -17,6 +17,8 @@ public static class KafkaBuilderExtensions
     private const int KafkaBrokerPort = 9092;
     private const int KafkaInternalBrokerPort = 9093;
     private const int KafkaUIPort = 8080;
+    private const int KafkaSchemaRegistryPort = 8081;
+
     private const string Target = "/var/lib/kafka/data";
 
     /// <summary>
@@ -150,6 +152,47 @@ public static class KafkaBuilderExtensions
     }
 
     /// <summary>
+    /// Adds a Kafka UI container to the application.
+    /// </summary>
+    /// <remarks>
+    /// This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.KafkaUiTag"/> tag of the <inheritdoc cref="KafkaContainerImageTags.KafkaUiImage"/> container image.
+    /// </remarks>
+    /// <param name="builder">The Kafka server resource builder.</param>
+    /// <param name="configureContainer">Configuration callback for KafkaUI container resource.</param>
+    /// <param name="containerName">The name of the container (Optional).</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KafkaServerResource}"/>.</returns>
+    public static IResourceBuilder<KafkaServerResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null, string? containerName = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (builder.ApplicationBuilder.Resources.OfType<KafkaSchemaRegistryResource>().SingleOrDefault() is { } existingKafkaSchemaRegistryResource)
+        {
+            var builderForExistingResource = builder.ApplicationBuilder.CreateResourceBuilder(existingKafkaSchemaRegistryResource);
+            configureContainer?.Invoke(builderForExistingResource);
+            return builder;
+        }
+
+        containerName ??= "kafka-schema-registry";
+        var kafkaSchemaRegistry = new KafkaSchemaRegistryResource(containerName);
+        var kafkaSchemaRegistryBuilder = builder.ApplicationBuilder.AddResource(kafkaSchemaRegistry)
+            .WithImage(KafkaContainerImageTags.KafkaSchemaRegistryImage, KafkaContainerImageTags.KafkaSchemaRegistryTag)
+            .WithImageRegistry(KafkaContainerImageTags.Registry)
+            .WithHttpEndpoint(8081, targetPort: KafkaSchemaRegistryPort, name: "primary")
+            .WithEnvironment(context =>
+            {
+                context.EnvironmentVariables["SCHEMA_REGISTRY_HOST_NAME"] = "localhost";
+                context.EnvironmentVariables["SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS"] = "kafka:9093";
+                context.EnvironmentVariables["SCHEMA_REGISTRY_LISTENERS"] = $"http://0.0.0.0:{KafkaSchemaRegistryPort}"; })
+            .WithHttpHealthCheck("/subjects", 200, "primary")
+            .WaitFor(builder)
+            .ExcludeFromManifest();
+
+        configureContainer?.Invoke(kafkaSchemaRegistryBuilder);
+
+        return builder;
+    }
+
+    /// <summary>
     /// Configures the host port that the KafkaUI resource is exposed on instead of using randomly assigned port.
     /// </summary>
     /// <param name="builder">The resource builder for KafkaUI.</param>
@@ -163,6 +206,26 @@ public static class KafkaBuilderExtensions
         return builder.WithEndpoint("http", endpoint =>
         {
             endpoint.Port = port;
+        });
+    }
+
+    /// <summary>
+    /// Configures the host port that the Kakfa Schema Registry resource is exposed on instead of using randomly assigned port.
+    /// </summary>
+    /// <param name="builder">The resource builder for Kakfa Schema Registry.</param>
+    /// <param name="port">The port to bind on the host. If <see langword="null"/> is used random port will be assigned.</param>
+    /// <returns>The resource builder for Kakfa Schema Registry.</returns>
+    public static IResourceBuilder<KafkaSchemaRegistryResource> WithHostPort(this IResourceBuilder<KafkaSchemaRegistryResource> builder, int? port)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEndpoint("primary", endpoint =>
+        {
+            endpoint.Port = port;
+            if (endpoint.TargetPort == 0)
+            {
+                endpoint.TargetPort = KafkaSchemaRegistryPort;
+            }
         });
     }
 

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -164,15 +164,8 @@ public static class KafkaBuilderExtensions
     public static IResourceBuilder<KafkaSchemaRegistryResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null, string? containerName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-
-        if (builder.ApplicationBuilder.Resources.OfType<KafkaSchemaRegistryResource>().SingleOrDefault() is { } existingKafkaSchemaRegistryResource)
-        {
-            var builderForExistingResource = builder.ApplicationBuilder.CreateResourceBuilder(existingKafkaSchemaRegistryResource);
-            configureContainer?.Invoke(builderForExistingResource);
-            return builderForExistingResource;
-        }
-
         containerName ??= "kafka-schema-registry";
+
         var kafkaSchemaRegistry = new KafkaSchemaRegistryResource(containerName);
         var kafkaSchemaRegistryBuilder = builder.ApplicationBuilder.AddResource(kafkaSchemaRegistry)
             .WithImage(KafkaContainerImageTags.KafkaSchemaRegistryImage, KafkaContainerImageTags.KafkaSchemaRegistryTag)

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -158,9 +158,11 @@ public static class KafkaBuilderExtensions
     /// This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.KafkaSchemaRegistryTag"/> tag of the <inheritdoc cref="KafkaContainerImageTags.KafkaSchemaRegistryImage"/> container image.
     /// </remarks>
     /// <param name="builder">The Kafka server resource builder.</param>
-    /// <param name="configureContainer">Configuration callback for KafkaUI container resource.</param>
+    /// <param name="configureContainer">Configuration callback for Kafka Schema Registry container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KafkaSchemaRegistryResource}"/>.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport(RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<KafkaSchemaRegistryResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null, string? containerName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -175,7 +177,8 @@ public static class KafkaBuilderExtensions
             {
                 context.EnvironmentVariables["SCHEMA_REGISTRY_HOST_NAME"] = "localhost";
                 context.EnvironmentVariables["SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS"] = builder.Resource.InternalEndpoint.Property(EndpointProperty.HostAndPort);
-                context.EnvironmentVariables["SCHEMA_REGISTRY_LISTENERS"] = $"http://0.0.0.0:{KafkaSchemaRegistryPort}"; })
+                context.EnvironmentVariables["SCHEMA_REGISTRY_LISTENERS"] = $"http://0.0.0.0:{KafkaSchemaRegistryPort}";
+            })
             .WithHttpHealthCheck("/subjects", 200, "primary")
             .WaitFor(builder)
             .ExcludeFromManifest();
@@ -208,6 +211,7 @@ public static class KafkaBuilderExtensions
     /// <param name="builder">The resource builder for Kafka Schema Registry.</param>
     /// <param name="port">The port to bind on the host. If <see langword="null"/> is used random port will be assigned.</param>
     /// <returns>The resource builder for Kafka Schema Registry.</returns>
+    [AspireExport("withKafkaSchemaRegistryHostPort", MethodName = "withHostPort")]
     public static IResourceBuilder<KafkaSchemaRegistryResource> WithHostPort(this IResourceBuilder<KafkaSchemaRegistryResource> builder, int? port)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -161,7 +161,7 @@ public static class KafkaBuilderExtensions
     /// <param name="configureContainer">Configuration callback for KafkaUI container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KafkaServerResource}"/>.</returns>
-    public static IResourceBuilder<KafkaServerResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null, string? containerName = null)
+    public static IResourceBuilder<KafkaServerResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, string? containerName = null, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -177,7 +177,7 @@ public static class KafkaBuilderExtensions
         var kafkaSchemaRegistryBuilder = builder.ApplicationBuilder.AddResource(kafkaSchemaRegistry)
             .WithImage(KafkaContainerImageTags.KafkaSchemaRegistryImage, KafkaContainerImageTags.KafkaSchemaRegistryTag)
             .WithImageRegistry(KafkaContainerImageTags.Registry)
-            .WithHttpEndpoint(8081, targetPort: KafkaSchemaRegistryPort, name: "primary")
+            .WithHttpEndpoint(targetPort: KafkaSchemaRegistryPort, name: "primary")
             .WithEnvironment(context =>
             {
                 context.EnvironmentVariables["SCHEMA_REGISTRY_HOST_NAME"] = "localhost";
@@ -222,10 +222,6 @@ public static class KafkaBuilderExtensions
         return builder.WithEndpoint("primary", endpoint =>
         {
             endpoint.Port = port;
-            if (endpoint.TargetPort == 0)
-            {
-                endpoint.TargetPort = KafkaSchemaRegistryPort;
-            }
         });
     }
 

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -185,14 +185,14 @@ public static class KafkaBuilderExtensions
         var kafkaSchemaRegistryBuilder = builder.ApplicationBuilder.AddResource(kafkaSchemaRegistry)
             .WithImage(KafkaContainerImageTags.KafkaSchemaRegistryImage, KafkaContainerImageTags.KafkaSchemaRegistryTag)
             .WithImageRegistry(KafkaContainerImageTags.Registry)
-            .WithHttpEndpoint(targetPort: KafkaSchemaRegistryPort, name: "primary")
+            .WithHttpEndpoint(targetPort: KafkaSchemaRegistryPort, name: KafkaSchemaRegistryResource.PrimaryEndpointName)
             .WithEnvironment(context =>
             {
                 context.EnvironmentVariables["SCHEMA_REGISTRY_HOST_NAME"] = "localhost";
                 context.EnvironmentVariables["SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS"] = builder.Resource.InternalEndpoint.Property(EndpointProperty.HostAndPort);
                 context.EnvironmentVariables["SCHEMA_REGISTRY_LISTENERS"] = $"http://0.0.0.0:{KafkaSchemaRegistryPort}";
             })
-            .WithHttpHealthCheck("/subjects", 200, "primary")
+            .WithHttpHealthCheck("/subjects", 200, KafkaSchemaRegistryResource.PrimaryEndpointName)
             .WaitFor(builder)
             .WithParentRelationship(builder.Resource)
             .ExcludeFromManifest();
@@ -230,7 +230,7 @@ public static class KafkaBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.WithEndpoint("primary", endpoint =>
+        return builder.WithEndpoint(KafkaSchemaRegistryResource.PrimaryEndpointName, endpoint =>
         {
             endpoint.Port = port;
         });

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -118,13 +118,15 @@ public static class KafkaBuilderExtensions
             builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(kafkaUi, (e, ct) =>
             {
                 var kafkaResources = builder.ApplicationBuilder.Resources.OfType<KafkaServerResource>();
+                var kafkaSchemaRegistryResources = builder.ApplicationBuilder.Resources.OfType<KafkaSchemaRegistryResource>().ToArray();
 
                 int i = 0;
                 foreach (var kafkaResource in kafkaResources)
                 {
-                    var endpoint = kafkaResource.InternalEndpoint;
+                    var schemaRegistryResource = kafkaSchemaRegistryResources.FirstOrDefault(
+                        schemaRegistry => StringComparer.OrdinalIgnoreCase.Equals(schemaRegistry.KafkaServer.Name, kafkaResource.Name));
                     int index = i;
-                    kafkaUiBuilder.WithEnvironment(context => ConfigureKafkaUIContainer(context, endpoint, index));
+                    kafkaUiBuilder.WithEnvironment(context => ConfigureKafkaUIContainer(context, kafkaResource, schemaRegistryResource, index));
 
                     i++;
                 }
@@ -137,8 +139,9 @@ public static class KafkaBuilderExtensions
             return builder;
         }
 
-        static void ConfigureKafkaUIContainer(EnvironmentCallbackContext context, EndpointReference endpoint, int index)
+        static void ConfigureKafkaUIContainer(EnvironmentCallbackContext context, KafkaServerResource kafkaResource, KafkaSchemaRegistryResource? schemaRegistryResource, int index)
         {
+            var endpoint = kafkaResource.InternalEndpoint;
             var bootstrapServers = context.ExecutionContext.IsRunMode
                 // In run mode, Kafka UI assumes Kafka is being accessed over a default Aspire container network and hardcodes the host as the Kafka resource name
                 // This will need to be refactored once updated service discovery APIs are available
@@ -147,6 +150,16 @@ public static class KafkaBuilderExtensions
 
             context.EnvironmentVariables[$"KAFKA_CLUSTERS_{index}_NAME"] = endpoint.Resource.Name;
             context.EnvironmentVariables[$"KAFKA_CLUSTERS_{index}_BOOTSTRAPSERVERS"] = bootstrapServers;
+
+            if (schemaRegistryResource is not null)
+            {
+                var schemaRegistryEndpoint = schemaRegistryResource.PrimaryEndpoint;
+                var schemaRegistryUrl = context.ExecutionContext.IsRunMode
+                    ? ReferenceExpression.Create($"http://{schemaRegistryEndpoint.Resource.Name}:{schemaRegistryEndpoint.Property(EndpointProperty.TargetPort)}")
+                    : ReferenceExpression.Create($"{schemaRegistryEndpoint.Property(EndpointProperty.Url)}");
+
+                context.EnvironmentVariables[$"KAFKA_CLUSTERS_{index}_SCHEMAREGISTRY"] = schemaRegistryUrl;
+            }
         }
 
     }
@@ -166,9 +179,9 @@ public static class KafkaBuilderExtensions
     public static IResourceBuilder<KafkaSchemaRegistryResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null, string? containerName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        containerName ??= "kafka-schema-registry";
+        containerName ??= $"{builder.Resource.Name}-schema-registry";
 
-        var kafkaSchemaRegistry = new KafkaSchemaRegistryResource(containerName);
+        var kafkaSchemaRegistry = new KafkaSchemaRegistryResource(containerName, builder.Resource);
         var kafkaSchemaRegistryBuilder = builder.ApplicationBuilder.AddResource(kafkaSchemaRegistry)
             .WithImage(KafkaContainerImageTags.KafkaSchemaRegistryImage, KafkaContainerImageTags.KafkaSchemaRegistryTag)
             .WithImageRegistry(KafkaContainerImageTags.Registry)
@@ -181,6 +194,7 @@ public static class KafkaBuilderExtensions
             })
             .WithHttpHealthCheck("/subjects", 200, "primary")
             .WaitFor(builder)
+            .WithParentRelationship(builder.Resource)
             .ExcludeFromManifest();
 
         configureContainer?.Invoke(kafkaSchemaRegistryBuilder);

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -161,7 +161,7 @@ public static class KafkaBuilderExtensions
     /// <param name="configureContainer">Configuration callback for KafkaUI container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KafkaSchemaRegistryResource}"/>.</returns>
-    public static IResourceBuilder<KafkaSchemaRegistryResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, string? containerName = null, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null)
+    public static IResourceBuilder<KafkaSchemaRegistryResource> WithKafkaSchemaRegistry(this IResourceBuilder<KafkaServerResource> builder, Action<IResourceBuilder<KafkaSchemaRegistryResource>>? configureContainer = null, string? containerName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -181,7 +181,7 @@ public static class KafkaBuilderExtensions
             .WithEnvironment(context =>
             {
                 context.EnvironmentVariables["SCHEMA_REGISTRY_HOST_NAME"] = "localhost";
-                context.EnvironmentVariables["SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS"] = "kafka:9093";
+                context.EnvironmentVariables["SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS"] = builder.Resource.InternalEndpoint.Property(EndpointProperty.HostAndPort);
                 context.EnvironmentVariables["SCHEMA_REGISTRY_LISTENERS"] = $"http://0.0.0.0:{KafkaSchemaRegistryPort}"; })
             .WithHttpHealthCheck("/subjects", 200, "primary")
             .WaitFor(builder)

--- a/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
@@ -19,5 +19,10 @@ internal static class KafkaContainerImageTags
 
     /// <remarks>v1.5.0</remarks>
     public const string KafkaUiTag = "v1.5.0";
-}
 
+    /// <remarks>confluentinc/cp-schema-registry</remarks>
+    public const string KafkaSchemaRegistryImage = "confluentinc/cp-schema-registry";
+
+    /// <remarks>8.1.0</remarks>
+    public const string KafkaSchemaRegistryTag = "8.1.0";
+}

--- a/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
@@ -9,4 +9,21 @@ namespace Aspire.Hosting;
 /// A resource that represents a Kafka UI container.
 /// </summary>
 /// <param name="name"></param>
-public sealed class KafkaSchemaRegistryResource(string name) : ContainerResource(name);
+public sealed class KafkaSchemaRegistryResource(string name) : ContainerResource(name), IResourceWithConnectionString
+{
+
+    // This endpoint is used for host processes Kafka schema registry communication.
+    private const string PrimaryEndpointName = "primary";
+    private EndpointReference? _primaryEndpoint;
+
+    /// <summary>
+    /// Gets the primary endpoint for the Kafka schema registry
+    /// </summary>
+    public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+
+    /// <summary>
+    /// Gets the connection string expression for the Kafka schema registry.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"http://{PrimaryEndpoint.Property(EndpointProperty.HostAndPort)}");
+}

--- a/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
@@ -6,9 +6,9 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting;
 
 /// <summary>
-/// A resource that represents a Kafka UI container.
+/// A resource that represents a Kafka Schema Registry container.
 /// </summary>
-/// <param name="name"></param>
+/// <param name="name">The name of the resource.</param>
 public sealed class KafkaSchemaRegistryResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
 

--- a/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// A resource that represents a Kafka UI container.
+/// </summary>
+/// <param name="name"></param>
+public sealed class KafkaSchemaRegistryResource(string name) : ContainerResource(name);

--- a/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
@@ -24,6 +24,5 @@ public sealed class KafkaSchemaRegistryResource(string name) : ContainerResource
     /// <summary>
     /// Gets the connection string expression for the Kafka schema registry.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"http://{PrimaryEndpoint.Property(EndpointProperty.HostAndPort)}");
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{PrimaryEndpoint}");
 }

--- a/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting;
 public sealed class KafkaSchemaRegistryResource(string name, KafkaServerResource kafkaServer) : ContainerResource(name), IResourceWithConnectionString
 {
     // This endpoint is used for host processes Kafka schema registry communication.
-    private const string PrimaryEndpointName = "primary";
+    internal const string PrimaryEndpointName = "primary";
     private EndpointReference? _primaryEndpoint;
 
     /// <summary>

--- a/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
@@ -11,13 +11,12 @@ namespace Aspire.Hosting;
 /// <param name="name">The name of the resource.</param>
 public sealed class KafkaSchemaRegistryResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
-
     // This endpoint is used for host processes Kafka schema registry communication.
     private const string PrimaryEndpointName = "primary";
     private EndpointReference? _primaryEndpoint;
 
     /// <summary>
-    /// Gets the primary endpoint for the Kafka schema registry
+    /// Gets the primary endpoint for the Kafka schema registry.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 

--- a/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaSchemaRegistryResource.cs
@@ -9,11 +9,17 @@ namespace Aspire.Hosting;
 /// A resource that represents a Kafka Schema Registry container.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
-public sealed class KafkaSchemaRegistryResource(string name) : ContainerResource(name), IResourceWithConnectionString
+/// <param name="kafkaServer">The Kafka server resource associated with this schema registry.</param>
+public sealed class KafkaSchemaRegistryResource(string name, KafkaServerResource kafkaServer) : ContainerResource(name), IResourceWithConnectionString
 {
     // This endpoint is used for host processes Kafka schema registry communication.
     private const string PrimaryEndpointName = "primary";
     private EndpointReference? _primaryEndpoint;
+
+    /// <summary>
+    /// Gets the Kafka server resource associated with this schema registry.
+    /// </summary>
+    public KafkaServerResource KafkaServer { get; } = kafkaServer ?? throw new ArgumentNullException(nameof(kafkaServer));
 
     /// <summary>
     /// Gets the primary endpoint for the Kafka schema registry.

--- a/src/Aspire.Hosting.Kafka/README.md
+++ b/src/Aspire.Hosting.Kafka/README.md
@@ -36,6 +36,8 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
 
 To have a schema registry associated with the Kafka resource, use the following code:
 
+**C#**
+
 ```csharp
 var kafka = builder.AddKafka("messaging");
 
@@ -45,6 +47,23 @@ var schemaRegistry =
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(kafka)
                        .WithReference(schemaRegistry);
+```
+
+**TypeScript**
+
+```typescript
+const kafka = await builder.addKafka("messaging");
+
+const schemaRegistry = await kafka.withKafkaSchemaRegistry({
+    configureContainer: async (registry) => {
+        await registry.withHostPort({ port: 7000 });
+    },
+    containerName: "schema-registry",
+});
+
+const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
+                       .withReference(kafka)
+                       .withReference(schemaRegistry);
 ```
 
 ## Connection Properties

--- a/src/Aspire.Hosting.Kafka/README.md
+++ b/src/Aspire.Hosting.Kafka/README.md
@@ -34,6 +34,19 @@ const myService = await builder.addNodeApp("myService", "../my-service", "server
                        .withReference(kafka);
 ```
 
+To have a schema registry associated with the Kafka resource, use the following code:
+
+```csharp
+var kafka = builder.AddKafka("messaging");
+
+var schemaRegistry =
+    kafka.WithKafkaSchemaRegistry(registry => registry.WithHostPort(7000), "schema-registry");
+
+var myService = builder.AddProject<Projects.MyService>()
+                       .WithReference(kafka)
+                       .WithReference(schemaRegistry);
+```
+
 ## Connection Properties
 
 When you reference a Kafka resource using `WithReference`, the following connection properties are made available to the consuming project:

--- a/tests/Aspire.Hosting.Kafka.Tests/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/AddKafkaTests.cs
@@ -196,9 +196,9 @@ public class AddKafkaTests(ITestOutputHelper testOutputHelper)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var configureContainerInvocations = 0;
-        Action<IResourceBuilder<KafkaSchemaRegistryResource>> kafkaSchemaRegistryCallback = kafkaUi =>
+        Action<IResourceBuilder<KafkaSchemaRegistryResource>> kafkaSchemaRegistryCallback = registry =>
         {
-            kafkaUi.WithHostPort(port);
+            registry.WithHostPort(port);
             configureContainerInvocations++;
         };
         builder.AddKafka("kafka1")

--- a/tests/Aspire.Hosting.Kafka.Tests/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/AddKafkaTests.cs
@@ -179,6 +179,39 @@ public class AddKafkaTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(port, kafkaUiEndpoint.Port);
     }
 
+    public static TheoryData<string?, string, int?> WithKafkaSchemaRegistryAddsAnUniqueContainerSetsItsNameAndInvokesConfigurationCallbackTestVariations()
+    {
+        return new()
+        {
+            { "kafka-schema-registry", "kafka-schema-registry", 8082 },
+            { null, "kafka-schema-registry", 8082 },
+            { "kafka-schema-registry", "kafka-schema-registry", null },
+            { null, "kafka-schema-registry", null },
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(WithKafkaSchemaRegistryAddsAnUniqueContainerSetsItsNameAndInvokesConfigurationCallbackTestVariations))]
+    public void WithKafkaSchemaRegistryAddsAnUniqueContainerSetsItsNameAndInvokesConfigurationCallback(string? containerName, string expectedContainerName, int? port)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var configureContainerInvocations = 0;
+        Action<IResourceBuilder<KafkaSchemaRegistryResource>> kafkaSchemaRegistryCallback = kafkaUi =>
+        {
+            kafkaUi.WithHostPort(port);
+            configureContainerInvocations++;
+        };
+        builder.AddKafka("kafka1")
+            .WithKafkaSchemaRegistry(containerName: containerName, kafkaSchemaRegistryCallback);
+
+        Assert.Single(builder.Resources.OfType<KafkaSchemaRegistryResource>());
+        var kafkaSchemaResource = Assert.Single(builder.Resources, r => r.Name == expectedContainerName);
+        Assert.Equal(1, configureContainerInvocations);
+        var kafkaSchemaRegistryEndpoint = kafkaSchemaResource.Annotations.OfType<EndpointAnnotation>().Single();
+        Assert.Equal(8081, kafkaSchemaRegistryEndpoint.TargetPort);
+        Assert.Equal(port, kafkaSchemaRegistryEndpoint.Port);
+    }
+
     [Fact]
     public async Task KafkaEnvironmentCallbackIsIdempotent()
     {

--- a/tests/Aspire.Hosting.Kafka.Tests/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/AddKafkaTests.cs
@@ -202,7 +202,7 @@ public class AddKafkaTests(ITestOutputHelper testOutputHelper)
             configureContainerInvocations++;
         };
         builder.AddKafka("kafka1")
-            .WithKafkaSchemaRegistry(containerName: containerName, kafkaSchemaRegistryCallback);
+            .WithKafkaSchemaRegistry(kafkaSchemaRegistryCallback, containerName: containerName);
 
         Assert.Single(builder.Resources.OfType<KafkaSchemaRegistryResource>());
         var kafkaSchemaResource = Assert.Single(builder.Resources, r => r.Name == expectedContainerName);

--- a/tests/Aspire.Hosting.Kafka.Tests/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/AddKafkaTests.cs
@@ -184,9 +184,9 @@ public class AddKafkaTests(ITestOutputHelper testOutputHelper)
         return new()
         {
             { "kafka-schema-registry", "kafka-schema-registry", 8082 },
-            { null, "kafka-schema-registry", 8082 },
+            { null, "kafka1-schema-registry", 8082 },
             { "kafka-schema-registry", "kafka-schema-registry", null },
-            { null, "kafka-schema-registry", null },
+            { null, "kafka1-schema-registry", null },
         };
     }
 
@@ -205,11 +205,43 @@ public class AddKafkaTests(ITestOutputHelper testOutputHelper)
             .WithKafkaSchemaRegistry(kafkaSchemaRegistryCallback, containerName: containerName);
 
         Assert.Single(builder.Resources.OfType<KafkaSchemaRegistryResource>());
+        var kafkaResource = Assert.Single(builder.Resources.OfType<KafkaServerResource>());
         var kafkaSchemaResource = Assert.Single(builder.Resources, r => r.Name == expectedContainerName);
+        var kafkaSchemaRegistryResource = Assert.IsType<KafkaSchemaRegistryResource>(kafkaSchemaResource);
+        Assert.Same(kafkaResource, kafkaSchemaRegistryResource.KafkaServer);
         Assert.Equal(1, configureContainerInvocations);
         var kafkaSchemaRegistryEndpoint = kafkaSchemaResource.Annotations.OfType<EndpointAnnotation>().Single();
         Assert.Equal(8081, kafkaSchemaRegistryEndpoint.TargetPort);
         Assert.Equal(port, kafkaSchemaRegistryEndpoint.Port);
+    }
+
+    [Fact]
+    public async Task KafkaUIEnvironmentIncludesSchemaRegistriesForMatchingKafkaResources()
+    {
+        using var appBuilder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var kafka1 = appBuilder.AddKafka("kafka1").WithKafkaUI();
+        kafka1.WithKafkaSchemaRegistry();
+
+        var kafka2 = appBuilder.AddKafka("kafka2");
+        kafka2.WithKafkaSchemaRegistry();
+
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var kafkaUiResource = Assert.Single(appModel.Resources.OfType<KafkaUIContainerResource>());
+
+        await appBuilder.Eventing.PublishAsync(
+            new BeforeResourceStartedEvent(kafkaUiResource, app.Services),
+            EventDispatchBehavior.BlockingSequential);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(kafkaUiResource);
+
+        Assert.Equal("kafka1", config["KAFKA_CLUSTERS_0_NAME"]);
+        Assert.Equal("kafka1:9093", config["KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS"]);
+        Assert.Equal("http://kafka1-schema-registry:8081", config["KAFKA_CLUSTERS_0_SCHEMAREGISTRY"]);
+        Assert.Equal("kafka2", config["KAFKA_CLUSTERS_1_NAME"]);
+        Assert.Equal("kafka2:9093", config["KAFKA_CLUSTERS_1_BOOTSTRAPSERVERS"]);
+        Assert.Equal("http://kafka2-schema-registry:8081", config["KAFKA_CLUSTERS_1_SCHEMAREGISTRY"]);
     }
 
     [Fact]

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kafka/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kafka/TypeScript/apphost.mts
@@ -24,6 +24,14 @@ await kafkaWithUi.withDataVolume();
 const kafka2 = await builder.addKafka("broker2", { port: 19092 });
 await kafka2.withDataBindMount("/tmp/kafka-data");
 
+// withKafkaSchemaRegistry — adds a Kafka Schema Registry container with callback
+const _schemaRegistry = await kafka2.withKafkaSchemaRegistry({
+    configureContainer: async (registry) => {
+        await registry.withHostPort({ port: 7000 });
+    },
+    containerName: "my-schema-registry",
+});
+
 // ---- Property access on KafkaServerResource ----
 const _endpoint = await kafka.primaryEndpoint();
 const _host = await kafka.host();


### PR DESCRIPTION
## Description

This pull request introduces support for adding a Kafka Schema Registry resource alongside existing Kafka resources in the Aspire hosting framework. The main changes include new APIs for adding, configuring, and referencing a Schema Registry container, updates to documentation, and new tests to ensure correct behavior.

**Schema Registry Support:**

* Added a new `KafkaSchemaRegistryResource` class to represent the schema registry container, including support for connection strings and endpoint management.
* Introduced the `WithKafkaSchemaRegistry` extension method on `IResourceBuilder<KafkaServerResource>` to add and configure a schema registry container, including image/tag selection, environment variables, health checks, and host port binding.
* Added the `WithHostPort` extension method for `KafkaSchemaRegistryResource` to allow specifying a fixed host port for the schema registry container.
* Defined image and tag constants for the schema registry container in `KafkaContainerImageTags`.

**Sample and Documentation Updates:**

* Updated the playground app (`Program.cs`) to demonstrate adding and referencing a schema registry resource, and updated the README with usage instructions and code samples for associating a schema registry with Kafka. [[1]](diffhunk://#diff-393038862bdb95b8adc4ac5cba69db50c2ea6d0583660e3874bb391512f3645aR9-R13) [[2]](diffhunk://#diff-d39c40cf4b67b8835087443f1c9197fbc8ace3b13113c66bf625ad007de363e9R26-R38)

**Testing:**

* Added comprehensive tests for the new schema registry resource, covering container naming, port configuration, and callback invocation.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No - Although I can't find the docs to update.
