### PR TITLE
Fix: Complete channel writer when logger is removed

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -244,6 +244,7 @@ public class ResourceLoggerService
         finally
         {
             LoggerAdded -= OnLoggerAdded;
+            channel.Writer.Complete();
         }
     }
 


### PR DESCRIPTION
The test uses DefaultTimeout which wraps the enumerator with await using, triggering DisposeAsync() when breaking out of the loop early. Without
  channel.Writer.Complete(), the compiler-generated disposal code can't properly clean up the async iterator, resulting in the NotSupportedException.

This was causing some test flakiness
