### PR TITLE
Fix deployment state file case sensitivity issue on Linux

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -787,7 +787,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             return;
         }
 
-        var environment = _innerBuilder.Environment.EnvironmentName;
+        var environment = _innerBuilder.Environment.EnvironmentName.ToLowerInvariant();
         var deploymentStatePath = Path.Combine(
             System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
             ".aspire",

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1201,7 +1201,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
             ".aspire",
             "deployments",
             appHostSha,
-            $"Production.json"
+            $"production.json"
         );
         Directory.CreateDirectory(Path.GetDirectoryName(deploymentStatePath)!);
         var cachedState = new JsonObject


### PR DESCRIPTION
## Description

Fixes #13102 - a case sensitivity bug in deployment state file caching on Linux and macOS systems that prevented `aspire deploy` from loading cached deployment state unless an explicit `--environment` flag with the exact casing was provided.

## Problem

When running `aspire deploy` on Linux/macOS, the deployment state cache was not being loaded properly due to a case mismatch in environment name handling:

- **Saving**: `FileDeploymentStateManager` saves state files with lowercase environment names (e.g., `production.json`)
- **Loading**: `DistributedApplicationBuilder.LoadDeploymentState` was using the original casing from `EnvironmentName` (e.g., `Production.json`)

Since Linux and macOS filesystems are case-sensitive, this caused cache loading to fail silently. The deployment would work only when explicitly specifying `aspire deploy --environment production` (lowercase).

## Solution

Normalized the environment name to lowercase in `LoadDeploymentState` method using `.ToLowerInvariant()` to match the behavior in `FileDeploymentStateManager.GetStatePath()`.

## Changes

- **src/Aspire.Hosting/DistributedApplicationBuilder.cs**: Added `.ToLowerInvariant()` to environment name when constructing deployment state path
- **tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs**: Updated test to use lowercase `production.json` instead of `Production.json` to reflect actual behavior

## Testing

- ✅ Existing test `DeployAsync_WithCachedDeploymentState_LoadsFromCache` passes with updated filename
- ✅ Verified consistency with `FileDeploymentStateManager.GetStatePath()` implementation
- ✅ Verified `DeployAsync_WithStagingEnvironment_UsesStagingStateFile` already uses lowercase `staging.json`

## Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?org=dotnet&repo=aspire&pr=)