### PR TITLE
[release/13.0] Update dependencies from microsoft/usvc-apiserver

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.18.13">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.18.15">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>518dd532b47521a52dff9d1c9ba4639229f39953</Sha>
+      <Sha>e5b86f4057668b95e59d02a1f77cf7680c9823b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.18.13">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.18.15">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>518dd532b47521a52dff9d1c9ba4639229f39953</Sha>
+      <Sha>e5b86f4057668b95e59d02a1f77cf7680c9823b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.18.13">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.18.15">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>518dd532b47521a52dff9d1c9ba4639229f39953</Sha>
+      <Sha>e5b86f4057668b95e59d02a1f77cf7680c9823b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.18.13">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.18.15">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>518dd532b47521a52dff9d1c9ba4639229f39953</Sha>
+      <Sha>e5b86f4057668b95e59d02a1f77cf7680c9823b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.18.13">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.18.15">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>518dd532b47521a52dff9d1c9ba4639229f39953</Sha>
+      <Sha>e5b86f4057668b95e59d02a1f77cf7680c9823b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.18.13">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.18.15">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>518dd532b47521a52dff9d1c9ba4639229f39953</Sha>
+      <Sha>e5b86f4057668b95e59d02a1f77cf7680c9823b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.18.13">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.18.15">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>518dd532b47521a52dff9d1c9ba4639229f39953</Sha>
+      <Sha>e5b86f4057668b95e59d02a1f77cf7680c9823b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.18.13">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.18.15">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>518dd532b47521a52dff9d1c9ba4639229f39953</Sha>
+      <Sha>e5b86f4057668b95e59d02a1f77cf7680c9823b8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="10.0.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,14 +28,14 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.18.13</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.18.13</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.18.13</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.18.13</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.18.13</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindows386Version>0.18.13</MicrosoftDeveloperControlPlanewindows386Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.18.13</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.18.13</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.18.15</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.18.15</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.18.15</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.18.15</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.18.15</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindows386Version>0.18.15</MicrosoftDeveloperControlPlanewindows386Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.18.15</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.18.15</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>11.0.0-beta.25509.1</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>11.0.0-beta.25509.1</MicrosoftDotNetXUnitV3ExtensionsVersion>


### PR DESCRIPTION
Update the build of DCP in release/13.0 to 0.18.15.

0.18.15 includes several dependency updates with both security and bug fixes, as well as a fix for a timing issue with the  experimental container to host tunnel feature introduced in Aspire 13.0.0.