### PR TITLE
Fix PATH lookup to prefer PATHEXT extensions over exact matches on WIndows

### DIFF
--- a/tests/Aspire.Cli.Tests/Utils/PathLookupHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/PathLookupHelperTests.cs
@@ -136,9 +136,12 @@ public class PathLookupHelperTests
     }
 
     [Fact]
-    public void FindFullPathFromPath_WithPathExtensions_PrefersExactMatchOverExtension()
+    public void FindFullPathFromPath_WithPathExtensions_PrefersExtensionOverExactMatch()
     {
-        // Arrange - when the command exists without extension, it's preferred
+        // Arrange - when both exist, the extension-based file is preferred on Windows
+        // This is important because Windows cannot execute extension-less scripts directly.
+        // For example, "code" in VS Code's bin folder is a shell script that Windows can't run,
+        // but "code.cmd" is the proper executable wrapper.
         var dir = Path.Combine("testdir", "bin");
         var exactPath = Path.Combine(dir, "code");
         var cmdPath = Path.Combine(dir, "code.CMD");
@@ -149,8 +152,27 @@ public class PathLookupHelperTests
         };
         var pathExtensions = new[] { ".COM", ".EXE", ".BAT", ".CMD" };
 
-        // Act - should find "code" exactly, not "code.CMD"
+        // Act - should find "code.CMD", not "code" (extension-based files preferred on Windows)
         var result = PathLookupHelper.FindFullPathFromPath("code", dir, ';', existingFiles.Contains, pathExtensions);
+
+        // Assert
+        Assert.Equal(cmdPath, result);
+    }
+
+    [Fact]
+    public void FindFullPathFromPath_WithPathExtensions_FallsBackToExactMatchIfNoExtensionFound()
+    {
+        // Arrange - when no extension-based file exists, fall back to exact match
+        var dir = Path.Combine("testdir", "bin");
+        var exactPath = Path.Combine(dir, "mytool");
+        var existingFiles = new HashSet<string>
+        {
+            exactPath
+        };
+        var pathExtensions = new[] { ".COM", ".EXE", ".BAT", ".CMD" };
+
+        // Act - no extension files exist, so should fall back to exact match
+        var result = PathLookupHelper.FindFullPathFromPath("mytool", dir, ';', existingFiles.Contains, pathExtensions);
 
         // Assert
         Assert.Equal(exactPath, result);
@@ -173,6 +195,41 @@ public class PathLookupHelperTests
 
         // Assert
         Assert.Equal(expectedPath, result);
+    }
+
+    [Fact]
+    public void FindFullPathFromPath_WithPathExtensions_CommandWithExtensionNotFound_ReturnsNull()
+    {
+        // Arrange - command has known extension but file doesn't exist
+        var dir = Path.Combine("testdir", "bin");
+        var existingFiles = new HashSet<string>();
+        var pathExtensions = new[] { ".COM", ".EXE", ".BAT", ".CMD" };
+
+        // Act - searching for "code.EXE" when it doesn't exist should return null
+        var result = PathLookupHelper.FindFullPathFromPath("code.EXE", dir, ';', existingFiles.Contains, pathExtensions);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void FindFullPathFromPath_WithPathExtensions_CommandWithExtension_DoesNotTryOtherExtensions()
+    {
+        // Arrange - when command has a known extension, don't try other extensions
+        var dir = Path.Combine("testdir", "bin");
+        var cmdPath = Path.Combine(dir, "code.CMD");
+        var existingFiles = new HashSet<string>
+        {
+            cmdPath
+        };
+        var pathExtensions = new[] { ".COM", ".EXE", ".BAT", ".CMD" };
+
+        // Act - searching for "code.EXE" should NOT find "code.CMD"
+        // (we should not strip .EXE and try .CMD)
+        var result = PathLookupHelper.FindFullPathFromPath("code.EXE", dir, ';', existingFiles.Contains, pathExtensions);
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

On Windows, extension-less files like `code` in VS Code's bin folder are shell scripts that Windows cannot execute directly. The previous logic checked for exact matches first, which would find these unusable files instead of the proper `.cmd` wrappers.

This change reorders the search to check PATHEXT extensions first, then fall back to exact matches. This fixes Win32Exception (193) errors when the CLI attempts to execute extension-less scripts.
