### PR TITLE
Log entries for a GenAI span now link to GenAI visualizer

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
@@ -63,8 +63,6 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
     private Dictionary<SpanKey, OtlpSpan> _currentCache = new Dictionary<SpanKey, OtlpSpan>();
     private Dictionary<SpanKey, OtlpSpan> _newCache = new Dictionary<SpanKey, OtlpSpan>();
 
-    private readonly record struct SpanKey(string TraceId, string SpanId);
-
     protected override void OnInitialized()
     {
         // Copy the token so there is no chance it is accessed on CTS after it is disposed.

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -116,7 +116,7 @@ public partial class SpanDetails : IDisposable
             }
         });
 
-        if (GenAIHelpers.IsGenAISpan(ViewModel.Span.Attributes))
+        if (GenAIHelpers.HasGenAIAttribute(ViewModel.Span.Attributes))
         {
             _spanActionsMenuItems.Add(new MenuButtonItem
             {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -148,7 +148,7 @@
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@MessageColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]">
                                             @* Tooltip is displayed by the message GridValue instance *@
-                                            <LogMessageColumnDisplay FilterText="@(ViewModel.FilterText)" LogEntry="@context" LaunchGenAIVisualizerCallback="@LaunchGenAIVisualizerAsync" />
+                                            <LogMessageColumnDisplay FilterText="@(ViewModel.FilterText)" LogEntry="@context" IsGenAILogCallback="@IsGenAILogEntry" LaunchGenAIVisualizerCallback="@LaunchGenAIVisualizerAsync" />
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@TraceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
                                             @if (!string.IsNullOrEmpty(context.TraceId))

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -554,19 +554,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             return true;
         }
 
-        var span = TelemetryRepository.GetSpan(logEntry.TraceId, logEntry.SpanId);
-        if (span == null)
-        {
-            return false;
-        }
-
-        if (GenAIHelpers.HasGenAIAttribute(span.Attributes))
-        {
-            // Log entry belongs to a span that has GenAI telemetry.
-            return true;
-        }
-
-        return false;
+        return ViewModel.HasGenAISpan(logEntry.TraceId, logEntry.SpanId);
     }
 
     private async Task LaunchGenAIVisualizerAsync(OtlpLogEntry logEntry)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -544,7 +544,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
     private static bool IsGenAISpan(SpanWaterfallViewModel spanViewModel)
     {
-        return GenAIHelpers.IsGenAISpan(spanViewModel.Span.Attributes);
+        return GenAIHelpers.HasGenAIAttribute(spanViewModel.Span.Attributes);
     }
 
     private async Task OnGenAIClickedAsync(OtlpSpan span)

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
@@ -17,9 +17,7 @@
            HighlightText="@FilterText"
            StopClickPropagation="true">
     <ContentInButtonArea>
-        @if (!string.IsNullOrEmpty(LogEntry.TraceId) &&
-            !string.IsNullOrEmpty(LogEntry.SpanId) &&
-            GenAIHelpers.IsGenAISpan(LogEntry.Attributes))
+        @if (IsGenAILogCallback(LogEntry))
         {
             <FluentButton Appearance="Appearance.Lightweight"
                           Title="@ControlStringsLoc[nameof(ControlsStrings.GenAIDetailsTitle)]"

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
@@ -17,6 +17,9 @@ public partial class LogMessageColumnDisplay
     [Parameter, EditorRequired]
     public required EventCallback<OtlpLogEntry> LaunchGenAIVisualizerCallback { get; set; }
 
+    [Parameter, EditorRequired]
+    public required Func<OtlpLogEntry, bool> IsGenAILogCallback { get; set; }
+
     private string? _exceptionText;
 
     protected override void OnInitialized()

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIHelpers.cs
@@ -34,7 +34,7 @@ public static class GenAIHelpers
 
     public const string ErrorType = "error.type";
 
-    public static bool IsGenAISpan(KeyValuePair<string, string>[] attributes)
+    public static bool HasGenAIAttribute(KeyValuePair<string, string>[] attributes)
     {
         return attributes.GetValueWithFallback(GenAISystem, GenAIProviderName) is { Length: > 0 };
     }

--- a/src/Aspire.Dashboard/Otlp/Model/SpanKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/SpanKey.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Otlp.Model;
+
+public readonly record struct SpanKey(string TraceId, string SpanId);


### PR DESCRIPTION
## Description

Improve structured logs page to link to GenAI visualizer when the log entry belongs to a span with GenAI telemetry.

note: This button isn't new. It would appear if the log entry contained GenAI telemetry. Now it also appears if the log entry is for a span and the span has GenAI telemetry.

<img width="1607" height="992" alt="image" src="https://github.com/user-attachments/assets/28993258-78ee-4aba-be23-2b2d8d4fee88" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
