### PR TITLE
[release/13.1] Support registry pipeline step and resource for Docker Compose

### DIFF
--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -24,6 +24,8 @@ namespace Aspire.Hosting.Docker;
 /// </remarks>
 public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentResource
 {
+    private const string DockerComposeUpTag = "docker-compose-up";
+
     /// <summary>
     /// The name of an existing network to be used.
     /// </summary>
@@ -112,7 +114,7 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
             {
                 Name = $"docker-compose-up-{Name}",
                 Action = ctx => DockerComposeUpAsync(ctx),
-                Tags = ["docker-compose-up"],
+                Tags = [DockerComposeUpTag],
                 DependsOnSteps = [$"prepare-{Name}"]
             };
             dockerComposeUpStep.RequiredBy(WellKnownPipelineSteps.Deploy);
@@ -170,6 +172,15 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
                 buildSteps.RequiredBy(WellKnownPipelineSteps.Deploy)
                         .RequiredBy($"docker-compose-up-{Name}")
                         .DependsOn(WellKnownPipelineSteps.DeployPrereq);
+            }
+
+            // This ensures that resources that have to be pushed before deployments are handled
+            foreach (var pushResource in context.Model.GetBuildAndPushResources())
+            {
+                var pushSteps = context.GetSteps(pushResource, WellKnownPipelineTags.PushContainerImage);
+                var dockerComposeUpSteps = context.GetSteps(this, DockerComposeUpTag);
+
+                dockerComposeUpSteps.DependsOn(pushSteps);
             }
         }));
     }
@@ -342,9 +353,9 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
                 defaultValue = await parameter.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
             }
 
-            if (envVar.Source is ContainerImageReference cir && cir.Resource.TryGetContainerImageName(out var imageName))
+            if (envVar.Source is ContainerImageReference cir)
             {
-                defaultValue = imageName;
+                defaultValue = await ((IValueProvider)cir).GetValueAsync(context.CancellationToken).ConfigureAwait(false);
             }
 
             envFile.Add(entry.Key, defaultValue, envVar.Description, onlyIfMissing: false);

--- a/src/Aspire.Hosting.Docker/LocalContainerRegistry.cs
+++ b/src/Aspire.Hosting.Docker/LocalContainerRegistry.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Docker;
+
+/// <summary>
+/// Represents a local container registry (used for Docker Compose scenarios where images are built and used locally).
+/// </summary>
+internal sealed class LocalContainerRegistry : IContainerRegistry
+{
+    /// <summary>
+    /// Gets a singleton instance of <see cref="LocalContainerRegistry"/>.
+    /// </summary>
+    public static LocalContainerRegistry Instance { get; } = new();
+
+    private LocalContainerRegistry()
+    {
+    }
+
+    /// <inheritdoc/>
+    public ReferenceExpression Name => ReferenceExpression.Create($"local");
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Returns an empty string for local Docker Compose scenarios where images are built and used locally
+    /// without being pushed to a remote registry. The empty endpoint indicates no remote registry is involved.
+    /// </remarks>
+    public ReferenceExpression Endpoint => ReferenceExpression.Create($"");
+
+    /// <inheritdoc/>
+    public ReferenceExpression? Repository => null;
+}

--- a/src/Aspire.Hosting/ApplicationModel/ContainerImagePushOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerImagePushOptions.cs
@@ -85,7 +85,7 @@ public sealed class ContainerImagePushOptions
         // Parse the RemoteImageName to check if it contains a host override
         var (host, imagePath) = ParseImageReference(RemoteImageName);
 
-        if (host is not null)
+        if (!string.IsNullOrEmpty(host))
         {
             // RemoteImageName contains a host, use it directly instead of the registry endpoint
             return $"{host}/{imagePath}:{tag}";
@@ -101,14 +101,19 @@ public sealed class ContainerImagePushOptions
             ? await registry.Repository.GetValueAsync(cancellationToken).ConfigureAwait(false)
             : null;
 
-        if (!string.IsNullOrEmpty(repository))
+        // Combine registry endpoint, repository, and image path
+        if (!string.IsNullOrEmpty(repository) && !string.IsNullOrEmpty(registryEndpoint))
         {
-            // Combine registry endpoint, repository, and image path
             return $"{registryEndpoint}/{repository}/{imagePath}:{tag}";
         }
 
         // No repository, just use registry endpoint and image path
-        return $"{registryEndpoint}/{imagePath}:{tag}";
+        if (!string.IsNullOrEmpty(registryEndpoint))
+        {
+            return $"{registryEndpoint}/{imagePath}:{tag}";
+        }
+
+        return $"{imagePath}:{tag}";
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModelExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModelExtensions.cs
@@ -58,4 +58,26 @@ public static class DistributedApplicationModelExtensions
             }
         }
     }
+
+    /// <summary>
+    /// Returns the build and push resources from the <see cref="DistributedApplicationModel"/>.
+    /// Build and push resources are those that require building and pushing container images to a registry, and are not marked to be ignored by the manifest publishing callback annotation.
+    /// </summary>
+    /// <param name="model">The distributed application model to extract build and push resources from.</param>
+    /// <returns>An enumerable of build and push <see cref="IResource"/> in the model.</returns>
+    public static IEnumerable<IResource> GetBuildAndPushResources(this DistributedApplicationModel model)
+    {
+        foreach (var r in model.Resources)
+        {
+            if (r.IsExcludedFromPublish())
+            {
+                continue;
+            }
+
+            if (r.RequiresImageBuildAndPush())
+            {
+                yield return r;
+            }
+        }
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/IContainerRegistry.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IContainerRegistry.cs
@@ -16,6 +16,10 @@ public interface IContainerRegistry
     /// <summary>
     /// Gets the endpoint URL of the container registry.
     /// </summary>
+    /// <remarks>
+    /// An empty endpoint value indicates a local container registry where images are built and used locally
+    /// without being pushed to a remote registry (e.g., Docker Compose scenarios).
+    /// </remarks>
     ReferenceExpression Endpoint { get; }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1099,25 +1099,25 @@ public static class ResourceExtensions
     /// <remarks>
     /// This method checks for a container registry in the following order:
     /// <list type="number">
-    /// <item>The <see cref="DeploymentTargetAnnotation"/> on the resource.</item>
     /// <item>The <see cref="ContainerRegistryReferenceAnnotation"/> on the resource (set via <c>WithContainerRegistry</c>).</item>
+    /// <item>The <see cref="DeploymentTargetAnnotation"/> on the resource.</item>
     /// <item>The <see cref="RegistryTargetAnnotation"/> on the resource (automatically added when a registry is added to the app model).</item>
     /// </list>
     /// </remarks>
     internal static IContainerRegistry GetContainerRegistry(this IResource resource)
     {
-        // Try to get the container registry from DeploymentTargetAnnotation first
-        var deploymentTarget = resource.GetDeploymentTargetAnnotation();
-        if (deploymentTarget?.ContainerRegistry is not null)
-        {
-            return deploymentTarget.ContainerRegistry;
-        }
-
         // Try ContainerRegistryReferenceAnnotation (explicit WithContainerRegistry call)
         var registryAnnotation = resource.Annotations.OfType<ContainerRegistryReferenceAnnotation>().LastOrDefault();
         if (registryAnnotation is not null)
         {
             return registryAnnotation.Registry;
+        }
+
+        // Try to get the container registry from DeploymentTargetAnnotation first
+        var deploymentTarget = resource.GetDeploymentTargetAnnotation();
+        if (deploymentTarget?.ContainerRegistry is not null)
+        {
+            return deploymentTarget.ContainerRegistry;
         }
 
         // Fall back to RegistryTargetAnnotation (added automatically via BeforeStartEvent)

--- a/src/Aspire.Hosting/Pipelines/PipelineStepHelpers.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineStepHelpers.cs
@@ -18,6 +18,7 @@ internal static class PipelineStepHelpers
 {
     /// <summary>
     /// Pushes a container image to a registry with proper logging and task reporting.
+    /// If the registry is a local registry (empty endpoint), only tags the image without pushing.
     /// </summary>
     /// <param name="resource">The resource whose image should be pushed.</param>
     /// <param name="context">The pipeline step context for logging and task reporting.</param>
@@ -25,6 +26,66 @@ internal static class PipelineStepHelpers
     public static async Task PushImageToRegistryAsync(IResource resource, PipelineStepContext context)
     {
         var registry = resource.GetContainerRegistry();
+        var registryEndpoint = await registry.Endpoint.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+
+        // Check if this is a local registry (empty endpoint means no remote push needed)
+        var isLocalRegistry = string.IsNullOrEmpty(registryEndpoint);
+
+        if (isLocalRegistry)
+        {
+            await TagImageForLocalRegistryAsync(resource, context).ConfigureAwait(false);
+        }
+        else
+        {
+            await PushImageToRemoteRegistryAsync(resource, registry, context).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task TagImageForLocalRegistryAsync(IResource resource, PipelineStepContext context)
+    {
+        IValueProvider cir = new ContainerImageReference(resource);
+        var targetTag = await cir.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+
+        var tagTask = await context.ReportingStep.CreateTaskAsync(
+            $"Tagging **{resource.Name}** for local use",
+            context.CancellationToken).ConfigureAwait(false);
+
+        await using (tagTask.ConfigureAwait(false))
+        {
+            try
+            {
+                if (targetTag is null)
+                {
+                    throw new InvalidOperationException($"Failed to get target tag for {resource.Name}");
+                }
+
+                // Get the local image name
+                var localImageName = resource.TryGetContainerImageName(out var imageName)
+                    ? imageName
+                    : resource.Name.ToLowerInvariant();
+
+                // Only tag the image, don't push to a remote registry
+                var containerRuntime = context.Services.GetRequiredService<IContainerRuntime>();
+                await containerRuntime.TagImageAsync(localImageName, targetTag, context.CancellationToken).ConfigureAwait(false);
+
+                await tagTask.CompleteAsync(
+                    $"Successfully tagged **{resource.Name}** as `{targetTag}`",
+                    CompletionState.Completed,
+                    context.CancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                await tagTask.CompleteAsync(
+                    $"Failed to tag **{resource.Name}**: {ex.Message}",
+                    CompletionState.CompletedWithError,
+                    context.CancellationToken).ConfigureAwait(false);
+                throw;
+            }
+        }
+    }
+
+    private static async Task PushImageToRemoteRegistryAsync(IResource resource, IContainerRegistry registry, PipelineStepContext context)
+    {
         var registryName = await registry.Name.GetValueAsync(context.CancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException("Failed to retrieve container registry information.");
 

--- a/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
+++ b/tests/Aspire.Hosting.Docker.Tests/Aspire.Hosting.Docker.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ContainerRegistry\Aspire.Hosting.Azure.ContainerRegistry.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Docker\Aspire.Hosting.Docker.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
     <ProjectReference Include="..\Aspire.TestUtilities\Aspire.TestUtilities.csproj" />

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationModelExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationModelExtensionsTests.cs
@@ -34,6 +34,39 @@ public class DistributedApplicationModelExtensionsTests
             item => Assert.Equal(emulator.Resource, item));
     }
 
+    [Fact]
+    public void GetBuildAndPushResources_Returns_Projects_And_Resources_With_Dockerfiles_Excludes_BuildOnly_And_Ignored()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Projects always require build and push
+        var project = builder.AddProject<Projects.ServiceA>("ServiceA");
+        
+        // Regular containers don't require build/push (they use existing images)
+        var regularContainer = builder.AddContainer("regularContainer", "image");
+        
+        // Containers with DockerfileBuildAnnotation require build and push
+        var containerWithDockerfile = builder.AddContainer("containerWithDockerfile", "image");
+        containerWithDockerfile.Resource.Annotations.Add(new DockerfileBuildAnnotation("/context", "/Dockerfile", null));
+        
+        // Build-only containers (no entrypoint) should be excluded
+        var buildOnlyContainer = builder.AddContainer("buildOnlyContainer", "image");
+        buildOnlyContainer.Resource.Annotations.Add(new DockerfileBuildAnnotation("/context", "/Dockerfile", null) { HasEntrypoint = false });
+        
+        // Excluded resources should not be returned
+        var ignored = builder.AddProject<Projects.ServiceB>("ServiceB")
+            .ExcludeFromManifest();
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var result = appModel.GetBuildAndPushResources().ToList();
+
+        Assert.Collection(result,
+            item => Assert.Equal(project.Resource, item),
+            item => Assert.Equal(containerWithDockerfile.Resource, item));
+    }
+
     private sealed class CustomResource : IResource
     {
         public string Name { get; set; } = "CustomResource";


### PR DESCRIPTION
## Customer Impact

Support custom registry pushes for Docker Compose Environments, a currently unsupported scenario.

## Testing

Manual and automated tests.

## Risk

This change completes the custom registry story for 13.1. Without it, the changes in the 13.1 branch don't allow people to fully model custom registries and pushes to them.

## Regression?

No.