### PR TITLE
Fix: Update explicit port handling and add test for manifest project …

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1086,7 +1086,7 @@ public static class ResourceExtensions
             ResolvedPort exposedPort = (endpoint.UriScheme, endpoint.Port, targetPort.Value) switch
             {
                 // Port set explicitly, use it
-                (_, int port, int) => ResolvedPort.Explicit(port),
+                (_, int port, _) => ResolvedPort.Explicit(port),
 
                 // We have a target port, infer the exposedPort from it
                 (_, null, int targetPortValue) => ResolvedPort.Implicit(targetPortValue),

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -664,12 +664,55 @@ public class WithEndpointTests
         await app.StopAsync();
     }
 
+    [Fact]
+    public async Task VerifyManifestProjectWithExplicitPortAndNoLaunchProfile()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddProject<TestProjectNoLaunchSettings>("proj", launchProfileName: null)
+            .WithHttpEndpoint(port: 5001);
+
+        var manifest = await ManifestUtils.GetManifest(project.Resource).DefaultTimeout();
+
+        var expectedManifest =
+            """
+            {
+              "type": "project.v0",
+              "path": "projectpath",
+              "env": {
+                "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+                "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
+                "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
+                "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
+                "HTTP_PORTS": "{proj.bindings.http.targetPort}"
+              },
+              "bindings": {
+                "http": {
+                  "scheme": "http",
+                  "protocol": "tcp",
+                  "transport": "http",
+                  "port": 5001
+                }
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, manifest.ToString());
+    }
+
     private sealed class TestProject : IProjectMetadata
     {
         public string ProjectPath => "projectpath";
 
         public LaunchSettings? LaunchSettings { get; } = new();
     }
+
+    private sealed class TestProjectNoLaunchSettings : IProjectMetadata
+    {
+        public string ProjectPath => "projectpath";
+
+        public LaunchSettings? LaunchSettings => null;
+    }
+
     private sealed class ProjectA : IProjectMetadata
     {
         public string ProjectPath => "projectA";


### PR DESCRIPTION
…without launch profile

Follow up to https://github.com/dotnet/aspire/pull/13110, found via https://github.com/dotnet/aspire/pull/12895