### PR TITLE
Dashboard: Show copy button even when value is hidden

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -57,19 +57,6 @@
             </FluentButton>
         </span>
 
-        <span class="defaultHidden">
-            @{
-                var copyButtonId = $"copy-{Guid.NewGuid():N}";
-                var attributes = FluentUIExtensions.GetClipboardCopyAdditionalAttributes(Value, Loc[nameof(ControlsStrings.GridValueCopyToClipboard)], Loc[nameof(ControlsStrings.GridValueCopied)]);
-            }
-            <FluentButton Appearance="Appearance.Lightweight" Id="@copyButtonId" AdditionalAttributes="attributes">
-                <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom"
-                    Icon="Icons.Regular.Size16.Copy" />
-                <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom"
-                    Icon="Icons.Regular.Size16.Checkmark" />
-            </FluentButton>
-        </span>
-
         @if (ContentInButtonArea is not null)
         {
             @ContentInButtonArea

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -57,6 +57,19 @@
             </FluentButton>
         </span>
 
+        <span class="defaultHidden">
+            @{
+                var copyButtonId = $"copy-{Guid.NewGuid():N}";
+                var attributes = FluentUIExtensions.GetClipboardCopyAdditionalAttributes(Value, Loc[nameof(ControlsStrings.GridValueCopyToClipboard)], Loc[nameof(ControlsStrings.GridValueCopied)]);
+            }
+            <FluentButton Appearance="Appearance.Lightweight" Id="@copyButtonId" AdditionalAttributes="attributes">
+                <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom"
+                    Icon="Icons.Regular.Size16.Copy" />
+                <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom"
+                    Icon="Icons.Regular.Size16.Checkmark" />
+            </FluentButton>
+        </span>
+
         @if (ContentInButtonArea is not null)
         {
             @ContentInButtonArea

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -47,19 +47,27 @@
                     @Loc[nameof(Dialogs.TextVisualizerSecretWarningDescription)]
                 </div>
             </div>
-
-            <FluentButton Class="text-visualizer-unmask-content" OnClick="@UnmaskContentAsync">@Loc[nameof(Dialogs.TextVisualizerSecretWarningAcknowledge)]</FluentButton>
         }
 
-        <FluentButton Id="@_copyButtonId"
-                      Class="text-visualizer-copy"
-                      AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(TextVisualizerViewModel.FormattedText, ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
-            <span slot="start">
-                <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
-                <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
-            </span>
-            @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
-        </FluentButton>
+        <div class="button-container">
+            @if (ShowSecretsWarning is true)
+            {
+                <FluentButton Class="text-visualizer-unmask-content"
+                              OnClick="@UnmaskContentAsync">
+                    @Loc[nameof(Dialogs.TextVisualizerSecretWarningAcknowledge)]
+                </FluentButton>
+            }
+
+            <FluentButton Id="@_copyButtonId"
+                          Class="text-visualizer-copy"
+                          AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(TextVisualizerViewModel.FormattedText, ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
+                <span slot="start">
+                    <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
+                    <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
+                </span>
+                @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
+            </FluentButton>
+        </div>
     </div>
 </FluentDialogBody>
 

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -33,16 +33,6 @@
         @if (IsTextContentDisplayed)
         {
             <TextVisualizer ViewModel="TextVisualizerViewModel" />
-
-            <FluentButton Id="@_copyButtonId"
-                          Class="text-visualizer-copy"
-                          AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(TextVisualizerViewModel.FormattedText, ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
-                <span slot="start">
-                    <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
-                    <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
-                </span>
-                @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
-            </FluentButton>
         }
         else if (ShowSecretsWarning is true)
         {
@@ -60,6 +50,16 @@
 
             <FluentButton Class="text-visualizer-unmask-content" OnClick="@UnmaskContentAsync">@Loc[nameof(Dialogs.TextVisualizerSecretWarningAcknowledge)]</FluentButton>
         }
+
+        <FluentButton Id="@_copyButtonId"
+                      Class="text-visualizer-copy"
+                      AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(TextVisualizerViewModel.FormattedText, ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
+            <span slot="start">
+                <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
+                <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
+            </span>
+            @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
+        </FluentButton>
     </div>
 </FluentDialogBody>
 

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
@@ -7,14 +7,18 @@
     background: transparent;
 }
 
-.text-visualizer-container ::deep.text-visualizer-unmask-content {
+.text-visualizer-container ::deep.button-container {
+    display: flex;
+    width: 100%;
     margin-top: auto;
-    align-self: start;
+}
+
+.text-visualizer-container ::deep.text-visualizer-unmask-content {
+    margin-left: 0;
 }
 
 .text-visualizer-container ::deep.text-visualizer-copy {
-    margin-top: auto;
-    align-self: end;
+    margin-left: auto;
 }
 
 .text-visualizer-container {


### PR DESCRIPTION
## Description

This PR adds a copy button to the property grid in the dashboard, enabling the ability to copy a secret value without having to unmask it first. 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
