### PR TITLE
Project template: clickable link in API service

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/13.0/Aspire-StarterApplication.1.ApiService/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/13.0/Aspire-StarterApplication.1.ApiService/Program.cs
@@ -25,7 +25,11 @@ if (app.Environment.IsDevelopment())
 #endif
 string[] summaries = ["Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"];
 
-app.MapGet("/", () => new { link = "/weatherforecast", message = "API service is running. Use the link to see sample data." });
+app.MapGet("/", () => new
+{
+    link = "/weatherforecast",
+    message = "API service is running. Use the link to see sample data."
+});
 
 app.MapGet("/weatherforecast", () =>
 {

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/13.0/Aspire-StarterApplication.1.ApiService/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/13.0/Aspire-StarterApplication.1.ApiService/Program.cs
@@ -25,7 +25,7 @@ if (app.Environment.IsDevelopment())
 #endif
 string[] summaries = ["Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"];
 
-app.MapGet("/", () => "API service is running. Navigate to /weatherforecast to see sample data.");
+app.MapGet("/", () => new { link = "/weatherforecast", message = "API service is running. Use the link to see sample data." });
 
 app.MapGet("/weatherforecast", () =>
 {


### PR DESCRIPTION
This change renders a clickable link in the browser:

<img width="553" height="93" alt="image" src="https://github.com/user-attachments/assets/4471c81b-1e99-40b4-a31b-7a8d0436bcba" />

instead of the original, non-clickable link:

<img width="537" height="28" alt="image" src="https://github.com/user-attachments/assets/afc0a9e9-1714-49b6-9b9a-bd1b815ab148" />
