### PR TITLE
Better DCP logs in tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -273,8 +273,7 @@ jobs:
         if: ${{ inputs.requiresNugets }}
         working-directory: ${{ github.workspace }}/run-tests/
         env:
-          DCP_DIAGNOSTICS_LOG_LEVEL: debug
-          DCP_DIAGNOSTICS_LOG_FOLDER: ${{ github.workspace }}/testresults/dcp
+          ASPIRE__TEST__DCPLOGBASEPATH: ${{ github.workspace }}/testresults/dcp
           BUILT_NUGETS_PATH: ${{ github.workspace }}/artifacts/packages/Debug/Shipping
           NUGET_PACKAGES: ${{ github.workspace }}/nuget-cache
           PLAYWRIGHT_INSTALLED: ${{ !inputs.enablePlaywrightInstall && 'false' || 'true' }}
@@ -296,8 +295,7 @@ jobs:
         if: ${{ ! inputs.requiresNugets }}
         id: run-tests
         env:
-          DCP_DIAGNOSTICS_LOG_LEVEL: debug
-          DCP_DIAGNOSTICS_LOG_FOLDER: ${{ github.workspace }}/testresults/dcp
+          ASPIRE__TEST__DCPLOGBASEPATH: ${{ github.workspace }}/testresults/dcp
           # During restore and build, we use -ci, which causes NUGET_PACKAGES to point to a local cache (Arcade behavior).
           # In this step, we are not using Arcade, but want to make sure that MSBuild is able to evaluate correctly.
           # So, we manually set NUGET_PACKAGES

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -123,9 +123,7 @@ steps:
         DOCKER_BUILDKIT: 1
         # https://github.com/dotnet/aspire/issues/5195#issuecomment-2271687822
         DOTNET_ASPIRE_DEPENDENCY_CHECK_TIMEOUT: 180
-        DCP_DIAGNOSTICS_LOG_LEVEL: debug
-        DCP_DIAGNOSTICS_LOG_FOLDER: $(Build.ArtifactStagingDirectory)/artifacts/log/dcp
-        DCP_PRESERVE_EXECUTABLE_LOGS: 1
+        ASPIRE__TEST__DCPLOGBASEPATH: $(Build.ArtifactStagingDirectory)/artifacts/log/dcp
         DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
       displayName: Run non-helix tests
 

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -231,6 +231,12 @@ internal sealed class DcpHost
             dcpProcessSpec.EnvironmentVariables["DCP_DIAGNOSTICS_LOG_LEVEL"] = _dcpOptions.DiagnosticsLogLevel;
         }
 
+        // Set preserve executable logs if configured (takes precedence over environment variable)
+        if (_dcpOptions.PreserveExecutableLogs == true)
+        {
+            dcpProcessSpec.EnvironmentVariables["DCP_PRESERVE_EXECUTABLE_LOGS"] = "1";
+        }
+
         return dcpProcessSpec;
     }
 

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -218,6 +218,19 @@ internal sealed class DcpHost
                 dcpProcessSpec.EnvironmentVariables[key] = val;
             }
         }
+
+        // Set diagnostic log folder if configured (takes precedence over environment variable)
+        if (!string.IsNullOrEmpty(_dcpOptions.DiagnosticsLogFolder))
+        {
+            dcpProcessSpec.EnvironmentVariables["DCP_DIAGNOSTICS_LOG_FOLDER"] = _dcpOptions.DiagnosticsLogFolder;
+        }
+
+        // Set diagnostic log level if configured (takes precedence over environment variable)
+        if (!string.IsNullOrEmpty(_dcpOptions.DiagnosticsLogLevel))
+        {
+            dcpProcessSpec.EnvironmentVariables["DCP_DIAGNOSTICS_LOG_LEVEL"] = _dcpOptions.DiagnosticsLogLevel;
+        }
+
         return dcpProcessSpec;
     }
 

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -96,6 +96,18 @@ internal sealed class DcpOptions
     public string? LogFileNameSuffix { get; set; }
 
     /// <summary>
+    /// Gets or sets the folder path where DCP diagnostics logs are written.
+    /// If set, overrides the DCP_DIAGNOSTICS_LOG_FOLDER environment variable.
+    /// </summary>
+    public string? DiagnosticsLogFolder { get; set; }
+
+    /// <summary>
+    /// Gets or sets the DCP diagnostics log level.
+    /// If set, overrides the DCP_DIAGNOSTICS_LOG_LEVEL environment variable.
+    /// </summary>
+    public string? DiagnosticsLogLevel { get; set; }
+
+    /// <summary>
     /// Enables Aspire container tunnel for container-to-host connectivity across all container orchestrators.
     /// </summary>
     public bool EnableAspireContainerTunnel { get; set; }
@@ -202,6 +214,8 @@ internal class ConfigureDefaultDcpOptions(
         options.ServiceStartupWatchTimeout = configuration.GetValue(KnownConfigNames.ServiceStartupWatchTimeout, KnownConfigNames.Legacy.ServiceStartupWatchTimeout, options.ServiceStartupWatchTimeout);
         options.ContainerRuntimeInitializationTimeout = dcpPublisherConfiguration.GetValue(nameof(options.ContainerRuntimeInitializationTimeout), options.ContainerRuntimeInitializationTimeout);
         options.LogFileNameSuffix = dcpPublisherConfiguration[nameof(options.LogFileNameSuffix)];
+        options.DiagnosticsLogFolder = dcpPublisherConfiguration[nameof(options.DiagnosticsLogFolder)];
+        options.DiagnosticsLogLevel = dcpPublisherConfiguration[nameof(options.DiagnosticsLogLevel)];
         options.EnableAspireContainerTunnel = configuration.GetValue(KnownConfigNames.EnableContainerTunnel, options.EnableAspireContainerTunnel);
     }
 

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -108,6 +108,12 @@ internal sealed class DcpOptions
     public string? DiagnosticsLogLevel { get; set; }
 
     /// <summary>
+    /// Gets or sets whether DCP should preserve executable logs.
+    /// If set to true, overrides the DCP_PRESERVE_EXECUTABLE_LOGS environment variable.
+    /// </summary>
+    public bool? PreserveExecutableLogs { get; set; }
+
+    /// <summary>
     /// Enables Aspire container tunnel for container-to-host connectivity across all container orchestrators.
     /// </summary>
     public bool EnableAspireContainerTunnel { get; set; }
@@ -216,6 +222,7 @@ internal class ConfigureDefaultDcpOptions(
         options.LogFileNameSuffix = dcpPublisherConfiguration[nameof(options.LogFileNameSuffix)];
         options.DiagnosticsLogFolder = dcpPublisherConfiguration[nameof(options.DiagnosticsLogFolder)];
         options.DiagnosticsLogLevel = dcpPublisherConfiguration[nameof(options.DiagnosticsLogLevel)];
+        options.PreserveExecutableLogs = dcpPublisherConfiguration.GetValue<bool?>(nameof(options.PreserveExecutableLogs), options.PreserveExecutableLogs);
         options.EnableAspireContainerTunnel = configuration.GetValue(KnownConfigNames.EnableContainerTunnel, options.EnableAspireContainerTunnel);
     }
 

--- a/tests/Aspire.Hosting.Tests/AsHttp2ServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/AsHttp2ServiceTests.cs
@@ -62,7 +62,7 @@ public class AsHttp2ServiceTests(ITestOutputHelper testOutputHelper)
     private TestProgram CreateTestProgram(string[] args)
     {
         var program = TestProgram.Create<AsHttp2ServiceTests>(args, disableDashboard: true);
-        program.AppBuilder.Services.AddTestAndResourceLogging(testOutputHelper);
+        program.AppBuilder.WithTestAndResourceLogging(testOutputHelper);
         return program;
     }
 }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1731,7 +1731,7 @@ public class DistributedApplicationTests
             randomizePorts: randomizePorts,
             trustDeveloperCertificate: trustDeveloperCertificate);
 
-        testProgram.AppBuilder.Services.AddTestAndResourceLogging(_testOutputHelper);
+        testProgram.AppBuilder.WithTestAndResourceLogging(_testOutputHelper);
 
         return testProgram;
     }

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -698,7 +698,7 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
     private TestProgram CreateTestProgramJsonDocumentManifestPublisher(bool includeIntegrationServices = false, bool includeNodeApp = false)
     {
         var program = TestProgram.Create<ManifestGenerationTests>(GetJsonManifestArgs(), includeIntegrationServices, includeNodeApp);
-        program.AppBuilder.Services.AddTestAndResourceLogging(testOutputHelper);
+        program.AppBuilder.WithTestAndResourceLogging(testOutputHelper);
         program.AppBuilder.Pipeline.AddJsonDocumentManifestPublishing();
         return program;
     }
@@ -718,14 +718,14 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
     private IDistributedApplicationBuilder CreateBuilder(DistributedApplicationOptions options)
     {
         var builder = DistributedApplication.CreateBuilder(options);
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
         return builder;
     }
 
     private IDistributedApplicationBuilder CreateBuilder()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
         return builder;
     }
 }

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -14,6 +14,7 @@ using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -27,7 +28,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task ParentPropertySetOnChildResource()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var parentResource = builder.AddContainer("database", "image");
         var childResource = builder.AddResource(new CustomChildResource("child", parentResource.Resource));
@@ -74,7 +75,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task ParentAnnotationOnChildResource()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var parentResource = builder.AddResource(new CustomResource("parent"));
         var childResource = builder.AddResource(new CustomResource("child"))
@@ -122,7 +123,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task InitializeResourceEventPublished()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var resource = builder.AddResource(new CustomResource("resource"));
 
@@ -169,7 +170,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task WithParentRelationshipSetsParentPropertyCorrectly()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var parent = builder.AddContainer("parent", "image");
         var child = builder.AddContainer("child", "image").WithParentRelationship(parent);
@@ -235,7 +236,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task LastWithParentRelationshipWins()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var firstParent = builder.AddContainer("firstParent", "image");
         var secondParent = builder.AddContainer("secondParent", "image");
@@ -293,7 +294,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task WithParentRelationshipWorksWithProjects()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var projectA = builder.AddProject<ProjectA>("projecta");
         var projectB = builder.AddProject<ProjectB>("projectb").WithParentRelationship(projectA);
@@ -359,7 +360,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task GrandChildResourceWithConnectionString()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var parentResource = builder.AddResource(new ParentResourceWithConnectionString("parent"));
         var childResource = builder.AddResource(
@@ -410,7 +411,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task ConnectionStringAvailableEventPublishesUpdateWithConnectionStringValue()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var resource = builder.AddResource(new TestResourceWithConnectionString("test-resource", "Server=localhost:5432;Database=testdb"));
 
@@ -461,7 +462,8 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         DashboardOptions? dashboardOptions = null)
     {
         var services = new ServiceCollection();
-        services.AddTestAndResourceLogging(testOutputHelper);
+        var configuration = new ConfigurationManager();
+        services.AddTestAndResourceLogging(testOutputHelper, configuration);
         var serviceProvider = services.BuildServiceProvider();
         resourceLoggerService ??= new ResourceLoggerService();
 
@@ -589,7 +591,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task ContainerChildResourcesWithOwnLifetimeDoNotReceiveParentStateChanges()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var parentContainer = builder.AddContainer("parent-container", "parent-image");
         var childContainer = builder.AddContainer("child-container", "child-image")
@@ -636,7 +638,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task ProjectChildResourcesWithOwnLifetimeDoNotReceiveParentStateChanges()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var parentContainer = builder.AddContainer("parent-container", "parent-image");
         var childProject = builder.AddProject<ProjectA>("child-project")
@@ -683,7 +685,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task WithChildRelationshipUsingResourceBuilderSetsParentPropertyCorrectly()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var parent = builder.AddContainer("parent", "image");
         var child = builder.AddContainer("child", "image");
@@ -740,7 +742,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task WithChildRelationshipUsingResourceSetsParentPropertyCorrectly()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var parent = builder.AddContainer("parent", "image");
         var child = builder.AddContainer("child", "image");
@@ -797,7 +799,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     public async Task WithChildRelationshipWorksWithProjects()
     {
         var builder = DistributedApplication.CreateBuilder();
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.WithTestAndResourceLogging(testOutputHelper);
 
         var parentProject = builder.AddProject<ProjectA>("parent-project");
         var childProject = builder.AddProject<ProjectB>("child-project");

--- a/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
+++ b/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
@@ -67,6 +67,7 @@ public static class DistributedApplicationTestingBuilderExtensions
             var uniqueFolder = Path.Combine(baseDcpLogFolder, folderName);
             configuration["DcpPublisher:DiagnosticsLogFolder"] = uniqueFolder;
             configuration["DcpPublisher:DiagnosticsLogLevel"] = "debug";
+            configuration["DcpPublisher:PreserveExecutableLogs"] = "true";
 
             // Register as hosted service to forward DCP logs to test output when app stops
             services.AddSingleton<IHostedService>(sp => new DcpLogForwarder(testOutputHelper, uniqueFolder));

--- a/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
+++ b/tests/Shared/DistributedApplicationTestingBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -19,13 +20,13 @@ public static class DistributedApplicationTestingBuilderExtensions
     public static string GetVolumePrefix(this IDistributedApplicationTestingBuilder builder) =>
         $"{VolumeNameGenerator.Sanitize(builder.Environment.ApplicationName).ToLowerInvariant()}-{builder.Configuration["AppHost:Sha256"]!.ToLowerInvariant()[..10]}";
 
-    public static IDistributedApplicationTestingBuilder WithTestAndResourceLogging(this IDistributedApplicationTestingBuilder builder, ITestOutputHelper testOutputHelper)
+    public static T WithTestAndResourceLogging<T>(this T builder, ITestOutputHelper testOutputHelper) where T : IDistributedApplicationBuilder
     {
-        builder.Services.AddTestAndResourceLogging(testOutputHelper);
+        builder.Services.AddTestAndResourceLogging(testOutputHelper, builder.Configuration, builder.Environment.ApplicationName);
         return builder;
     }
 
-    public static IServiceCollection AddTestAndResourceLogging(this IServiceCollection services, ITestOutputHelper testOutputHelper)
+    public static IServiceCollection AddTestAndResourceLogging(this IServiceCollection services, ITestOutputHelper testOutputHelper, IConfigurationManager configuration, string? applicationName = null)
     {
         services.AddXunitLogging(testOutputHelper);
         services.AddLogging(builder =>
@@ -34,6 +35,7 @@ public static class DistributedApplicationTestingBuilderExtensions
             // Suppress all console logging during tests to reduce noise
             builder.AddFilter<ConsoleLoggerProvider>(null, LogLevel.None);
         });
+        services.AddDcpDiagnostics(configuration, applicationName, testOutputHelper);
         return services;
     }
 
@@ -52,6 +54,27 @@ public static class DistributedApplicationTestingBuilderExtensions
         return builder;
     }
 
+    private static IServiceCollection AddDcpDiagnostics(this IServiceCollection services, IConfigurationManager configuration, string? applicationName, ITestOutputHelper testOutputHelper)
+    {
+        // Use Aspire:Test:DcpLogBasePath as the base path (set externally, e.g., in CI via env var ASPIRE__TEST__DCPLOGBASEPATH)
+        var baseDcpLogFolder = configuration["Aspire:Test:DcpLogBasePath"];
+        if (!string.IsNullOrEmpty(baseDcpLogFolder))
+        {
+            var uniqueId = Guid.NewGuid().ToString("N")[..8];
+            var folderName = !string.IsNullOrEmpty(applicationName)
+                ? $"{VolumeNameGenerator.Sanitize(applicationName).ToLowerInvariant()}-{uniqueId}"
+                : uniqueId;
+            var uniqueFolder = Path.Combine(baseDcpLogFolder, folderName);
+            configuration["DcpPublisher:DiagnosticsLogFolder"] = uniqueFolder;
+            configuration["DcpPublisher:DiagnosticsLogLevel"] = "debug";
+
+            // Register as hosted service to forward DCP logs to test output when app stops
+            services.AddSingleton<IHostedService>(sp => new DcpLogForwarder(testOutputHelper, uniqueFolder));
+        }
+
+        return services;
+    }
+
     /// <summary>
     /// Adds xunit logging and suppresses console logging for a host application builder used in tests.
     /// This redirects logs to the xunit test output and prevents console clutter during test runs.
@@ -61,5 +84,47 @@ public static class DistributedApplicationTestingBuilderExtensions
         builder.Logging.AddXunit(testOutputHelper);
         builder.Logging.AddFilter<ConsoleLoggerProvider>(null, LogLevel.None);
         return builder;
+    }
+}
+
+/// <summary>
+/// Forwards DCP log files to xUnit test output when stopped.
+/// Implements IHostedService so it gets automatically resolved and stopped when the app shuts down.
+/// </summary>
+internal sealed class DcpLogForwarder : IHostedService
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+    private readonly string _logFolder;
+
+    public DcpLogForwarder(ITestOutputHelper testOutputHelper, string logFolder)
+    {
+        _testOutputHelper = testOutputHelper;
+        _logFolder = logFolder;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(_logFolder))
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (var logFile in Directory.GetFiles(_logFolder, "*.log"))
+        {
+            try
+            {
+                _testOutputHelper.WriteLine($"=== DCP Log: {Path.GetFileName(logFile)} ===");
+                var content = File.ReadAllText(logFile);
+                _testOutputHelper.WriteLine(content);
+            }
+            catch (Exception ex)
+            {
+                _testOutputHelper.WriteLine($"Failed to read DCP log {logFile}: {ex.Message}");
+            }
+        }
+
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
This PR improves DCP (Developer Control Plane) diagnostic logging for tests by:

  1. Creating per-test unique log folders - Each test now gets its own DCP log folder (e.g., aspire.hosting.tests-abc12345/) instead of all tests
  writing to a shared folder. This makes it easier to correlate logs with specific failing tests.
  2. Forwarding DCP logs to xUnit test output - DCP log file contents are automatically written to ITestOutputHelper when each test completes, so logs
  appear in TRX files and CI test results without needing to download separate artifacts.
  3. Adding PreserveExecutableLogs configuration option - Added a new DcpOptions.PreserveExecutableLogs property that flows through configuration
  (DcpPublisher:PreserveExecutableLogs) instead of requiring the DCP_PRESERVE_EXECUTABLE_LOGS environment variable.
  4. Simplifying CI configuration - Replaced multiple DCP environment variables with a single ASPIRE__TEST__DCPLOGBASEPATH setting. The test
  infrastructure automatically configures:
    - DcpPublisher:DiagnosticsLogFolder (unique per-test)
    - DcpPublisher:DiagnosticsLogLevel = debug
    - DcpPublisher:PreserveExecutableLogs = true