### PR TITLE
[CI] don't build cli when building only tests

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <!-- Native build only -->
-  <ItemGroup Condition="'$(SkipNativeBuild)' != 'true'">
+  <ItemGroup Condition="'$(SkipNativeBuild)' != 'true' and '$(BuildTestsOnly)' != 'true'">
     <!-- Add Aspire.Cli project here for native-only builds so it gets picked
          up Restore, because Aspire.Cli.$(RID).csproj uses MSBuild task to build
          instead of a ProjectReference -->


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
