### PR TITLE
[release/13.1] Fix OpenAIResource.UriExpression

### DIFF
--- a/playground/AzureOpenAIEndToEnd/AzureOpenAIEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/AzureOpenAIEndToEnd/AzureOpenAIEndToEnd.AppHost/aspire-manifest.json
@@ -19,7 +19,9 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
         "HTTP_PORTS": "{webstory.bindings.http.targetPort}",
-        "ConnectionStrings__chat": "{chat.connectionString}"
+        "ConnectionStrings__chat": "{chat.connectionString}",
+        "CHAT_URI": "{openai.outputs.endpoint}",
+        "CHAT_MODELNAME": "chat"
       },
       "bindings": {
         "http": {

--- a/playground/AzureOpenAIEndToEnd/AzureOpenAIEndToEnd.AppHost/openai.module.bicep
+++ b/playground/AzureOpenAIEndToEnd/AzureOpenAIEndToEnd.AppHost/openai.module.bicep
@@ -36,4 +36,6 @@ resource chat 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
 
 output connectionString string = 'Endpoint=${openai.properties.endpoint}'
 
+output endpoint string = openai.properties.endpoint
+
 output name string = openai.name

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -65,6 +65,11 @@ public static class AzureOpenAIExtensions
                 Value = Interpolate($"Endpoint={cogServicesAccount.Properties.Endpoint}")
             });
 
+            infrastructure.Add(new ProvisioningOutput("endpoint", typeof(string))
+            {
+                Value = cogServicesAccount.Properties.Endpoint.ToBicepExpression()
+            });
+
             // We need to output name to externalize role assignments.
             infrastructure.Add(new ProvisioningOutput("name", typeof(string)) { Value = cogServicesAccount.Name.ToBicepExpression() });
 

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIResource.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIResource.cs
@@ -25,6 +25,11 @@ public class AzureOpenAIResource(string name, Action<AzureResourceInfrastructure
     public BicepOutputReference ConnectionString => new("connectionString", this);
 
     /// <summary>
+    /// Gets the service endpoint URI expression for the Azure OpenAI resource.
+    /// </summary>
+    public BicepOutputReference Endpoint => new("endpoint", this);
+
+    /// <summary>
     /// Gets the "name" output reference for the resource.
     /// </summary>
     public BicepOutputReference NameOutputReference => new("name", this);
@@ -36,7 +41,7 @@ public class AzureOpenAIResource(string name, Action<AzureResourceInfrastructure
     /// Format: The Azure OpenAI endpoint URL.
     /// </remarks>
     public ReferenceExpression UriExpression =>
-      ReferenceExpression.Create($"{ConnectionString}");
+        ReferenceExpression.Create($"{Endpoint}");
 
     /// <summary>
     /// Gets the connection string template for the manifest for the resource.

--- a/tests/Aspire.Hosting.Azure.Tests/AzureOpenAIConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureOpenAIConnectionPropertiesTests.cs
@@ -22,7 +22,7 @@ public class AzureOpenAIConnectionPropertiesTests
             property =>
             {
                 Assert.Equal("Uri", property.Key);
-                Assert.Equal("{openai.outputs.connectionString}", property.Value.ValueExpression);
+                Assert.Equal("{openai.outputs.endpoint}", property.Value.ValueExpression);
             });
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureOpenAIDeploymentConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureOpenAIDeploymentConnectionPropertiesTests.cs
@@ -23,7 +23,7 @@ public class AzureOpenAIDeploymentConnectionPropertiesTests
             property =>
             {
                 Assert.Equal("Uri", property.Key);
-                Assert.Equal("{openai.outputs.connectionString}", property.Value.ValueExpression);
+                Assert.Equal("{openai.outputs.endpoint}", property.Value.ValueExpression);
             },
             property =>
             {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureOpenAIExtensionsTests.AddAzureOpenAI_overrideLocalAuthDefault=False_useObsoleteApis=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureOpenAIExtensionsTests.AddAzureOpenAI_overrideLocalAuthDefault=False_useObsoleteApis=False.verified.bicep
@@ -55,4 +55,6 @@ resource embedding_model 'Microsoft.CognitiveServices/accounts/deployments@2024-
 
 output connectionString string = 'Endpoint=${openai.properties.endpoint}'
 
+output endpoint string = openai.properties.endpoint
+
 output name string = openai.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureOpenAIExtensionsTests.AddAzureOpenAI_overrideLocalAuthDefault=False_useObsoleteApis=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureOpenAIExtensionsTests.AddAzureOpenAI_overrideLocalAuthDefault=False_useObsoleteApis=True.verified.bicep
@@ -55,4 +55,6 @@ resource embedding_model 'Microsoft.CognitiveServices/accounts/deployments@2024-
 
 output connectionString string = 'Endpoint=${openai.properties.endpoint}'
 
+output endpoint string = openai.properties.endpoint
+
 output name string = openai.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureOpenAIExtensionsTests.AddAzureOpenAI_overrideLocalAuthDefault=True_useObsoleteApis=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureOpenAIExtensionsTests.AddAzureOpenAI_overrideLocalAuthDefault=True_useObsoleteApis=False.verified.bicep
@@ -55,4 +55,6 @@ resource embedding_model 'Microsoft.CognitiveServices/accounts/deployments@2024-
 
 output connectionString string = 'Endpoint=${openai.properties.endpoint}'
 
+output endpoint string = openai.properties.endpoint
+
 output name string = openai.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureOpenAIExtensionsTests.AddAzureOpenAI_overrideLocalAuthDefault=True_useObsoleteApis=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureOpenAIExtensionsTests.AddAzureOpenAI_overrideLocalAuthDefault=True_useObsoleteApis=True.verified.bicep
@@ -55,4 +55,6 @@ resource embedding_model 'Microsoft.CognitiveServices/accounts/deployments@2024-
 
 output connectionString string = 'Endpoint=${openai.properties.endpoint}'
 
+output endpoint string = openai.properties.endpoint
+
 output name string = openai.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureOpenAIWithResourceGroup.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/ExistingAzureResourceTests.SupportsExistingAzureOpenAIWithResourceGroup.verified.bicep
@@ -25,4 +25,6 @@ resource mymodel 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' =
 
 output connectionString string = 'Endpoint=${openAI.properties.endpoint}'
 
+output endpoint string = openAI.properties.endpoint
+
 output name string = openAI.name


### PR DESCRIPTION
It currently contains Endpoint= prefix which doesn't make sense and breaks languages trying to consume this property.

## Customer Impact

Non-.NET apps trying to consume Azure OpenAI aren't able to get the endpoint correctly

## Testing

Automated tests.

## Risk

Minimal as this is a new property in 13.1 and it is currently unusable.

## Regression?

No.