### PR TITLE
Fix up the js frontend template

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-js-frontend-starter/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-js-frontend-starter/.template.config/dotnetcli.host.json
@@ -4,11 +4,6 @@
       "Framework": {
         "longName": "framework"
       },
-      "XUnitVersion": {
-        "shortName": "",
-        "longName": "xunit-version",
-        "defaultValue": "v2"
-      },
       "appHostHttpPort": {
         "isHidden": true
       },
@@ -33,10 +28,10 @@
       "appHostResourceHttpsPort": {
         "isHidden": true
       },
-      "apiServiceHttpPort": {
+      "serverHttpPort": {
         "isHidden": true
       },
-      "apiServiceHttpsPort": {
+      "serverHttpsPort": {
         "isHidden": true
       },
       "NoHttps": {
@@ -47,17 +42,12 @@
         "longName": "use-redis-cache",
         "shortName": ""
       },
-      "TestFx": {
-        "longName": "test-framework",
-        "shortName": "t"
-      },
       "LocalhostTld": {
         "longName": "localhost-tld",
         "shortName": ""
       }
     },
     "usageExamples": [
-      "--use-redis-cache",
-      "--test-framework MSTest"
+      "--use-redis-cache"
     ]
   }

--- a/src/Aspire.ProjectTemplates/templates/aspire-js-frontend-starter/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-js-frontend-starter/.template.config/ide.host.json
@@ -11,18 +11,7 @@
   ],
   "symbolInfo": [
     {
-      "id": "XUnitVersion",
-      "isVisible": true,
-      "persistenceScope": "shared",
-      "persistenceScopeName": "aspireTemplates"
-    },
-    {
       "id": "UseRedisCache",
-      "isVisible": true,
-      "persistenceScope": "templateGroup"
-    },
-    {
-      "id": "TestFx",
       "isVisible": true,
       "persistenceScope": "templateGroup"
     },

--- a/src/Aspire.ProjectTemplates/templates/aspire-js-frontend-starter/Aspire-StarterApplication.1.Server/Aspire-StarterApplication.1.Server.http
+++ b/src/Aspire.ProjectTemplates/templates/aspire-js-frontend-starter/Aspire-StarterApplication.1.Server/Aspire-StarterApplication.1.Server.http
@@ -1,6 +1,6 @@
-@ApiService_HostAddress = http://localhost:5301
+@Server_HostAddress = http://localhost:5301
 
-GET {{ApiService_HostAddress}}/api/weatherforecast/
+GET {{Server_HostAddress}}/api/weatherforecast/
 Accept: application/json
 
 ###


### PR DESCRIPTION
There were some copy paste mistakes when making this template.

There is no test option for this template.
The .NET backend is named "server" not "ApiService".