### PR TITLE
Change KnownResourceStateStyle.Warn state string from 'warn' to 'warning'

### DIFF
--- a/src/Aspire.Hosting.Maui/Lifecycle/UnsupportedPlatformEventSubscriber.cs
+++ b/src/Aspire.Hosting.Maui/Lifecycle/UnsupportedPlatformEventSubscriber.cs
@@ -33,7 +33,7 @@ internal sealed class UnsupportedPlatformEventSubscriber(ResourceNotificationSer
                     // Set the state to "Unsupported" with a warning style and the reason
                     await notificationService.PublishUpdateAsync(resource, s => s with
                     {
-                        State = new ResourceStateSnapshot($"Unsupported: {annotation.Reason}", "warning")
+                        State = new ResourceStateSnapshot($"Unsupported: {annotation.Reason}", KnownResourceStateStyles.Warn)
                     }).ConfigureAwait(false);
                 }
             }

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -351,9 +351,9 @@ public static class KnownResourceStateStyles
     public static readonly string Info = "info";
 
     /// <summary>
-    /// The warn state. Useful for showing warnings.
+    /// The warning state. Useful for showing warnings.
     /// </summary>
-    public static readonly string Warn = "warn";
+    public static readonly string Warn = "warning";
 }
 
 /// <summary>


### PR DESCRIPTION
## Description

The `KnownResourceStateStyle` has a wrong value of `warn`, where the dashboard is expecting `warning`. Also updated the MAUI Hosting reference to this.

https://github.com/dotnet/aspire/blob/main/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs#L77

Closes #12278

Made this a new PR, the other one was in some weird Git state