### PR TITLE
Don't apply combobox filter if no items match

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -117,10 +117,11 @@ public partial class FilterDialog
         ValueChanged();
     }
 
-    // There is a bug in FluentUI that prevents the value changing immediately. Will be fixed in a future FluentUI update.
-    // https://github.com/microsoft/fluentui-blazor/issues/2672
     private void ValueChanged()
     {
+        // Limit to 1000 items to avoid the combo box have too many items and impacting UI perf.
+        const int maxItems = 1000;
+
         if (_allValues != null)
         {
             IEnumerable<SelectViewModel<FieldValue>> newValues = _allValues;
@@ -129,8 +130,10 @@ public partial class FilterDialog
                 newValues = newValues.Where(vm => vm.Name.Contains(value, StringComparison.OrdinalIgnoreCase));
             }
 
-            // Limit to 1000 items to avoid the combo box have too many items and impacting UI perf.
-            _filteredValues = newValues.Take(1000).ToList();
+            // If no values match the filter, don't apply the filter.
+            // This improves user experience and fixes some combobox issues.
+            // https://github.com/microsoft/fluentui-blazor/issues/4314#issuecomment-3577475233
+            _filteredValues = newValues.Any() ? newValues.Take(maxItems).ToList() : _allValues.Take(maxItems).ToList();
         }
         else
         {

--- a/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Interaction/InputViewModel.cs
@@ -64,7 +64,17 @@ public sealed class InputViewModel
             return SelectOptions;
         }
 
-        return SelectOptions.Where(vm => vm.Name.Contains(value, StringComparison.OrdinalIgnoreCase));
+        var filteredValues = SelectOptions.Where(vm => vm.Name.Contains(value, StringComparison.OrdinalIgnoreCase));
+
+        // If no values match the filter, don't apply the filter.
+        // This improves user experience and fixes some combobox issues.
+        // https://github.com/microsoft/fluentui-blazor/issues/4314#issuecomment-3577475233
+        if (!filteredValues.Any())
+        {
+            filteredValues = SelectOptions;
+        }
+
+        return filteredValues;
     }
 
     public string? Value

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -253,12 +253,12 @@ internal sealed class DashboardClient : IDashboardClient
             await Task.WhenAll(
                 Task.Run(async () =>
                 {
-                    await WatchWithRecoveryAsync(WatchResourcesAsync, cancellationToken).ConfigureAwait(false);
+                    await WatchWithRecoveryAsync(WatchResourcesAsync, "resources", cancellationToken).ConfigureAwait(false);
                     _resourceWatchCompleteTcs.TrySetResult();
                 }, cancellationToken),
                 Task.Run(async () =>
                 {
-                    await WatchWithRecoveryAsync(WatchInteractionsAsync, cancellationToken).ConfigureAwait(false);
+                    await WatchWithRecoveryAsync(WatchInteractionsAsync, "interactions", cancellationToken).ConfigureAwait(false);
                     _interactionWatchCompleteTcs.TrySetResult();
                 }, cancellationToken)).ConfigureAwait(false);
         }
@@ -294,7 +294,7 @@ internal sealed class DashboardClient : IDashboardClient
         public int ErrorCount { get; set; }
     }
 
-    private async Task WatchWithRecoveryAsync(Func<RetryContext, CancellationToken, Task<RetryResult>> action, CancellationToken cancellationToken)
+    private async Task WatchWithRecoveryAsync(Func<RetryContext, CancellationToken, Task<RetryResult>> action, string actionName, CancellationToken cancellationToken)
     {
         // Track the number of errors we've seen since the last successfully received message.
         // As this number climbs, we extend the amount of time between reconnection attempts, in
@@ -333,7 +333,7 @@ internal sealed class DashboardClient : IDashboardClient
             {
                 retryContext.ErrorCount++;
 
-                _logger.LogError(ex, "Error #{ErrorCount} watching resources.", retryContext.ErrorCount);
+                _logger.LogError(ex, "Error #{ErrorCount} watching {WatchName}.", retryContext.ErrorCount, actionName);
             }
         }
 


### PR DESCRIPTION
## Description

Fixes bug and (IMO) improves behavior to show all items instead of none when there are no matches.

Fixes https://github.com/dotnet/aspire/issues/12909

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
