### PR TITLE
Add test logging to various functional tests for improved output

### DIFF
--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
@@ -56,6 +56,7 @@ public class KustoFunctionalTests
         await rns.WaitForResourceHealthyAsync(kusto.Resource.Name, cancellationToken: cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(_testOutputHelper);
         hb.Configuration["ConnectionStrings:KustoConnection"] = await kusto.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
         hb.Services.AddSingleton<ICslQueryProvider>(sp =>
         {
@@ -107,6 +108,7 @@ public class KustoFunctionalTests
         await rns.WaitForResourceHealthyAsync(kustoDb.Resource.Name, cancellationToken: cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(_testOutputHelper);
         hb.Configuration["ConnectionStrings:KustoTestDbConnection"] = await kustoDb.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
         hb.Services.AddSingleton<ICslQueryProvider>(sp =>
         {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
@@ -93,6 +93,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
         await app.ResourceNotifications.WaitForResourceHealthyAsync(db.Resource.Name, cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
         hb.Configuration[$"ConnectionStrings:{db.Resource.Name}"] = await cosmos.Resource.ConnectionStringExpression.GetValueAsync(default);
         hb.AddAzureCosmosClient(db.Resource.Name);
         hb.AddCosmosDbContext<EFCoreCosmosDbContext>(db.Resource.Name, databaseName);
@@ -223,6 +224,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
             try
             {
                 var hb = Host.CreateApplicationBuilder();
+                hb.AddTestLogging(testOutputHelper);
 
                 hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                 {
@@ -290,6 +292,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
         await rns.WaitForResourceHealthyAsync(cosmos.Resource.Name, cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
         hb.Configuration[$"ConnectionStrings:{cosmos.Resource.Name}"] = await cosmos.Resource.ConnectionStringExpression.GetValueAsync(default);
         hb.AddAzureCosmosClient(cosmos.Resource.Name);
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageEmulatorFunctionalTests.cs
@@ -172,6 +172,7 @@ public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHel
         await app.StartAsync();
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
         hb.Configuration[$"ConnectionStrings:{blobsResourceName}"] = await blobs.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
         hb.Configuration[$"ConnectionStrings:{blobContainerName}"] = await container.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
         hb.Configuration[$"ConnectionStrings:{queuesResourceName}"] = await queues.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
@@ -223,6 +224,7 @@ public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHel
         await rns.WaitForResourceHealthyAsync(blobContainer.Resource.Name, cancellationToken: cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
         hb.Configuration["ConnectionStrings:BlobConnection"] = await blobs.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
         hb.AddAzureBlobServiceClient("BlobConnection");
 
@@ -262,6 +264,7 @@ public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHel
         await rns.WaitForResourceHealthyAsync(queue.Resource.Name, cancellationToken: cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
         hb.Configuration["ConnectionStrings:QueueConnection"] = await queues.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
         hb.AddAzureQueueServiceClient("QueueConnection");
 

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -70,6 +70,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{garnet.Resource.Name}"] = await garnet.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -149,6 +150,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{garnet1.Resource.Name}"] = $"{await garnet1.Resource.ConnectionStringExpression.GetValueAsync(default)}";
 
@@ -200,6 +202,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{garnet2.Resource.Name}"] = $"{await garnet2.Resource.ConnectionStringExpression.GetValueAsync(default)}";
 

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -70,6 +70,7 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{kafka.Resource.Name}"] = await kafka.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -165,6 +166,7 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{kafka1.Resource.Name}"] = await kafka1.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -214,6 +216,7 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{kafka2.Resource.Name}"] = await kafka2.Resource.ConnectionStringExpression.GetValueAsync(default);
 

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -30,6 +30,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.WaitForTextAsync("Milvus Proxy successfully initialized and ready to serve", milvus.Resource.Name);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{db.Resource.Name}"] = await db.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -108,6 +109,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{db1.Resource.Name}"] = await db1.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -155,6 +157,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{db2.Resource.Name}"] = await db2.Resource.ConnectionStringExpression.GetValueAsync(default);
 

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -81,6 +81,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{db.Resource.Name}"] = await db.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -145,6 +146,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{db1.Resource.Name}"] = await db1.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -189,6 +191,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{db2.Resource.Name}"] = await db2.Resource.ConnectionStringExpression.GetValueAsync(default);
 

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -84,6 +84,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.WaitForTextAsync(s_mySqlReadyText, cts.Token).WaitAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -160,6 +161,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {
@@ -229,6 +231,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {
@@ -488,6 +491,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.WaitForTextAsync(s_mySqlReadyText, cts.Token).WaitAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -647,6 +651,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -722,6 +727,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
                 await app.StartAsync(cts.Token);
 
                 var hb = Host.CreateApplicationBuilder();
+                hb.AddTestLogging(testOutputHelper);
 
                 hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -779,6 +785,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         foreach (var db in dbs)
         {
@@ -824,6 +831,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
         hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
         hb.AddMySqlDataSource(newDb.Resource.Name);
 

--- a/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
@@ -35,6 +35,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.WaitForTextAsync("Listening for client connections", nats.Resource.Name);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{nats.Resource.Name}"] = await nats.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -80,6 +81,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.WaitForTextAsync("Listening for client connections", nats.Resource.Name);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         var connectionString = await nats.Resource.ConnectionStringExpression.GetValueAsync(default);
         hb.Configuration[$"ConnectionStrings:{nats.Resource.Name}"] = connectionString;
@@ -122,6 +124,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.WaitForTextAsync("Listening for client connections", nats.Resource.Name);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         var connectionString = await nats.Resource.ConnectionStringExpression.GetValueAsync(default);
         var modifiedConnectionString = user is null
@@ -185,6 +188,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{nats1.Resource.Name}"] = await nats1.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -233,6 +237,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{nats2.Resource.Name}"] = await nats2.Resource.ConnectionStringExpression.GetValueAsync(default);
                     hb.AddNatsClient("nats", configureOptions: opts =>

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -46,6 +46,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.WaitForTextAsync(DatabaseReadyText, cancellationToken: cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{db.Resource.Name}"] = await db.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -131,6 +132,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{db1.Resource.Name}"] = await db1.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -191,6 +193,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration[$"ConnectionStrings:{db2.Resource.Name}"] = await db2.Resource.ConnectionStringExpression.GetValueAsync(default);
 

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -235,6 +235,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {
@@ -297,6 +298,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {
@@ -607,6 +609,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -648,6 +651,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -717,6 +721,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
                 await app.StartAsync(cts.Token);
 
                 var hb = Host.CreateApplicationBuilder();
+                hb.AddTestLogging(testOutputHelper);
 
                 hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -774,6 +779,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         foreach (var db in dbs)
         {

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -38,6 +38,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -123,6 +124,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {
@@ -168,6 +170,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 
 namespace Aspire.Hosting.RabbitMQ.Tests;
@@ -67,6 +66,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
         hb.Configuration[$"ConnectionStrings:{rabbitMQ.Resource.Name}"] = await rabbitMQ.Resource.ConnectionStringExpression.GetValueAsync(default);
         hb.AddRabbitMQClient(rabbitMQ.Resource.Name);
 
@@ -130,8 +130,8 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
                     hb.Configuration[$"ConnectionStrings:{rabbitMQ1.Resource.Name}"] = await rabbitMQ1.Resource.ConnectionStringExpression.GetValueAsync(default);
-                    hb.Services.AddXunitLogging(testOutputHelper);
                     hb.AddRabbitMQClient(rabbitMQ1.Resource.Name);
 
                     using (var host = hb.Build())
@@ -187,8 +187,8 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
                     hb.Configuration[$"ConnectionStrings:{rabbitMQ2.Resource.Name}"] = await rabbitMQ2.Resource.ConnectionStringExpression.GetValueAsync(default);
-                    hb.Services.AddXunitLogging(testOutputHelper);
                     hb.AddRabbitMQClient(rabbitMQ2.Resource.Name);
 
                     using (var host = hb.Build())

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -106,6 +106,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -211,6 +212,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
             await app.StartAsync();
 
             var hb = Host.CreateApplicationBuilder();
+            hb.AddTestLogging(testOutputHelper);
 
             // BGSAVE is only available in admin mode, enable it for this instance
             hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
@@ -248,6 +250,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
             await app.StartAsync();
 
             var hb = Host.CreateApplicationBuilder();
+            hb.AddTestLogging(testOutputHelper);
 
             hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -294,6 +297,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
             await app.StartAsync();
 
             var hb = Host.CreateApplicationBuilder();
+            hb.AddTestLogging(testOutputHelper);
 
             // BGSAVE is only available in admin mode, enable it for this instance
             hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
@@ -378,6 +382,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
             await app.StartAsync();
 
             var hb = Host.CreateApplicationBuilder();
+            hb.AddTestLogging(testOutputHelper);
 
             // BGSAVE is only available in admin mode, enable it for this instance
             hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
@@ -409,6 +414,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
             await app.StartAsync();
 
             var hb = Host.CreateApplicationBuilder();
+            hb.AddTestLogging(testOutputHelper);
 
             hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
             {

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -76,6 +76,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -182,6 +183,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
             try
             {
                 var hb1 = Host.CreateApplicationBuilder();
+                hb1.AddTestLogging(testOutputHelper);
 
                 hb1.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                 {
@@ -267,6 +269,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb2 = Host.CreateApplicationBuilder();
+                    hb2.AddTestLogging(testOutputHelper);
 
                     hb2.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {
@@ -365,6 +368,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -418,6 +422,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -490,6 +495,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                 await app.StartAsync(cts.Token);
 
                 var hb = Host.CreateApplicationBuilder();
+                hb.AddTestLogging(testOutputHelper);
 
                 hb.Configuration[$"ConnectionStrings:{newDb.Resource.Name}"] = await newDb.Resource.ConnectionStringExpression.GetValueAsync(default);
 
@@ -548,6 +554,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync(cts.Token);
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         foreach (var db in dbs)
         {

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -30,6 +30,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         var hb = Host.CreateApplicationBuilder();
+        hb.AddTestLogging(testOutputHelper);
 
         hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -92,6 +93,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     // BGSAVE is only available in admin mode, enable it for this instance
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
@@ -144,6 +146,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
                 try
                 {
                     var hb = Host.CreateApplicationBuilder();
+                    hb.AddTestLogging(testOutputHelper);
 
                     hb.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
                     {

--- a/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
+++ b/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Xunit;
@@ -48,6 +49,17 @@ public static class DistributedApplicationTestingBuilderExtensions
     public static IDistributedApplicationTestingBuilder WithResourceCleanUp(this IDistributedApplicationTestingBuilder builder, bool? resourceCleanup = null)
     {
         builder.Configuration["DcpPublisher:WaitForResourceCleanup"] = resourceCleanup.ToString();
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds xunit logging and suppresses console logging for a host application builder used in tests.
+    /// This redirects logs to the xunit test output and prevents console clutter during test runs.
+    /// </summary>
+    public static IHostApplicationBuilder AddTestLogging(this IHostApplicationBuilder builder, ITestOutputHelper testOutputHelper)
+    {
+        builder.Logging.AddXunit(testOutputHelper);
+        builder.Logging.AddFilter<ConsoleLoggerProvider>(null, LogLevel.None);
         return builder;
     }
 }


### PR DESCRIPTION
Forward to xunit test logger in more cases, still not 100% for example kafka's native library spams to stderr so this doesn't fix the kafka output.