### PR TITLE
Use optimized method in ConfigurationSchemaGenerator

### DIFF
--- a/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
+++ b/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
@@ -717,17 +717,12 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
 
     private static void ReplaceNodeWithKeyCasingChange(JsonObject jsonObject, string key, JsonNode value)
     {
-        // In System.Text.Json v9, the casing of the new key is not adapted. See https://github.com/dotnet/runtime/issues/108790.
-        // So instead, remove the existing node and insert a new one with the updated key.
-        var index = jsonObject.IndexOf(key);
-        if (index != -1)
+        if (!jsonObject.TryAdd(key, value, out var index))
         {
+            // Since System.Text.Json v9, the casing of the new key is not adapted. See https://github.com/dotnet/runtime/issues/108790.
+            // So instead, remove the existing node and insert a new one with the updated key.
             jsonObject.RemoveAt(index);
             jsonObject.Insert(index, key, value);
-        }
-        else
-        {
-            jsonObject[key] = value;
         }
     }
 

--- a/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
+++ b/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
@@ -719,7 +719,7 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
     {
         if (!jsonObject.TryAdd(key, value, out var index))
         {
-            // Since System.Text.Json v9, the casing of the new key is not adapted. See https://github.com/dotnet/runtime/issues/108790.
+            // Starting from System.Text.Json v9, the casing of the new key is not adapted. See https://github.com/dotnet/runtime/issues/108790.
             // So instead, remove the existing node and insert a new one with the updated key.
             jsonObject.RemoveAt(index);
             jsonObject.Insert(index, key, value);

--- a/src/Tools/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj
+++ b/src/Tools/ConfigurationSchemaGenerator/ConfigurationSchemaGenerator.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="System.Text.Json" VersionOverride="9.0.7" />
+    <PackageReference Include="System.Text.Json" VersionOverride="10.0.1" />
 
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>

--- a/tests/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
+++ b/tests/ConfigurationSchemaGenerator.Tests/ConfigurationSchemaGenerator.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="System.Text.Json" VersionOverride="9.0.7" />
+    <PackageReference Include="System.Text.Json" VersionOverride="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Update `System.Text.Json` and use the new optimized method `JsonObject.TryAdd` in ConfigurationSchemaGenerator.

Fixes #13024

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
