### PR TITLE
Docker compose summary fixes

### DIFF
--- a/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
+++ b/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
@@ -15,6 +15,7 @@
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Shared\ProcessUtil.cs" />
     <Compile Include="$(SharedDir)ResourceNameComparer.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)PublishingContextUtils.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedDir)StringComparers.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)Yaml\*.cs" LinkBase="Shared\Yaml" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResourceBuilderExtensions.cs
@@ -40,7 +40,8 @@ public static class DockerComposeAspireDashboardResourceBuilderExtensions
                       // Expose the HTTP endpoint externally for the dashboard, it is password protected
                       // and disabled by default so an explicit call is required to turn it on.
                       .WithEndpoint("http", e => e.IsExternal = true)
-                      .WithHttpEndpoint(name: "otlp-grpc", targetPort: 18889);
+                      .WithHttpEndpoint(name: "otlp-grpc", targetPort: 18889)
+                      .WithHttpEndpoint(name: "otlp-http", targetPort: 18890);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResourceBuilderExtensions.cs
@@ -37,6 +37,9 @@ public static class DockerComposeAspireDashboardResourceBuilderExtensions
         return builder.CreateResourceBuilder(resource)
                       .WithImage("mcr.microsoft.com/dotnet/nightly/aspire-dashboard")
                       .WithHttpEndpoint(targetPort: 18888)
+                      // Expose the HTTP endpoint externally for the dashboard, it is password protected
+                      // and disabled by default so an explicit call is required to turn it on.
+                      .WithEndpoint("http", e => e.IsExternal = true)
                       .WithHttpEndpoint(name: "otlp-grpc", targetPort: 18889);
     }
 

--- a/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
@@ -329,7 +329,7 @@ public class DockerComposeServiceResource : Resource, IResourceWithParent<Docker
         if (endpoints.Count > 0)
         {
             var endpointList = string.Join(", ", endpoints.Select(e => $"[{e}]({e})"));
-            context.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{TargetResource.Name}** to {endpointList}", enableMarkdown: true);
+            context.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{TargetResource.Name}** to {endpointList}.", enableMarkdown: true);
         }
         else
         {
@@ -409,7 +409,7 @@ public class DockerComposeServiceResource : Resource, IResourceWithParent<Docker
         List<EndpointMapping> externalEndpointMappings,
         ILogger logger)
     {
-        var endpoints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var endpoints = new HashSet<string>(StringComparers.EndpointAnnotationName);
         var serviceName = TargetResource.Name.ToLowerInvariant();
 
         foreach (var line in outputLines)

--- a/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
@@ -420,7 +420,7 @@ public class DockerComposeServiceResource : Resource, IResourceWithParent<Docker
 
                 // Skip if not our service
                 if (serviceInfo is null ||
-                    !string.Equals(serviceInfo.Service, serviceName, StringComparison.OrdinalIgnoreCase))
+                    !string.Equals(serviceInfo.Service, serviceName, StringComparisons.ResourceName))
                 {
                     continue;
                 }

--- a/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
@@ -310,130 +310,161 @@ public class DockerComposeServiceResource : Resource, IResourceWithParent<Docker
     {
         var outputPath = PublishingContextUtils.GetEnvironmentOutputPath(context, environment);
 
-        try
+        // No external endpoints configured - this is valid for internal-only services
+        var externalEndpointMappings = EndpointMappings.Values.Where(m => m.IsExternal).ToList();
+        if (externalEndpointMappings.Count == 0)
         {
-            // Use docker compose ps to get the running containers and their port mappings
-            var arguments = DockerComposeEnvironmentResource.GetDockerComposeArguments(context, environment);
-            arguments += " ps --format json";
+            context.ReportingStep.Log(LogLevel.Information,
+                $"Successfully deployed **{TargetResource.Name}** to Docker Compose environment **{environment.Name}**. No public endpoints were configured.",
+                enableMarkdown: true);
+            return;
+        }
 
-            var outputLines = new List<string>();
+        // Query the running container for its published ports
+        var outputLines = await RunDockerComposePsAsync(context, environment, outputPath).ConfigureAwait(false);
+        var endpoints = outputLines is not null
+            ? ParseServiceEndpoints(outputLines, externalEndpointMappings, context.Logger)
+            : [];
 
-            var spec = new ProcessSpec("docker")
+        if (endpoints.Count > 0)
+        {
+            var endpointList = string.Join(", ", endpoints.Select(e => $"[{e}]({e})"));
+            context.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{TargetResource.Name}** to {endpointList}", enableMarkdown: true);
+        }
+        else
+        {
+            // No published ports found in docker compose ps output.
+            context.ReportingStep.Log(LogLevel.Information,
+                $"Successfully deployed **{TargetResource.Name}** to Docker Compose environment **{environment.Name}**.",
+                enableMarkdown: true);
+        }
+    }
+
+    /// <summary>
+    /// Runs 'docker compose ps --format json' to get container status and port mappings.
+    /// </summary>
+    /// <returns>List of JSON output lines, or null if the command failed.</returns>
+    private static async Task<List<string>?> RunDockerComposePsAsync(
+        PipelineStepContext context,
+        DockerComposeEnvironmentResource environment,
+        string outputPath)
+    {
+        var arguments = DockerComposeEnvironmentResource.GetDockerComposeArguments(context, environment);
+        arguments += " ps --format json";
+
+        var outputLines = new List<string>();
+
+        var spec = new ProcessSpec("docker")
+        {
+            Arguments = arguments,
+            WorkingDirectory = outputPath,
+            ThrowOnNonZeroReturnCode = false,
+            InheritEnv = true,
+            OnOutputData = output =>
             {
-                Arguments = arguments,
-                WorkingDirectory = outputPath,
-                ThrowOnNonZeroReturnCode = false,
-                InheritEnv = true,
-                OnOutputData = output =>
+                if (!string.IsNullOrWhiteSpace(output))
                 {
-                    if (!string.IsNullOrWhiteSpace(output))
-                    {
-                        outputLines.Add(output);
-                    }
-                },
-                OnErrorData = error =>
-                {
-                    if (!string.IsNullOrWhiteSpace(error))
-                    {
-                        context.Logger.LogDebug("docker compose ps (stderr): {Error}", error);
-                    }
+                    outputLines.Add(output);
                 }
-            };
-
-            var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
-
-            await using (processDisposable)
+            },
+            OnErrorData = error =>
             {
-                var processResult = await pendingProcessResult
-                    .WaitAsync(context.CancellationToken)
-                    .ConfigureAwait(false);
-
-                if (processResult.ExitCode != 0)
+                if (!string.IsNullOrWhiteSpace(error))
                 {
-                    context.Logger.LogWarning("Failed to query Docker Compose services for {ResourceName}. Exit code: {ExitCode}", TargetResource.Name, processResult.ExitCode);
-                    return;
-                }
-
-                // Parse the JSON output to find port mappings for this service
-                var serviceName = TargetResource.Name.ToLowerInvariant();
-                var endpoints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-                // Get all external endpoint mappings for this resource
-                var externalEndpointMappings = EndpointMappings.Values.Where(m => m.IsExternal).ToList();
-
-                // If there are no external endpoints configured, we're done
-                if (externalEndpointMappings.Count == 0)
-                {
-                    context.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{TargetResource.Name}** to Docker Compose environment **{environment.Name}**. No public endpoints were configured.", enableMarkdown: true);
-                    return;
-                }
-
-                foreach (var line in outputLines)
-                {
-                    try
-                    {
-                        var serviceInfo = JsonSerializer.Deserialize(line, DockerComposeJsonContext.Default.DockerComposeServiceInfo);
-
-                        if (serviceInfo is null ||
-                            !string.Equals(serviceInfo.Service, serviceName, StringComparison.OrdinalIgnoreCase))
-                        {
-                            continue;
-                        }
-
-                        if (serviceInfo.Publishers is not { Count: > 0 })
-                        {
-                            continue;
-                        }
-
-                        foreach (var publisher in serviceInfo.Publishers)
-                        {
-                            // Skip ports that aren't actually published (port 0 or null means not exposed)
-                            if (publisher.PublishedPort is not > 0)
-                            {
-                                continue;
-                            }
-
-                            // Try to find a matching external endpoint to get the scheme
-                            // Match by internal port (numeric) or by exposed port
-                            // InternalPort may be a placeholder like ${API_PORT} for projects, so also check ExposedPort
-                            var targetPortStr = publisher.TargetPort?.ToString(CultureInfo.InvariantCulture);
-                            var endpointMapping = externalEndpointMappings
-                                .FirstOrDefault(m => m.InternalPort == targetPortStr || m.ExposedPort == publisher.TargetPort);
-
-                            // If we found a matching endpoint, use its scheme; otherwise default to http for external ports
-                            var scheme = endpointMapping.Scheme ?? "http";
-
-                            // Only add if we found a matching external endpoint OR if scheme is http/https
-                            // (published ports are external by definition in docker compose)
-                            if (endpointMapping.IsExternal || scheme is "http" or "https")
-                            {
-                                var endpoint = $"{scheme}://localhost:{publisher.PublishedPort}";
-                                endpoints.Add(endpoint);
-                            }
-                        }
-                    }
-                    catch (JsonException ex)
-                    {
-                        context.Logger.LogDebug(ex, "Failed to parse docker compose ps output line: {Line}", line);
-                    }
-                }
-
-                // Display the endpoints
-                if (endpoints.Count > 0)
-                {
-                    var endpointList = string.Join(", ", endpoints.Select(e => $"[{e}]({e})"));
-                    context.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{TargetResource.Name}** to {endpointList}", enableMarkdown: true);
-                }
-                else
-                {
-                    context.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{TargetResource.Name}** to Docker Compose environment **{environment.Name}**. No public endpoints were configured.", enableMarkdown: true);
+                    context.Logger.LogDebug("docker compose ps (stderr): {Error}", error);
                 }
             }
-        }
-        catch (Exception ex)
+        };
+
+        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+
+        await using (processDisposable)
         {
-            context.Logger.LogWarning(ex, "Failed to retrieve endpoints for {ResourceName}", TargetResource.Name);
+            var processResult = await pendingProcessResult
+                .WaitAsync(context.CancellationToken)
+                .ConfigureAwait(false);
+
+            if (processResult.ExitCode != 0)
+            {
+                context.Logger.LogDebug("docker compose ps failed with exit code {ExitCode}", processResult.ExitCode);
+                return null;
+            }
         }
+
+        return outputLines;
+    }
+
+    /// <summary>
+    /// Parses the JSON output from 'docker compose ps' to extract endpoint URLs for this service.
+    /// </summary>
+    /// <example>
+    /// Example JSON line from 'docker compose ps --format json':
+    /// <code>
+    /// {"Service":"myservice","State":"running","Publishers":[{"URL":"","TargetPort":80,"PublishedPort":8080,"Protocol":"tcp"}]}
+    /// </code>
+    /// Note: PublishedPort is 0 when the port is exposed but not mapped to the host.
+    /// </example>
+    private HashSet<string> ParseServiceEndpoints(
+        List<string> outputLines,
+        List<EndpointMapping> externalEndpointMappings,
+        ILogger logger)
+    {
+        var endpoints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var serviceName = TargetResource.Name.ToLowerInvariant();
+
+        foreach (var line in outputLines)
+        {
+            try
+            {
+                var serviceInfo = JsonSerializer.Deserialize(line, DockerComposeJsonContext.Default.DockerComposeServiceInfo);
+
+                // Skip if not our service
+                if (serviceInfo is null ||
+                    !string.Equals(serviceInfo.Service, serviceName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Skip if no published ports
+                if (serviceInfo.Publishers is not { Count: > 0 })
+                {
+                    continue;
+                }
+
+                foreach (var publisher in serviceInfo.Publishers)
+                {
+                    // Skip ports that aren't actually published (port 0 or null means not exposed)
+                    if (publisher.PublishedPort is not > 0)
+                    {
+                        continue;
+                    }
+
+                    // Try to find a matching external endpoint to get the scheme
+                    // Match by internal port (numeric) or by exposed port
+                    // InternalPort may be a placeholder like ${API_PORT} for projects, so also check ExposedPort
+                    var targetPortStr = publisher.TargetPort?.ToString(CultureInfo.InvariantCulture);
+                    var endpointMapping = externalEndpointMappings
+                        .FirstOrDefault(m => m.InternalPort == targetPortStr || m.ExposedPort == publisher.TargetPort);
+
+                    // If we found a matching endpoint, use its scheme; otherwise default to http for external ports
+                    var scheme = endpointMapping.Scheme ?? "http";
+
+                    // Only add if we found a matching external endpoint OR if scheme is http/https
+                    // (published ports are external by definition in docker compose)
+                    if (endpointMapping.IsExternal || scheme is "http" or "https")
+                    {
+                        var endpoint = $"{scheme}://localhost:{publisher.PublishedPort}";
+                        endpoints.Add(endpoint);
+                    }
+                }
+            }
+            catch (JsonException ex)
+            {
+                logger.LogDebug(ex, "Failed to parse docker compose ps output line: {Line}", line);
+            }
+        }
+
+        return endpoints;
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
@@ -47,6 +47,7 @@
 
     <Compile Include="$(TestsSharedDir)\TestInteractionService.cs" />
     <Compile Include="$(TestsSharedDir)\TestModuleInitializer.cs" />
+    <Compile Include="$(TestsSharedDir)\TestPipelineActivityReporter.cs" />
     
     <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="KnownProperties.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="StringComparers.cs" />

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -22,7 +22,6 @@ using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -127,26 +126,14 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     {
         // Arrange
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
-        var armClientProvider = new TestArmClientProvider(deploymentName =>
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
+        var armClientProvider = new TestArmClientProvider(new Dictionary<string, object>
         {
-            return deploymentName switch
-            {
-                string name when name.StartsWith("env-acr") => new Dictionary<string, object>
-                {
-                    ["name"] = new { type = "String", value = "testregistry" },
-                    ["loginServer"] = new { type = "String", value = "testregistry.azurecr.io" }
-                },
-                string name when name.StartsWith("env") => new Dictionary<string, object>
-                {
-                    ["AZURE_CONTAINER_REGISTRY_NAME"] = new { type = "String", value = "testregistry" },
-                    ["AZURE_CONTAINER_REGISTRY_ENDPOINT"] = new { type = "String", value = "testregistry.azurecr.io" },
-                    ["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity" },
-                    ["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "test.westus.azurecontainerapps.io" },
-                    ["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv" }
-                },
-                _ => []
-            };
+            ["AZURE_CONTAINER_REGISTRY_NAME"] = new { type = "String", value = "testregistry" },
+            ["AZURE_CONTAINER_REGISTRY_ENDPOINT"] = new { type = "String", value = "testregistry.azurecr.io" },
+            ["AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity" },
+            ["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"] = new { type = "String", value = "test.westus.azurecontainerapps.io" },
+            ["AZURE_CONTAINER_APPS_ENVIRONMENT_ID"] = new { type = "String", value = "/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.App/managedEnvironments/testenv" }
         });
         ConfigureTestServices(builder, armClientProvider: armClientProvider, activityReporter: mockActivityReporter);
 
@@ -171,7 +158,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.WaitForShutdownAsync();
 
         // Assert that publish completed without errors
-        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.ResultCompletionState);
 
         // Assert - Verify MockImageBuilder was only called to build an image and not push it
         var mockImageBuilder = app.Services.GetRequiredService<IResourceContainerImageManager>() as MockImageBuilder;
@@ -186,7 +173,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     public async Task DeployAsync_WithAzureStorageResourcesWorks()
     {
         // Arrange
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         var fakeContainerRuntime = new FakeContainerRuntime();
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
         var armClientProvider = new TestArmClientProvider(deploymentName =>
@@ -225,7 +212,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.WaitForShutdownAsync();
 
         // Assert that publish completed without errors
-        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.ResultCompletionState);
 
         // Assert that ACR login was not called given no compute resources
         Assert.False(fakeContainerRuntime.WasLoginToRegistryCalled);
@@ -244,7 +231,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     public async Task DeployAsync_WithContainer_Works()
     {
         // Arrange
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
@@ -280,7 +267,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.WaitForShutdownAsync();
 
         // Assert that publish completed without errors
-        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.ResultCompletionState);
 
         // Assert that container environment outputs are propagated to outputs because they are
         // hoisted up for the container resource
@@ -304,7 +291,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     public async Task DeployAsync_WithDockerfile_Works()
     {
         // Arrange
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
@@ -340,7 +327,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.WaitForShutdownAsync();
 
         // Assert that publish completed without errors
-        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.ResultCompletionState);
 
         // Assert that container environment outputs are propagated to outputs because they are
         // hoisted up for the container resource
@@ -372,7 +359,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         // Arrange
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
         var armClientProvider = new TestArmClientProvider(deploymentName =>
         {
@@ -406,7 +393,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.WaitForShutdownAsync();
 
         // Assert that publish completed without errors
-        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.ResultCompletionState);
 
         // Assert that container environment outputs are propagated to outputs because they are
         // hoisted up for the container resource
@@ -441,7 +428,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: step);
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         var armClientProvider = new TestArmClientProvider(deploymentName =>
         {
             return deploymentName switch
@@ -501,7 +488,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.WaitForShutdownAsync();
 
         // Assert that publish completed without errors
-        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.ResultCompletionState);
 
         if (step == "diagnostics")
         {
@@ -673,7 +660,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         // Arrange
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
         var armClientProvider = new TestArmClientProvider(deploymentName =>
         {
@@ -709,7 +696,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.WaitForShutdownAsync();
 
         // Assert that publish completed without errors
-        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.ResultCompletionState);
 
         // Assert that container environment outputs are propagated
         Assert.Equal("testregistry", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_NAME"]);
@@ -737,7 +724,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         // Arrange
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
         var armClientProvider = new TestArmClientProvider(deploymentName =>
         {
@@ -771,7 +758,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.WaitForShutdownAsync();
 
         // Assert that publish completed without errors
-        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.ResultCompletionState);
 
         // Assert that container environment outputs are propagated
         Assert.Equal("test.westus.azurecontainerapps.io", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN"]);
@@ -958,7 +945,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
             _ => []
         };
 
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         var armClientProvider = ProvisioningTestHelpers.CreateArmClientProvider(deploymentOutputsProvider);
         ConfigureTestServices(builder, armClientProvider: armClientProvider, activityReporter: mockActivityReporter, processRunner: mockProcessRunner, containerRuntime: fakeContainerRuntime);
 
@@ -979,7 +966,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await app.WaitForShutdownAsync();
 
         // Assert that publish completed without errors
-        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.CompletionState);
+        Assert.NotEqual(CompletionState.CompletedWithError, mockActivityReporter.ResultCompletionState);
 
         // Assert that container environment outputs are propagated
         Assert.Equal("testregistry", containerAppEnv.Resource.Outputs["AZURE_CONTAINER_REGISTRY_NAME"]);
@@ -1022,7 +1009,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: step);
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         var armClientProvider = new TestArmClientProvider(deploymentName =>
         {
             return deploymentName switch
@@ -1093,7 +1080,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         var mockProcessRunner = new MockProcessRunner();
         var fakeContainerRuntime = new FakeContainerRuntime();
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: "diagnostics");
-        var mockActivityReporter = new TestPublishingActivityReporter(testOutputHelper);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
         var armClientProvider = new TestArmClientProvider(deploymentName =>
         {
             return deploymentName switch
@@ -1591,107 +1578,5 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
         builder.Services.AddSingleton<IContainerRuntime>(new FakeContainerRuntime());
         builder.Services.AddSingleton<IAcrLoginService>(sp => new FakeAcrLoginService(sp.GetRequiredService<IContainerRuntime>()));
-    }
-
-    private sealed class TestPublishingActivityReporter : IPipelineActivityReporter
-    {
-        private readonly ITestOutputHelper? _output;
-
-        public TestPublishingActivityReporter(ITestOutputHelper? output = null)
-        {
-            _output = output;
-        }
-
-        public bool CompletePublishCalled { get; private set; }
-        public string? CompletionMessage { get; private set; }
-        public CompletionState? CompletionState { get; private set; }
-        public List<string> CreatedSteps { get; } = [];
-        public List<(string StepTitle, string TaskStatusText)> CreatedTasks { get; } = [];
-        public List<(string StepTitle, string CompletionText, CompletionState CompletionState)> CompletedSteps { get; } = [];
-        public List<(string TaskStatusText, string? CompletionMessage, CompletionState CompletionState)> CompletedTasks { get; } = [];
-        public List<(string TaskStatusText, string StatusText)> UpdatedTasks { get; } = [];
-        public List<(string StepTitle, LogLevel LogLevel, string Message)> LoggedMessages { get; } = [];
-
-        public Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, CancellationToken cancellationToken = default)
-        {
-            CompletePublishCalled = true;
-            CompletionMessage = completionMessage;
-            CompletionState = completionState;
-            _output?.WriteLine($"[CompletePublish] {completionMessage} (State: {completionState})");
-            return Task.CompletedTask;
-        }
-
-        public Task<IReportingStep> CreateStepAsync(string title, CancellationToken cancellationToken = default)
-        {
-            CreatedSteps.Add(title);
-            _output?.WriteLine($"[CreateStep] {title}");
-            return Task.FromResult<IReportingStep>(new TestReportingStep(this, title, _output));
-        }
-
-        private sealed class TestReportingStep : IReportingStep
-        {
-            private readonly TestPublishingActivityReporter _reporter;
-            private readonly string _title;
-            private readonly ITestOutputHelper? _output;
-
-            public TestReportingStep(TestPublishingActivityReporter reporter, string title, ITestOutputHelper? output)
-            {
-                _reporter = reporter;
-                _title = title;
-                _output = output;
-            }
-
-            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-
-            public Task CompleteAsync(string completionText, Pipelines.CompletionState completionState = Pipelines.CompletionState.Completed, CancellationToken cancellationToken = default)
-            {
-                _reporter.CompletedSteps.Add((_title, completionText, completionState));
-                _output?.WriteLine($"  [CompleteStep:{_title}] {completionText} (State: {completionState})");
-                return Task.CompletedTask;
-            }
-
-            public Task<IReportingTask> CreateTaskAsync(string statusText, CancellationToken cancellationToken = default)
-            {
-                _reporter.CreatedTasks.Add((_title, statusText));
-                _output?.WriteLine($"    [CreateTask:{_title}] {statusText}");
-                return Task.FromResult<IReportingTask>(new TestReportingTask(_reporter, statusText, _output));
-            }
-
-            public void Log(LogLevel logLevel, string message, bool enableMarkdown)
-            {
-                _reporter.LoggedMessages.Add((_title, logLevel, message));
-                _output?.WriteLine($"    [{logLevel}:{_title}] {message}");
-            }
-        }
-
-        private sealed class TestReportingTask : IReportingTask
-        {
-            private readonly TestPublishingActivityReporter _reporter;
-            private readonly string _initialStatusText;
-            private readonly ITestOutputHelper? _output;
-
-            public TestReportingTask(TestPublishingActivityReporter reporter, string initialStatusText, ITestOutputHelper? output)
-            {
-                _reporter = reporter;
-                _initialStatusText = initialStatusText;
-                _output = output;
-            }
-
-            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-
-            public Task CompleteAsync(string? completionMessage = null, Pipelines.CompletionState completionState = Pipelines.CompletionState.Completed, CancellationToken cancellationToken = default)
-            {
-                _reporter.CompletedTasks.Add((_initialStatusText, completionMessage, completionState));
-                _output?.WriteLine($"      [CompleteTask:{_initialStatusText}] {completionMessage} (State: {completionState})");
-                return Task.CompletedTask;
-            }
-
-            public Task UpdateAsync(string statusText, CancellationToken cancellationToken = default)
-            {
-                _reporter.UpdatedTasks.Add((_initialStatusText, statusText));
-                _output?.WriteLine($"      [UpdateTask:{_initialStatusText}] {statusText}");
-                return Task.CompletedTask;
-            }
-        }
     }
 }

--- a/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
+++ b/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Docker\Aspire.Hosting.Docker.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
+    <ProjectReference Include="..\Aspire.TestUtilities\Aspire.TestUtilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,6 +25,7 @@
   <ItemGroup>
 
     <Compile Include="$(TestsSharedDir)\TestModuleInitializer.cs" />
+    <Compile Include="$(TestsSharedDir)\TestPipelineActivityReporter.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppliesServiceCustomizations.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppliesServiceCustomizations.verified.yaml
@@ -6,6 +6,7 @@ services:
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "default-network"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppliesServiceCustomizations.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppliesServiceCustomizations.verified.yaml
@@ -2,8 +2,9 @@
 services:
   docker-compose-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "default-network"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeCorrectlyEmitsPortMappings.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeCorrectlyEmitsPortMappings.verified.yaml
@@ -1,8 +1,9 @@
 ﻿services:
   docker-compose-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeCorrectlyEmitsPortMappings.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeCorrectlyEmitsPortMappings.verified.yaml
@@ -5,6 +5,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeWithProjectResources.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeWithProjectResources.verified.yaml
@@ -1,8 +1,9 @@
 ﻿services:
   docker-compose-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeWithProjectResources.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeWithProjectResources.verified.yaml
@@ -5,6 +5,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile.verified.yaml
@@ -1,8 +1,9 @@
 ﻿services:
   docker-compose-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile.verified.yaml
@@ -5,6 +5,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_MultipleResourcesWithOtlp_ConfiguresAllForDashboard.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_MultipleResourcesWithOtlp_ConfiguresAllForDashboard.verified.yaml
@@ -1,8 +1,9 @@
 ﻿services:
   docker-compose-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_MultipleResourcesWithOtlp_ConfiguresAllForDashboard.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_MultipleResourcesWithOtlp_ConfiguresAllForDashboard.verified.yaml
@@ -5,6 +5,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_WithDashboardEnabled_IncludesDashboardService.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_WithDashboardEnabled_IncludesDashboardService.verified.yaml
@@ -1,8 +1,9 @@
 ﻿services:
   docker-compose-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_WithDashboardEnabled_IncludesDashboardService.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_WithDashboardEnabled_IncludesDashboardService.verified.yaml
@@ -5,6 +5,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_WithDashboard_UsesCustomConfiguration.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_WithDashboard_UsesCustomConfiguration.verified.yaml
@@ -8,6 +8,7 @@
       - "8081:18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DashboardWithForwardedHeadersWritesEnvVar.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DashboardWithForwardedHeadersWritesEnvVar.verified.yaml
@@ -3,8 +3,9 @@
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
     environment:
       ASPIRE_DASHBOARD_FORWARDEDHEADERS_ENABLED: "true"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DashboardWithForwardedHeadersWritesEnvVar.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DashboardWithForwardedHeadersWritesEnvVar.verified.yaml
@@ -7,6 +7,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerComposeOnlyExposesExternalEndpoints.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerComposeOnlyExposesExternalEndpoints.verified.yaml
@@ -1,8 +1,9 @@
 ﻿services:
   docker-compose-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerComposeOnlyExposesExternalEndpoints.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerComposeOnlyExposesExternalEndpoints.verified.yaml
@@ -5,6 +5,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmDeploymentLabelsSerializedCorrectly.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmDeploymentLabelsSerializedCorrectly.verified.yaml
@@ -1,8 +1,9 @@
 ﻿services:
   swarm-env-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmDeploymentLabelsSerializedCorrectly.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmDeploymentLabelsSerializedCorrectly.verified.yaml
@@ -5,6 +5,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env1/docker-compose.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env1/docker-compose.verified.yaml
@@ -5,6 +5,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env1/docker-compose.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env1/docker-compose.verified.yaml
@@ -1,8 +1,9 @@
 ﻿services:
   env1-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env2/docker-compose.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env2/docker-compose.verified.yaml
@@ -1,8 +1,9 @@
 ﻿services:
   env2-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
-    expose:
+    ports:
       - "18888"
+    expose:
       - "18889"
     networks:
       - "aspire"

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env2/docker-compose.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env2/docker-compose.verified.yaml
@@ -5,6 +5,7 @@
       - "18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/YarpConfigGeneratorTests.GenerateEnvVariablesConfigurationDockerCompose.verified.env
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/YarpConfigGeneratorTests.GenerateEnvVariablesConfigurationDockerCompose.verified.env
@@ -5,6 +5,7 @@
       - "18888:18888"
     expose:
       - "18889"
+      - "18890"
     networks:
       - "aspire"
     restart: "always"

--- a/tests/Shared/TestPipelineActivityReporter.cs
+++ b/tests/Shared/TestPipelineActivityReporter.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.Utils;
 /// <summary>
 /// A test implementation of <see cref="IPipelineActivityReporter"/> that captures activity for test assertions.
 /// </summary>
-public sealed class TestPipelineActivityReporter : IPipelineActivityReporter
+internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
 {
     private readonly ITestOutputHelper _testOutputHelper;
 
@@ -65,11 +65,51 @@ public sealed class TestPipelineActivityReporter : IPipelineActivityReporter
     /// </summary>
     public string? CompletionMessage { get; private set; }
 
+    /// <summary>
+    /// Gets the completion state passed to <see cref="CompletePublishAsync"/>.
+    /// </summary>
+    public CompletionState? ResultCompletionState { get; private set; }
+
+    /// <summary>
+    /// Clears all captured state to allow reuse between pipeline runs.
+    /// </summary>
+    public void Clear()
+    {
+        lock (CreatedSteps)
+        {
+            CreatedSteps.Clear();
+        }
+        lock (CreatedTasks)
+        {
+            CreatedTasks.Clear();
+        }
+        lock (CompletedSteps)
+        {
+            CompletedSteps.Clear();
+        }
+        lock (CompletedTasks)
+        {
+            CompletedTasks.Clear();
+        }
+        lock (UpdatedTasks)
+        {
+            UpdatedTasks.Clear();
+        }
+        lock (LoggedMessages)
+        {
+            LoggedMessages.Clear();
+        }
+        CompletePublishCalled = false;
+        CompletionMessage = null;
+        ResultCompletionState = null;
+    }
+
     /// <inheritdoc />
     public Task CompletePublishAsync(string? completionMessage = null, CompletionState? completionState = null, CancellationToken cancellationToken = default)
     {
         CompletePublishCalled = true;
         CompletionMessage = completionMessage;
+        ResultCompletionState = completionState;
         _testOutputHelper.WriteLine($"[CompletePublish] {completionMessage} (State: {completionState})");
 
         return Task.CompletedTask;


### PR DESCRIPTION
## Description

This PR enhances Docker Compose deployments by displaying resource endpoint URLs after deployment completes, and improves test infrastructure for
  Docker Compose tests.

  ### Changes:
  - **Display resource endpoints** - After `docker compose up` completes, endpoint URLs for each deployed resource are printed to the console with
  markdown formatting (e.g., `Successfully deployed **nginx** to [http://localhost:52341](http://localhost:52341)`)
  - ~**Add retry logic for endpoint retrieval** - Handles transient states where containers are starting up and ports aren't immediately available (up to
   5 retries with exponential backoff)~ Turns out this does not matter
  - **Refactor endpoint querying** - Split `QueryContainerEndpointsAsync` into separate methods (`RunDockerComposePsAsync` and `ParseServiceEndpoints`)
  for better testability and maintainability
  - **Consolidate test utilities** - Added `Clear()` method to `TestPipelineActivityReporter` to support reuse between pipeline runs
  - **Improve test cleanup** - Docker Compose tests now use the built-in `docker-compose-down` pipeline steps for proper cleanup instead of manual
  cleanup

Fixes https://github.com/dotnet/aspire/issues/10609

  ## Checklist

  - Is this feature complete?
    - [x] Yes. Ready to ship.
  - Are you including unit tests for the changes and scenario tests if relevant?
    - [x] Yes
  - Did you add public API?
    - [x] No
  - Does the change make any security assumptions or guarantees?
    - [x] No
  - Does the change require an update in our Aspire docs?
    - [x] No