### PR TITLE
Fix graph to always update after all filter changes

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -159,22 +159,24 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private async Task OnAllFilterVisibilityCheckedChangedAsync()
     {
-        await ClearSelectedResourceAsync();
-        await _dataGrid.SafeRefreshDataAsync();
+        await VisibleResourcesChangedAsync();
         UpdateMenuButtons();
         await this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false);
     }
 
     private async Task OnResourceFilterVisibilityChangedAsync(string resourceType, bool isVisible)
     {
-        await UpdateResourceGraphResourcesAsync();
-        await ClearSelectedResourceAsync();
-        await _dataGrid.SafeRefreshDataAsync();
+        await VisibleResourcesChangedAsync();
         UpdateMenuButtons();
         await this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: false);
     }
 
     private async Task HandleSearchFilterChangedAsync()
+    {
+        await VisibleResourcesChangedAsync();
+    }
+
+    private async Task VisibleResourcesChangedAsync()
     {
         await UpdateResourceGraphResourcesAsync();
         await ClearSelectedResourceAsync();
@@ -524,13 +526,15 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             _showHiddenResources,
             _resourceByName.Values,
             SessionStorage,
-            EventCallback.Factory.Create<bool>(this,
-            async value =>
-            {
-                _showHiddenResources = value;
-                UpdateMenuButtons();
-                await _dataGrid.SafeRefreshDataAsync();
-            }));
+            EventCallback.Factory.Create<bool>(
+                this,
+                async value =>
+                {
+                    _showHiddenResources = value;
+                    UpdateMenuButtons();
+
+                    await VisibleResourcesChangedAsync();
+                }));
     }
 
     private bool HasCollapsedResources()


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/13456

Toggling hidden resources only updated the table. PR centralizes updating page and toggling hidden resources calls it.

Not high priority. Doesn't need to be in 13.1.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
