### PR TITLE
[CI] Fix workflows, and run Quarantined tests every four hours

### DIFF
--- a/.github/workflows/specialized-test-runner.yml
+++ b/.github/workflows/specialized-test-runner.yml
@@ -108,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         tests: ${{ fromJson(needs.generate_tests_matrix.outputs.runsheet) }}
-    if: ${{ github.repository_owner == 'dotnet' && needs.generate_tests_matrix.result == 'success' && (needs.build_packages.result == 'success' || needs.build_packages.result == 'skipped') }}
+    if: ${{ github.repository_owner == 'dotnet' && !cancelled() && !failure() }}
     uses: ./.github/workflows/run-tests.yml
     with:
       testShortName: ${{ matrix.tests.project }}

--- a/.github/workflows/specialized-test-runner.yml
+++ b/.github/workflows/specialized-test-runner.yml
@@ -184,7 +184,19 @@ jobs:
       - name: Fail if any dependency failed
         # 'skipped' can be when a transitive dependency fails and the dependent job gets 'skipped'.
         # For example, one of setup_* jobs failing and the Integration test jobs getting 'skipped'
-        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')) }}
+        # Note: build_packages being skipped is expected when requiresNugets is false, so we check it separately
+        if: >-
+          ${{
+            always() && (
+              needs.generate_tests_matrix.result == 'failure' ||
+              needs.generate_tests_matrix.result == 'cancelled' ||
+              needs.run_tests.result == 'failure' ||
+              needs.run_tests.result == 'cancelled' ||
+              needs.run_tests.result == 'skipped' ||
+              (needs.build_packages.result == 'failure') ||
+              (needs.build_packages.result == 'cancelled')
+            )
+          }}
         run: |
           echo "One or more dependent jobs failed."
           exit 1

--- a/.github/workflows/tests-quarantine.yml
+++ b/.github/workflows/tests-quarantine.yml
@@ -14,7 +14,8 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: '0 2,14 * * *'  # Twice daily at 02:00 and 14:00 UTC
+    # Run every 4 hours
+    - cron: '0 */4 * * *'
 
   # TEMPORARILY DISABLED pull_request trigger due to #12143 (disk space issues): https://github.com/dotnet/aspire/issues/12143
   # pull_request:


### PR DESCRIPTION
Fixes - the main `run-tests` job was getting skipped whenever `build_packages` job was skipped.

Changes the frequency of the Quarantined tests workflow to every 4 hours. This is a temporary measure so we can quickly collect data on flakiness, to cover missed coverage over past few weeks.