### PR TITLE
Fix flaky test

### DIFF
--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -181,8 +181,9 @@ public class TestingBuilderTests(ITestOutputHelper output)
         await using var app = await builder.BuildAsync();
         await app.StartAsync();
 
-        // Wait for the application to be ready
-        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+        // Wait for the application to be ready - must specify "mywebapp1" to avoid race condition
+        // where myworker1 logs "Application started." first
+        await app.WaitForTextAsync("Application started.", "mywebapp1").WaitAsync(TimeSpan.FromMinutes(1));
 
         var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
         {
@@ -240,8 +241,9 @@ public class TestingBuilderTests(ITestOutputHelper output)
         await using var app = await builder.BuildAsync();
         await app.StartAsync();
 
-        // Wait for the application to be ready
-        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+        // Wait for the application to be ready - must specify "mywebapp1" to avoid race condition
+        // where myworker1 logs "Application started." first
+        await app.WaitForTextAsync("Application started.", "mywebapp1").WaitAsync(TimeSpan.FromMinutes(1));
 
         var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
         {
@@ -278,8 +280,9 @@ public class TestingBuilderTests(ITestOutputHelper output)
         await using var app = await builder.BuildAsync();
         await app.StartAsync();
 
-        // Wait for the application to be ready
-        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+        // Wait for the application to be ready - must specify "mywebapp1" to avoid race condition
+        // where myworker1 logs "Application started." first
+        await app.WaitForTextAsync("Application started.", "mywebapp1").WaitAsync(TimeSpan.FromMinutes(1));
 
         var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
         {
@@ -321,8 +324,9 @@ public class TestingBuilderTests(ITestOutputHelper output)
         await using var app = await builder.BuildAsync();
         await app.StartAsync();
 
-        // Wait for the application to be ready
-        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+        // Wait for the application to be ready - must specify "mywebapp1" to avoid race condition
+        // where myworker1 logs "Application started." first
+        await app.WaitForTextAsync("Application started.", "mywebapp1").WaitAsync(TimeSpan.FromMinutes(1));
 
         var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
         {
@@ -372,8 +376,9 @@ public class TestingBuilderTests(ITestOutputHelper output)
         await using var app = await builder.BuildAsync();
         await app.StartAsync();
 
-        // Wait for the application to be ready
-        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+        // Wait for the application to be ready - must specify "mywebapp1" to avoid race condition
+        // where myworker1 logs "Application started." first
+        await app.WaitForTextAsync("Application started.", "mywebapp1").WaitAsync(TimeSpan.FromMinutes(1));
 
         var httpClient = app.CreateHttpClientWithResilience("mywebapp1", null, opts =>
         {
@@ -421,8 +426,9 @@ public class TestingBuilderTests(ITestOutputHelper output)
         var profileName = config["DOTNET_LAUNCH_PROFILE"];
         Assert.Equal("https", profileName);
 
-        // Wait for the application to be ready
-        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+        // Wait for the application to be ready - must specify "mywebapp1" to avoid race condition
+        // where myworker1 logs "Application started." first
+        await app.WaitForTextAsync("Application started.", "mywebapp1").WaitAsync(TimeSpan.FromMinutes(1));
 
         // Explicitly get the HTTPS endpoint - this is only available on the "https" launch profile.
         var httpClient = app.CreateHttpClientWithResilience("mywebapp1", "https", opts =>


### PR DESCRIPTION
https://github.com/dotnet/aspire/actions/runs/19914335224/job/57089880760?pr=13322 failure 

## AI generated 😄 

Fix race condition in TestingBuilderTests where myworker1 logs "Application started." before mywebapp1

  Problem

  The test ArgsPropagateToAppHostConfiguration(genericEntryPoint: True, directArgs: True) was failing intermittently on Linux CI with a 400 Bad Request
  error.

  Root Cause Analysis

  Investigation of the CI failure revealed a race condition in the test setup:

  1. The test uses WaitForTextAsync("Application started.") without specifying a resource name
  2. The myworker1 (worker) process starts faster than mywebapp1 (web app) on slower CI runners
  3. When myworker1 logs "Application started." first, the wait completes even though mywebapp1 isn't ready
  4. The subsequent HTTP request to mywebapp1 fails with 400 Bad Request because the web app hasn't finished initializing

  Evidence from CI logs:
  myworker1: Application started. Press Ctrl+C to shut down.
  [Error] Response status code does not indicate success: 400 (Bad Request)
  Note: No "Application started." log from mywebapp1 appeared before the error.

  Fix

  Added the resource name filter "mywebapp1" to WaitForTextAsync calls to ensure we wait specifically for the web app to be ready before making HTTP
  requests:

  // Before
  await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));

  // After
  await app.WaitForTextAsync("Application started.", "mywebapp1").WaitAsync(TimeSpan.FromMinutes(1));

  Fixed 6 occurrences of this pattern in TestingBuilderTests.cs.

  Why it was intermittent

  - On fast machines (local dev), mywebapp1 usually starts quickly enough
  - On slower CI runners (Linux ubuntu-latest), the worker starts faster than the webapp, triggering the race condition