### PR TITLE
Remove DefaultContainerRegistry property

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -27,11 +27,6 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
     private const string DockerComposeUpTag = "docker-compose-up";
 
     /// <summary>
-    /// The container registry to use.
-    /// </summary>
-    public string? DefaultContainerRegistry { get; set; }
-
-    /// <summary>
     /// The name of an existing network to be used.
     /// </summary>
     public string? DefaultNetworkName { get; set; }


### PR DESCRIPTION
Removed the DefaultContainerRegistry property from the DockerComposeEnvironmentResource class.
