### PR TITLE
Only fire BeforeResourceStartedEvent when actually starting a resource

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1485,6 +1485,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         {
             AspireEventSource.Instance.CreateAspireExecutableResourcesStart(resource.Name);
 
+            var explicitStartup = resource.TryGetAnnotationsOfType<ExplicitStartupAnnotation>(out _) is true;
+
             // Publish snapshots built from DCP resources. Do this now to populate more values from DCP (source) to ensure they're
             // available if the resource isn't immediately started because it's waiting or is configured for explicit start.
             foreach (var er in executables)
@@ -1501,18 +1503,28 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     er.DcpResourceName, new ResourceStatus(null, null, null),
                     snapshotBuild)
                 ).ConfigureAwait(false);
+
+                if (explicitStartup)
+                {
+                    // If explicit startup is configured, we need to set the resource state to NotStarted
+                    await _executorEvents.PublishAsync(new OnResourceChangedContext(
+                        cancellationToken, resourceType, resource,
+                        er.DcpResource.Metadata.Name, new ResourceStatus(KnownResourceStates.NotStarted, null, null), s => s with { State = new ResourceStateSnapshot(KnownResourceStates.NotStarted, null) })
+                    ).ConfigureAwait(false);
+                }
             }
 
-            await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resource, DcpResourceName: null)).ConfigureAwait(false);
+            if (explicitStartup)
+            {
+                return;
+            }
+            else
+            {
+                await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resource, DcpResourceName: null)).ConfigureAwait(false);
+            }
 
             foreach (var er in executables)
             {
-                if (er.ModelResource.TryGetAnnotationsOfType<ExplicitStartupAnnotation>(out _) is true)
-                {
-                    await _executorEvents.PublishAsync(new OnResourceChangedContext(cancellationToken, resourceType, resource, er.DcpResource.Metadata.Name, new ResourceStatus(KnownResourceStates.NotStarted, null, null), s => s with { State = new ResourceStateSnapshot(KnownResourceStates.NotStarted, null) })).ConfigureAwait(false);
-                    continue;
-                }
-
                 try
                 {
                     await createResourceFunc(er, resourceLogger, cancellationToken).ConfigureAwait(false);
@@ -1915,7 +1927,11 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             var modelContainerResource = cr.ModelResource;
             AspireEventSource.Instance.DcpObjectCreationStart(dcpContainerResource.Kind, dcpContainerResource.Metadata.Name);
 
-            await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResource.Metadata.Name)).ConfigureAwait(false);
+            var explicitStartup = cr.ModelResource.TryGetAnnotationsOfType<ExplicitStartupAnnotation>(out _) is true;
+            if (!explicitStartup)
+            {
+                await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResource.Metadata.Name)).ConfigureAwait(false);
+            }
 
             await ApplyBuildArgumentsAsync(dcpContainerResource, modelContainerResource, _executionContext.ServiceProvider, cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1518,11 +1518,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             {
                 return;
             }
-            else
-            {
-                await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resource, DcpResourceName: null)).ConfigureAwait(false);
-            }
 
+            await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resource, DcpResourceName: null)).ConfigureAwait(false);
             foreach (var er in executables)
             {
                 try

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1516,6 +1516,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             if (explicitStartup)
             {
+                // If explicit startup is configured, we aren't going to start the resource now.
+                // We need to exit before we send the BeforeResourceStarted event or create any DCP resources.
+                // The resource can be explicitly started later via user action or API at which point BeforeResourceStarted
+                // will be published and the DCP resource created.
                 return;
             }
 
@@ -1927,6 +1931,9 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             var explicitStartup = cr.ModelResource.TryGetAnnotationsOfType<ExplicitStartupAnnotation>(out _) is true;
             if (!explicitStartup)
             {
+                // If explicit startup is configured, we aren't going to start the resource now. A DCP resource WILL be created,
+                // but it will be explicitly set to not start. We don't want to send the BeforeResourceStarted event here as it will
+                // be sent later when the resource is explicitly started via user action or API.
                 await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResource.Metadata.Name)).ConfigureAwait(false);
             }
 

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -238,6 +238,131 @@ public class DistributedApplicationTests
     }
 
     [Fact]
+    public async Task BeforeResourceStartedEvent_NotFiredForExplicitStartOnInitialCreation()
+    {
+        const string testName = "before-start-event-explicit-start";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false);
+
+        var explicitStartEventCount = 0;
+        var normalEventCount = 0;
+
+        testProgram.ServiceABuilder.WithExplicitStart()
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                Interlocked.Increment(ref explicitStartEventCount);
+                return Task.CompletedTask;
+            });
+        
+        // ServiceB is a normal resource without explicit start
+        testProgram.ServiceBBuilder
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                Interlocked.Increment(ref normalEventCount);
+                return Task.CompletedTask;
+            });
+
+        using var app = testProgram.Build();
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
+        var token = cts.Token;
+
+        // Start app in background - it won't complete because of explicit start resource
+        _ = app.StartAsync(token);
+
+        var normalResourceName = $"{testName}-serviceb";
+        var explicitStartResourceName = $"{testName}-servicea";
+
+        // Wait for normal resource to be running
+        await rns.WaitForResourceAsync(normalResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        
+        // Wait for explicit start resource to be NotStarted
+        await rns.WaitForResourceAsync(explicitStartResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.NotStarted, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        // Wait a bit to ensure all events have been processed
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        // Verify BeforeResourceStartedEvent was fired for normal resource but NOT for explicit start resource
+        Assert.Equal(1, normalEventCount);
+        Assert.Equal(0, explicitStartEventCount);
+
+        await app.StopAsync(token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+    }
+
+    [Fact]
+    public async Task BeforeResourceStartedEvent_FiredWhenExplicitStartResourceIsManuallyStarted()
+    {
+        const string testName = "before-start-event-manual-start";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false);
+
+        var eventCount = 0;
+
+        testProgram.ServiceABuilder.WithExplicitStart()
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                Interlocked.Increment(ref eventCount);
+                return Task.CompletedTask;
+            });
+
+        using var app = testProgram.Build();
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+        var orchestrator = app.Services.GetRequiredService<ApplicationOrchestrator>();
+
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
+        var token = cts.Token;
+
+        // Start app in background
+        _ = app.StartAsync(token);
+
+        var explicitStartResourceName = $"{testName}-servicea";
+
+        // Wait for the resource to be in NotStarted state
+        var notStartedResourceEvent = await rns.WaitForResourceAsync(explicitStartResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.NotStarted, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        // Verify no event has been fired yet (initial creation should not fire the event)
+        Assert.Equal(0, eventCount);
+
+        // Manually start the resource
+        await orchestrator.StartResourceAsync(notStartedResourceEvent.ResourceId, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        // Wait for the resource to be running
+        await rns.WaitForResourceAsync(explicitStartResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.Running, token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+
+        // Wait a bit to ensure all events have been processed
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        // Verify that BeforeResourceStartedEvent WAS fired when manually started
+        Assert.Equal(1, eventCount);
+
+        await app.StopAsync(token).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+    }
+
+    [Fact]
+    public async Task BeforeResourceStartedEvent_FiredForNormalResourcesOnInitialStartup()
+    {
+        const string testName = "before-start-event-normal-resource";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false);
+
+        var eventCount = 0;
+
+        // Don't call WithExplicitStart() - this is a normal resource
+        testProgram.ServiceABuilder
+            .OnBeforeResourceStarted((_, _, _) =>
+            {
+                Interlocked.Increment(ref eventCount);
+                return Task.CompletedTask;
+            });
+
+        using var app = testProgram.Build();
+
+        await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+
+        Assert.Equal(1, eventCount);
+
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+    }
+
+    [Fact]
     [RequiresDocker]
     public async Task ExplicitStart_StartContainer()
     {

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -287,7 +287,7 @@ public class DistributedApplicationTests
         // Wait for explicit start resource to be NotStarted
         await rns.WaitForResourceAsync(explicitStartResourceName, e => e.Snapshot.State?.Text == KnownResourceStates.NotStarted, token).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
-        // Wait a bit to ensure all events have been processed
+        // Wait for resource to finish being created.
         await resourcesCreatedTcs.Task.DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
         // Verify BeforeResourceStartedEvent was fired for normal resource but NOT for explicit start resource


### PR DESCRIPTION
## Description

We currently fire `BeforeResourceStartedEvent` when creating resources even if a resource is set to explicit start. This means the event can't be used to reliably do work only before a resource is actually starting without doing ref counting. This change skips firing the initial event if the resource is marked for explicit startup.

Fixes #13068
Fixes #13070