### PR TITLE
Add container network alias annotation

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ContainerNetworkAliasAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerNetworkAliasAnnotation.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents an annotation for a custom network alias for a container resource.
+/// </summary>
+/// <remarks>
+/// Network aliases enable DNS resolution of the container on the network by custom names.
+/// Multiple aliases can be specified for a single container by adding multiple annotations.
+/// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Alias = {Alias}, Network = {NetworkIdentifier}")]
+public sealed class ContainerNetworkAliasAnnotation : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets or sets the network alias for the container.
+    /// </summary>
+    public required string Alias { get; set; }
+
+    /// <summary>
+    /// Gets or sets the network identifier for the network to which the alias applies.
+    /// </summary>
+    /// <remarks>
+    /// If not specified, defaults to the default Aspire container network.
+    /// </remarks>
+    public NetworkIdentifier Network { get; set; } = KnownNetworkIdentifiers.DefaultAspireContainerNetwork;
+}

--- a/src/Aspire.Hosting/ApplicationModel/ContainerNetworkAliasAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerNetworkAliasAnnotation.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// Network aliases enable DNS resolution of the container on the network by custom names.
 /// Multiple aliases can be specified for a single container by adding multiple annotations.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Alias = {Alias}, Network = {NetworkIdentifier}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Alias = {Alias}, Network = {Network}")]
 public sealed class ContainerNetworkAliasAnnotation : IResourceAnnotation
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ContainerNetworkAliasAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerNetworkAliasAnnotation.cs
@@ -15,10 +15,22 @@ namespace Aspire.Hosting.ApplicationModel;
 [DebuggerDisplay("Type = {GetType().Name,nq}, Alias = {Alias}, Network = {Network}")]
 public sealed class ContainerNetworkAliasAnnotation : IResourceAnnotation
 {
+    private readonly string _alias;
+    private NetworkIdentifier _network = KnownNetworkIdentifiers.DefaultAspireContainerNetwork;
+
     /// <summary>
-    /// Gets or sets the network alias for the container.
+    /// Creates a new instance of the <see cref="ContainerNetworkAliasAnnotation"/> class with the specified alias.
     /// </summary>
-    public required string Alias { get; set; }
+    public ContainerNetworkAliasAnnotation(string alias)
+    {
+        ArgumentOutOfRangeException.ThrowIfNullOrWhiteSpace(alias, nameof(alias));
+        _alias = alias;
+    }
+
+    /// <summary>
+    /// Gets the network alias for the container.
+    /// </summary>
+    public string Alias => _alias;
 
     /// <summary>
     /// Gets or sets the network identifier for the network to which the alias applies.
@@ -26,5 +38,14 @@ public sealed class ContainerNetworkAliasAnnotation : IResourceAnnotation
     /// <remarks>
     /// If not specified, defaults to the default Aspire container network.
     /// </remarks>
-    public NetworkIdentifier Network { get; set; } = KnownNetworkIdentifiers.DefaultAspireContainerNetwork;
+    public NetworkIdentifier Network
+    {
+        get => _network;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value, nameof(value));
+            ArgumentOutOfRangeException.ThrowIfNullOrWhiteSpace(value.Value, nameof(value));
+            _network = value;
+        }
+    }
 }

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -1503,6 +1503,60 @@ public static class ContainerResourceBuilderExtensions
             RuntimeImage = runtimeImage
         }, ResourceAnnotationMutationBehavior.Replace);
     }
+
+    /// <summary>
+    /// Adds a network alias to container resource.
+    /// </summary>
+    /// <typeparam name="T">The type of container resource.</typeparam>
+    /// <param name="builder">The resource builder for the container resource.</param>
+    /// <param name="alias">The network alias for the container.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// Network aliases enable DNS resolution of the container on the network by custom names.
+    /// By default, containers are accessible on the network using their resource name as a DNS alias.
+    /// This method allows adding additional aliases for the same container.
+    /// </para>
+    /// <para>
+    /// Multiple aliases can be added by calling this method multiple times.
+    /// </para>
+    /// </remarks>
+    public static IResourceBuilder<T> WithContainerNetworkAlias<T>(this IResourceBuilder<T> builder, string alias) where T : ContainerResource
+    {
+        return builder.WithContainerNetworkAlias(alias, KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+    }
+
+    /// <summary>
+    /// Adds a network alias to container resource.
+    /// </summary>
+    /// <typeparam name="T">The type of container resource.</typeparam>
+    /// <param name="builder">The resource builder for the container resource.</param>
+    /// <param name="alias">The network alias for the container.</param>
+    /// <param name="network">The identifier of the network to which the alias should be applied.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// Network aliases enable DNS resolution of the container on the network by custom names.
+    /// By default, containers are accessible on the network using their resource name as a DNS alias.
+    /// This method allows adding additional aliases for the same container.
+    /// </para>
+    /// <para>
+    /// Multiple aliases can be added by calling this method multiple times.
+    /// </para>
+    /// </remarks>
+    public static IResourceBuilder<T> WithContainerNetworkAlias<T>(this IResourceBuilder<T> builder, string alias, NetworkIdentifier network) where T : ContainerResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(alias);
+        ArgumentException.ThrowIfNullOrWhiteSpace(network.Value);
+
+        if (network != KnownNetworkIdentifiers.DefaultAspireContainerNetwork)
+        {
+            throw new ArgumentOutOfRangeException(nameof(network), "Custom container networks are not supported yet.");
+        }
+
+        return builder.WithAnnotation(new ContainerNetworkAliasAnnotation { Alias = alias, Network = network });
+    }
 }
 
 internal static class IListExtensions

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -1523,39 +1523,7 @@ public static class ContainerResourceBuilderExtensions
     /// </remarks>
     public static IResourceBuilder<T> WithContainerNetworkAlias<T>(this IResourceBuilder<T> builder, string alias) where T : ContainerResource
     {
-        return builder.WithContainerNetworkAlias(alias, KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
-    }
-
-    /// <summary>
-    /// Adds a network alias to container resource.
-    /// </summary>
-    /// <typeparam name="T">The type of container resource.</typeparam>
-    /// <param name="builder">The resource builder for the container resource.</param>
-    /// <param name="alias">The network alias for the container.</param>
-    /// <param name="network">The identifier of the network to which the alias should be applied.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <remarks>
-    /// <para>
-    /// Network aliases enable DNS resolution of the container on the network by custom names.
-    /// By default, containers are accessible on the network using their resource name as a DNS alias.
-    /// This method allows adding additional aliases for the same container.
-    /// </para>
-    /// <para>
-    /// Multiple aliases can be added by calling this method multiple times.
-    /// </para>
-    /// </remarks>
-    public static IResourceBuilder<T> WithContainerNetworkAlias<T>(this IResourceBuilder<T> builder, string alias, NetworkIdentifier network) where T : ContainerResource
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentException.ThrowIfNullOrWhiteSpace(alias);
-        ArgumentException.ThrowIfNullOrWhiteSpace(network.Value);
-
-        if (network != KnownNetworkIdentifiers.DefaultAspireContainerNetwork)
-        {
-            throw new ArgumentOutOfRangeException(nameof(network), "Custom container networks are not supported yet.");
-        }
-
-        return builder.WithAnnotation(new ContainerNetworkAliasAnnotation { Alias = alias, Network = network });
+        return builder.WithAnnotation(new ContainerNetworkAliasAnnotation(alias) { Network = KnownNetworkIdentifiers.DefaultAspireContainerNetwork });
     }
 }
 

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1789,7 +1789,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             var aanns = container.Annotations.OfType<ContainerNetworkAliasAnnotation>().ToImmutableArray();
             if (aanns.Any(a => a.Network != KnownNetworkIdentifiers.DefaultAspireContainerNetwork))
             {
-                throw new InvalidOperationException("Custom container networks are not supported by Aspire yet");
+                throw new InvalidOperationException("Custom container networks are not supported yet.");
             }
 
             ctr.Spec.Networks = new List<ContainerNetworkConnection>


### PR DESCRIPTION
## Description

Adds ability to specify custom DNS names (aliases) for containers.

Fixes https://github.com/dotnet/aspire/issues/11906

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
I think this does not warrant a documentation update--doc comments, which are included, should suffice--but I am happy to open a doc issue if people think otherwise.