### PR TITLE
Fix flaky deployment tests

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -663,7 +663,7 @@ public sealed class BicepOutputReference(string name, AzureBicepResource resourc
         {
             if (!Resource.Outputs.TryGetValue(Name, out var value))
             {
-                throw new InvalidOperationException($"No output for {Name}");
+                throw new InvalidOperationException($"No output for {Name} on resource {Resource.Name}");
             }
 
             return value?.ToString();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -127,6 +127,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     {
         // Arrange
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
+        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
         var armClientProvider = new TestArmClientProvider(new Dictionary<string, object>
         {
             ["AZURE_CONTAINER_REGISTRY_NAME"] = new { type = "String", value = "testregistry" },
@@ -135,7 +136,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "test.westus.azurecontainerapps.io" },
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv" }
         });
-        ConfigureTestServices(builder, armClientProvider: armClientProvider);
+        ConfigureTestServices(builder, armClientProvider: armClientProvider, activityReporter: mockActivityReporter);
 
         var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
 
@@ -157,6 +158,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
         await app.WaitForShutdownAsync();
 
+        // Assert that publish completed without errors
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+
         // Assert - Verify MockImageBuilder was only called to build an image and not push it
         var mockImageBuilder = app.Services.GetRequiredService<IResourceContainerImageBuilder>() as MockImageBuilder;
         Assert.NotNull(mockImageBuilder);
@@ -170,6 +174,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     public async Task DeployAsync_WithAzureStorageResourcesWorks()
     {
         // Arrange
+        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
         var fakeContainerRuntime = new FakeContainerRuntime();
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
         var armClientProvider = new TestArmClientProvider(new Dictionary<string, object>
@@ -180,7 +185,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "test.westus.azurecontainerapps.io" },
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv" }
         });
-        ConfigureTestServices(builder, armClientProvider: armClientProvider, containerRuntime: fakeContainerRuntime);
+        ConfigureTestServices(builder, armClientProvider: armClientProvider, activityReporter: mockActivityReporter, containerRuntime: fakeContainerRuntime);
 
         var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
         var azureEnv = builder.AddAzureEnvironment();
@@ -194,6 +199,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         using var app = builder.Build();
         await app.StartAsync();
         await app.WaitForShutdownAsync();
+
+        // Assert that publish completed without errors
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
 
         // Assert that ACR login was not called given no compute resources
         Assert.False(fakeContainerRuntime.WasLoginToRegistryCalled);
@@ -212,6 +220,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     public async Task DeployAsync_WithContainer_Works()
     {
         // Arrange
+        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
@@ -223,7 +232,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "test.westus.azurecontainerapps.io" },
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv" }
         });
-        ConfigureTestServices(builder, armClientProvider: armClientProvider, processRunner: mockProcessRunner, containerRuntime: fakeContainerRuntime);
+        ConfigureTestServices(builder, armClientProvider: armClientProvider, activityReporter: mockActivityReporter, processRunner: mockProcessRunner, containerRuntime: fakeContainerRuntime);
 
         var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
         var azureEnv = builder.AddAzureEnvironment();
@@ -233,6 +242,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         using var app = builder.Build();
         await app.StartAsync();
         await app.WaitForShutdownAsync();
+
+        // Assert that publish completed without errors
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
 
         // Assert that container environment outputs are propagated to outputs because they are
         // hoisted up for the container resource
@@ -256,6 +268,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     public async Task DeployAsync_WithDockerfile_Works()
     {
         // Arrange
+        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
@@ -267,7 +280,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "test.westus.azurecontainerapps.io" },
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv" }
         });
-        ConfigureTestServices(builder, armClientProvider: armClientProvider, processRunner: mockProcessRunner, containerRuntime: fakeContainerRuntime);
+        ConfigureTestServices(builder, armClientProvider: armClientProvider, activityReporter: mockActivityReporter, processRunner: mockProcessRunner, containerRuntime: fakeContainerRuntime);
 
         var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
         var azureEnv = builder.AddAzureEnvironment();
@@ -277,6 +290,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         using var app = builder.Build();
         await app.StartAsync();
         await app.WaitForShutdownAsync();
+
+        // Assert that publish completed without errors
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
 
         // Assert that container environment outputs are propagated to outputs because they are
         // hoisted up for the container resource
@@ -308,6 +324,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         // Arrange
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
+        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
         var armClientProvider = new TestArmClientProvider(new Dictionary<string, object>
         {
@@ -317,7 +334,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "test.westus.azurecontainerapps.io" },
             ["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv" }
         });
-        ConfigureTestServices(builder, armClientProvider: armClientProvider, processRunner: mockProcessRunner, containerRuntime: fakeContainerRuntime);
+        ConfigureTestServices(builder, armClientProvider: armClientProvider, processRunner: mockProcessRunner, activityReporter: mockActivityReporter, containerRuntime: fakeContainerRuntime);
 
         var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
         var azureEnv = builder.AddAzureEnvironment();
@@ -327,6 +344,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         using var app = builder.Build();
         await app.StartAsync();
         await app.WaitForShutdownAsync();
+
+        // Assert that publish completed without errors
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
 
         // Assert that container environment outputs are propagated to outputs because they are
         // hoisted up for the container resource
@@ -371,6 +391,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
                     ["AZURE_CONTAINER_REGISTRY_NAME"] = new { type = "String", value = "acaregistry" },
                     ["AZURE_CONTAINER_REGISTRY_ENDPOINT"] = new { type = "String", value = "acaregistry.azurecr.io" },
                     ["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aca-identity" },
+                    ["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID"] = new { type = "String", value = "aca-client-id" },
                     ["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "aca.westus.azurecontainerapps.io" },
                     ["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/acaenv" }
                 },
@@ -379,8 +400,12 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
                     ["AZURE_CONTAINER_REGISTRY_NAME"] = new { type = "String", value = "aasregistry" },
                     ["AZURE_CONTAINER_REGISTRY_ENDPOINT"] = new { type = "String", value = "aasregistry.azurecr.io" },
                     ["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aas-identity" },
+                    ["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID"] = new { type = "String", value = "aas-client-id" },
+                    ["AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aas-website-identity" },
+                    ["AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID"] = new { type = "String", value = "aas-website-principal-id" },
+                    ["webSiteSuffix"] = new { type = "String", value = ".azurewebsites.net" },
                     ["planId"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.Web/serverfarms/aasplan" },
-                    ["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID"] = new { type = "String", value = "aas-client-id" }
+                    ["AZURE_APP_SERVICE_DASHBOARD_URI"] = new { type = "String", value = "https://infra-aspiredashboard-test.azurewebsites.net" }
                 },
                 _ => []
             };
@@ -404,6 +429,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         using var app = builder.Build();
         await app.StartAsync();
         await app.WaitForShutdownAsync();
+
+        // Assert that publish completed without errors
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
 
         if (step == "diagnostics")
         {
@@ -598,6 +626,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
         await app.WaitForShutdownAsync();
 
+        // Assert that publish completed without errors
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+
         // Assert that container environment outputs are propagated
         Assert.Equal("testregistry", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_NAME"]);
         Assert.Equal("testregistry.azurecr.io", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_ENDPOINT"]);
@@ -644,6 +675,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         using var app = builder.Build();
         await app.StartAsync();
         await app.WaitForShutdownAsync();
+
+        // Assert that publish completed without errors
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
 
         // Assert that container environment outputs are propagated
         Assert.Equal("test.westus.azurecontainerapps.io", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"]);
@@ -783,6 +817,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         {
             string name when name.StartsWith("env") => new Dictionary<string, object>
             {
+                ["name"] = new { type = "String", value = "env" },
                 ["AZURE_CONTAINER_REGISTRY_NAME"] = new { type = "String", value = "testregistry" },
                 ["AZURE_CONTAINER_REGISTRY_ENDPOINT"] = new { type = "String", value = "testregistry.azurecr.io" },
                 ["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity" },
@@ -805,11 +840,16 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
             },
             string name when name.StartsWith("funcapp-identity") => new Dictionary<string, object>
             {
+                ["id"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/funcapp-identity" },
+                ["clientId"] = new { type = "String", value = "funcapp-client-id" },
                 ["principalId"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity" },
             },
             string name when name.StartsWith("funcapp-containerapp") => new Dictionary<string, object>
             {
-                ["id"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/containerApps/funcapp" }
+                ["id"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/containerApps/funcapp" },
+                ["name"] = new { type = "String", value = "funcapp" },
+                ["fqdn"] = new { type = "String", value = "funcapp.azurecontainerapps.io" },
+                ["environmentId"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/env" }
             },
             string name when name.StartsWith("funcapp") => new Dictionary<string, object>
             {
@@ -819,8 +859,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
             _ => []
         };
 
+        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider(deploymentOutputsProvider);
-        ConfigureTestServices(builder, armClientProvider: armClientProvider, processRunner: mockProcessRunner, containerRuntime: fakeContainerRuntime);
+        ConfigureTestServices(builder, armClientProvider: armClientProvider, activityReporter: mockActivityReporter, processRunner: mockProcessRunner, containerRuntime: fakeContainerRuntime);
 
         var containerAppEnv = builder.AddAzureContainerAppEnvironment("env");
         var azureEnv = builder.AddAzureEnvironment();
@@ -837,6 +878,9 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         using var app = builder.Build();
         await app.StartAsync();
         await app.WaitForShutdownAsync();
+
+        // Assert that publish completed without errors
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
 
         // Assert that container environment outputs are propagated
         Assert.Equal("testregistry", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_NAME"]);
@@ -1461,6 +1505,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
 
         public bool CompletePublishCalled { get; private set; }
         public string? CompletionMessage { get; private set; }
+        public CompletionState? CompletionState { get; private set; }
         public List<string> CreatedSteps { get; } = [];
         public List<(string StepTitle, string TaskStatusText)> CreatedTasks { get; } = [];
         public List<(string StepTitle, string CompletionText, CompletionState CompletionState)> CompletedSteps { get; } = [];
@@ -1472,6 +1517,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         {
             CompletePublishCalled = true;
             CompletionMessage = completionMessage;
+            CompletionState = completionState;
             _output?.WriteLine($"[CompletePublish] {completionMessage} (State: {completionState})");
             return Task.CompletedTask;
         }
@@ -1498,7 +1544,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
 
             public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-            public Task CompleteAsync(string completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+            public Task CompleteAsync(string completionText, Pipelines.CompletionState completionState = Pipelines.CompletionState.Completed, CancellationToken cancellationToken = default)
             {
                 _reporter.CompletedSteps.Add((_title, completionText, completionState));
                 _output?.WriteLine($"  [CompleteStep:{_title}] {completionText} (State: {completionState})");
@@ -1534,7 +1580,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
 
             public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-            public Task CompleteAsync(string? completionMessage = null, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+            public Task CompleteAsync(string? completionMessage = null, Pipelines.CompletionState completionState = Pipelines.CompletionState.Completed, CancellationToken cancellationToken = default)
             {
                 _reporter.CompletedTasks.Add((_initialStatusText, completionMessage, completionState));
                 _output?.WriteLine($"      [CompleteTask:{_initialStatusText}] {completionMessage} (State: {completionState})");

--- a/tools/scripts/DownloadFailingJobLogs.cs
+++ b/tools/scripts/DownloadFailingJobLogs.cs
@@ -1,0 +1,317 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+if (args.Length == 0)
+{
+    Console.WriteLine("Usage: dotnet run -- <run-id>");
+    Console.WriteLine("Example: dotnet run -- 19846215629");
+    return;
+}
+
+var runId = args[0];
+var repo = "dotnet/aspire";
+
+Console.WriteLine($"Finding failed jobs for run {runId}...");
+
+// Get all jobs for the run
+var getJobsProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+{
+    FileName = "gh",
+    Arguments = $"api repos/{repo}/actions/runs/{runId}/jobs --paginate",
+    RedirectStandardOutput = true,
+    UseShellExecute = false
+});
+
+var jobsJson = await getJobsProcess!.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+await getJobsProcess.WaitForExitAsync().ConfigureAwait(false);
+
+if (getJobsProcess.ExitCode != 0)
+{
+    Console.WriteLine($"Error getting jobs: exit code {getJobsProcess.ExitCode}");
+    return;
+}
+
+// Parse jobs - gh --paginate returns multiple JSON objects concatenated
+var jobs = new List<JsonElement>();
+var reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(jobsJson));
+while (JsonDocument.TryParseValue(ref reader, out var doc))
+{
+    if (doc != null && doc.RootElement.TryGetProperty("jobs", out var jobsArray))
+    {
+        jobs.AddRange(jobsArray.EnumerateArray());
+    }
+}
+
+Console.WriteLine($"Found {jobs.Count} total jobs");
+
+// Filter failed jobs
+var failedJobs = jobs.Where(j =>
+{
+    var conclusion = j.GetProperty("conclusion").GetString();
+    return conclusion == "failure";
+}).ToList();
+
+Console.WriteLine($"Found {failedJobs.Count} failed jobs");
+
+if (failedJobs.Count == 0)
+{
+    Console.WriteLine("No failed jobs found!");
+    return;
+}
+
+// Download logs and artifacts for each failed job
+int counter = 0;
+foreach (var job in failedJobs)
+{
+    var jobId = job.GetProperty("id").GetInt64();
+    var jobName = job.GetProperty("name").GetString();
+    var jobUrl = job.GetProperty("html_url").GetString();
+
+    Console.WriteLine($"\n=== Failed Job {counter + 1}/{failedJobs.Count} ===");
+    Console.WriteLine($"Name: {jobName}");
+    Console.WriteLine($"ID: {jobId}");
+    Console.WriteLine($"URL: {jobUrl}");
+
+    // Download job logs
+    Console.WriteLine("Downloading job logs...");
+    var downloadProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+    {
+        FileName = "gh",
+        Arguments = $"api repos/{repo}/actions/jobs/{jobId}/logs",
+        RedirectStandardOutput = true,
+        UseShellExecute = false
+    });
+
+    var logs = await downloadProcess!.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+    await downloadProcess.WaitForExitAsync().ConfigureAwait(false);
+
+    if (downloadProcess.ExitCode == 0)
+    {
+        // Save logs to file
+        var safeName = Regex.Replace(jobName ?? $"job_{jobId}", @"[^a-zA-Z0-9_-]", "_");
+        var filename = $"failed_job_{counter}_{safeName}.log";
+        File.WriteAllText(filename, logs);
+        Console.WriteLine($"Saved job logs to: {filename} ({logs.Length} characters)");
+
+        // Extract and display test failures
+        Console.WriteLine("\nSearching for test failures in job logs...");
+        var failedTestPattern = @"Failed\s+(.+?)\s*\[";
+        var errorPattern = @"Error Message:\s*(.+?)(?:\r?\n|$)";
+        var exceptionPattern = @"(System\.\w+Exception:.+?)(?:\r?\n   at|\r?\n\r?\n|$)";
+
+        var failedTests = new HashSet<string>();
+        var errors = new List<string>();
+
+        foreach (Match match in Regex.Matches(logs, failedTestPattern))
+        {
+            failedTests.Add(match.Groups[1].Value.Trim());
+        }
+
+        foreach (Match match in Regex.Matches(logs, errorPattern))
+        {
+            errors.Add(match.Groups[1].Value.Trim());
+        }
+
+        foreach (Match match in Regex.Matches(logs, exceptionPattern, RegexOptions.Singleline))
+        {
+            var exception = match.Groups[1].Value.Trim();
+            if (!errors.Contains(exception))
+            {
+                errors.Add(exception);
+            }
+        }
+
+        if (failedTests.Count > 0)
+        {
+            Console.WriteLine($"\nFailed tests ({failedTests.Count}):");
+            foreach (var test in failedTests.Take(5))
+            {
+                Console.WriteLine($"  - {test}");
+            }
+            if (failedTests.Count > 5)
+            {
+                Console.WriteLine($"  ... and {failedTests.Count - 5} more");
+            }
+        }
+
+        if (errors.Count > 0)
+        {
+            Console.WriteLine($"\nErrors found ({errors.Count}):");
+            foreach (var error in errors.Take(3))
+            {
+                var displayError = error.Length > 200 ? string.Concat(error.AsSpan(0, 200), "...") : error;
+                Console.WriteLine($"  - {displayError}");
+            }
+            if (errors.Count > 3)
+            {
+                Console.WriteLine($"  ... and {errors.Count - 3} more");
+            }
+        }
+    }
+    else
+    {
+        Console.WriteLine($"Error downloading job logs: exit code {downloadProcess.ExitCode}");
+    }
+
+    // Try to download artifact based on job name
+    // Job name format: "Tests / Integrations macos (Hosting.Azure) / Hosting.Azure (macos-latest)"
+    // Artifact name format: "logs-{testShortName}-{os}"
+    // Extract testShortName and os from job name
+    var artifactMatch = Regex.Match(jobName ?? "", @".*\(([^)]+)\)\s*/\s*\S+\s+\(([^)]+)\)");
+    if (artifactMatch.Success)
+    {
+        var testShortName = artifactMatch.Groups[1].Value.Trim();
+        var os = artifactMatch.Groups[2].Value.Trim();
+        var artifactName = $"logs-{testShortName}-{os}";
+
+        Console.WriteLine($"\nAttempting to download artifact: {artifactName}");
+
+        // Query all artifacts (manual pagination through all pages)
+        string? artifactId = null;
+        var allArtifactNames = new List<string>();
+
+        // Manually paginate through all pages (GitHub API returns 30 per page by default, with up to 100 per page max)
+        int page = 1;
+        bool hasMorePages = true;
+
+        while (hasMorePages)
+        {
+            var getArtifactsProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "gh",
+                Arguments = $"api repos/{repo}/actions/runs/{runId}/artifacts?page={page}&per_page=100",
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            });
+
+            var artifactsJson = await getArtifactsProcess!.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+            await getArtifactsProcess.WaitForExitAsync().ConfigureAwait(false);
+
+            if (getArtifactsProcess.ExitCode != 0)
+            {
+                Console.WriteLine($"Error getting artifacts page {page}: exit code {getArtifactsProcess.ExitCode}");
+                break;
+            }
+
+            var artifactsDoc = JsonDocument.Parse(artifactsJson);
+            if (artifactsDoc.RootElement.TryGetProperty("artifacts", out var artifactsArray))
+            {
+                var artifactsOnPage = artifactsArray.GetArrayLength();
+                if (artifactsOnPage == 0)
+                {
+                    hasMorePages = false;
+                    break;
+                }
+
+                foreach (var artifact in artifactsArray.EnumerateArray())
+                {
+                    if (artifact.TryGetProperty("name", out var nameProperty))
+                    {
+                        var name = nameProperty.GetString();
+                        allArtifactNames.Add(name ?? "null");
+
+                        if (name == artifactName && artifact.TryGetProperty("id", out var idProperty))
+                        {
+                            artifactId = idProperty.GetInt64().ToString(CultureInfo.InvariantCulture);
+                        }
+                    }
+                }
+
+                // If we got fewer than 100 artifacts, this is the last page
+                if (artifactsOnPage < 100)
+                {
+                    hasMorePages = false;
+                }
+            }
+            else
+            {
+                hasMorePages = false;
+            }
+
+            page++;
+        }
+
+        Console.WriteLine($"Found {allArtifactNames.Count} total artifacts");
+
+        if (artifactId != null)
+        {
+            Console.WriteLine($"Found artifact ID: {artifactId}");
+
+            // Download artifact
+            var artifactZip = $"artifact_{counter}_{testShortName}_{os}.zip";
+            var downloadArtifactProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "gh",
+                Arguments = $"api repos/{repo}/actions/artifacts/{artifactId}/zip",
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            });
+
+            using (var fileStream = File.Create(artifactZip))
+            {
+                await downloadArtifactProcess!.StandardOutput.BaseStream.CopyToAsync(fileStream).ConfigureAwait(false);
+            }
+            await downloadArtifactProcess.WaitForExitAsync().ConfigureAwait(false);
+
+            if (downloadArtifactProcess.ExitCode == 0)
+            {
+                Console.WriteLine($"Downloaded artifact to: {artifactZip}");
+
+                // Unzip artifact using System.IO.Compression
+                var extractDir = $"artifact_{counter}_{testShortName}_{os}";
+                try
+                {
+                    // Delete existing directory if it exists
+                    if (Directory.Exists(extractDir))
+                    {
+                        Directory.Delete(extractDir, true);
+                    }
+
+                    ZipFile.ExtractToDirectory(artifactZip, extractDir);
+                    Console.WriteLine($"Extracted artifact to: {extractDir}");
+
+                    // List .trx files
+                    var trxFiles = Directory.GetFiles(extractDir, "*.trx", SearchOption.AllDirectories);
+                    if (trxFiles.Length > 0)
+                    {
+                        Console.WriteLine($"\nFound {trxFiles.Length} .trx file(s):");
+                        foreach (var trxFile in trxFiles)
+                        {
+                            Console.WriteLine($"  - {trxFile}");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("\nNo .trx files found in artifact.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error extracting artifact: {ex.Message}");
+                }
+            }
+            else
+            {
+                Console.WriteLine($"Error downloading artifact: exit code {downloadArtifactProcess.ExitCode}");
+            }
+        }
+        else
+        {
+            Console.WriteLine($"Artifact '{artifactName}' not found for this run.");
+        }
+    }
+    else
+    {
+        Console.WriteLine("\nCould not parse job name to determine artifact name.");
+    }
+
+    counter++;
+}
+
+Console.WriteLine($"\n=== Summary ===");
+Console.WriteLine($"Total jobs: {jobs.Count}");
+Console.WriteLine($"Failed jobs: {failedJobs.Count}");
+Console.WriteLine($"Logs downloaded: {counter}");
+Console.WriteLine($"\nAll logs saved in current directory with pattern: failed_job_*.log");

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -107,7 +107,7 @@ All logs saved in current directory with pattern: failed_job_*.log
 
 ### Technical Details
 
-- **Language**: C# 9.0+ (file-based program)
+- **Language**: C# 10+ (file-based program)
 - **Runtime**: .NET 10
 - **Key Dependencies**:
   - `System.IO.Compression` - For extracting zip artifacts

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -1,0 +1,137 @@
+# GitHub Actions Failure Analysis Tools
+
+This directory contains tools for analyzing and diagnosing GitHub Actions test failures.
+
+## DownloadFailingJobLogs.cs
+
+A .NET file-based program that automatically downloads logs and artifacts for failed GitHub Actions jobs.
+
+### What it does
+
+This tool helps you quickly investigate GitHub Actions test failures by:
+
+1. **Finding all failed jobs** in a GitHub Actions workflow run
+2. **Downloading job logs** for each failed job
+3. **Extracting test failures and errors** from the logs using regex patterns
+4. **Determining artifact names** from job names based on the workflow's naming convention
+5. **Downloading test artifacts** containing .trx files and test logs
+6. **Extracting artifacts** to local directories for inspection
+
+### Prerequisites
+
+- .NET 10 SDK or later
+- GitHub CLI (`gh`) installed and authenticated
+- Access to the dotnet/aspire repository (or appropriate permissions for your target repo)
+
+### Usage
+
+Run the tool by passing a GitHub Actions run ID:
+
+```bash
+dotnet tools/scripts/DownloadFailingJobLogs.cs <run-id>
+```
+
+**Example:**
+```bash
+dotnet tools/scripts/DownloadFailingJobLogs.cs 19846215629
+```
+
+You can find the run ID from the GitHub Actions URL:
+```
+https://github.com/dotnet/aspire/actions/runs/19846215629
+                                                  ^^^^^^^^^^
+                                                  run ID
+```
+
+### Output
+
+The tool creates the following files in your current directory:
+
+- **`failed_job_<n>_<job-name>.log`** - Raw job logs from GitHub Actions
+- **`artifact_<n>_<testname>_<os>.zip`** - Downloaded artifact zip files
+- **`artifact_<n>_<testname>_<os>/`** - Extracted artifact directories containing:
+  - `.trx` test result files
+  - Test logs
+  - Build binary logs (`.binlog`)
+  - DCP (Distributed Application) diagnostic logs
+
+### Example Output
+
+```
+Finding failed jobs for run 19846215629...
+Found 100 total jobs
+Found 1 failed jobs
+
+=== Failed Job 1/1 ===
+Name: Tests / Integrations macos (Hosting.Azure) / Hosting.Azure (macos-latest)
+ID: 56864254427
+URL: https://github.com/dotnet/aspire/actions/runs/19846215629/job/56864254427
+Downloading job logs...
+Saved job logs to: failed_job_0_Tests___Integrations_macos__Hosting_Azure____Hosting_Azure__macos-latest_.log (354209 characters)
+
+Searching for test failures in job logs...
+
+Errors found (2):
+  - System.InvalidOperationException: Step 'provision-api-service-website' failed: No output for AZURE_APP_SERVICE_DASHBOARD_URI
+  ...
+
+Attempting to download artifact: logs-Hosting.Azure-macos-latest
+Found 282 total artifacts
+Found artifact ID: 4732859962
+Downloaded artifact to: artifact_0_Hosting.Azure_macos-latest.zip
+Extracted artifact to: artifact_0_Hosting.Azure_macos-latest
+
+Found 1 .trx file(s):
+  - artifact_0_Hosting.Azure_macos-latest/testresults/Hosting.Azure_net8.0_20251202034715.trx
+
+=== Summary ===
+Total jobs: 100
+Failed jobs: 1
+Logs downloaded: 1
+
+All logs saved in current directory with pattern: failed_job_*.log
+```
+
+### How it works
+
+1. **Job Discovery**: Uses `gh api` to query all jobs in the workflow run with manual pagination to handle 200+ artifacts
+2. **Failure Detection**: Filters jobs by `conclusion == "failure"`
+3. **Log Download**: Downloads raw logs for each failed job via the GitHub API
+4. **Error Extraction**: Uses regex patterns to find:
+   - Failed test names
+   - Error messages
+   - Exception stack traces
+5. **Artifact Matching**: Parses job names to determine the artifact name using the pattern `logs-{testShortName}-{os}`
+6. **Artifact Download**: Downloads the matching artifact containing test results
+7. **Extraction**: Uses `System.IO.Compression.ZipFile` to extract artifacts
+
+### Technical Details
+
+- **Language**: C# 9.0+ (file-based program)
+- **Runtime**: .NET 10
+- **Key Dependencies**:
+  - `System.IO.Compression` - For extracting zip artifacts
+  - `System.Text.Json` - For parsing GitHub API responses
+  - `System.Text.RegularExpressions` - For extracting test failures
+- **GitHub API**: Uses `gh api` command-line tool for authenticated API access
+
+### Troubleshooting
+
+**No failed jobs found:**
+- Verify the run ID is correct
+- Check that the workflow run actually has failed jobs
+- Ensure you have access to the repository
+
+**Artifact not found:**
+- The artifact may have expired (GitHub Actions artifacts are typically retained for 90 days)
+- The job may not have uploaded an artifact (e.g., if it failed before tests ran)
+
+**Permission denied:**
+- Ensure you're authenticated with `gh auth login`
+- Verify you have read access to the repository
+
+### See Also
+
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [GitHub CLI Documentation](https://cli.github.com/manual/)
+- [.NET File-Based Programs](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/tutorials/file-based-programs)


### PR DESCRIPTION
- The tests did not capture the underlying failure because we didn't assert that the pipeline completed without an error.
- Added C# script to dowload test logs for a run. Helps when the agent needs to investigate failures.
