### PR TITLE
Pin versions of yarn/vsce in azure-pipelines.yml

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install VSCE tool
-        run: npm i -g @vscode/vsce
+        run: npm i -g @vscode/vsce@3.7.1
 
       - name: Build with packages
         run: ./build.sh -restore -build -build-extension -ci -pack -bl -p:InstallBrowsersForPlaywright=false -p:SkipTestProjects=true -p:SkipPlaygroundProjects=true ${{ inputs.versionOverrideArg }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Run tests
         run: yarn test
       - name: Package VSIX
-        run: npx @vscode/vsce package --yarn --pre-release -o out/aspire-extension.vsix
+        run: npx @vscode/vsce@3.7.1 package --yarn --pre-release -o out/aspire-extension.vsix
       - name: Upload VSIX
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -239,7 +239,7 @@ extends:
                   targetType: 'inline'
                   script: |
                     $env:NPM_CONFIG_USERCONFIG="$(Build.SourcesDirectory)\.npmrc"
-                    npm install -g yarn
+                    npm install -g yarn@2.4.3
                     yarn --version
                   workingDirectory: '$(Build.SourcesDirectory)'
 
@@ -249,7 +249,7 @@ extends:
                   targetType: 'inline'
                   script: |
                     $env:NPM_CONFIG_USERCONFIG="$(Build.SourcesDirectory)\.npmrc"
-                    npm install -g @vscode/vsce
+                    npm install -g @vscode/vsce@3.7.1
                     vsce --version
                   workingDirectory: '$(Build.SourcesDirectory)'
 

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -239,7 +239,7 @@ extends:
                   targetType: 'inline'
                   script: |
                     $env:NPM_CONFIG_USERCONFIG="$(Build.SourcesDirectory)\.npmrc"
-                    npm install -g yarn@2.4.3
+                    npm install -g yarn@1.22.22
                     yarn --version
                   workingDirectory: '$(Build.SourcesDirectory)'
 


### PR DESCRIPTION
The AzDO npm feed needs authentication to ingest the latest version so the build would break whenever there's a newer version in the upstream npm registry.

Follow-up to https://github.com/dotnet/aspire/pull/13358
