### PR TITLE
Decode string values returned by tools in GenAI visualizer

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -494,6 +494,15 @@ app.MapGet("/genai-trace", async () =>
                 ]
               },
               {
+                "role": "tool",
+                "parts": [
+                  {
+                    "type": "tool_call_response",
+                    "response": "- First\r\n- Second"
+                  }
+                ]
+              },
+              {
                 "role": "user",
                 "parts": [
                   {

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
@@ -75,7 +75,14 @@ public sealed class GenAIItemPartViewModel
         }
         if (p is ToolCallResponsePart toolCallResponsePart)
         {
-            return new TextVisualizerViewModel(toolCallResponsePart.Response?.ToJsonString() ?? string.Empty, indentText: true);
+            // If a tool response is a string then decode it.
+            // This handles situations where telemetry is reported incorrectly, i.e. a structured JSON response is encoded inside a string.
+            // And it allow possible Markdown content inside the string to be formatted.
+            var toolResponseContent = (toolCallResponsePart.Response?.GetValueKind() == JsonValueKind.String)
+                ? toolCallResponsePart.Response.GetValue<string>()
+                : toolCallResponsePart.Response?.ToJsonString() ?? string.Empty;
+
+            return new TextVisualizerViewModel(toolResponseContent, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
         }
 
         var additionalProperties = p is GenericPart genericPart ? genericPart.AdditionalProperties ?? [] : [];

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
@@ -77,7 +77,7 @@ public sealed class GenAIItemPartViewModel
         {
             // If a tool response is a string then decode it.
             // This handles situations where telemetry is reported incorrectly, i.e. a structured JSON response is encoded inside a string.
-            // And it allow possible Markdown content inside the string to be formatted.
+            // And it allows possible Markdown content inside the string to be formatted.
             var toolResponseContent = (toolCallResponsePart.Response?.GetValueKind() == JsonValueKind.String)
                 ? toolCallResponsePart.Response.GetValue<string>()
                 : toolCallResponsePart.Response?.ToJsonString() ?? string.Empty;

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
@@ -53,4 +53,46 @@ public sealed class GenAIItemPartViewModelTests
             """,
             itemPart.TextVisualizerViewModel.FormattedText);
     }
+
+    [Fact]
+    public void CreateMessagePart_ToolCallResponse_ArrayResponse_SerializedAsJson()
+    {
+        // Arrange
+        var responsePart = new ToolCallResponsePart
+        {
+            Response = JsonNode.Parse("""["Jack","Jane"]""")
+        };
+
+        // Act
+        var itemPart = GenAIItemPartViewModel.CreateMessagePart(responsePart);
+
+        // Assert
+        Assert.Equal("""["Jack","Jane"]""", itemPart.TextVisualizerViewModel.Text);
+        Assert.Equal(DashboardUIHelpers.JsonFormat, itemPart.TextVisualizerViewModel.FormatKind);
+        Assert.Equal(
+            """
+            [
+              "Jack",
+              "Jane"
+            ]
+            """,
+            itemPart.TextVisualizerViewModel.FormattedText);
+    }
+
+    [Fact]
+    public void CreateMessagePart_ToolCallResponse_ObjectResponse_SerializedAsJson()
+    {
+        // Arrange
+        var responsePart = new ToolCallResponsePart
+        {
+            Response = JsonNode.Parse("""{"name":"Jack","age":30}""")
+        };
+
+        // Act
+        var itemPart = GenAIItemPartViewModel.CreateMessagePart(responsePart);
+
+        // Assert
+        Assert.Equal("""{"name":"Jack","age":30}""", itemPart.TextVisualizerViewModel.Text);
+        Assert.Equal(DashboardUIHelpers.JsonFormat, itemPart.TextVisualizerViewModel.FormatKind);
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using Aspire.Dashboard.Model.GenAI;
+using Aspire.Dashboard.Utils;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class GenAIItemPartViewModelTests
+{
+    [Fact]
+    public void CreateMessagePart_ToolCallResponse_StringResponseDecoded()
+    {
+        // Arrange
+        var responsePart = new ToolCallResponsePart
+        {
+            Response = JsonValue.Create("**Markdown**")
+        };
+
+        // Act
+        var itemPart = GenAIItemPartViewModel.CreateMessagePart(responsePart);
+
+        // Assert
+        Assert.Equal("**Markdown**", itemPart.TextVisualizerViewModel.Text);
+        Assert.Equal(DashboardUIHelpers.MarkdownFormat, itemPart.TextVisualizerViewModel.FormatKind);
+        Assert.Equal("**Markdown**", itemPart.TextVisualizerViewModel.FormattedText);
+    }
+
+    [Fact]
+    public void CreateMessagePart_ToolCallResponse_StringResponseContainingJsonFormatted()
+    {
+        // Arrange
+        const string expectedText = """{"answer":42,"unit":"C"}""";
+        var responsePart = new ToolCallResponsePart
+        {
+            Response = JsonValue.Create(expectedText)
+        };
+
+        // Act
+        var itemPart = GenAIItemPartViewModel.CreateMessagePart(responsePart);
+
+        // Assert
+        Assert.Equal(expectedText, itemPart.TextVisualizerViewModel.Text);
+        Assert.Equal(DashboardUIHelpers.JsonFormat, itemPart.TextVisualizerViewModel.FormatKind);
+        Assert.Equal(
+            """
+            {
+              "answer": 42,
+              "unit": "C"
+            }
+            """,
+            itemPart.TextVisualizerViewModel.FormattedText);
+    }
+}


### PR DESCRIPTION
## Description

Inspired by discussion at https://github.com/dotnet/extensions/pull/7125 about how to handle string results from tool calls.

I think the most user friendly thing to do when visualizing a string response from a tool is to decode the string.

cc @stephentoub 

Before:
<img width="1268" height="972" alt="image" src="https://github.com/user-attachments/assets/8c8a2f5d-b98c-4a2c-a2e6-ac107a0c441d" />

After:
<img width="1270" height="972" alt="image" src="https://github.com/user-attachments/assets/c0d28d06-7636-4b60-b088-6f3534ed24c5" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
