### PR TITLE
Fix: Use consistent warning icon for unresolved parameters

### DIFF
--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -208,11 +208,17 @@ public sealed class ParameterProcessor(
                 "Value missing" :
                 "Error initializing parameter";
 
+            // Use warning style for missing parameters to match the notification banner,
+            // and error style for actual initialization errors.
+            var stateStyle = ex is MissingParameterValueException ?
+                KnownResourceStateStyles.Warn :
+                KnownResourceStateStyles.Error;
+
             await notificationService.PublishUpdateAsync(parameterResource, s =>
             {
                 return s with
                 {
-                    State = new(stateText, KnownResourceStateStyles.Error),
+                    State = new(stateText, stateStyle),
                     Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, ex.Message)
                 };
             })


### PR DESCRIPTION
## Summary

This PR fixes #11992 by changing the state style for missing parameter values from `error` to `warning` to match the notification banner icon.

## Problem

When parameters are unresolved:
- The notification banner shows a **warning triangle** (using `MessageIntent.Warning`)
- But the parameter resources in the grid show an **error circle** (using `KnownResourceStateStyles.Error`)

## Solution

Changed `ParameterProcessor.cs` to use `KnownResourceStateStyles.Warn` for `MissingParameterValueException` cases, while keeping `KnownResourceStateStyles.Error` for actual initialization errors.

This makes the icons consistent:
- Missing parameter value → Warning icon (yellow triangle)
- Actual error → Error icon (red circle)

## Changes

- `src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs`: Use warning style for missing parameters

## Testing

The change only affects the visual representation (icon style) for missing parameter values. The functionality remains the same.