### PR TITLE
Ensure we install a consistent .NET SDK version between ./dotnet.sh and actions/setup-dotnet

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Setup vars (Linux)
         if: ${{ inputs.os == 'ubuntu-latest' || inputs.os == 'macos-latest' }}
         run: |
+          echo "DOTNET_ROOT=${{ github.workspace }}/.dotnet" >> $GITHUB_ENV
           echo "DOTNET_SCRIPT=./dotnet.sh" >> $GITHUB_ENV
           echo "BUILD_SCRIPT=./build.sh" >> $GITHUB_ENV
           echo "TEST_RUN_PATH=${{ github.workspace }}/run-tests" >> $GITHUB_ENV

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -78,7 +78,6 @@ jobs:
       - name: Setup vars (Linux)
         if: ${{ inputs.os == 'ubuntu-latest' || inputs.os == 'macos-latest' }}
         run: |
-          echo "DOTNET_ROOT=${{ github.workspace }}/.dotnet" >> $GITHUB_ENV
           echo "DOTNET_SCRIPT=./dotnet.sh" >> $GITHUB_ENV
           echo "BUILD_SCRIPT=./build.sh" >> $GITHUB_ENV
           echo "TEST_RUN_PATH=${{ github.workspace }}/run-tests" >> $GITHUB_ENV
@@ -104,6 +103,8 @@ jobs:
             8.x
             9.x
             10.x
+        env:
+          DOTNET_INSTALL_DIR: ${{ env.DOTNET_ROOT }}
 
       - name: Trust HTTPS development certificate (Linux)
         if: inputs.os == 'ubuntu-latest'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.101",
     "rollForward": "major",
     "allowPrerelease": true,
     "paths": [
@@ -10,7 +10,7 @@
     "errorMessage": "The .NET SDK could not be found. Run ./restore.sh (Linux/macOS) or ./restore.cmd (Windows) to install the local SDK."
   },
   "tools": {
-    "dotnet": "10.0.100",
+    "dotnet": "10.0.101",
     "runtimes": {
       "dotnet/x64": [
         "$(DotNetRuntimePreviousVersionForTesting)",

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
@@ -22,7 +22,7 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
     [Trait("scenario", "basicservices")]
     [InlineData(TestResourceNames.postgres)]
     [InlineData(TestResourceNames.efnpgsql)]
-    [InlineData(TestResourceNames.redis, Skip = "https://github.com/dotnet/aspire/issues/13457")]
+    [InlineData(TestResourceNames.redis)]
     public Task VerifyComponentWorks(TestResourceNames resourceName)
         => RunTestAsync(async (cancellationToken) =>
         {


### PR DESCRIPTION
## Description

The test runner was installing both 10.0.100 and 10.0.101 which was leading to unexpected certificate trust behavior due to the 101 patch including an updated dev cert version. This ensures that the SDK is installed to a consistent location and the version installed remains consistent as well.

Fixes #13457