### PR TITLE
[release/13.1] Added extension methods to support deploying slot for Azure App Service (#12810)

### DIFF
--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceComputeResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceComputeResourceExtensions.cs
@@ -13,11 +13,12 @@ namespace Aspire.Hosting;
 public static class AzureAppServiceComputeResourceExtensions
 {
     /// <summary>
-    /// Publishes the specified compute resource as an Azure App Service.
+    /// Publishes the specified compute resource as an Azure App Service or Azure App Service Slot.
     /// </summary>
     /// <typeparam name="T">The type of the compute resource.</typeparam>
     /// <param name="builder">The compute resource builder.</param>
     /// <param name="configure">The configuration action for the App Service WebSite resource.</param>
+    /// <param name="configureSlot">The configuration action for the App Service WebSite Slot resource.</param>
     /// <returns>The updated compute resource builder.</returns>
     /// <remarks>
     /// <example>
@@ -29,11 +30,16 @@ public static class AzureAppServiceComputeResourceExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    public static IResourceBuilder<T> PublishAsAzureAppServiceWebsite<T>(this IResourceBuilder<T> builder, Action<AzureResourceInfrastructure, WebSite> configure)
+    public static IResourceBuilder<T> PublishAsAzureAppServiceWebsite<T>(this IResourceBuilder<T> builder,
+        Action<AzureResourceInfrastructure, WebSite>? configure = null,
+        Action<AzureResourceInfrastructure, WebSiteSlot>? configureSlot = null)
         where T : IComputeResource
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configure);
+        if (configure == null && configureSlot == null)
+        {
+            throw new ArgumentException("configure or configureSlot must be provided.");
+        }
 
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
@@ -42,6 +48,15 @@ public static class AzureAppServiceComputeResourceExtensions
 
         builder.ApplicationBuilder.AddAzureAppServiceInfrastructureCore();
 
-        return builder.WithAnnotation(new AzureAppServiceWebsiteCustomizationAnnotation(configure));
+        if (configure != null)
+        {
+            builder = builder.WithAnnotation(new AzureAppServiceWebsiteCustomizationAnnotation(configure));
+        }
+
+        if (configureSlot != null)
+        {
+            builder = builder.WithAnnotation(new AzureAppServiceWebsiteSlotCustomizationAnnotation(configureSlot));
+        }
+        return builder;
     }
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContextAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentContextAnnotation.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents an annotation for the Azure App Service environment context.
+/// </summary>
+internal sealed class AzureAppServiceEnvironmentContextAnnotation(AzureAppServiceEnvironmentContext context)
+    : IResourceAnnotation
+{
+    /// <summary>
+    /// Get the Azure App Service environment context.
+    /// </summary>
+    public AzureAppServiceEnvironmentContext EnvironmentContext { get; } = context;
+}

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -288,6 +288,36 @@ public static partial class AzureAppServiceEnvironmentExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Configures the slot to which the Azure App Services should be deployed.
+    /// </summary>
+    /// <param name="builder">The AzureAppServiceEnvironmentResource to configure.</param>
+    /// <param name="deploymentSlot">The deployment slot parameter for all App Services in the App Service Environment.</param>
+    /// <returns><see cref="IResourceBuilder{T}"/></returns>
+    public static IResourceBuilder<AzureAppServiceEnvironmentResource> WithDeploymentSlot(this IResourceBuilder<AzureAppServiceEnvironmentResource> builder, IResourceBuilder<ParameterResource> deploymentSlot)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(deploymentSlot);
+
+        builder.Resource.DeploymentSlotParameter = deploymentSlot.Resource;
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the slot to which the Azure App Services should be deployed.
+    /// </summary>
+    /// <param name="builder">The AzureAppServiceEnvironmentResource to configure.</param>
+    /// <param name="deploymentSlot">The deployment slot for all App Services in the App Service Environment.</param>
+    /// <returns><see cref="IResourceBuilder{T}"/></returns>
+    public static IResourceBuilder<AzureAppServiceEnvironmentResource> WithDeploymentSlot(this IResourceBuilder<AzureAppServiceEnvironmentResource> builder, string deploymentSlot)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(deploymentSlot);
+
+        builder.Resource.DeploymentSlot = deploymentSlot;
+        return builder;
+    }
+
     private static AzureContainerRegistryResource CreateDefaultAzureContainerRegistry(IDistributedApplicationBuilder builder, string name)
     {
         var configureInfrastructure = (AzureResourceInfrastructure infrastructure) =>

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -174,6 +174,16 @@ public class AzureAppServiceEnvironmentResource :
     internal AzureApplicationInsightsResource? ApplicationInsightsResource { get; set; }
 
     /// <summary>
+    /// Deployment slot parameter resource for the App Service Environment.
+    /// </summary>
+    internal ParameterResource? DeploymentSlotParameter { get; set; }
+
+    /// <summary>
+    /// Deployment slot for the App Service Environment.
+    /// </summary>
+    internal string? DeploymentSlot { get; set; }
+
+    /// <summary>
     /// Gets the name of the App Service Plan.
     /// </summary>
     public BicepOutputReference NameOutputReference => new("name", this);

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceInfrastructure.cs
@@ -45,6 +45,9 @@ internal sealed class AzureAppServiceInfrastructure(
                 appServiceEnvironment,
                 @event.Services);
 
+            // Annotate the environment with its context
+            appServiceEnvironment.Annotations.Add(new AzureAppServiceEnvironmentContextAnnotation(appServiceEnvironmentContext));
+
             foreach (var resource in @event.Model.GetComputeResources())
             {
                 // Support project resources and containers with Dockerfile

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -6,8 +6,12 @@
 #pragma warning disable ASPIREPIPELINES003
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.Provisioning.Internal;
 using Aspire.Hosting.Pipelines;
+using Azure.Core;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Azure;
 
@@ -39,6 +43,69 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
 
             var steps = new List<PipelineStep>();
 
+            var websiteExistsCheckStep = new PipelineStep
+            {
+                Name = $"check-{targetResource.Name}-exists",
+                Action = async ctx =>
+                {
+                    var computerEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
+                    var isSlotDeployment = computerEnv.DeploymentSlot is not null || computerEnv.DeploymentSlotParameter is not null;
+                    if (!isSlotDeployment)
+                    {
+                        return;
+                    }
+
+                    var websiteName = await GetAppServiceWebsiteNameAsync(ctx).ConfigureAwait(false);
+                    var exists = await CheckWebSiteExistsAsync(websiteName, ctx).ConfigureAwait(false);
+                    
+                    if (!exists)
+                    {
+                        ctx.ReportingStep.Log(LogLevel.Information, $"Website {websiteName} does not exist. Adding annotation to refresh provisionable resource", false);
+                        targetResource.Annotations.Add(new AzureAppServiceWebsiteRefreshProvisionableResourceAnnotation());
+                    }
+                },
+                Tags = ["check-website-exists"],
+                DependsOnSteps = new List<string> { "create-provisioning-context" },
+            };
+
+            steps.Add(websiteExistsCheckStep);
+
+            var updateProvisionableResourceStep = new PipelineStep
+            {
+                Name = $"update-{targetResource.Name}-provisionable-resource",
+                Action = async ctx =>
+                {
+                    var computerEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
+
+                    if (!targetResource.TryGetLastAnnotation<AzureAppServiceWebsiteRefreshProvisionableResourceAnnotation>(out _))
+                    {
+                        return;
+                    } 
+
+                    if (computerEnv.TryGetLastAnnotation<AzureAppServiceEnvironmentContextAnnotation>(out var environmentContextAnnotation))
+                    {
+                        var context = environmentContextAnnotation.EnvironmentContext.GetAppServiceContext(targetResource);
+                        var provisioningOptions = ctx.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>();
+                        var provisioningResource = new AzureAppServiceWebSiteResource(targetResource.Name + "-website", context.BuildWebSite, targetResource)
+                        {
+                            ProvisioningBuildOptions = provisioningOptions.Value.ProvisioningBuildOptions
+                        };
+
+                        deploymentTargetAnnotation.DeploymentTarget = provisioningResource;
+
+                        ctx.ReportingStep.Log(LogLevel.Information, $"Updated provisionable resource to deploy website and deployment slot", false);
+                    }
+                    else
+                    {
+                        ctx.ReportingStep.Log(LogLevel.Warning, $"No environment context annotation on the environment resource", false);
+                    }
+                },
+                Tags = ["update-website-provisionable-resource"],
+                DependsOnSteps = new List<string> { "create-provisioning-context" },
+            };
+
+            steps.Add(updateProvisionableResourceStep);
+
             if (!targetResource.TryGetEndpoints(out var endpoints))
             {
                 endpoints = [];
@@ -51,14 +118,16 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
                 Action = async ctx =>
                 {
                     var computerEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
+                    string? deploymentSlot = null;
 
-                    var websiteSuffix = await computerEnv.WebSiteSuffix.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false);
-
-                    var hostName = $"{targetResource.Name.ToLowerInvariant()}-{websiteSuffix}";
-                    if (hostName.Length > 60)
+                    if (computerEnv.DeploymentSlot is not null || computerEnv.DeploymentSlotParameter is not null)
                     {
-                        hostName = hostName.Substring(0, 60);
+                        deploymentSlot = computerEnv.DeploymentSlotParameter is null ?
+                           computerEnv.DeploymentSlot :
+                           await computerEnv.DeploymentSlotParameter.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false);
                     }
+
+                    var hostName = await GetAppServiceWebsiteNameAsync(ctx, deploymentSlot).ConfigureAwait(false);
                     var endpoint = $"https://{hostName}.azurewebsites.net";
                     ctx.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})", enableMarkdown: true);
                 },
@@ -91,6 +160,12 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
             var pushSteps = context.GetSteps(targetResource, WellKnownPipelineTags.PushContainerImage);
             provisionSteps.DependsOn(pushSteps);
 
+            // Ensure website existence check and resource update steps run before provision
+            var checkWebsiteExistsSteps = context.GetSteps(this, "check-website-exists");
+            var updateWebsiteResourceSteps = context.GetSteps(this, "update-website-provisionable-resource");
+            updateWebsiteResourceSteps.DependsOn(checkWebsiteExistsSteps);
+            provisionSteps.DependsOn(updateWebsiteResourceSteps);
+
             // Ensure summary step runs after provision
             context.GetSteps(this, "print-summary").DependsOn(provisionSteps);
         }));
@@ -100,4 +175,82 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     /// Gets the target resource that this Azure Web Site is being created for.
     /// </summary>
     public IResource TargetResource { get; }
+
+    /// <summary>
+    /// Checks if an Azure App Service website exists.
+    /// </summary>
+    /// <param name="websiteName">The name of the website to check.</param>
+    /// <param name="context">The pipeline step context.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains <c>true</c> if the website exists; otherwise, <c>false</c>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when required services or configuration are not available.</exception>
+    private static async Task<bool> CheckWebSiteExistsAsync(string websiteName, PipelineStepContext context)
+    {
+        // Get required services
+        var httpClientFactory = context.Services.GetService<IHttpClientFactory>();
+
+        if (httpClientFactory is null)
+        {
+            throw new InvalidOperationException("IHttpClientFactory is not registered in the service provider.");
+        }
+
+        var tokenCredentialProvider = context.Services.GetRequiredService<ITokenCredentialProvider>();
+
+        // Find the AzureEnvironmentResource from the application model
+        var azureEnvironment = context.Model.Resources.OfType<AzureEnvironmentResource>().FirstOrDefault();
+        if (azureEnvironment == null)
+        {
+            throw new InvalidOperationException("AzureEnvironmentResource must be present in the application model.");
+        }
+
+        var provisioningContext = await azureEnvironment.ProvisioningContextTask.Task.ConfigureAwait(false);
+        var subscriptionId = provisioningContext.Subscription.Id.SubscriptionId?.ToString()
+            ?? throw new InvalidOperationException("SubscriptionId is required.");
+        var resourceGroupName = provisioningContext.ResourceGroup.Name
+            ?? throw new InvalidOperationException("ResourceGroup name is required.");
+
+        context.ReportingStep.Log(LogLevel.Information, $"Check if website {websiteName} exists", false);
+        // Prepare ARM endpoint and request
+        var url = $"{AzureManagementEndpoint}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{websiteName}?api-version=2025-03-01";
+
+        // Get access token for ARM
+        var tokenRequest = new TokenRequestContext([AzureManagementScope]);
+        var token = await tokenCredentialProvider.TokenCredential
+            .GetTokenAsync(tokenRequest, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        var httpClient = httpClientFactory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.Token);
+
+        using var response = await httpClient.SendAsync(request, context.CancellationToken).ConfigureAwait(false);
+
+        return response.StatusCode == System.Net.HttpStatusCode.OK;
+    }
+
+    /// <summary>
+    /// Gets the Azure App Service website name, optionally including the deployment slot suffix.
+    /// </summary>
+    /// <param name="context">The pipeline step context.</param>
+    /// <param name="deploymentSlot">The optional deployment slot name to append to the website name.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the website name.</returns>
+    private async Task<string> GetAppServiceWebsiteNameAsync(PipelineStepContext context, string? deploymentSlot = null)
+    {
+        var computerEnv = (AzureAppServiceEnvironmentResource)TargetResource.GetDeploymentTargetAnnotation()!.ComputeEnvironment!;
+        var websiteSuffix = await computerEnv.WebSiteSuffix.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+        var websiteName = $"{TargetResource.Name.ToLowerInvariant()}-{websiteSuffix}";
+
+        if (!string.IsNullOrWhiteSpace(deploymentSlot))
+        {
+            websiteName += $"-{deploymentSlot}";
+        }
+
+        if (websiteName.Length > 60)
+        {
+            websiteName = websiteName.Substring(0, 60);
+        }
+        return websiteName;
+    }
+
+    private const string AzureManagementScope = "https://management.azure.com/.default";
+    private const string AzureManagementEndpoint = "https://management.azure.com/";
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Utils;
+using Azure.Core;
 using Azure.Provisioning;
 using Azure.Provisioning.AppService;
 using Azure.Provisioning.Authorization;
@@ -22,6 +23,7 @@ internal sealed class AzureAppServiceWebsiteContext(
     record struct EndpointMapping(string Scheme, BicepValue<string> Host, int Port, int? TargetPort, bool IsHttpIngress, bool External);
 
     private readonly Dictionary<string, EndpointMapping> _endpointMapping = [];
+    private readonly Dictionary<string, EndpointMapping> _slotEndpointMapping = [];
 
     // Resolved environment variables and command line args
     // These contain the values that need to be further transformed into
@@ -34,13 +36,23 @@ internal sealed class AzureAppServiceWebsiteContext(
 
     // Naming the app service is globally unique (domain names), so we use the resource group ID to create a unique name
     // within the naming spec for the app service.
-    public BicepValue<string> HostName => BicepFunction.Take(
+    private BicepValue<string> HostName => BicepFunction.Take(
         BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), 60);
+
+    /// <summary>
+    /// Gets the hostname for a deployment slot by appending the slot name to the base website name.
+    /// </summary>
+    /// <param name="deploymentSlot">The deployment slot name.</param>
+    /// <returns>A <see cref="BicepValue{T}"/> representing the slot hostname, truncated to 60 characters.</returns>
+    public BicepValue<string> GetSlotHostName(BicepValue<string> deploymentSlot)
+    {
+        return BicepFunction.Take(
+        BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}-{BicepFunction.ToLower(deploymentSlot)}"), 60);
+    }
 
     public async Task ProcessAsync(CancellationToken cancellationToken)
     {
         ProcessEndpoints();
-
         await ProcessEnvironmentAsync(cancellationToken).ConfigureAwait(true);
         await ProcessArgumentsAsync(cancellationToken).ConfigureAwait(true);
     }
@@ -125,7 +137,7 @@ internal sealed class AzureAppServiceWebsiteContext(
         }
     }
 
-    private (object, SecretType) ProcessValue(object value, SecretType secretType = SecretType.None, object? parent = null)
+    private (object, SecretType) ProcessValue(object value, SecretType secretType = SecretType.None, object? parent = null, bool isSlot = false)
     {
         if (value is string s)
         {
@@ -135,7 +147,9 @@ internal sealed class AzureAppServiceWebsiteContext(
         if (value is EndpointReference ep)
         {
             var context = environmentContext.GetAppServiceContext(ep.Resource);
-            return (GetEndpointValue(context._endpointMapping[ep.EndpointName], EndpointProperty.Url), secretType);
+            return isSlot ?
+                (GetEndpointValue(context._slotEndpointMapping[ep.EndpointName], EndpointProperty.Url), secretType) :
+                (GetEndpointValue(context._endpointMapping[ep.EndpointName], EndpointProperty.Url), secretType);
         }
 
         if (value is ParameterResource param)
@@ -146,12 +160,12 @@ internal sealed class AzureAppServiceWebsiteContext(
 
         if (value is ConnectionStringReference cs)
         {
-            return ProcessValue(cs.Resource.ConnectionStringExpression, secretType, parent);
+            return ProcessValue(cs.Resource.ConnectionStringExpression, secretType, parent, isSlot);
         }
 
         if (value is IResourceWithConnectionString csrs)
         {
-            return ProcessValue(csrs.ConnectionStringExpression, secretType, parent);
+            return ProcessValue(csrs.ConnectionStringExpression, secretType, parent, isSlot);
         }
 
         if (value is BicepOutputReference output)
@@ -172,7 +186,7 @@ internal sealed class AzureAppServiceWebsiteContext(
         if (value is EndpointReferenceExpression epExpr)
         {
             var context = environmentContext.GetAppServiceContext(epExpr.Endpoint.Resource);
-            var mapping = context._endpointMapping[epExpr.Endpoint.EndpointName];
+            var mapping = isSlot ? context._slotEndpointMapping[epExpr.Endpoint.EndpointName] : context._endpointMapping[epExpr.Endpoint.EndpointName];
             var val = GetEndpointValue(mapping, epExpr.Property);
             return (val, secretType);
         }
@@ -181,7 +195,7 @@ internal sealed class AzureAppServiceWebsiteContext(
         {
             if (expr.Format == "{0}" && expr.ValueProviders.Count == 1)
             {
-                var val = ProcessValue(expr.ValueProviders[0], secretType, parent: parent);
+                var val = ProcessValue(expr.ValueProviders[0], secretType, parent: parent, isSlot);
 
                 if (expr.StringFormats[0] is string format)
                 {
@@ -197,7 +211,7 @@ internal sealed class AzureAppServiceWebsiteContext(
 
             foreach (var vp in expr.ValueProviders)
             {
-                var (val, secret) = ProcessValue(vp, secretType, expr);
+                var (val, secret) = ProcessValue(vp, secretType, expr, isSlot);
                 if (secret != SecretType.None)
                 {
                     finalSecretType = SecretType.Normal;
@@ -236,64 +250,162 @@ internal sealed class AzureAppServiceWebsiteContext(
 
     public void BuildWebSite(AzureResourceInfrastructure infra)
     {
+        bool buildWebAppAndSlot = resource.TryGetAnnotationsOfType<AzureAppServiceWebsiteRefreshProvisionableResourceAnnotation>(out _);
+
         _infrastructure = infra;
 
-        // We need to reference the container registry URL so that it exists in the manifest
-        var containerRegistryUrl = environmentContext.Environment.ContainerRegistryUrl.AsProvisioningParameter(infra);
-        var appServicePlanParameter = environmentContext.Environment.PlanIdOutputReference.AsProvisioningParameter(infra);
-        var acrMidParameter = environmentContext.Environment.ContainerRegistryManagedIdentityId.AsProvisioningParameter(infra);
-        var acrClientIdParameter = environmentContext.Environment.ContainerRegistryClientId.AsProvisioningParameter(infra);
-        var containerImage = AllocateParameter(new ContainerImageReference(Resource));
-
-        var webSite = new WebSite("webapp")
+        // Check for deployment slot
+        // If specified, update hostnames to endpoint references
+        BicepValue<string>? deploymentSlotValue = null;
+        if (environmentContext.Environment.DeploymentSlotParameter is not null || environmentContext.Environment.DeploymentSlot is not null)
         {
-            // Use the host name as the name of the web app
-            Name = HostName,
-            AppServicePlanId = appServicePlanParameter,
-            // Creating the app service with new sidecar configuration
-            SiteConfig = new SiteConfigProperties()
-            {
-                LinuxFxVersion = "SITECONTAINERS",
-                AcrUserManagedIdentityId = acrClientIdParameter,
-                UseManagedIdentityCreds = true,
-                // Setting NumberOfWorkers to maximum allowed value for Premium SKU
-                // https://learn.microsoft.com/en-us/azure/app-service/manage-scale-up
-                // This is required due to use of feature PerSiteScaling for the App Service plan
-                // We want the web apps to scale normally as defined for the app service plan
-                // so setting the maximum number of workers to the maximum allowed for Premium V2 SKU.
-                NumberOfWorkers = 30,
-                AppSettings = []
-            },
-            Identity = new ManagedServiceIdentity()
-            {
-                ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned,
-                UserAssignedIdentities = []
-            },
-        };
+            deploymentSlotValue = environmentContext.Environment.DeploymentSlotParameter != null
+                ? environmentContext.Environment.DeploymentSlotParameter.AsProvisioningParameter(infra)
+                : environmentContext.Environment.DeploymentSlot!;
 
-        // Defining the main container for the app service
-        var mainContainer = new SiteContainer("mainContainer")
+            UpdateHostNameForSlot(deploymentSlotValue);
+        }
+
+        if (deploymentSlotValue is not null && buildWebAppAndSlot)
         {
-            Parent = webSite,
-            Name = "main",
-            Image = containerImage,
-            AuthType = SiteContainerAuthType.UserAssigned,
-            UserManagedIdentityClientId = acrClientIdParameter,
-            IsMain = true
-        };
+            BuildWebSiteAndSlot(infra, deploymentSlotValue!);
+            return;
+        }
+
+        BuildWebSiteCore(infra, deploymentSlotValue);
+    }
+
+    /// <summary>
+    /// Creates and configures an Azure App Service WebSite or WebSiteSlot.
+    /// </summary>
+    /// <param name="infra">The Azure resource infrastructure.</param>
+    /// <param name="name">The name of the website or slot.</param>
+    /// <param name="appServicePlanParameter">The App Service plan parameter.</param>
+    /// <param name="acrMidParameter">The Azure Container Registry managed identity parameter.</param>
+    /// <param name="acrClientIdParameter">The Azure Container Registry client ID parameter.</param>
+    /// <param name="containerImage">The container image parameter.</param>
+    /// <param name="isSlot">Indicates whether this is a deployment slot.</param>
+    /// <param name="parentWebSite">The parent website when creating a slot.</param>
+    /// <param name="deploymentSlot">The deployment slot name.</param>
+    /// <returns>A dynamic object representing either a WebSite or WebSiteSlot.</returns>
+    private object CreateAndConfigureWebSite(
+    AzureResourceInfrastructure infra,
+    BicepValue<string> name,
+    BicepValue<ResourceIdentifier> appServicePlanParameter,
+    BicepValue<string> acrMidParameter,
+    ProvisioningParameter acrClientIdParameter,
+    ProvisioningParameter containerImage,
+    bool isSlot = false,
+    WebSite? parentWebSite = null,
+    BicepValue<string>? deploymentSlot = null)
+    {
+        object webSite;
+        object mainContainer;
+
+        if (isSlot && parentWebSite is not null && deploymentSlot is not null)
+        {
+            var slot = new WebSiteSlot("webappslot")
+            {
+                Parent = parentWebSite,
+                Name = deploymentSlot,
+                AppServicePlanId = appServicePlanParameter,
+                SiteConfig = new SiteConfigProperties()
+                {
+                    LinuxFxVersion = "SITECONTAINERS",
+                    AcrUserManagedIdentityId = acrClientIdParameter,
+                    UseManagedIdentityCreds = true,
+                    NumberOfWorkers = 30,
+                    AppSettings = []
+                },
+                Identity = new ManagedServiceIdentity()
+                {
+                    ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned,
+                    UserAssignedIdentities = []
+                },
+            };
+
+            var slotContainer = new SiteSlotSiteContainer("mainContainerSlot")
+            {
+                Parent = slot,
+                Name = "main",
+                Image = containerImage,
+                AuthType = SiteContainerAuthType.UserAssigned,
+                UserManagedIdentityClientId = acrClientIdParameter,
+                IsMain = true
+            };
+
+            webSite = slot;
+            mainContainer = slotContainer;
+        }
+        else
+        {
+            var site = new WebSite("webapp")
+            {
+                Name = name,
+                AppServicePlanId = appServicePlanParameter,
+                // Creating the app service with new sidecar configuration
+                SiteConfig = new SiteConfigProperties()
+                {
+                    LinuxFxVersion = "SITECONTAINERS",
+                    AcrUserManagedIdentityId = acrClientIdParameter,
+                    UseManagedIdentityCreds = true,
+                    // Setting NumberOfWorkers to maximum allowed value for Premium SKU
+                    // https://learn.microsoft.com/en-us/azure/app-service/manage-scale-up
+                    // This is required due to use of feature PerSiteScaling for the App Service plan
+                    // We want the web apps to scale normally as defined for the app service plan
+                    // so setting the maximum number of workers to the maximum allowed for Premium V2 SKU.
+                    NumberOfWorkers = 30,
+                    AppSettings = []
+                },
+                Identity = new ManagedServiceIdentity()
+                {
+                    ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned,
+                    UserAssignedIdentities = []
+                },
+            };
+
+            // Defining the main container for the app service
+            var siteContainer = new SiteContainer("mainContainer")
+            {
+                Parent = site,
+                Name = "main",
+                Image = containerImage,
+                AuthType = SiteContainerAuthType.UserAssigned,
+                UserManagedIdentityClientId = acrClientIdParameter,
+                IsMain = true
+            };
+
+            webSite = site;
+            mainContainer = siteContainer;
+        }
 
         // There should be a single valid target port
-        if (_endpointMapping.FirstOrDefault() is var  (_, mapping))
+        if (_endpointMapping.FirstOrDefault() is var (_, mapping))
         {
             var targetPort = GetEndpointValue(mapping, EndpointProperty.TargetPort);
 
-            mainContainer.TargetPort = targetPort;
-            webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITES_PORT", Value = targetPort });
+            if (mainContainer is SiteContainer container)
+            {
+                container.TargetPort = targetPort;
+            }
+            else if (mainContainer is SiteSlotSiteContainer slotContainer)
+            {
+                slotContainer.TargetPort = targetPort;
+            }
+
+            if (webSite is WebSite site)
+            {
+                site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITES_PORT", Value = targetPort });
+            }
+            else if (webSite is WebSiteSlot slot)
+            {
+                slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITES_PORT", Value = targetPort });
+            }
         }
 
         foreach (var kv in EnvironmentVariables)
         {
-            var (val, secretType) = ProcessValue(kv.Value);
+            var (val, secretType) = ProcessValue(kv.Value, isSlot: isSlot);
             var value = ResolveValue(val);
 
             if (secretType == SecretType.KeyVault)
@@ -303,7 +415,14 @@ internal sealed class AzureAppServiceWebsiteContext(
                 value = BicepFunction.Interpolate($"@Microsoft.KeyVault(SecretUri={val})");
             }
 
-            webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = kv.Key, Value = value });
+            if (webSite is WebSite site)
+            {
+                site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = kv.Key, Value = value });
+            }
+            else if (webSite is WebSiteSlot slot)
+            {
+                slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = kv.Key, Value = value });
+            }
         }
 
         if (Args.Count > 0)
@@ -324,13 +443,35 @@ internal sealed class AzureAppServiceWebsiteContext(
 
             var arrayExpression = new ArrayExpression([.. args.Select(a => a.Compile())]);
 
-            mainContainer.StartUpCommand = Join(arrayExpression, " ");
+            if (mainContainer is SiteContainer container)
+            {
+                container.StartUpCommand = Join(arrayExpression, " ");
+            }
+            else if (mainContainer is SiteSlotSiteContainer slotContainer)
+            {
+                slotContainer.StartUpCommand = Join(arrayExpression, " ");
+            }
         }
 
-        infra.Add(mainContainer);
+        if (mainContainer is SiteContainer mainSiteContainer)
+        {
+            infra.Add(mainSiteContainer);
+        }
+        else if (mainContainer is SiteSlotSiteContainer mainSiteSlotContainer)
+        {
+            infra.Add(mainSiteSlotContainer);
+        }
 
         var id = BicepFunction.Interpolate($"{acrMidParameter}").Compile().ToString();
-        webSite.Identity.UserAssignedIdentities[id] = new UserAssignedIdentityDetails();
+
+        if (webSite is WebSite siteObject)
+        {
+            siteObject.Identity.UserAssignedIdentities[id] = new UserAssignedIdentityDetails();
+        }
+        else if (webSite is WebSiteSlot slot)
+        {
+            slot.Identity.UserAssignedIdentities[id] = new UserAssignedIdentityDetails();
+        }
 
         // This is the user assigned identity associated with the web app, not the container registry
         if (resource.TryGetLastAnnotation<AppIdentityAnnotation>(out var appIdentityAnnotation))
@@ -341,27 +482,54 @@ internal sealed class AzureAppServiceWebsiteContext(
 
             var cid = BicepFunction.Interpolate($"{computeIdentity}").Compile().ToString();
 
-            webSite.KeyVaultReferenceIdentity = computeIdentity;
-
-            webSite.Identity.ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned;
-            webSite.Identity.UserAssignedIdentities[cid] = new UserAssignedIdentityDetails();
-
-            webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+            if (webSite is WebSite site)
             {
-                Name = "AZURE_CLIENT_ID",
-                Value = appIdentityResource.ClientId.AsProvisioningParameter(infra)
-            });
+                site.KeyVaultReferenceIdentity = computeIdentity;
+                site.Identity.ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned;
+                site.Identity.UserAssignedIdentities[cid] = new UserAssignedIdentityDetails();
 
-            // DefaultAzureCredential should only use ManagedIdentityCredential when running in Azure
-            webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+                site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+                {
+                    Name = "AZURE_CLIENT_ID",
+                    Value = appIdentityResource.ClientId.AsProvisioningParameter(infra)
+                });
+
+                // DefaultAzureCredential should only use ManagedIdentityCredential when running in Azure
+                site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+                {
+                    Name = "AZURE_TOKEN_CREDENTIALS",
+                    Value = "ManagedIdentityCredential"
+                });
+            }
+            else if (webSite is WebSiteSlot slot)
             {
-                Name = "AZURE_TOKEN_CREDENTIALS",
-                Value = "ManagedIdentityCredential"
-            });
+                slot.KeyVaultReferenceIdentity = computeIdentity;
+                slot.Identity.UserAssignedIdentities[id] = new UserAssignedIdentityDetails();
+                slot.Identity.ManagedServiceIdentityType = ManagedServiceIdentityType.UserAssigned;
+                slot.Identity.UserAssignedIdentities[cid] = new UserAssignedIdentityDetails();
+                slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+                {
+                    Name = "AZURE_CLIENT_ID",
+                    Value = appIdentityResource.ClientId.AsProvisioningParameter(infra)
+                });
+                // DefaultAzureCredential should only use ManagedIdentityCredential when running in Azure
+                slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+                {
+                    Name = "AZURE_TOKEN_CREDENTIALS",
+                    Value = "ManagedIdentityCredential"
+                });
+            }
         }
 
         // Added appsetting to identify the resource in a specific aspire environment
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "ASPIRE_ENVIRONMENT_NAME", Value = environmentContext.Environment.Name });
+        if (webSite is WebSite siteObj)
+        {
+            siteObj.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "ASPIRE_ENVIRONMENT_NAME", Value = environmentContext.Environment.Name });
+        }
+        else if (webSite is WebSiteSlot slot)
+        {
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "ASPIRE_ENVIRONMENT_NAME", Value = environmentContext.Environment.Name });
+        }
 
         // Probes
 #pragma warning disable ASPIREPROBES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
@@ -375,7 +543,14 @@ internal sealed class AzureAppServiceWebsiteContext(
 
             if (endpointProbeAnnotation is not null)
             {
-                webSite.SiteConfig.HealthCheckPath = endpointProbeAnnotation.Path;
+                if (webSite is WebSiteSlot slot)
+                {
+                    slot.SiteConfig.HealthCheckPath = endpointProbeAnnotation.Path;
+                }
+                else if (webSite is WebSite site)
+                {
+                    site.SiteConfig.HealthCheckPath = endpointProbeAnnotation.Path;
+                }
             }
         }
 #pragma warning restore ASPIREPROBES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
@@ -383,10 +558,18 @@ internal sealed class AzureAppServiceWebsiteContext(
         RoleAssignment? webSiteRa = null;
         if (environmentContext.Environment.EnableDashboard)
         {
-            webSiteRa = AddDashboardPermissionAndSettings(webSite, acrClientIdParameter);
+            webSiteRa = AddDashboardPermissionAndSettings(webSite, acrClientIdParameter, deploymentSlot);
         }
 
-        infra.Add(webSite);
+        if (webSite is WebSite webSiteObject)
+        {
+            infra.Add(webSiteObject);
+        }
+        else if (webSite is WebSiteSlot slot)
+        {
+            infra.Add(slot);
+        }
+
         if (webSiteRa is not null)
         {
             infra.Add(webSiteRa);
@@ -397,12 +580,126 @@ internal sealed class AzureAppServiceWebsiteContext(
             EnableApplicationInsightsForWebSite(webSite);
         }
 
+        return webSite;
+    }
+
+    /// <summary>
+    /// Builds either a standalone website or a deployment slot based on whether a deployment slot is specified.
+    /// </summary>
+    /// <param name="infra">The Azure resource infrastructure.</param>
+    /// <param name="deploymentSlot">The optional deployment slot name.</param>
+    private void BuildWebSiteCore(
+        AzureResourceInfrastructure infra,
+        BicepValue<string>? deploymentSlot = null)
+    {
+        _infrastructure = infra;
+
+        _ = environmentContext.Environment.ContainerRegistryUrl.AsProvisioningParameter(infra);
+        var appServicePlanParameter = environmentContext.Environment.PlanIdOutputReference.AsProvisioningParameter(infra);
+        var acrMidParameter = environmentContext.Environment.ContainerRegistryManagedIdentityId.AsProvisioningParameter(infra);
+        var acrClientIdParameter = environmentContext.Environment.ContainerRegistryClientId.AsProvisioningParameter(infra);
+        var containerImage = AllocateParameter(new ContainerImageReference(Resource));
+
+        // Create parent WebSite from existing
+        WebSite? parentWebSite = null;
+
+        if (deploymentSlot is not null)
+        {
+            parentWebSite = WebSite.FromExisting("webapp");
+            parentWebSite.Name = HostName;
+            Infra.Add(parentWebSite);
+        }
+
+        var webSite = CreateAndConfigureWebSite(
+            infra,
+            HostName,
+            appServicePlanParameter,
+            acrMidParameter,
+            acrClientIdParameter,
+            containerImage,
+            isSlot: deploymentSlot is not null,
+            parentWebSite: parentWebSite,
+            deploymentSlot: deploymentSlot);
+
         // Allow users to customize the web app here
+        if (deploymentSlot is not null)
+        {
+            if (resource.TryGetAnnotationsOfType<AzureAppServiceWebsiteSlotCustomizationAnnotation>(out var customizeWebSiteSlotAnnotations))
+            {
+                var slot = (WebSiteSlot)webSite;
+                foreach (var customizeWebSiteSlotAnnotation in customizeWebSiteSlotAnnotations)
+                {
+                    customizeWebSiteSlotAnnotation.Configure(Infra, slot);
+                }
+            }
+        }
+        else
+        {
+            if (resource.TryGetAnnotationsOfType<AzureAppServiceWebsiteCustomizationAnnotation>(out var customizeWebSiteAnnotations))
+            {
+                var site = (WebSite)webSite;
+                foreach (var customizeWebSiteAnnotation in customizeWebSiteAnnotations)
+                {
+                    customizeWebSiteAnnotation.Configure(infra, site);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds both the main website and a deployment slot when deploying to a slot for the first time.
+    /// </summary>
+    /// <param name="infra">The Azure resource infrastructure.</param>
+    /// <param name="deploymentSlot">The deployment slot name.</param>
+    private void BuildWebSiteAndSlot(
+        AzureResourceInfrastructure infra,
+        BicepValue<string> deploymentSlot)
+    {
+        _infrastructure = infra;
+
+        _ = environmentContext.Environment.ContainerRegistryUrl.AsProvisioningParameter(infra);
+        var appServicePlanParameter = environmentContext.Environment.PlanIdOutputReference.AsProvisioningParameter(infra);
+        var acrMidParameter = environmentContext.Environment.ContainerRegistryManagedIdentityId.AsProvisioningParameter(infra);
+        var acrClientIdParameter = environmentContext.Environment.ContainerRegistryClientId.AsProvisioningParameter(infra);
+        var containerImage = AllocateParameter(new ContainerImageReference(Resource));
+
+        // Main site
+        var webSite = (WebSite)CreateAndConfigureWebSite(
+            infra,
+            HostName,
+            appServicePlanParameter,
+            acrMidParameter,
+            acrClientIdParameter,
+            containerImage,
+            isSlot: false);
+
+        // Slot
+        var webSiteSlot = (WebSiteSlot)CreateAndConfigureWebSite(
+            infra,
+            deploymentSlot,
+            appServicePlanParameter,
+            acrMidParameter,
+            acrClientIdParameter,
+            containerImage,
+            isSlot: true,
+            parentWebSite: (WebSite)webSite,
+            deploymentSlot: deploymentSlot);
+
+        // Allow users to customize the website
         if (resource.TryGetAnnotationsOfType<AzureAppServiceWebsiteCustomizationAnnotation>(out var customizeWebSiteAnnotations))
         {
             foreach (var customizeWebSiteAnnotation in customizeWebSiteAnnotations)
             {
                 customizeWebSiteAnnotation.Configure(infra, webSite);
+            }
+        }
+
+        // Allow users to customize the slot
+        if (resource.TryGetAnnotationsOfType<AzureAppServiceWebsiteSlotCustomizationAnnotation>(out var customizeWebSiteSlotAnnotations))
+        {
+            foreach (var customizeWebSiteSlotAnnotation in customizeWebSiteSlotAnnotations)
+            {
+                customizeWebSiteSlotAnnotation.Configure(infra, webSiteSlot);
             }
         }
     }
@@ -435,59 +732,128 @@ internal sealed class AzureAppServiceWebsiteContext(
         return parameter.AsProvisioningParameter(Infra, isSecure: secretType == SecretType.Normal);
     }
 
-    private RoleAssignment AddDashboardPermissionAndSettings(WebSite webSite, ProvisioningParameter acrClientIdParameter)
+    private RoleAssignment AddDashboardPermissionAndSettings(object webSite, ProvisioningParameter acrClientIdParameter, BicepValue<string>? deploymentSlot = null)
     {
+        bool isSlot = deploymentSlot is not null;
         var dashboardUri = environmentContext.Environment.DashboardUriReference.AsProvisioningParameter(Infra);
         var contributorId = environmentContext.Environment.WebsiteContributorManagedIdentityId.AsProvisioningParameter(Infra);
         var contributorPrincipalId = environmentContext.Environment.WebsiteContributorManagedIdentityPrincipalId.AsProvisioningParameter(Infra);
-
-        // Add the appsettings specific to sending telemetry data to dashboard
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_SERVICE_NAME", Value = resource.Name });
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_EXPORTER_OTLP_PROTOCOL", Value = "grpc" });
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_EXPORTER_OTLP_ENDPOINT", Value = "http://localhost:6001" });
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR", Value = "true" });
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_COLLECTOR_URL", Value = dashboardUri });
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_CLIENT_ID", Value = acrClientIdParameter });
+        var otelServiceName = isSlot ? BicepFunction.Interpolate($"{resource.Name}-{deploymentSlot}") : resource.Name;
 
         // Add Website Contributor role assignment to dashboard's managed identity for this webapp
         var websiteRaId = BicepFunction.GetSubscriptionResourceId(
                     "Microsoft.Authorization/roleDefinitions",
                     "de139f84-1756-47ae-9be6-808fbbe84772");
-        var websiteRaName = BicepFunction.CreateGuid(webSite.Id, contributorId, websiteRaId);
 
-        return new RoleAssignment(Infrastructure.NormalizeBicepIdentifier($"{Infra.AspireResource.Name}_ra"))
+        string raResourceName = isSlot
+            ? Infrastructure.NormalizeBicepIdentifier($"{Infra.AspireResource.Name}_slot_ra")
+            : Infrastructure.NormalizeBicepIdentifier($"{Infra.AspireResource.Name}_ra");
+
+        RoleAssignment? roleAssignment = null;
+
+        if (webSite is WebSite site)
         {
-            Name = websiteRaName,
-            Scope = new IdentifierExpression(webSite.BicepIdentifier),
-            PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
-            PrincipalId = contributorPrincipalId,
-            RoleDefinitionId = websiteRaId,
-        };
+            // Add the appsettings specific to sending telemetry data to dashboard
+            site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_SERVICE_NAME", Value = otelServiceName });
+            site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_EXPORTER_OTLP_PROTOCOL", Value = "grpc" });
+            site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_EXPORTER_OTLP_ENDPOINT", Value = "http://localhost:6001" });
+            site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR", Value = "true" });
+            site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_COLLECTOR_URL", Value = dashboardUri });
+            site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_CLIENT_ID", Value = acrClientIdParameter });
+
+            var websiteRaName = BicepFunction.CreateGuid(site.Id, contributorId, websiteRaId);
+            roleAssignment = new RoleAssignment(raResourceName)
+            {
+                Name = websiteRaName,
+                Scope = new IdentifierExpression(site.BicepIdentifier),
+                PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
+                PrincipalId = contributorPrincipalId,
+                RoleDefinitionId = websiteRaId,
+            };
+        }
+        else if (webSite is WebSiteSlot slot)
+        {
+            // Add the appsettings specific to sending telemetry data to dashboard
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_SERVICE_NAME", Value = otelServiceName });
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_EXPORTER_OTLP_PROTOCOL", Value = "grpc" });
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_EXPORTER_OTLP_ENDPOINT", Value = "http://localhost:6001" });
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR", Value = "true" });
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_COLLECTOR_URL", Value = dashboardUri });
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "OTEL_CLIENT_ID", Value = acrClientIdParameter });
+
+            var websiteRaName = BicepFunction.CreateGuid(slot.Id, contributorId, websiteRaId);
+            roleAssignment = new RoleAssignment(raResourceName)
+            {
+                Name = websiteRaName,
+                Scope = new IdentifierExpression(slot.BicepIdentifier),
+                PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
+                PrincipalId = contributorPrincipalId,
+                RoleDefinitionId = websiteRaId,
+            };
+        }
+
+        return roleAssignment!;
     }
 
-    private void EnableApplicationInsightsForWebSite(WebSite webSite)
+    private void EnableApplicationInsightsForWebSite(object webSite)
     {
         var appInsightsInstrumentationKey = environmentContext.Environment.AzureAppInsightsInstrumentationKeyReference.AsProvisioningParameter(Infra);
         var appInsightsConnectionString = environmentContext.Environment.AzureAppInsightsConnectionStringReference.AsProvisioningParameter(Infra);
 
-        // Website configuration for Application Insights
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+        if (webSite is WebSite site)
         {
-            Name = "APPINSIGHTS_INSTRUMENTATIONKEY",
-            Value = appInsightsInstrumentationKey
-        });
+            site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+            {
+                Name = "APPINSIGHTS_INSTRUMENTATIONKEY",
+                Value = appInsightsInstrumentationKey
+            });
+            site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+            {
+                Name = "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                Value = appInsightsConnectionString
+            });
+            site.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+            {
+                Name = "ApplicationInsightsAgent_EXTENSION_VERSION",
+                Value = "~3"
+            });
+        }
+        else if (webSite is WebSiteSlot slot)
+        {
+            // Website configuration for Application Insights
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+            {
+                Name = "APPINSIGHTS_INSTRUMENTATIONKEY",
+                Value = appInsightsInstrumentationKey
+            });
 
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
-        {
-            Name = "APPLICATIONINSIGHTS_CONNECTION_STRING",
-            Value = appInsightsConnectionString
-        });
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+            {
+                Name = "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                Value = appInsightsConnectionString
+            });
 
-        webSite.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+            slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair
+            {
+                Name = "ApplicationInsightsAgent_EXTENSION_VERSION",
+                Value = "~3"
+            });
+        }                                                  
+    }
+
+    /// <summary>
+    /// Updates endpoint mappings to use deployment slot hostnames.
+    /// </summary>
+    /// <param name="slotName">The deployment slot name.</param>
+    private void UpdateHostNameForSlot(BicepValue<string> slotName)
+    {
+        foreach (var (name, mapping) in _endpointMapping.ToList())
         {
-            Name = "ApplicationInsightsAgent_EXTENSION_VERSION",
-            Value = "~3"
-        });
+            BicepValue<string> hostValue;
+
+            hostValue = GetSlotHostName(slotName);
+            _slotEndpointMapping[name] = mapping with { Host = hostValue };
+        }
     }
 
     enum SecretType

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteRefreshProvisionableResourceAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteRefreshProvisionableResourceAnnotation.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents an annotation for the creation of an Azure App Service website and its deployment slot, including
+/// configuration customization.
+/// </summary>
+internal sealed class AzureAppServiceWebsiteRefreshProvisionableResourceAnnotation
+    : IResourceAnnotation
+{
+}

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteSlotCustomizationAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteSlotCustomizationAnnotation.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Azure.Provisioning.AppService;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents an annotation for customizing an Azure Web App slot.
+/// </summary>
+/// <param name="configure">The configuration action for customizing the Azure Web App slot.</param>
+public sealed class AzureAppServiceWebsiteSlotCustomizationAnnotation(Action<AzureResourceInfrastructure, WebSiteSlot> configure)
+    : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the configuration action for customizing the Azure Web App slot.
+    /// </summary>
+    public Action<AzureResourceInfrastructure, WebSiteSlot> Configure { get; } = configure ?? throw new ArgumentNullException(nameof(configure));
+}

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.ContainerRegistry" />
+    <InternalsVisibleTo Include="Aspire.Hosting.Azure.AppService" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting/ApplicationModel/DeploymentTargetAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DeploymentTargetAnnotation.cs
@@ -11,7 +11,7 @@ public sealed class DeploymentTargetAnnotation(IResource target) : IResourceAnno
     /// <summary>
     /// The deployment target.
     /// </summary>
-    public IResource DeploymentTarget { get; } = target;
+    public IResource DeploymentTarget { get; set; } = target;
 
     /// <summary>
     /// Gets or sets the container registry information associated with

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceEnvironmentWithoutDashboardAddsEnvironmentResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceEnvironmentWithoutDashboardAddsEnvironmentResource.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsDefaultLocation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsDefaultLocation.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocation.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocationParam.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocationParam.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlot.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlot.verified.json
@@ -1,0 +1,15 @@
+{
+  "type": "azure.bicep.v0",
+  "path": "project1-website.module.bicep",
+  "params": {
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "project1_containerimage": "{project1.containerImage}",
+    "project1_containerport": "{project1.containerPort}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlotParameter.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlotParameter.verified.bicep
@@ -1,6 +1,8 @@
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
+param deploymentSlot string
+
 param env_outputs_azure_container_registry_endpoint string
 
 param env_outputs_planid string
@@ -9,7 +11,9 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param env_outputs_azure_container_registry_managed_identity_client_id string
 
-param project2_containerimage string
+param project1_containerimage string
+
+param project1_containerport string
 
 param env_outputs_azure_app_service_dashboard_uri string
 
@@ -17,20 +21,24 @@ param env_outputs_azure_website_contributor_managed_identity_id string
 
 param env_outputs_azure_website_contributor_managed_identity_principal_id string
 
-resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
+resource webapp 'Microsoft.Web/sites@2025-03-01' existing = {
+  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
+}
+
+resource mainContainerSlot 'Microsoft.Web/sites/slots/sitecontainers@2025-03-01' = {
   name: 'main'
   properties: {
     authType: 'UserAssigned'
-    image: project2_containerimage
+    image: project1_containerimage
     isMain: true
-    targetPort: '8000'
+    targetPort: project1_containerport
     userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
   }
-  parent: webapp
+  parent: webappslot
 }
 
-resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
+resource webappslot 'Microsoft.Web/sites/slots@2025-03-01' = {
+  name: deploymentSlot
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -42,7 +50,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
       appSettings: [
         {
           name: 'WEBSITES_PORT'
-          value: '8000'
+          value: project1_containerport
         }
         {
           name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
@@ -62,11 +70,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'HTTP_PORTS'
-          value: '8000'
-        }
-        {
-          name: 'HTTPS_PORTS'
-          value: '8000'
+          value: project1_containerport
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -74,7 +78,7 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'OTEL_SERVICE_NAME'
-          value: 'project2'
+          value: 'project1-${deploymentSlot}'
         }
         {
           name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
@@ -105,14 +109,15 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
       '${env_outputs_azure_container_registry_managed_identity_id}': { }
     }
   }
+  parent: webapp
 }
 
-resource project2_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+resource project1_website_slot_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webappslot.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
   properties: {
     principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
     principalType: 'ServicePrincipal'
   }
-  scope: webapp
+  scope: webappslot
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlotParameter.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlotParameter.verified.json
@@ -1,0 +1,16 @@
+{
+  "type": "azure.bicep.v0",
+  "path": "project1-website.module.bicep",
+  "params": {
+    "deploymentSlot": "{deploymentSlot.value}",
+    "env_outputs_azure_container_registry_endpoint": "{env.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+    "env_outputs_planid": "{env.outputs.planId}",
+    "env_outputs_azure_container_registry_managed_identity_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_container_registry_managed_identity_client_id": "{env.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID}",
+    "project1_containerimage": "{project1.containerImage}",
+    "project1_containerport": "{project1.containerPort}",
+    "env_outputs_azure_app_service_dashboard_uri": "{env.outputs.AZURE_APP_SERVICE_DASHBOARD_URI}",
+    "env_outputs_azure_website_contributor_managed_identity_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID}",
+    "env_outputs_azure_website_contributor_managed_identity_principal_id": "{env.outputs.AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithExistingApplicationInsights.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithExistingApplicationInsights.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsEnvironmentResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsEnvironmentResource.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanReferenceExistingAppServicePlan.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanReferenceExistingAppServicePlan.verified.bicep
@@ -1,4 +1,4 @@
-﻿@description('The location for the resource(s) to be deployed.')
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 27
+Total steps defined: 29
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -21,26 +21,28 @@ Steps with no dependencies run first, followed by steps that depend on them.
   5. build
   6. validate-azure-login
   7. create-provisioning-context
-  8. provision-api-identity
-  9. provision-env-acr
- 10. provision-env
- 11. provision-kv
- 12. login-to-acr-env-acr
- 13. push-prereq
- 14. push-api
- 15. provision-api-website
- 16. print-api-summary
- 17. provision-api-roles-kv
- 18. provision-azure-bicep-resources
- 19. print-dashboard-url-env
- 20. deploy
- 21. deploy-api
- 22. diagnostics
- 23. publish-prereq
- 24. publish-azure634f9
- 25. publish
- 26. publish-manifest
- 27. push
+  8. check-api-exists
+  9. provision-api-identity
+ 10. provision-env-acr
+ 11. provision-env
+ 12. provision-kv
+ 13. login-to-acr-env-acr
+ 14. push-prereq
+ 15. push-api
+ 16. update-api-provisionable-resource
+ 17. provision-api-website
+ 18. print-api-summary
+ 19. provision-api-roles-kv
+ 20. provision-azure-bicep-resources
+ 21. print-dashboard-url-env
+ 22. deploy
+ 23. deploy-api
+ 24. diagnostics
+ 25. publish-prereq
+ 26. publish-azure634f9
+ 27. publish
+ 28. publish-manifest
+ 29. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -60,6 +62,11 @@ Step: build-api
 Step: build-prereq
     Description: Prerequisite step that runs before any build operations.
     Dependencies: ✓ process-parameters
+
+Step: check-api-exists
+    Dependencies: ✓ create-provisioning-context
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: check-website-exists
 
 Step: create-provisioning-context
     Description: Creates the Azure provisioning context for infrastructure deployment.
@@ -119,7 +126,7 @@ Step: provision-api-roles-kv
 
 Step: provision-api-website
     Description: Provisions the Azure Bicep resource api-website using Azure infrastructure.
-    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-env, ✓ provision-kv, ✓ push-api
+    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-env, ✓ provision-kv, ✓ push-api, ✓ update-api-provisionable-resource
     Resource: api-website (AzureAppServiceWebSiteResource)
     Tags: provision-infra
 
@@ -177,6 +184,11 @@ Step: push-prereq
     Description: Prerequisite step that runs before any push operations.
     Dependencies: ✓ login-to-acr-env-acr
 
+Step: update-api-provisionable-resource
+    Dependencies: ✓ check-api-exists, ✓ create-provisioning-context
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: update-website-provisionable-resource
+
 Step: validate-azure-login
     Description: Validates Azure CLI authentication before deployment.
     Dependencies: ✓ deploy-prereq
@@ -217,6 +229,16 @@ If targeting 'build-prereq':
     [0] process-parameters
     [1] build-prereq
 
+If targeting 'check-api-exists':
+  Direct dependencies: create-provisioning-context
+  Total steps: 5
+  Execution order:
+    [0] process-parameters
+    [1] deploy-prereq
+    [2] validate-azure-login
+    [3] create-provisioning-context
+    [4] check-api-exists
+
 If targeting 'create-provisioning-context':
   Direct dependencies: deploy-prereq, validate-azure-login
   Total steps: 4
@@ -228,14 +250,14 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 19
+  Total steps: 21
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-env-acr | provision-kv (parallel)
-    [5] login-to-acr-env-acr | provision-api-roles-kv | provision-env (parallel)
+    [4] check-api-exists | provision-api-identity | provision-env-acr | provision-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-kv | provision-env | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -245,14 +267,14 @@ If targeting 'deploy':
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 16
+  Total steps: 18
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-env-acr | provision-kv (parallel)
-    [5] login-to-acr-env-acr | provision-env (parallel)
+    [4] check-api-exists | provision-api-identity | provision-env-acr | provision-kv (parallel)
+    [5] login-to-acr-env-acr | provision-env | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -285,14 +307,14 @@ If targeting 'login-to-acr-env-acr':
 
 If targeting 'print-api-summary':
   Direct dependencies: provision-api-website
-  Total steps: 15
+  Total steps: 17
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-env-acr | provision-kv (parallel)
-    [5] login-to-acr-env-acr | provision-env (parallel)
+    [4] check-api-exists | provision-api-identity | provision-env-acr | provision-kv (parallel)
+    [5] login-to-acr-env-acr | provision-env | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -300,14 +322,14 @@ If targeting 'print-api-summary':
 
 If targeting 'print-dashboard-url-env':
   Direct dependencies: provision-azure-bicep-resources, provision-env
-  Total steps: 17
+  Total steps: 19
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-env-acr | provision-kv (parallel)
-    [5] login-to-acr-env-acr | provision-api-roles-kv | provision-env (parallel)
+    [4] check-api-exists | provision-api-identity | provision-env-acr | provision-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-kv | provision-env | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -342,29 +364,29 @@ If targeting 'provision-api-roles-kv':
     [5] provision-api-roles-kv
 
 If targeting 'provision-api-website':
-  Direct dependencies: create-provisioning-context, provision-api-identity, provision-env, provision-kv, push-api
-  Total steps: 14
-  Execution order:
-    [0] process-parameters
-    [1] build-prereq | deploy-prereq (parallel)
-    [2] build-api | validate-azure-login (parallel)
-    [3] create-provisioning-context
-    [4] provision-api-identity | provision-env-acr | provision-kv (parallel)
-    [5] login-to-acr-env-acr | provision-env (parallel)
-    [6] push-prereq
-    [7] push-api
-    [8] provision-api-website
-
-If targeting 'provision-azure-bicep-resources':
-  Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-kv, provision-api-website, provision-env, provision-env-acr, provision-kv
+  Direct dependencies: create-provisioning-context, provision-api-identity, provision-env, provision-kv, push-api, update-api-provisionable-resource
   Total steps: 16
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-env-acr | provision-kv (parallel)
-    [5] login-to-acr-env-acr | provision-api-roles-kv | provision-env (parallel)
+    [4] check-api-exists | provision-api-identity | provision-env-acr | provision-kv (parallel)
+    [5] login-to-acr-env-acr | provision-env | update-api-provisionable-resource (parallel)
+    [6] push-prereq
+    [7] push-api
+    [8] provision-api-website
+
+If targeting 'provision-azure-bicep-resources':
+  Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-kv, provision-api-website, provision-env, provision-env-acr, provision-kv
+  Total steps: 18
+  Execution order:
+    [0] process-parameters
+    [1] build-prereq | deploy-prereq (parallel)
+    [2] build-api | validate-azure-login (parallel)
+    [3] create-provisioning-context
+    [4] check-api-exists | provision-api-identity | provision-env-acr | provision-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-kv | provision-env | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -469,6 +491,17 @@ If targeting 'push-prereq':
     [4] provision-env-acr
     [5] login-to-acr-env-acr
     [6] push-prereq
+
+If targeting 'update-api-provisionable-resource':
+  Direct dependencies: check-api-exists, create-provisioning-context
+  Total steps: 6
+  Execution order:
+    [0] process-parameters
+    [1] deploy-prereq
+    [2] validate-azure-login
+    [3] create-provisioning-context
+    [4] check-api-exists
+    [5] update-api-provisionable-resource
 
 If targeting 'validate-azure-login':
   Direct dependencies: deploy-prereq

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 37
+Total steps defined: 39
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -22,35 +22,37 @@ Steps with no dependencies run first, followed by steps that depend on them.
   6. build
   7. validate-azure-login
   8. create-provisioning-context
-  9. provision-aas-env-acr
- 10. provision-aas-env
- 11. login-to-acr-aas-env-acr
- 12. provision-aca-env-acr
- 13. login-to-acr-aca-env-acr
- 14. push-prereq
- 15. push-api-service
- 16. provision-api-service-website
- 17. print-api-service-summary
- 18. provision-aca-env
- 19. provision-cache-containerapp
- 20. print-cache-summary
- 21. push-python-app
- 22. provision-python-app-containerapp
- 23. provision-storage
- 24. provision-azure-bicep-resources
- 25. print-dashboard-url-aas-env
- 26. print-dashboard-url-aca-env
- 27. print-python-app-summary
- 28. deploy
- 29. deploy-api-service
- 30. deploy-cache
- 31. deploy-python-app
- 32. diagnostics
- 33. publish-prereq
- 34. publish-azure634f9
- 35. publish
- 36. publish-manifest
- 37. push
+  9. check-api-service-exists
+ 10. provision-aas-env-acr
+ 11. provision-aas-env
+ 12. login-to-acr-aas-env-acr
+ 13. provision-aca-env-acr
+ 14. login-to-acr-aca-env-acr
+ 15. push-prereq
+ 16. push-api-service
+ 17. update-api-service-provisionable-resource
+ 18. provision-api-service-website
+ 19. print-api-service-summary
+ 20. provision-aca-env
+ 21. provision-cache-containerapp
+ 22. print-cache-summary
+ 23. push-python-app
+ 24. provision-python-app-containerapp
+ 25. provision-storage
+ 26. provision-azure-bicep-resources
+ 27. print-dashboard-url-aas-env
+ 28. print-dashboard-url-aca-env
+ 29. print-python-app-summary
+ 30. deploy
+ 31. deploy-api-service
+ 32. deploy-cache
+ 33. deploy-python-app
+ 34. diagnostics
+ 35. publish-prereq
+ 36. publish-azure634f9
+ 37. publish
+ 38. publish-manifest
+ 39. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -75,6 +77,11 @@ Step: build-python-app
     Dependencies: ✓ build-prereq, ✓ deploy-prereq, ✓ deploy-prereq
     Resource: python-app (ContainerResource)
     Tags: build-compute
+
+Step: check-api-service-exists
+    Dependencies: ✓ create-provisioning-context
+    Resource: api-service-website (AzureAppServiceWebSiteResource)
+    Tags: check-website-exists
 
 Step: create-provisioning-context
     Description: Creates the Azure provisioning context for infrastructure deployment.
@@ -181,7 +188,7 @@ Step: provision-aca-env-acr
 
 Step: provision-api-service-website
     Description: Provisions the Azure Bicep resource api-service-website using Azure infrastructure.
-    Dependencies: ✓ create-provisioning-context, ✓ provision-aas-env, ✓ push-api-service
+    Dependencies: ✓ create-provisioning-context, ✓ provision-aas-env, ✓ push-api-service, ✓ update-api-service-provisionable-resource
     Resource: api-service-website (AzureAppServiceWebSiteResource)
     Tags: provision-infra
 
@@ -244,6 +251,11 @@ Step: push-python-app
     Resource: python-app (ContainerResource)
     Tags: push-container-image
 
+Step: update-api-service-provisionable-resource
+    Dependencies: ✓ check-api-service-exists, ✓ create-provisioning-context
+    Resource: api-service-website (AzureAppServiceWebSiteResource)
+    Tags: update-website-provisionable-resource
+
 Step: validate-azure-login
     Description: Validates Azure CLI authentication before deployment.
     Dependencies: ✓ deploy-prereq
@@ -292,6 +304,16 @@ If targeting 'build-python-app':
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-python-app
 
+If targeting 'check-api-service-exists':
+  Direct dependencies: create-provisioning-context
+  Total steps: 5
+  Execution order:
+    [0] process-parameters
+    [1] deploy-prereq
+    [2] validate-azure-login
+    [3] create-provisioning-context
+    [4] check-api-service-exists
+
 If targeting 'create-provisioning-context':
   Direct dependencies: deploy-prereq, validate-azure-login
   Total steps: 4
@@ -303,14 +325,14 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api-service, build-python-app, create-provisioning-context, print-api-service-summary, print-cache-summary, print-dashboard-url-aas-env, print-dashboard-url-aca-env, print-python-app-summary, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 27
+  Total steps: 29
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
-    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env (parallel)
+    [4] check-api-service-exists | provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
+    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env | update-api-service-provisionable-resource (parallel)
     [6] provision-cache-containerapp | push-prereq (parallel)
     [7] print-cache-summary | push-api-service | push-python-app (parallel)
     [8] provision-api-service-website | provision-python-app-containerapp (parallel)
@@ -320,14 +342,14 @@ If targeting 'deploy':
 
 If targeting 'deploy-api-service':
   Direct dependencies: print-api-service-summary
-  Total steps: 16
+  Total steps: 18
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-aas-env-acr | provision-aca-env-acr (parallel)
-    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env (parallel)
+    [4] check-api-service-exists | provision-aas-env-acr | provision-aca-env-acr (parallel)
+    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | update-api-service-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api-service
     [8] provision-api-service-website
@@ -401,14 +423,14 @@ If targeting 'login-to-acr-aca-env-acr':
 
 If targeting 'print-api-service-summary':
   Direct dependencies: provision-api-service-website
-  Total steps: 15
+  Total steps: 17
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-aas-env-acr | provision-aca-env-acr (parallel)
-    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env (parallel)
+    [4] check-api-service-exists | provision-aas-env-acr | provision-aca-env-acr (parallel)
+    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | update-api-service-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api-service
     [8] provision-api-service-website
@@ -429,14 +451,14 @@ If targeting 'print-cache-summary':
 
 If targeting 'print-dashboard-url-aas-env':
   Direct dependencies: provision-aas-env, provision-azure-bicep-resources
-  Total steps: 22
+  Total steps: 24
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
-    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env (parallel)
+    [4] check-api-service-exists | provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
+    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env | update-api-service-provisionable-resource (parallel)
     [6] provision-cache-containerapp | push-prereq (parallel)
     [7] push-api-service | push-python-app (parallel)
     [8] provision-api-service-website | provision-python-app-containerapp (parallel)
@@ -445,14 +467,14 @@ If targeting 'print-dashboard-url-aas-env':
 
 If targeting 'print-dashboard-url-aca-env':
   Direct dependencies: provision-aca-env, provision-azure-bicep-resources
-  Total steps: 22
+  Total steps: 24
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
-    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env (parallel)
+    [4] check-api-service-exists | provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
+    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env | update-api-service-provisionable-resource (parallel)
     [6] provision-cache-containerapp | push-prereq (parallel)
     [7] push-api-service | push-python-app (parallel)
     [8] provision-api-service-website | provision-python-app-containerapp (parallel)
@@ -523,29 +545,29 @@ If targeting 'provision-aca-env-acr':
     [4] provision-aca-env-acr
 
 If targeting 'provision-api-service-website':
-  Direct dependencies: create-provisioning-context, provision-aas-env, push-api-service
-  Total steps: 14
+  Direct dependencies: create-provisioning-context, provision-aas-env, push-api-service, update-api-service-provisionable-resource
+  Total steps: 16
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-aas-env-acr | provision-aca-env-acr (parallel)
-    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env (parallel)
+    [4] check-api-service-exists | provision-aas-env-acr | provision-aca-env-acr (parallel)
+    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | update-api-service-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api-service
     [8] provision-api-service-website
 
 If targeting 'provision-azure-bicep-resources':
   Direct dependencies: create-provisioning-context, deploy-prereq, provision-aas-env, provision-aas-env-acr, provision-aca-env, provision-aca-env-acr, provision-api-service-website, provision-cache-containerapp, provision-python-app-containerapp, provision-storage
-  Total steps: 21
+  Total steps: 23
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api-service | build-python-app | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
-    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env (parallel)
+    [4] check-api-service-exists | provision-aas-env-acr | provision-aca-env-acr | provision-storage (parallel)
+    [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr | provision-aas-env | provision-aca-env | update-api-service-provisionable-resource (parallel)
     [6] provision-cache-containerapp | push-prereq (parallel)
     [7] push-api-service | push-python-app (parallel)
     [8] provision-api-service-website | provision-python-app-containerapp (parallel)
@@ -668,6 +690,17 @@ If targeting 'push-python-app':
     [5] login-to-acr-aas-env-acr | login-to-acr-aca-env-acr (parallel)
     [6] push-prereq
     [7] push-python-app
+
+If targeting 'update-api-service-provisionable-resource':
+  Direct dependencies: check-api-service-exists, create-provisioning-context
+  Total steps: 6
+  Execution order:
+    [0] process-parameters
+    [1] deploy-prereq
+    [2] validate-azure-login
+    [3] create-provisioning-context
+    [4] check-api-service-exists
+    [5] update-api-service-provisionable-resource
 
 If targeting 'validate-azure-login':
   Direct dependencies: deploy-prereq

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 34
+Total steps defined: 36
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -21,33 +21,35 @@ Steps with no dependencies run first, followed by steps that depend on them.
   5. build
   6. validate-azure-login
   7. create-provisioning-context
-  8. provision-api-identity
-  9. provision-cache-kv
- 10. provision-cache
- 11. provision-cosmos-kv
- 12. provision-cosmos
- 13. provision-env-acr
- 14. provision-env
- 15. provision-pg-kv
- 16. provision-pg
- 17. login-to-acr-env-acr
- 18. push-prereq
- 19. push-api
- 20. provision-api-website
- 21. print-api-summary
- 22. provision-api-roles-cache-kv
- 23. provision-api-roles-cosmos-kv
- 24. provision-api-roles-pg-kv
- 25. provision-azure-bicep-resources
- 26. print-dashboard-url-env
- 27. deploy
- 28. deploy-api
- 29. diagnostics
- 30. publish-prereq
- 31. publish-azure634f9
- 32. publish
- 33. publish-manifest
- 34. push
+  8. check-api-exists
+  9. provision-api-identity
+ 10. provision-cache-kv
+ 11. provision-cache
+ 12. provision-cosmos-kv
+ 13. provision-cosmos
+ 14. provision-env-acr
+ 15. provision-env
+ 16. provision-pg-kv
+ 17. provision-pg
+ 18. login-to-acr-env-acr
+ 19. push-prereq
+ 20. push-api
+ 21. update-api-provisionable-resource
+ 22. provision-api-website
+ 23. print-api-summary
+ 24. provision-api-roles-cache-kv
+ 25. provision-api-roles-cosmos-kv
+ 26. provision-api-roles-pg-kv
+ 27. provision-azure-bicep-resources
+ 28. print-dashboard-url-env
+ 29. deploy
+ 30. deploy-api
+ 31. diagnostics
+ 32. publish-prereq
+ 33. publish-azure634f9
+ 34. publish
+ 35. publish-manifest
+ 36. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -67,6 +69,11 @@ Step: build-api
 Step: build-prereq
     Description: Prerequisite step that runs before any build operations.
     Dependencies: ✓ process-parameters
+
+Step: check-api-exists
+    Dependencies: ✓ create-provisioning-context
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: check-website-exists
 
 Step: create-provisioning-context
     Description: Creates the Azure provisioning context for infrastructure deployment.
@@ -138,7 +145,7 @@ Step: provision-api-roles-pg-kv
 
 Step: provision-api-website
     Description: Provisions the Azure Bicep resource api-website using Azure infrastructure.
-    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cache, ✓ provision-cache-kv, ✓ provision-cosmos, ✓ provision-cosmos-kv, ✓ provision-env, ✓ provision-pg, ✓ provision-pg-kv, ✓ push-api
+    Dependencies: ✓ create-provisioning-context, ✓ provision-api-identity, ✓ provision-cache, ✓ provision-cache-kv, ✓ provision-cosmos, ✓ provision-cosmos-kv, ✓ provision-env, ✓ provision-pg, ✓ provision-pg-kv, ✓ push-api, ✓ update-api-provisionable-resource
     Resource: api-website (AzureAppServiceWebSiteResource)
     Tags: provision-infra
 
@@ -226,6 +233,11 @@ Step: push-prereq
     Description: Prerequisite step that runs before any push operations.
     Dependencies: ✓ login-to-acr-env-acr
 
+Step: update-api-provisionable-resource
+    Dependencies: ✓ check-api-exists, ✓ create-provisioning-context
+    Resource: api-website (AzureAppServiceWebSiteResource)
+    Tags: update-website-provisionable-resource
+
 Step: validate-azure-login
     Description: Validates Azure CLI authentication before deployment.
     Dependencies: ✓ deploy-prereq
@@ -266,6 +278,16 @@ If targeting 'build-prereq':
     [0] process-parameters
     [1] build-prereq
 
+If targeting 'check-api-exists':
+  Direct dependencies: create-provisioning-context
+  Total steps: 5
+  Execution order:
+    [0] process-parameters
+    [1] deploy-prereq
+    [2] validate-azure-login
+    [3] create-provisioning-context
+    [4] check-api-exists
+
 If targeting 'create-provisioning-context':
   Direct dependencies: deploy-prereq, validate-azure-login
   Total steps: 4
@@ -277,14 +299,14 @@ If targeting 'create-provisioning-context':
 
 If targeting 'deploy':
   Direct dependencies: build-api, create-provisioning-context, print-api-summary, print-dashboard-url-env, provision-azure-bicep-resources, validate-azure-login
-  Total steps: 26
+  Total steps: 28
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
-    [5] login-to-acr-env-acr | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-env | provision-pg (parallel)
+    [4] check-api-exists | provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-env | provision-pg | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -294,14 +316,14 @@ If targeting 'deploy':
 
 If targeting 'deploy-api':
   Direct dependencies: print-api-summary
-  Total steps: 21
+  Total steps: 23
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
-    [5] login-to-acr-env-acr | provision-cache | provision-cosmos | provision-env | provision-pg (parallel)
+    [4] check-api-exists | provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
+    [5] login-to-acr-env-acr | provision-cache | provision-cosmos | provision-env | provision-pg | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -334,14 +356,14 @@ If targeting 'login-to-acr-env-acr':
 
 If targeting 'print-api-summary':
   Direct dependencies: provision-api-website
-  Total steps: 20
+  Total steps: 22
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
-    [5] login-to-acr-env-acr | provision-cache | provision-cosmos | provision-env | provision-pg (parallel)
+    [4] check-api-exists | provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
+    [5] login-to-acr-env-acr | provision-cache | provision-cosmos | provision-env | provision-pg | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -349,14 +371,14 @@ If targeting 'print-api-summary':
 
 If targeting 'print-dashboard-url-env':
   Direct dependencies: provision-azure-bicep-resources, provision-env
-  Total steps: 24
+  Total steps: 26
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
-    [5] login-to-acr-env-acr | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-env | provision-pg (parallel)
+    [4] check-api-exists | provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-env | provision-pg | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -413,29 +435,29 @@ If targeting 'provision-api-roles-pg-kv':
     [5] provision-api-roles-pg-kv
 
 If targeting 'provision-api-website':
-  Direct dependencies: create-provisioning-context, provision-api-identity, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-pg, provision-pg-kv, push-api
-  Total steps: 19
+  Direct dependencies: create-provisioning-context, provision-api-identity, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-pg, provision-pg-kv, push-api, update-api-provisionable-resource
+  Total steps: 21
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
-    [5] login-to-acr-env-acr | provision-cache | provision-cosmos | provision-env | provision-pg (parallel)
+    [4] check-api-exists | provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
+    [5] login-to-acr-env-acr | provision-cache | provision-cosmos | provision-env | provision-pg | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
 
 If targeting 'provision-azure-bicep-resources':
   Direct dependencies: create-provisioning-context, deploy-prereq, provision-api-identity, provision-api-roles-cache-kv, provision-api-roles-cosmos-kv, provision-api-roles-pg-kv, provision-api-website, provision-cache, provision-cache-kv, provision-cosmos, provision-cosmos-kv, provision-env, provision-env-acr, provision-pg, provision-pg-kv
-  Total steps: 23
+  Total steps: 25
   Execution order:
     [0] process-parameters
     [1] build-prereq | deploy-prereq (parallel)
     [2] build-api | validate-azure-login (parallel)
     [3] create-provisioning-context
-    [4] provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
-    [5] login-to-acr-env-acr | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-env | provision-pg (parallel)
+    [4] check-api-exists | provision-api-identity | provision-cache-kv | provision-cosmos-kv | provision-env-acr | provision-pg-kv (parallel)
+    [5] login-to-acr-env-acr | provision-api-roles-cache-kv | provision-api-roles-cosmos-kv | provision-api-roles-pg-kv | provision-cache | provision-cosmos | provision-env | provision-pg | update-api-provisionable-resource (parallel)
     [6] push-prereq
     [7] push-api
     [8] provision-api-website
@@ -593,6 +615,17 @@ If targeting 'push-prereq':
     [4] provision-env-acr
     [5] login-to-acr-env-acr
     [6] push-prereq
+
+If targeting 'update-api-provisionable-resource':
+  Direct dependencies: check-api-exists, create-provisioning-context
+  Total steps: 6
+  Execution order:
+    [0] process-parameters
+    [1] deploy-prereq
+    [2] validate-azure-login
+    [3] create-provisioning-context
+    [4] check-api-exists
+    [5] update-api-provisionable-resource
 
 If targeting 'validate-azure-login':
   Direct dependencies: deploy-prereq


### PR DESCRIPTION

Backport of #12810 to release/13.1

/cc @ShilpiRach 

## Customer Impact

One piece of feedback we heard about AppService is the ability to deploy to a slot, and then "swap" the production version for a staging version. This enables that feature in AppService, it was one of the features marked as required for declaring AppService "stable". Getting it into 13.1 will allow customers to use and provide feedback.

## Testing

@ShilpiRach and @eerhardt independently verified that slots work. @eerhardt was able to slot swap an app between 2 versions.

## Risk

Low - only affects App Service

## Regression?
No

## Description

- Added 2 extension methods to accept DeploymentSlot as a string or resource parameter
- If DeploymentSlot is specified, all compute resources (project images) are deployed to the slot and not the main web app
    - Changes to ensure that the endpoint references are resolved to the respective slots and not the main web app (i.e. staging slot of a web app will refer to the staging slot of another web app).
    - If the main web app does not exist, we deploy changes to both the main web app and the deployment slot.
    - There is no change in dashboard - there would be a single dashboard that would show production and other deployment slots for the compute resources. 
 
- To achieve the first deployment experience (i.e.  If the main web app does not exist, we deploy changes to both the main web app and the deployment slot), we have added new pipeline steps:
    - A pipeline step `check-{targetResource.Name}-exists` checks if the main web app exists (only if a deployment slot is specified for the app service environment). If yes, it is a no-op. Otherwise, it adds `AzureAppServiceWebsiteRefreshProvisionableResourceAnnotation` object to the target resource. - Website existence check is done with an ARM call
    - A pipeline step `update-{targetResource.Name}-provisionable-resource` updates the provisionable resource if the annotation is present and updates the TargetResource of the TargetResourceAnnotation.
    
Fixes #9667