### PR TITLE
Revert the extension method to support automatic scaling of Azure App Service

### DIFF
--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -98,11 +98,8 @@ public static partial class AzureAppServiceEnvironmentExtensions
                 },
                 Kind = "Linux",
                 IsReserved = true,
-                // Enable perSiteScaling or automatic scaling so each app service can scale independently
-                IsPerSiteScaling = !resource.EnableAutomaticScaling,
-                IsElasticScaleEnabled = resource.EnableAutomaticScaling,
-                // Capping the automatic scaling limit to 10 as per best practices
-                MaximumElasticWorkerCount = 10
+                // Enable perSiteScaling so each app service can scale independently
+                IsPerSiteScaling = true
             };
 
             infra.Add(plan);
@@ -278,17 +275,6 @@ public static partial class AzureAppServiceEnvironmentExtensions
     {
         builder.WithAzureApplicationInsights();
         builder.Resource.ApplicationInsightsResource = applicationInsightsBuilder.Resource;
-        return builder;
-    }
-
-    /// <summary>
-    /// Configures whether automatic scaling should be enabled for the app services in Azure App Service environment.
-    /// </summary>
-    /// <param name="builder">The <see cref="IResourceBuilder{AzureAppServiceEnvironmentResource}"/> to configure.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining additional configuration.</returns>
-    public static IResourceBuilder<AzureAppServiceEnvironmentResource> WithAutomaticScaling(this IResourceBuilder<AzureAppServiceEnvironmentResource> builder)
-    {
-        builder.Resource.EnableAutomaticScaling = true;
         return builder;
     }
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -190,11 +190,6 @@ public class AzureAppServiceEnvironmentResource :
     internal AzureApplicationInsightsResource? ApplicationInsightsResource { get; set; }
 
     /// <summary>
-    /// Enables or disables automatic scaling for the App Service Plan.
-    /// </summary>
-    internal bool EnableAutomaticScaling { get; set; }
-
-    /// <summary>
     /// Gets the name of the App Service Plan.
     /// </summary>
     public BicepOutputReference NameOutputReference => new("name", this);

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
@@ -66,8 +66,6 @@ internal static class AzureAppServiceEnvironmentUtility
                 Http20ProxyFlag = 1,
                 // Setting instance count to 1 to ensure dashboard runs on 1 instance
                 NumberOfWorkers = 1,
-                FunctionAppScaleLimit = 1,
-                ElasticWebAppScaleLimit = 1,
                 // IsAlwaysOn set to true ensures the app is always running
                 IsAlwaysOn = true,
                 AppSettings = []

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -455,27 +455,6 @@ public class AzureAppServiceTests
     }
 
     [Fact]
-    public async Task AddAppServiceToEnvironmentWithAutomaticScaling()
-    {
-        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-
-        builder.AddAzureAppServiceEnvironment("env").WithAutomaticScaling();
-
-        using var app = builder.Build();
-
-        await ExecuteBeforeStartHooksAsync(app, default);
-
-        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
-
-        var environment = Assert.Single(model.Resources.OfType<AzureAppServiceEnvironmentResource>());
-
-        var (manifest, bicep) = await GetManifestWithBicep(environment);
-
-        await Verify(manifest.ToString(), "json")
-              .AppendContentAsFile(bicep, "bicep");
-    }
-
-    [Fact]
     public async Task AddAppServiceWithArgs()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceEnvironmentWithoutDashboardAddsEnvironmentResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceEnvironmentWithoutDashboardAddsEnvironmentResource.verified.bicep
@@ -34,10 +34,8 @@ resource env_asplan 'Microsoft.Web/serverfarms@2024-11-01' = {
   name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
-    elasticScaleEnabled: false
     perSiteScaling: true
     reserved: true
-    maximumElasticWorkerCount: 10
   }
   kind: 'Linux'
   sku: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsDefaultLocation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsDefaultLocation.verified.bicep
@@ -34,10 +34,8 @@ resource env_asplan 'Microsoft.Web/serverfarms@2024-11-01' = {
   name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
-    elasticScaleEnabled: false
     perSiteScaling: true
     reserved: true
-    maximumElasticWorkerCount: 10
   }
   kind: 'Linux'
   sku: {
@@ -115,8 +113,6 @@ resource dashboard 'Microsoft.Web/sites@2024-11-01' = {
       alwaysOn: true
       http20Enabled: true
       http20ProxyFlag: 1
-      functionAppScaleLimit: 1
-      elasticWebAppScaleLimit: 1
     }
   }
   identity: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocation.verified.bicep
@@ -34,10 +34,8 @@ resource env_asplan 'Microsoft.Web/serverfarms@2024-11-01' = {
   name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
-    elasticScaleEnabled: false
     perSiteScaling: true
     reserved: true
-    maximumElasticWorkerCount: 10
   }
   kind: 'Linux'
   sku: {
@@ -115,8 +113,6 @@ resource dashboard 'Microsoft.Web/sites@2024-11-01' = {
       alwaysOn: true
       http20Enabled: true
       http20ProxyFlag: 1
-      functionAppScaleLimit: 1
-      elasticWebAppScaleLimit: 1
     }
   }
   identity: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocationParam.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocationParam.verified.bicep
@@ -36,10 +36,8 @@ resource env_asplan 'Microsoft.Web/serverfarms@2024-11-01' = {
   name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
-    elasticScaleEnabled: false
     perSiteScaling: true
     reserved: true
-    maximumElasticWorkerCount: 10
   }
   kind: 'Linux'
   sku: {
@@ -117,8 +115,6 @@ resource dashboard 'Microsoft.Web/sites@2024-11-01' = {
       alwaysOn: true
       http20Enabled: true
       http20ProxyFlag: 1
-      functionAppScaleLimit: 1
-      elasticWebAppScaleLimit: 1
     }
   }
   identity: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithExistingApplicationInsights.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithExistingApplicationInsights.verified.bicep
@@ -36,10 +36,8 @@ resource env_asplan 'Microsoft.Web/serverfarms@2024-11-01' = {
   name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
-    elasticScaleEnabled: false
     perSiteScaling: true
     reserved: true
-    maximumElasticWorkerCount: 10
   }
   kind: 'Linux'
   sku: {
@@ -117,8 +115,6 @@ resource dashboard 'Microsoft.Web/sites@2024-11-01' = {
       alwaysOn: true
       http20Enabled: true
       http20ProxyFlag: 1
-      functionAppScaleLimit: 1
-      elasticWebAppScaleLimit: 1
     }
   }
   identity: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsEnvironmentResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsEnvironmentResource.verified.bicep
@@ -34,10 +34,8 @@ resource env_asplan 'Microsoft.Web/serverfarms@2024-11-01' = {
   name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
-    elasticScaleEnabled: false
     perSiteScaling: true
     reserved: true
-    maximumElasticWorkerCount: 10
   }
   kind: 'Linux'
   sku: {
@@ -115,8 +113,6 @@ resource dashboard 'Microsoft.Web/sites@2024-11-01' = {
       alwaysOn: true
       http20Enabled: true
       http20ProxyFlag: 1
-      functionAppScaleLimit: 1
-      elasticWebAppScaleLimit: 1
     }
   }
   identity: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanReferenceExistingAppServicePlan.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanReferenceExistingAppServicePlan.verified.bicep
@@ -34,10 +34,8 @@ resource env_asplan 'Microsoft.Web/serverfarms@2024-11-01' = {
   name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
   location: location
   properties: {
-    elasticScaleEnabled: false
     perSiteScaling: true
     reserved: true
-    maximumElasticWorkerCount: 10
   }
   kind: 'Linux'
   sku: {
@@ -115,8 +113,6 @@ resource dashboard 'Microsoft.Web/sites@2024-11-01' = {
       alwaysOn: true
       http20Enabled: true
       http20ProxyFlag: 1
-      functionAppScaleLimit: 1
-      elasticWebAppScaleLimit: 1
     }
   }
   identity: {


### PR DESCRIPTION
Reverts commit https://github.com/dotnet/aspire/pull/12305 (manually)

## Description

PR https://github.com/dotnet/aspire/pull/12305 added an extension method to enable automatic scaling of Azure App Service. However, we identified a platform issue that causes intermittent routing failures of grpc traffic if automatic scaling is enabled. Reverting the change

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
