### PR TITLE
Use `rediss://` as the default scheme for Azure Managed Redis uris

### DIFF
--- a/src/Aspire.Hosting.Azure.Redis/AzureManagedRedisResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureManagedRedisResource.cs
@@ -136,10 +136,10 @@ public class AzureManagedRedisResource(string name, Action<AzureResourceInfrastr
 
             if (UseAccessKeyAuthentication)
             {
-                return ReferenceExpression.Create($"redis://:{PrimaryAccessKeySecretOutput:uri}@{HostName}:{Port}");
+                return ReferenceExpression.Create($"rediss://:{PrimaryAccessKeySecretOutput:uri}@{HostName}:{Port}");
             }
 
-            return ReferenceExpression.Create($"redis://{HostName}:{Port}");
+            return ReferenceExpression.Create($"rediss://{HostName}:{Port}");
         }
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureManagedRedisConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureManagedRedisConnectionPropertiesTests.cs
@@ -31,7 +31,7 @@ public class AzureManagedRedisConnectionPropertiesTests
             property =>
             {
                 Assert.Equal("Uri", property.Key);
-                Assert.Equal("redis://{redis.outputs.hostName}:10000", property.Value.ValueExpression);
+                Assert.Equal("rediss://{redis.outputs.hostName}:10000", property.Value.ValueExpression);
             });
     }
 
@@ -58,7 +58,7 @@ public class AzureManagedRedisConnectionPropertiesTests
             property =>
             {
                 Assert.Equal("Uri", property.Key);
-                Assert.Equal("redis://:{redis-kv.secrets.primaryaccesskey--redis}@{redis.outputs.hostName}:10000", property.Value.ValueExpression);
+                Assert.Equal("rediss://:{redis-kv.secrets.primaryaccesskey--redis}@{redis.outputs.hostName}:10000", property.Value.ValueExpression);
             },
             property =>
             {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
@@ -70,7 +70,7 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
             }
             {
               name: 'REDIS_URI'
-              value: 'redis://${redis_outputs_hostname}:10000'
+              value: 'rediss://${redis_outputs_hostname}:10000'
             }
             {
               name: 'AZURE_CLIENT_ID'


### PR DESCRIPTION
## Description

The Python client (at least) requires `rediss://` to denote the connection is secured. We already make this assumption for .NET. The container has custom logic to switch.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ x No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
