### PR TITLE
Ensure we honor an endpoint reference network context when resolving

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -101,8 +101,8 @@ internal class ExpressionResolver(CancellationToken cancellationToken)
             ConnectionStringReference cs => await ResolveConnectionStringReferenceAsync(cs, context).ConfigureAwait(false),
             IResourceWithConnectionString cs and not ConnectionStringParameterResource => await ResolveInternalAsync(cs.ConnectionStringExpression, context).ConfigureAwait(false),
             ReferenceExpression ex => await EvalExpressionAsync(ex, context).ConfigureAwait(false),
-            EndpointReference er when networkContext == KnownNetworkIdentifiers.DefaultAspireContainerNetwork => new ResolvedValue(await ResolveInContainerContextAsync(er, EndpointProperty.Url, context).ConfigureAwait(false), false),
-            EndpointReferenceExpression ep when networkContext == KnownNetworkIdentifiers.DefaultAspireContainerNetwork => new ResolvedValue(await ResolveInContainerContextAsync(ep.Endpoint, ep.Property, context).ConfigureAwait(false), false),
+            EndpointReference er when er.ContextNetworkID == KnownNetworkIdentifiers.DefaultAspireContainerNetwork || (er.ContextNetworkID == null && networkContext == KnownNetworkIdentifiers.DefaultAspireContainerNetwork) => new ResolvedValue(await ResolveInContainerContextAsync(er, EndpointProperty.Url, context).ConfigureAwait(false), false),
+            EndpointReferenceExpression ep when ep.Endpoint.ContextNetworkID == KnownNetworkIdentifiers.DefaultAspireContainerNetwork || (ep.Endpoint.ContextNetworkID == null && networkContext == KnownNetworkIdentifiers.DefaultAspireContainerNetwork) => new ResolvedValue(await ResolveInContainerContextAsync(ep.Endpoint, ep.Property, context).ConfigureAwait(false), false),
             IValueProvider vp => await EvalValueProvider(vp, context).ConfigureAwait(false),
             _ => throw new NotImplementedException()
         };

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -222,7 +222,7 @@ public class ExpressionResolverTests
            .WithHttpEndpoint(targetPort: 8080)
            .WithEndpoint("http", e =>
            {
-               e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 8001, EndpointBindingMode.SingleAddress, "{{ targetPort }}", KnownNetworkIdentifiers.LocalhostNetwork);
+               e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 8001, EndpointBindingMode.SingleAddress, "{{ targetPort }}");
            });
 
         var dep = builder.AddContainer("container", "redis")
@@ -232,6 +232,28 @@ public class ExpressionResolverTests
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dep.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
         Assert.Equal("http://myContainer.dev.internal:8080", config["ConnectionStrings__myContainer"]);
+    }
+
+    [Fact]
+    public async Task ContainerToContainerEndpointWithLocalhostNetworkIdentifierShouldResolve()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var connectionStringResource = builder.AddResource(new MyContainerResource("myContainer"))
+           .WithImage("redis")
+           .WithHttpEndpoint(targetPort: 8080)
+           .WithEndpoint("http", e =>
+           {
+               e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 8001, EndpointBindingMode.SingleAddress, "{{ targetPort }}", KnownNetworkIdentifiers.LocalhostNetwork);
+           });
+
+        var dep = builder.AddContainer("container", "redis")
+           .WithReference(connectionStringResource)
+           .WaitFor(connectionStringResource);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dep.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
+
+        Assert.Equal("http://localhost:8001", config["ConnectionStrings__myContainer"]);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -219,11 +219,8 @@ public class ExpressionResolverTests
 
         var connectionStringResource = builder.AddResource(new MyContainerResource("myContainer"))
            .WithImage("redis")
-           .WithHttpEndpoint(targetPort: 8080)
-           .WithEndpoint("http", e =>
-           {
-               e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 8001, EndpointBindingMode.SingleAddress, "{{ targetPort }}");
-           });
+           .WithHttpEndpoint(port: 8001, targetPort: 8080)
+           .WithEndpoint("http", ep => ep.AllocatedEndpoint = new(ep, "localhost", 8001, EndpointBindingMode.SingleAddress, "{{ targetPort }}", KnownNetworkIdentifiers.LocalhostNetwork));
 
         var dep = builder.AddContainer("container", "redis")
            .WithReference(connectionStringResource)
@@ -241,19 +238,16 @@ public class ExpressionResolverTests
 
         var connectionStringResource = builder.AddResource(new MyContainerResource("myContainer"))
            .WithImage("redis")
-           .WithHttpEndpoint(targetPort: 8080)
-           .WithEndpoint("http", e =>
-           {
-               e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 8001, EndpointBindingMode.SingleAddress, "{{ targetPort }}", KnownNetworkIdentifiers.LocalhostNetwork);
-           });
+           .WithHttpEndpoint(port: 8001, targetPort: 8080)
+           .WithEndpoint("http", ep => ep.AllocatedEndpoint = new(ep, "localhost", 8001, EndpointBindingMode.SingleAddress, "{{ targetPort }}", KnownNetworkIdentifiers.LocalhostNetwork));
 
         var dep = builder.AddContainer("container", "redis")
-           .WithReference(connectionStringResource)
+           .WithEnvironment("MY_CONTAINER", connectionStringResource.GetEndpoint("http", KnownNetworkIdentifiers.LocalhostNetwork))
            .WaitFor(connectionStringResource);
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dep.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("http://localhost:8001", config["ConnectionStrings__myContainer"]);
+        Assert.Equal("http://localhost:8001", config["MY_CONTAINER"]);
     }
 
     [Fact]
@@ -283,7 +277,7 @@ sealed class MyContainerResource : ContainerResource, IResourceWithConnectionStr
 {
     public MyContainerResource(string name) : base(name)
     {
-        PrimaryEndpoint = new(this, "http", KnownNetworkIdentifiers.LocalhostNetwork);
+        PrimaryEndpoint = new(this, "http");
     }
 
     public EndpointReference PrimaryEndpoint { get; }


### PR DESCRIPTION
## Description

Check if the endpoint reference has a specific network context set before considering the default network context for the resource.

Fixes #13440
