### PR TITLE
Print app service url when deploying

### DIFF
--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -86,7 +86,8 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
                     var endpoint = $"https://{hostName}.azurewebsites.net";
                     ctx.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})", enableMarkdown: true);
                 },
-                Tags = ["print-summary"]
+                Tags = ["print-summary"],
+                RequiredBySteps = [WellKnownPipelineSteps.Deploy]
             };
 
             var deployStep = new PipelineStep

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
@@ -22,16 +22,16 @@ Steps with no dependencies run first, followed by steps that depend on them.
   6. validate-azure-login
   7. create-provisioning-context
   8. provision-api-identity
-  9. provision-kv
- 10. provision-api-roles-kv
- 11. provision-env
- 12. login-to-acr-env
- 13. push-api
- 14. provision-api-website
- 15. provision-azure-bicep-resources
- 16. print-dashboard-url-env
- 17. deploy
- 18. print-api-summary
+  9. provision-env
+ 10. provision-kv
+ 11. login-to-acr-env
+ 12. push-api
+ 13. provision-api-website
+ 14. print-api-summary
+ 15. provision-api-roles-kv
+ 16. provision-azure-bicep-resources
+ 17. print-dashboard-url-env
+ 18. deploy
  19. deploy-api
  20. diagnostics
  21. publish-prereq
@@ -60,7 +60,7 @@ Step: create-provisioning-context
     Resource: azure634f9 (AzureEnvironmentResource)
 
 Step: deploy
-    Dependencies: ✓ build-api, ✓ create-provisioning-context, ✓ print-dashboard-url-env, ✓ provision-azure-bicep-resources, ✓ validate-azure-login
+    Dependencies: ✓ build-api, ✓ create-provisioning-context, ✓ print-api-summary, ✓ print-dashboard-url-env, ✓ provision-azure-bicep-resources, ✓ validate-azure-login
 
 Step: deploy-api
     Dependencies: ✓ print-api-summary
@@ -188,8 +188,8 @@ If targeting 'create-provisioning-context':
     [3] create-provisioning-context
 
 If targeting 'deploy':
-  Direct dependencies: build-api, create-provisioning-context, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 16
+  Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
+  Total steps: 17
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -199,7 +199,7 @@ If targeting 'deploy':
     [5] login-to-acr-env | provision-api-roles-kv (parallel)
     [6] push-api
     [7] provision-api-website
-    [8] provision-azure-bicep-resources
+    [8] print-api-summary | provision-azure-bicep-resources (parallel)
     [9] print-dashboard-url-env
     [10] deploy
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
@@ -22,23 +22,23 @@ Steps with no dependencies run first, followed by steps that depend on them.
   6. build
   7. validate-azure-login
   8. create-provisioning-context
-  9. provision-aca-env
- 10. provision-cache-containerapp
- 11. print-cache-summary
- 12. provision-aas-env
- 13. login-to-acr-aas-env
- 14. push-api-service
- 15. provision-api-service-website
- 16. login-to-acr-aca-env
- 17. push-python-app
- 18. provision-python-app-containerapp
- 19. provision-storage
- 20. provision-azure-bicep-resources
- 21. print-dashboard-url-aas-env
- 22. print-dashboard-url-aca-env
- 23. print-python-app-summary
- 24. deploy
- 25. print-api-service-summary
+  9. provision-aas-env
+ 10. login-to-acr-aas-env
+ 11. push-api-service
+ 12. provision-api-service-website
+ 13. print-api-service-summary
+ 14. provision-aca-env
+ 15. provision-cache-containerapp
+ 16. print-cache-summary
+ 17. login-to-acr-aca-env
+ 18. push-python-app
+ 19. provision-python-app-containerapp
+ 20. provision-storage
+ 21. provision-azure-bicep-resources
+ 22. print-dashboard-url-aas-env
+ 23. print-dashboard-url-aca-env
+ 24. print-python-app-summary
+ 25. deploy
  26. deploy-api-service
  27. deploy-cache
  28. deploy-python-app
@@ -74,7 +74,7 @@ Step: create-provisioning-context
     Resource: azure634f9 (AzureEnvironmentResource)
 
 Step: deploy
-    Dependencies: ✓ build-api-service, ✓ build-python-app, ✓ create-provisioning-context, ✓ print-cache-summary, ✓ print-dashboard-url-aas-env, ✓ print-dashboard-url-aca-env, ✓ print-python-app-summary, ✓ provision-azure-bicep-resources, ✓ validate-azure-login
+    Dependencies: ✓ build-api-service, ✓ build-python-app, ✓ create-provisioning-context, ✓ print-api-service-summary, ✓ print-cache-summary, ✓ print-dashboard-url-aas-env, ✓ print-dashboard-url-aca-env, ✓ print-python-app-summary, ✓ provision-azure-bicep-resources, ✓ validate-azure-login
 
 Step: deploy-api-service
     Dependencies: ✓ print-api-service-summary
@@ -250,8 +250,8 @@ If targeting 'create-provisioning-context':
     [3] create-provisioning-context
 
 If targeting 'deploy':
-  Direct dependencies: build-api-service, build-python-app, create-provisioning-context, print-cache-summary, print-dashboard-url-aas-env, print-dashboard-url-aca-env, print-python-app-summary, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 23
+  Direct dependencies: build-api-service, build-python-app, create-provisioning-context, print-api-service-summary, print-cache-summary, print-dashboard-url-aas-env, print-dashboard-url-aca-env, print-python-app-summary, provision-azure-bicep-resources, validate-azure-login
+  Total steps: 24
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -261,7 +261,7 @@ If targeting 'deploy':
     [5] login-to-acr-aas-env | login-to-acr-aca-env | provision-cache-containerapp (parallel)
     [6] print-cache-summary | push-api-service | push-python-app (parallel)
     [7] provision-api-service-website | provision-python-app-containerapp (parallel)
-    [8] print-python-app-summary | provision-azure-bicep-resources (parallel)
+    [8] print-api-service-summary | print-python-app-summary | provision-azure-bicep-resources (parallel)
     [9] print-dashboard-url-aas-env | print-dashboard-url-aca-env (parallel)
     [10] deploy
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -23,22 +23,22 @@ Steps with no dependencies run first, followed by steps that depend on them.
   7. create-provisioning-context
   8. provision-api-identity
   9. provision-cache-kv
- 10. provision-api-roles-cache-kv
+ 10. provision-cache
  11. provision-cosmos-kv
- 12. provision-api-roles-cosmos-kv
- 13. provision-pg-kv
- 14. provision-api-roles-pg-kv
- 15. provision-cache
- 16. provision-cosmos
- 17. provision-env
- 18. provision-pg
- 19. login-to-acr-env
- 20. push-api
- 21. provision-api-website
- 22. provision-azure-bicep-resources
- 23. print-dashboard-url-env
- 24. deploy
- 25. print-api-summary
+ 12. provision-cosmos
+ 13. provision-env
+ 14. provision-pg-kv
+ 15. provision-pg
+ 16. login-to-acr-env
+ 17. push-api
+ 18. provision-api-website
+ 19. print-api-summary
+ 20. provision-api-roles-cache-kv
+ 21. provision-api-roles-cosmos-kv
+ 22. provision-api-roles-pg-kv
+ 23. provision-azure-bicep-resources
+ 24. print-dashboard-url-env
+ 25. deploy
  26. deploy-api
  27. diagnostics
  28. publish-prereq
@@ -67,7 +67,7 @@ Step: create-provisioning-context
     Resource: azure634f9 (AzureEnvironmentResource)
 
 Step: deploy
-    Dependencies: ✓ build-api, ✓ create-provisioning-context, ✓ print-dashboard-url-env, ✓ provision-azure-bicep-resources, ✓ validate-azure-login
+    Dependencies: ✓ build-api, ✓ create-provisioning-context, ✓ print-api-summary, ✓ print-dashboard-url-env, ✓ provision-azure-bicep-resources, ✓ validate-azure-login
 
 Step: deploy-api
     Dependencies: ✓ print-api-summary
@@ -230,8 +230,8 @@ If targeting 'create-provisioning-context':
     [3] create-provisioning-context
 
 If targeting 'deploy':
-  Direct dependencies: build-api, create-provisioning-context, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 23
+  Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
+  Total steps: 24
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
@@ -241,7 +241,7 @@ If targeting 'deploy':
     [5] login-to-acr-env | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-pg (parallel)
     [6] push-api
     [7] provision-api-website
-    [8] provision-azure-bicep-resources
+    [8] print-api-summary | provision-azure-bicep-resources (parallel)
     [9] print-dashboard-url-env
     [10] deploy
 


### PR DESCRIPTION
## Description

We don't print the URL to the app service website on `aspire deploy` because it was missing from the deploy DAG.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
