### PR TITLE
[release/13.1] Allow nullable format in ReferenceExpressionBuilder.AppendFormatted

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -327,13 +327,16 @@ public class ReferenceExpressionBuilder
     /// </summary>
     /// <param name="value">The formatted string to be appended to the interpolated string.</param>
     /// <param name="format">The format to be applied to the value. e.g., "uri"</param>
-    public void AppendFormatted(string? value, string format)
+    public void AppendFormatted(string? value, string? format)
     {
         ArgumentException.ThrowIfNullOrEmpty(nameof(value));
 
         if (value is not null)
         {
-            value = FormattingHelpers.FormatValue(value, format);
+            if (format is not null)
+            {
+                value = FormattingHelpers.FormatValue(value, format);
+            }
 
             _builder.Append(value);
         }

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -329,8 +329,6 @@ public class ReferenceExpressionBuilder
     /// <param name="format">The format to be applied to the value. e.g., "uri"</param>
     public void AppendFormatted(string? value, string? format)
     {
-        ArgumentException.ThrowIfNullOrEmpty(nameof(value));
-
         if (value is not null)
         {
             if (format is not null)

--- a/tests/Aspire.Hosting.Tests/ReferenceExpressionTests.cs
+++ b/tests/Aspire.Hosting.Tests/ReferenceExpressionTests.cs
@@ -102,6 +102,16 @@ public class ReferenceExpressionTests
         Assert.Equal("Text: Hello%20World", await expr.GetValueAsync(default));
     }
 
+    [Fact]
+    public async Task ReferenceExpressionBuilderSupportsNullFormat()
+    {
+        var b = new ReferenceExpressionBuilder();
+        b.Append($"Text: ");
+        b.AppendFormatted("foo", format: null);
+
+        Assert.Equal("Text: foo", await b.Build().GetValueAsync(default));
+    }
+
     private sealed class Value : IValueProvider, IManifestExpressionProvider
     {
         public string ValueExpression => "{value}";


### PR DESCRIPTION
This was an API break from Aspire 13.0.

Updated AppendFormatted to accept a nullable format parameter and only apply formatting when a format is provided. Added a unit test to ensure appending with a null format works as expected.

## Customer Impact

This API was changed in 13.1 to no longer allow null. This would be a breaking change if we don't fix it.

## Testing

Added a new test.

## Risk

Low. Users typically don't call this method if they don't want a format.

## Regression?

Yes