### PR TITLE
Handle relative endpoint URLs

### DIFF
--- a/playground/TestShop/TestShop.AppHost/AppHost.cs
+++ b/playground/TestShop/TestShop.AppHost/AppHost.cs
@@ -51,6 +51,20 @@ if (builder.Environment.IsDevelopment() && builder.ExecutionContext.IsRunMode)
 
 var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice")
                             .WithReference(catalogDb)
+                            // Modify the endpoint URL
+                            .WithUrlForEndpoint("https", u =>
+                            {
+                                u.Url = "/";
+                                u.DisplayText = "Catalog API";
+                            })
+                            // Add an endpoint URL
+                            .WithUrlForEndpoint("https", _ => new()
+                            {
+                                Url = "/swagger",
+                                DisplayText = "Swagger UI"
+                            })
+                            // Hide the http URL
+                            .WithUrlForEndpoint("http", u => u.DisplayLocation = UrlDisplayLocation.DetailsOnly)
                             .WithReplicas(2);
 
 var messaging = builder.AddRabbitMQ("messaging")

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -353,11 +353,12 @@ internal sealed class ApplicationOrchestrator
             var primaryUrl = urls.FirstOrDefault(u => string.Equals(u.Endpoint?.EndpointName, primaryLaunchProfileEndpoint.Name, StringComparisons.EndpointAnnotationName));
             if (primaryUrl is not null)
             {
-                var primaryUri = new Uri(primaryUrl.Url);
-                var primaryPath = primaryUri.AbsolutePath;
+                Uri.TryCreate(primaryUrl.Url, UriKind.RelativeOrAbsolute, out var primaryUri);
+                var primaryPath = primaryUri?.IsAbsoluteUri == true ? primaryUri.AbsolutePath : primaryUrl.Url;
 
-                if (primaryPath != "/")
+                if (primaryPath.StartsWith('/') && primaryPath.Length > 1)
                 {
+                    // The primary launch profile endpoint has a path, apply that path to all other launch profile endpoint URLs.
                     foreach (var url in urls)
                     {
                         if (url.Endpoint?.EndpointAnnotation == primaryLaunchProfileEndpoint && !string.Equals(url.Url, primaryUrl.Url, StringComparisons.Url))


### PR DESCRIPTION
## Description

Updates the logic for processing resource endpoint URLs to handle cases where the URL is set to a custom relative URL. The existing logic was assuming the URL was always absolute and a valid `Uri` and was silently throwing thus breaking all URL processing for impacted resources.

Added missing test coverage.

Fixes #13059

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
