### PR TITLE
Add tests for AzureSqlServerResource emulator connection properties

### DIFF
--- a/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
@@ -72,7 +72,6 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
         builder.Append($"{Host}");
         builder.AppendLiteral(":");
         builder.Append($"{Port}");
-        builder.AppendLiteral(";trustServerCertificate=true");
 
         if (!string.IsNullOrEmpty(databaseName))
         {
@@ -80,6 +79,8 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
             builder.AppendLiteral(";databaseName=");
             builder.Append($"{databaseNameReference}");
         }
+
+        builder.AppendLiteral(";trustServerCertificate=true");
 
         return builder.Build();
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSqlDatabaseConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSqlDatabaseConnectionPropertiesTests.cs
@@ -9,6 +9,39 @@ namespace Aspire.Hosting.Azure.Tests;
 public class AzureSqlDatabaseConnectionPropertiesTests
 {
     [Fact]
+    public void AzureSqlServerResourceGetConnectionPropertiesReturnsExpectedValues()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var sqlServer = builder.AddAzureSqlServer("sql");
+
+        var resource = Assert.Single(builder.Resources.OfType<AzureSqlServerResource>());
+        var properties = ((IResourceWithConnectionString)resource).GetConnectionProperties().ToDictionary(x => x.Key, x => x.Value);
+
+        Assert.Collection(
+            properties.OrderBy(p => p.Key),
+            property =>
+            {
+                Assert.Equal("Host", property.Key);
+                Assert.Equal("{sql.outputs.sqlServerFqdn}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("JdbcConnectionString", property.Key);
+                Assert.Equal("jdbc:sqlserver://{sql.outputs.sqlServerFqdn}:1433;encrypt=true;trustServerCertificate=false", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Port", property.Key);
+                Assert.Equal("1433", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Uri", property.Key);
+                Assert.Equal("mssql://{sql.outputs.sqlServerFqdn}:1433", property.Value.ValueExpression);
+            });
+    }
+
+    [Fact]
     public void AzureSqlDatabaseResourceGetConnectionPropertiesReturnsExpectedValues()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -44,6 +77,112 @@ public class AzureSqlDatabaseConnectionPropertiesTests
             {
                 Assert.Equal("Uri", property.Key);
                 Assert.Equal("mssql://{sql.outputs.sqlServerFqdn}:1433/mydb", property.Value.ValueExpression);
+            });
+    }
+
+    [Fact]
+    public void AzureSqlServerResourceWithRunAsContainerGetConnectionPropertiesReturnsExpectedValues()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var sqlServer = builder.AddAzureSqlServer("sql");
+        sqlServer.RunAsContainer(c =>
+        {
+            c.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1433));
+        });
+
+        // After RunAsContainer, the resource is still an AzureSqlServerResource but with InnerResource set
+        var resource = sqlServer.Resource;
+        Assert.True(resource.IsContainer);
+
+        var properties = ((IResourceWithConnectionString)resource).GetConnectionProperties().ToDictionary(x => x.Key, x => x.Value);
+
+        Assert.Collection(
+            properties.OrderBy(p => p.Key),
+            property =>
+            {
+                Assert.Equal("Host", property.Key);
+                Assert.Equal("{sql.bindings.tcp.host}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("JdbcConnectionString", property.Key);
+                Assert.Equal("jdbc:sqlserver://{sql.bindings.tcp.host}:{sql.bindings.tcp.port};trustServerCertificate=true", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Password", property.Key);
+                Assert.NotEmpty(property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Port", property.Key);
+                Assert.Equal("{sql.bindings.tcp.port}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Uri", property.Key);
+                Assert.Equal("mssql://sa:{sql-password.value}@{sql.bindings.tcp.host}:{sql.bindings.tcp.port}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Username", property.Key);
+                Assert.Equal("sa", property.Value.ValueExpression);
+            });
+    }
+
+    [Fact]
+    public void AzureSqlDatabaseResourceWithRunAsContainerGetConnectionPropertiesReturnsExpectedValues()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var sqlServer = builder.AddAzureSqlServer("sql");
+        var database = sqlServer.AddDatabase("database", "mydb");
+        sqlServer.RunAsContainer(c =>
+        {
+            c.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1433));
+        });
+
+        // After RunAsContainer, the database resource still exists but its parent has InnerResource set
+        var resource = database.Resource;
+        Assert.True(resource.IsContainer);
+
+        var properties = ((IResourceWithConnectionString)resource).GetConnectionProperties().ToDictionary(x => x.Key, x => x.Value);
+
+        Assert.Collection(
+            properties.OrderBy(p => p.Key),
+            property =>
+            {
+                Assert.Equal("DatabaseName", property.Key);
+                Assert.Equal("mydb", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Host", property.Key);
+                Assert.Equal("{sql.bindings.tcp.host}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("JdbcConnectionString", property.Key);
+                Assert.Equal("jdbc:sqlserver://{sql.bindings.tcp.host}:{sql.bindings.tcp.port};databaseName=mydb;trustServerCertificate=true", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Password", property.Key);
+                Assert.NotEmpty(property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Port", property.Key);
+                Assert.Equal("{sql.bindings.tcp.port}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Uri", property.Key);
+                Assert.Equal("mssql://sa:{sql-password.value}@{sql.bindings.tcp.host}:{sql.bindings.tcp.port}/mydb", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Username", property.Key);
+                Assert.Equal("sa", property.Value.ValueExpression);
             });
     }
 }

--- a/tests/Aspire.Hosting.SqlServer.Tests/ConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/ConnectionPropertiesTests.cs
@@ -16,7 +16,7 @@ public class ConnectionPropertiesTests
         var properties = ((IResourceWithConnectionString)resource).GetConnectionProperties().ToArray();
 
         Assert.Collection(
-            properties,
+            properties.OrderBy(p => p.Key),
             property =>
             {
                 Assert.Equal("Host", property.Key);
@@ -24,13 +24,8 @@ public class ConnectionPropertiesTests
             },
             property =>
             {
-                Assert.Equal("Port", property.Key);
-                Assert.Equal("{sql.bindings.tcp.port}", property.Value.ValueExpression);
-            },
-            property =>
-            {
-                Assert.Equal("Username", property.Key);
-                Assert.Equal("sa", property.Value.ValueExpression);
+                Assert.Equal("JdbcConnectionString", property.Key);
+                Assert.Equal("jdbc:sqlserver://{sql.bindings.tcp.host}:{sql.bindings.tcp.port};trustServerCertificate=true", property.Value.ValueExpression);
             },
             property =>
             {
@@ -39,35 +34,66 @@ public class ConnectionPropertiesTests
             },
             property =>
             {
+                Assert.Equal("Port", property.Key);
+                Assert.Equal("{sql.bindings.tcp.port}", property.Value.ValueExpression);
+            },
+            property =>
+            {
                 Assert.Equal("Uri", property.Key);
                 Assert.Equal("mssql://sa:{password.value}@{sql.bindings.tcp.host}:{sql.bindings.tcp.port}", property.Value.ValueExpression);
             },
             property =>
             {
-                Assert.Equal("JdbcConnectionString", property.Key);
-                Assert.Equal("jdbc:sqlserver://{sql.bindings.tcp.host}:{sql.bindings.tcp.port};trustServerCertificate=true", property.Value.ValueExpression);
+                Assert.Equal("Username", property.Key);
+                Assert.Equal("sa", property.Value.ValueExpression);
             });
     }
 
     [Fact]
     public void SqlServerDatabaseResourceGetConnectionPropertiesIncludesDatabaseSpecificValues()
     {
-    var password = new ParameterResource("password", _ => "p@ssw0rd1", secret: true);
+        var password = new ParameterResource("password", _ => "p@ssw0rd1", secret: true);
         var server = new SqlServerServerResource("sql", password);
         var resource = new SqlServerDatabaseResource("sqlDb", "Orders", server);
 
         var properties = ((IResourceWithConnectionString)resource).GetConnectionProperties().ToArray();
 
-        Assert.Contains(properties, property => property.Key == "Host" && property.Value.ValueExpression == "{sql.bindings.tcp.host}");
-        Assert.Contains(properties, property => property.Key == "Port" && property.Value.ValueExpression == "{sql.bindings.tcp.port}");
-        Assert.Contains(properties, property => property.Key == "Username" && property.Value.ValueExpression == "sa");
-        Assert.Contains(properties, property => property.Key == "Password" && property.Value.ValueExpression == "{password.value}");
-        Assert.Contains(properties, property => property.Key == "DatabaseName" && property.Value.ValueExpression == "Orders");
-        Assert.Contains(properties, property => property.Key == "Uri" && property.Value.ValueExpression == "mssql://sa:{password.value}@{sql.bindings.tcp.host}:{sql.bindings.tcp.port}/Orders");
-
-        Assert.Contains(
+        Assert.Collection(
             properties,
-            property => property.Key == "JdbcConnectionString" &&
-                        property.Value.ValueExpression == "jdbc:sqlserver://{sql.bindings.tcp.host}:{sql.bindings.tcp.port};trustServerCertificate=true;databaseName=Orders");
+            property =>
+            {
+                Assert.Equal("DatabaseName", property.Key);
+                Assert.Equal("Orders", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Host", property.Key);
+                Assert.Equal("{sql.bindings.tcp.host}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("JdbcConnectionString", property.Key);
+                Assert.Equal("jdbc:sqlserver://{sql.bindings.tcp.host}:{sql.bindings.tcp.port};databaseName=Orders;trustServerCertificate=true", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Password", property.Key);
+                Assert.Equal("{password.value}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Port", property.Key);
+                Assert.Equal("{sql.bindings.tcp.port}", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Uri", property.Key);
+                Assert.Equal("mssql://sa:{password.value}@{sql.bindings.tcp.host}:{sql.bindings.tcp.port}/Orders", property.Value.ValueExpression);
+            },
+            property =>
+            {
+                Assert.Equal("Username", property.Key);
+                Assert.Equal("sa", property.Value.ValueExpression);
+            });
     }
 }

--- a/tests/Aspire.Hosting.SqlServer.Tests/ConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/ConnectionPropertiesTests.cs
@@ -59,7 +59,7 @@ public class ConnectionPropertiesTests
         var properties = ((IResourceWithConnectionString)resource).GetConnectionProperties().ToArray();
 
         Assert.Collection(
-            properties,
+            properties.OrderBy(p => p.Key),
             property =>
             {
                 Assert.Equal("DatabaseName", property.Key);


### PR DESCRIPTION
## Description

Adding tests on specific emulator properties for Azure SQL Server.

c.f. https://github.com/dotnet/aspire/pull/13290#discussion_r2611795479

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
