### PR TITLE
[tests] Fix preparing dotnet-tests for template and helix test runs

### DIFF
--- a/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
@@ -21,8 +21,7 @@ public class NewUpAndBuildStandaloneTemplateTests(ITestOutputHelper testOutput) 
             TestSdk.Current => BuildEnvironment.ForCurrentSdkOnly,
             TestSdk.Previous => BuildEnvironment.ForPreviousSdkOnly,
             TestSdk.Next => BuildEnvironment.ForNextSdkOnly,
-            TestSdk.CurrentSdkAndPreviousRuntime => BuildEnvironment.ForCurrentSdkAndPreviousRuntime,
-            TestSdk.NextSdkAndCurrentRuntime => BuildEnvironment.ForNextSdkAndCurrentRuntime,
+            TestSdk.NextSdkWithCurrentAndPreviousRuntime => BuildEnvironment.ForNextSdkWithCurrentAndPreviousRuntimes,
             _ => throw new ArgumentOutOfRangeException(nameof(sdk))
         };
 

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -19,8 +19,7 @@ public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper
             TestSdk.Current => BuildEnvironment.ForCurrentSdkOnly,
             TestSdk.Previous => BuildEnvironment.ForPreviousSdkOnly,
             TestSdk.Next => BuildEnvironment.ForNextSdkOnly,
-            TestSdk.CurrentSdkAndPreviousRuntime => BuildEnvironment.ForCurrentSdkAndPreviousRuntime,
-            TestSdk.NextSdkAndCurrentRuntime => BuildEnvironment.ForNextSdkAndCurrentRuntime,
+            TestSdk.NextSdkWithCurrentAndPreviousRuntime => BuildEnvironment.ForNextSdkWithCurrentAndPreviousRuntimes,
             _ => throw new ArgumentOutOfRangeException(nameof(sdk))
         };
 

--- a/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
@@ -362,11 +362,11 @@ public partial class TemplateTestsBase
             { templateName, extraArgs, TestSdk.Next, TestTargetFramework.Next, null },
 
             // Current SDK + previous runtime, Previous TFM
-            { templateName, extraArgs, TestSdk.CurrentSdkAndPreviousRuntime, TestTargetFramework.Previous, null },
+            { templateName, extraArgs, TestSdk.NextSdkWithCurrentAndPreviousRuntime, TestTargetFramework.Previous, null },
             // Current SDK + previous runtime, Current TFM
-            { templateName, extraArgs, TestSdk.CurrentSdkAndPreviousRuntime, TestTargetFramework.Current, null },
-            // Next SDK + current runtime, Current TFM
-            { templateName, extraArgs, TestSdk.NextSdkAndCurrentRuntime, TestTargetFramework.Current, null },
+            { templateName, extraArgs, TestSdk.NextSdkWithCurrentAndPreviousRuntime, TestTargetFramework.Current, null },
+            // Next SDK + current runtime, Next TFM
+            { templateName, extraArgs, TestSdk.NextSdkWithCurrentAndPreviousRuntime, TestTargetFramework.Next, null },
         };
 
     // Taken from dotnet/runtime src/tasks/Common/Utils.cs

--- a/tests/Aspire.Templates.Tests/TestSdk.cs
+++ b/tests/Aspire.Templates.Tests/TestSdk.cs
@@ -7,7 +7,6 @@ public enum TestSdk
 {
     Previous,
     Current,
-    CurrentSdkAndPreviousRuntime,
     Next,
-    NextSdkAndCurrentRuntime
+    NextSdkWithCurrentAndPreviousRuntime
 }

--- a/tests/Shared/Aspire.Templates.Testing.targets
+++ b/tests/Shared/Aspire.Templates.Testing.targets
@@ -29,8 +29,8 @@
     <SdkDirForNextTFM>$(ArtifactsBinDir)dotnet-10\</SdkDirForNextTFM>
     <SdkStampPathForNextTFM>$(SdkDirForNextTFM).version-$(SdkVersionForNextTFM).stamp</SdkStampPathForNextTFM>
 
-    <SdkDirForNextAndCurrentTFM>$(ArtifactsBinDir)dotnet-tests\</SdkDirForNextAndCurrentTFM>
-    <SdkStampPathForNextAndCurrentTFM>$(SdkDirForNextAndCurrentTFM).version-$(SdkVersionForNextTFM)-$(SdkVersionForCurrentTFM).stamp</SdkStampPathForNextAndCurrentTFM>
+    <SdkDirForNextWithCurrentAndPreviousRuntimes>$(ArtifactsBinDir)dotnet-tests\</SdkDirForNextWithCurrentAndPreviousRuntimes>
+    <SdkStampPathForNextAndCurrentTFM>$(SdkDirForNextWithCurrentAndPreviousRuntimes).version-$(SdkVersionForNextTFM)-$(SdkVersionForCurrentTFM).stamp</SdkStampPathForNextAndCurrentTFM>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)InstallSdk.props" />
@@ -62,66 +62,43 @@
              Targets="ProvisionSdk" />
     <Touch Files="$(SdkStampPathForNextTFM)" AlwaysCreate="true" />
 
-    <CallTarget Targets="ProvisionSdkForCurrentAndPreviousTFM" />
+    <CallTarget Targets="ProvisionNextSDKWithCurrentAndPreviousRuntimes" />
   </Target>
 
-  <Target Name="ProvisionSdkForCurrentAndPreviousTFM" Condition="!Exists($(SdkStampPathForCurrentAndPreviousTFM))">
+  <Target Name="ProvisionNextSDKWithCurrentAndPreviousRuntimes" Condition="!Exists($(SdkStampPathForNextAndCurrentTFM))">
 
-    <!-- Install For Current sdk + previous runtime -->
+    <!-- Install For Next sdk + current + prev runtimes -->
 
-    <!-- 1. Prepare the target dir -->
-    <RemoveDir Directories="$(SdkDirForCurrentAndPreviousTFM)" />
-    <MakeDir Directories="$(SdkDirForCurrentAndPreviousTFM)" />
-
-    <!-- 2. Make a copy of current -->
-    <ItemGroup>
-      <_SdkCurrentFile Include="$(SdkDirForCurrentTFM)\**\*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_SdkCurrentFile)" DestinationFolder="$(SdkDirForCurrentAndPreviousTFM)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-
-    <!-- 3. Install both current runtimes (.NET 9) and previous runtimes (.NET 8) -->
-    <Exec Condition="'%(CurrentRuntimeToInstallArguments.Identity)' != '' and !$([MSBuild]::IsOSPlatform('windows'))"
-          IgnoreStandardErrorWarningFormat="true"
-          Command="$(_DotNetInstallScriptPath) -InstallDir $(SdkDirForCurrentAndPreviousTFM) -SkipNonVersionedFiles %(CurrentRuntimeToInstallArguments.Identity)" />
-
-    <Exec Condition="'%(CurrentRuntimeToInstallArguments.Identity)' != '' and $([MSBuild]::IsOSPlatform('windows'))"
-          IgnoreStandardErrorWarningFormat="true"
-          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(SdkDirForCurrentAndPreviousTFM) -SkipNonVersionedFiles %(CurrentRuntimeToInstallArguments.Identity)"' />
-
-    <Exec Condition="'%(PreviousRuntimeToInstallArguments.Identity)' != '' and !$([MSBuild]::IsOSPlatform('windows'))"
-          IgnoreStandardErrorWarningFormat="true"
-          Command="$(_DotNetInstallScriptPath) -InstallDir $(SdkDirForCurrentAndPreviousTFM) -SkipNonVersionedFiles %(PreviousRuntimeToInstallArguments.Identity)" />
-
-    <Exec Condition="'%(PreviousRuntimeToInstallArguments.Identity)' != '' and $([MSBuild]::IsOSPlatform('windows'))"
-          IgnoreStandardErrorWarningFormat="true"
-          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(SdkDirForCurrentAndPreviousTFM) -SkipNonVersionedFiles %(PreviousRuntimeToInstallArguments.Identity)"' />
-
-    <Touch Files="$(SdkStampPathForCurrentAndPreviousTFM)" AlwaysCreate="true" />
-  </Target>
-
-  <Target Name="ProvisionSdkForNextAndCurrentTFM" Condition="!Exists($(SdkStampPathForNextAndCurrentTFM))">
-
-    <!-- Install For Next sdk + current runtime -->
+    <PropertyGroup>
+      <_SdkDirToInstallTo>$(SdkDirForNextWithCurrentAndPreviousRuntimes)</_SdkDirToInstallTo>
+    </PropertyGroup>
 
     <!-- 1. Prepare the target dir -->
-    <RemoveDir Directories="$(SdkDirForNextAndCurrentTFM)" />
-    <MakeDir Directories="$(SdkDirForNextAndCurrentTFM)" />
+    <RemoveDir Directories="$(SdkDirForNextWithCurrentAndPreviousRuntimes)" />
+    <MakeDir Directories="$(SdkDirForNextWithCurrentAndPreviousRuntimes)" />
 
     <!-- 2. Make a copy of next -->
     <ItemGroup>
       <_SdkNextFile Include="$(SdkDirForNextTFM)\**\*" />
     </ItemGroup>
-    <Copy SourceFiles="@(_SdkNextFile)" DestinationFolder="$(SdkDirForNextAndCurrentTFM)\%(RecursiveDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_SdkNextFile)" DestinationFolder="$(_SdkDirToInstallTo)\%(RecursiveDir)" SkipUnchangedFiles="true" />
 
     <!-- 3. Install current runtimes -->
     <Exec Condition="'%(CurrentRuntimeToInstallArguments.Identity)' != '' and !$([MSBuild]::IsOSPlatform('windows'))"
           IgnoreStandardErrorWarningFormat="true"
-          Command="$(_DotNetInstallScriptPath) -InstallDir $(SdkDirForNextAndCurrentTFM) -SkipNonVersionedFiles %(CurrentRuntimeToInstallArguments.Identity)" />
+          Command="$(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(CurrentRuntimeToInstallArguments.Identity)" />
 
     <Exec Condition="'%(CurrentRuntimeToInstallArguments.Identity)' != '' and $([MSBuild]::IsOSPlatform('windows'))"
           IgnoreStandardErrorWarningFormat="true"
-          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(SdkDirForNextAndCurrentTFM) -SkipNonVersionedFiles %(CurrentRuntimeToInstallArguments.Identity)"' />
+          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(CurrentRuntimeToInstallArguments.Identity)"' />
 
+    <Exec Condition="'%(PreviousRuntimeToInstallArguments.Identity)' != '' and !$([MSBuild]::IsOSPlatform('windows'))"
+          IgnoreStandardErrorWarningFormat="true"
+          Command="$(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(PreviousRuntimeToInstallArguments.Identity)" />
+
+    <Exec Condition="'%(PreviousRuntimeToInstallArguments.Identity)' != '' and $([MSBuild]::IsOSPlatform('windows'))"
+          IgnoreStandardErrorWarningFormat="true"
+          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(PreviousRuntimeToInstallArguments.Identity)"' />
     <Touch Files="$(SdkStampPathForNextAndCurrentTFM)" AlwaysCreate="true" />
   </Target>
 

--- a/tests/Shared/TemplatesTesting/BuildEnvironment.cs
+++ b/tests/Shared/TemplatesTesting/BuildEnvironment.cs
@@ -46,17 +46,13 @@ public class BuildEnvironment
     private static readonly Lazy<BuildEnvironment> s_instance_100 = new(() =>
         new BuildEnvironment(sdkDirName: "dotnet-10"));
 
-    private static readonly Lazy<BuildEnvironment> s_instance_90_80 = new(() =>
-        new BuildEnvironment(sdkDirName: "dotnet-tests"));
-
-    private static readonly Lazy<BuildEnvironment> s_instance_100_90 = new(() =>
+    private static readonly Lazy<BuildEnvironment> s_instance_100_90_80 = new(() =>
         new BuildEnvironment(sdkDirName: "dotnet-tests"));
 
     public static BuildEnvironment ForPreviousSdkOnly => s_instance_80.Value;
     public static BuildEnvironment ForCurrentSdkOnly => s_instance_90.Value;
     public static BuildEnvironment ForNextSdkOnly => s_instance_100.Value;
-    public static BuildEnvironment ForCurrentSdkAndPreviousRuntime => s_instance_90_80.Value;
-    public static BuildEnvironment ForNextSdkAndCurrentRuntime => s_instance_100_90.Value;
+    public static BuildEnvironment ForNextSdkWithCurrentAndPreviousRuntimes => s_instance_100_90_80.Value;
 
     public static BuildEnvironment ForDefaultFramework =>
         DefaultTargetFramework switch
@@ -65,7 +61,7 @@ public class BuildEnvironment
 
             // Use current+previous to allow running tests on helix built with 9.0 sdk
             // but targeting 8.0 tfm
-            TestTargetFramework.Current => ForCurrentSdkAndPreviousRuntime,
+            TestTargetFramework.Current => ForNextSdkWithCurrentAndPreviousRuntimes,
 
             _ => throw new ArgumentOutOfRangeException(nameof(DefaultTargetFramework))
         };


### PR DESCRIPTION
Various test projects that multi-target and run on helix depend on using `dotnet-tests`. But `dotnet-tests` was not installing `.net 10` which caused the tests to fail.

Now, `dotnet-tests` will have the `next` sdk (so 10.0) with 8.0 and 9.0
runtimes. `dotnet-tests` gets used as the installation that can run all
the TFMs.