### PR TITLE
GenAI visualizer improvements to UI and content parsing safety

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -15,6 +15,7 @@
         <FluentIcon Value="@(new Icons.Regular.Size24.Sparkle())" Style="grid-area: dialog-icon; align-self: center;" />
         <FluentLabel Typo="Typography.PaneHeader" Class="col-long-content" Style="grid-area: dialog-title;">
             @Content.Title
+            <span class="trace-id">@OtlpHelpers.ToShortenedId(Content.Span.SpanId)</span>
         </FluentLabel>
 
         @if (_contextSpans.Count > 1)
@@ -236,19 +237,17 @@
                                            Label="@Loc[nameof(Dialogs.GenAIInputOutputTabText)]"
                                            Icon="@(new Icons.Regular.Size24.Chat())">
                                 </FluentTab>
-                                <FluentTab LabelClass="tab-label"
-                                           Id="@($"tab-overview-{OverviewViewKind.Details}")"
-                                           Label="@Loc[nameof(Dialogs.GenAIDetailsTabText)]"
-                                           Icon="@(new Icons.Regular.Size24.Info())">
-                                </FluentTab>
-                                <FluentTab LabelClass="tab-label"
-                                           Id="@($"tab-overview-{OverviewViewKind.Tools}")"
-                                           Icon="@(new Icons.Regular.Size24.Wrench())">
-                                    <Header>
-                                        <span class="tab-text">@Loc[nameof(Dialogs.GenAIToolsTabText)]</span>
-                                        <FluentBadge Appearance="Appearance.Neutral" Circular="true">@Content.ToolDefinitions.Count</FluentBadge>
-                                    </Header>
-                                </FluentTab>
+                                @if (Content.ToolDefinitions.Count > 0)
+                                {
+                                    <FluentTab LabelClass="tab-label"
+                                               Id="@($"tab-overview-{OverviewViewKind.Tools}")"
+                                               Icon="@(new Icons.Regular.Size24.Wrench())">
+                                        <Header>
+                                            <span class="tab-text">@Loc[nameof(Dialogs.GenAIToolsTabText)]</span>
+                                            <FluentBadge Appearance="Appearance.Neutral" Circular="true">@Content.ToolDefinitions.Count</FluentBadge>
+                                        </Header>
+                                    </FluentTab>
+                                }
                                 @if (Content.Evaluations.Count > 0)
                                 {
                                     <FluentTab LabelClass="tab-label"
@@ -260,6 +259,11 @@
                                         </Header>
                                     </FluentTab>
                                 }
+                                <FluentTab LabelClass="tab-label"
+                                           Id="@($"tab-overview-{OverviewViewKind.Details}")"
+                                           Label="@Loc[nameof(Dialogs.GenAIDetailsTabText)]"
+                                           Icon="@(new Icons.Regular.Size24.Info())">
+                                </FluentTab>
                             </FluentTabs>
                         </div>
                         @if (OverviewActiveView == OverviewViewKind.InputOutput)

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -37,6 +37,14 @@
     font-weight: 600;
 }
 
+.dialog-title-grid ::deep .trace-id {
+    color: var(--foreground-subtext-rest);
+    padding-left: 0.5rem;
+    font-size: 12px;
+    font-weight: normal;
+    line-height: 1;
+}
+
 .genai-visualizer-container ::deep .fluent-splitter::part(median) {
     opacity: 0;
 }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -287,7 +287,7 @@ public sealed class GenAIVisualizerDialogViewModel
                 var content = item.Attributes.GetValue(GenAIHelpers.GenAIEventContent);
                 if (!string.IsNullOrEmpty(content))
                 {
-                    var parts = !string.IsNullOrEmpty(content) ? DeserializeEventContent(index, type.Value, content) : [];
+                    var parts = DeserializeEventContent(index, type.Value, content);
                     viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type.Value, parts, internalId: null));
                     currentIndex++;
                 }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -77,7 +77,7 @@ public sealed class GenAIVisualizerDialogViewModel
 
         // Parse tool definitions if present
         var toolDefinitionsJson = viewModel.Span.Attributes.GetValue(GenAIHelpers.GenAIToolDefinitions);
-        if (toolDefinitionsJson != null)
+        if (!string.IsNullOrEmpty(toolDefinitionsJson))
         {
             try
             {
@@ -241,19 +241,19 @@ public sealed class GenAIVisualizerDialogViewModel
         var inputMessages = viewModel.Span.Attributes.GetValue(GenAIHelpers.GenAIInputMessages);
         var outputMessages = viewModel.Span.Attributes.GetValue(GenAIHelpers.GenAIOutputInstructions);
 
-        if (systemInstructions != null || inputMessages != null || outputMessages != null)
+        if (!string.IsNullOrEmpty(systemInstructions) || !string.IsNullOrEmpty(inputMessages) || !string.IsNullOrEmpty(outputMessages))
         {
-            if (systemInstructions != null)
+            if (!string.IsNullOrEmpty(systemInstructions))
             {
                 var instructionParts = DeserializeWithErrorHandling(GenAIHelpers.GenAISystemInstructions, systemInstructions, GenAIMessagesContext.Default.ListMessagePart)!;
                 viewModel.Items.Add(CreateMessage(viewModel, currentIndex, GenAIItemType.SystemMessage, instructionParts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList(), internalId: null));
                 currentIndex++;
             }
-            if (inputMessages != null)
+            if (!string.IsNullOrEmpty(inputMessages))
             {
                 ParseMessages(viewModel, inputMessages, GenAIHelpers.GenAIInputMessages, isOutput: false, ref currentIndex);
             }
-            if (outputMessages != null)
+            if (!string.IsNullOrEmpty(outputMessages))
             {
                 ParseMessages(viewModel, outputMessages, GenAIHelpers.GenAIOutputInstructions, isOutput: true, ref currentIndex);
             }
@@ -265,7 +265,7 @@ public sealed class GenAIVisualizerDialogViewModel
         var logEntries = GetSpanLogEntries(telemetryRepository, viewModel.Span);
         foreach (var (item, index) in logEntries.OrderBy(i => i.TimeStamp).Select((l, i) => (l, i)))
         {
-            if (item.Attributes.GetValue("event.name") is { } name && TryMapEventName(name, out var type))
+            if (!string.IsNullOrEmpty(item.Message) && item.Attributes.GetValue("event.name") is { } name && TryMapEventName(name, out var type))
             {
                 var parts = DeserializeEventContent(index, type.Value, item.Message);
                 viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type.Value, parts, internalId: item.InternalId));
@@ -285,9 +285,12 @@ public sealed class GenAIVisualizerDialogViewModel
             if (TryMapEventName(item.Name, out var type))
             {
                 var content = item.Attributes.GetValue(GenAIHelpers.GenAIEventContent);
-                var parts = content != null ? DeserializeEventContent(index, type.Value, content) : [];
-                viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type.Value, parts, internalId: null));
-                currentIndex++;
+                if (!string.IsNullOrEmpty(content))
+                {
+                    var parts = !string.IsNullOrEmpty(content) ? DeserializeEventContent(index, type.Value, content) : [];
+                    viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type.Value, parts, internalId: null));
+                    currentIndex++;
+                }
             }
         }
 
@@ -339,7 +342,7 @@ public sealed class GenAIVisualizerDialogViewModel
             var role = GetMessageRole(message, defaultRole: "user");
             var content = GetMessageContent(message);
 
-            if (content != null)
+            if (!string.IsNullOrEmpty(content))
             {
                 var parts = new List<GenAIItemPartViewModel>
                 {
@@ -366,7 +369,7 @@ public sealed class GenAIVisualizerDialogViewModel
             var role = GetMessageRole(message, defaultRole: "assistant");
             var content = GetMessageContent(message);
 
-            if (content != null)
+            if (!string.IsNullOrEmpty(content))
             {
                 var parts = new List<GenAIItemPartViewModel>
                 {


### PR DESCRIPTION
## Description

Addresses https://github.com/microsoft/agent-framework/discussions/2559 by checking for empty string before attempting to deserialize content.

Also, some minor UI improvements.
- Add span id to dialog header
- Details tab is now consistently last
- Tools tab is only visible when there are tools

<img width="1242" height="958" alt="image" src="https://github.com/user-attachments/assets/8fa285b3-28cf-4634-adb0-bc27759c0385" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
