### PR TITLE
Add `DebuggerDisplayAttribute` to resource types & `DistributedApplication`

### DIFF
--- a/playground/orleans/Orleans.AppHost/Program.cs
+++ b/playground/orleans/Orleans.AppHost/Program.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Hosting;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage").RunAsEmulator();
@@ -36,5 +39,7 @@ builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard
 
 using var app = builder.Build();
 
-await app.RunAsync();
-
+await app.StartAsync();
+await Task.Delay(TimeSpan.FromSeconds(4));
+Debugger.Break();
+await app.WaitForShutdownAsync();

--- a/playground/orleans/Orleans.AppHost/Program.cs
+++ b/playground/orleans/Orleans.AppHost/Program.cs
@@ -1,6 +1,3 @@
-using System.Diagnostics;
-using Microsoft.Extensions.Hosting;
-
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage").RunAsEmulator();
@@ -39,7 +36,5 @@ builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard
 
 using var app = builder.Build();
 
-await app.StartAsync();
-await Task.Delay(TimeSpan.FromSeconds(4));
-Debugger.Break();
-await app.WaitForShutdownAsync();
+await app.RunAsync();
+

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Container = {ContainerName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Container = {ContainerName}")]
 public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<AzureCosmosDBDatabaseResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
@@ -14,6 +15,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Container = {ContainerName}", Name = "{Name}")]
 public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<AzureCosmosDBDatabaseResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBContainerResource.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Container = {ContainerName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Container = {ContainerName,nq}")]
 public class AzureCosmosDBContainerResource : Resource, IResourceWithParent<AzureCosmosDBDatabaseResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
 public class AzureCosmosDBDatabaseResource(string name, string databaseName, AzureCosmosDBResource parent)
     : Resource(name), IResourceWithParent<AzureCosmosDBResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
 public class AzureCosmosDBDatabaseResource(string name, string databaseName, AzureCosmosDBResource parent)
     : Resource(name), IResourceWithParent<AzureCosmosDBResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Database = {DatabaseName}")]
 public class AzureCosmosDBDatabaseResource(string name, string databaseName, AzureCosmosDBResource parent)
     : Resource(name), IResourceWithParent<AzureCosmosDBResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
@@ -17,7 +17,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, ConsumerGroup = {ConsumerGroupName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, ConsumerGroup = {ConsumerGroupName}")]
 public class AzureEventHubConsumerGroupResource(string name, string consumerGroupName, AzureEventHubResource parent)
     : Resource(name), IResourceWithParent<AzureEventHubResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -16,6 +17,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, ConsumerGroup = {ConsumerGroupName}", Name = "{Name}")]
 public class AzureEventHubConsumerGroupResource(string name, string consumerGroupName, AzureEventHubResource parent)
     : Resource(name), IResourceWithParent<AzureEventHubResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubConsumerGroupResource.cs
@@ -17,7 +17,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, ConsumerGroup = {ConsumerGroupName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, ConsumerGroup = {ConsumerGroupName,nq}")]
 public class AzureEventHubConsumerGroupResource(string name, string consumerGroupName, AzureEventHubResource parent)
     : Resource(name), IResourceWithParent<AzureEventHubResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
@@ -17,7 +17,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Hub = {HubName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Hub = {HubName}")]
 public class AzureEventHubResource(string name, string hubName, AzureEventHubsResource parent)
     : Resource(name), IResourceWithParent<AzureEventHubsResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -16,6 +17,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Hub = {HubName}", Name = "{Name}")]
 public class AzureEventHubResource(string name, string hubName, AzureEventHubsResource parent)
     : Resource(name), IResourceWithParent<AzureEventHubsResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs
@@ -17,7 +17,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Hub = {HubName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Hub = {HubName,nq}")]
 public class AzureEventHubResource(string name, string hubName, AzureEventHubsResource parent)
     : Resource(name), IResourceWithParent<AzureEventHubsResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Secret = {SecretName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Secret = {SecretName}")]
 public class AzureKeyVaultSecretResource(string name, string secretName, AzureKeyVaultResource parent, object value)
     : Resource(name), IResourceWithParent<AzureKeyVaultResource>, IAzureKeyVaultSecretReference
 {

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Secret = {SecretName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Secret = {SecretName,nq}")]
 public class AzureKeyVaultSecretResource(string name, string secretName, AzureKeyVaultResource parent, object value)
     : Resource(name), IResourceWithParent<AzureKeyVaultResource>, IAzureKeyVaultSecretReference
 {

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretResource.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultSecretResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Azure;
@@ -12,6 +13,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Secret = {SecretName}", Name = "{Name}")]
 public class AzureKeyVaultSecretResource(string name, string secretName, AzureKeyVaultResource parent, object value)
     : Resource(name), IResourceWithParent<AzureKeyVaultResource>, IAzureKeyVaultSecretReference
 {

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="postgresParentResource">The Azure PostgreSQL parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Database = {DatabaseName}")]
 public class AzurePostgresFlexibleServerDatabaseResource(string name, string databaseName, AzurePostgresFlexibleServerResource postgresParentResource)
     : Resource(name), IResourceWithParent<AzurePostgresFlexibleServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="postgresParentResource">The Azure PostgreSQL parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
 public class AzurePostgresFlexibleServerDatabaseResource(string name, string databaseName, AzurePostgresFlexibleServerResource postgresParentResource)
     : Resource(name), IResourceWithParent<AzurePostgresFlexibleServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerDatabaseResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="postgresParentResource">The Azure PostgreSQL parent resource associated with this database.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
 public class AzurePostgresFlexibleServerDatabaseResource(string name, string databaseName, AzurePostgresFlexibleServerResource postgresParentResource)
     : Resource(name), IResourceWithParent<AzurePostgresFlexibleServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
@@ -18,7 +18,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Queue = {QueueName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Queue = {QueueName,nq}")]
 public class AzureServiceBusQueueResource(string name, string queueName, AzureServiceBusResource parent)
     : Resource(name), IResourceWithParent<AzureServiceBusResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
@@ -18,7 +18,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Queue = {QueueName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Queue = {QueueName}")]
 public class AzureServiceBusQueueResource(string name, string queueName, AzureServiceBusResource parent)
     : Resource(name), IResourceWithParent<AzureServiceBusResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -17,6 +18,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Queue = {QueueName}", Name = "{Name}")]
 public class AzureServiceBusQueueResource(string name, string queueName, AzureServiceBusResource parent)
     : Resource(name), IResourceWithParent<AzureServiceBusResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusSubscriptionResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusSubscriptionResource.cs
@@ -18,7 +18,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Subscription = {SubscriptionName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Subscription = {SubscriptionName,nq}")]
 public class AzureServiceBusSubscriptionResource(string name, string subscriptionName, AzureServiceBusTopicResource parent)
     : Resource(name), IResourceWithParent<AzureServiceBusTopicResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusSubscriptionResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusSubscriptionResource.cs
@@ -18,7 +18,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Subscription = {SubscriptionName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Subscription = {SubscriptionName}")]
 public class AzureServiceBusSubscriptionResource(string name, string subscriptionName, AzureServiceBusTopicResource parent)
     : Resource(name), IResourceWithParent<AzureServiceBusTopicResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusSubscriptionResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusSubscriptionResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -17,6 +18,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Subscription = {SubscriptionName}", Name = "{Name}")]
 public class AzureServiceBusSubscriptionResource(string name, string subscriptionName, AzureServiceBusTopicResource parent)
     : Resource(name), IResourceWithParent<AzureServiceBusTopicResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusTopicResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusTopicResource.cs
@@ -18,7 +18,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Topic = {TopicName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Topic = {TopicName}")]
 public class AzureServiceBusTopicResource(string name, string topicName, AzureServiceBusResource parent)
     : Resource(name), IResourceWithParent<AzureServiceBusResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusTopicResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusTopicResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -17,6 +18,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Topic = {TopicName}", Name = "{Name}")]
 public class AzureServiceBusTopicResource(string name, string topicName, AzureServiceBusResource parent)
     : Resource(name), IResourceWithParent<AzureServiceBusResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusTopicResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusTopicResource.cs
@@ -18,7 +18,7 @@ namespace Aspire.Hosting.Azure;
 /// <remarks>
 /// Use <see cref="AzureProvisioningResourceExtensions.ConfigureInfrastructure{T}(ApplicationModel.IResourceBuilder{T}, Action{AzureResourceInfrastructure})"/> to configure specific <see cref="Azure.Provisioning"/> properties.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Topic = {TopicName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Topic = {TopicName,nq}")]
 public class AzureServiceBusTopicResource(string name, string topicName, AzureServiceBusResource parent)
     : Resource(name), IResourceWithParent<AzureServiceBusResource>, IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The Azure SQL Database (server) parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
 public class AzureSqlDatabaseResource(string name, string databaseName, AzureSqlServerResource parent)
     : Resource(name), IResourceWithParent<AzureSqlServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The Azure SQL Database (server) parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Database = {DatabaseName}")]
 public class AzureSqlDatabaseResource(string name, string databaseName, AzureSqlServerResource parent)
     : Resource(name), IResourceWithParent<AzureSqlServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The Azure SQL Database (server) parent resource associated with this database.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
 public class AzureSqlDatabaseResource(string name, string databaseName, AzureSqlServerResource parent)
     : Resource(name), IResourceWithParent<AzureSqlServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageContainerResource.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="blobContainerName">The name of the blob container.</param>
 /// <param name="parent">The <see cref="AzureBlobStorageResource"/> that the resource is stored in.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, BlobContainer = {BlobContainerName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, BlobContainer = {BlobContainerName}")]
 public class AzureBlobStorageContainerResource(string name, string blobContainerName, AzureBlobStorageResource parent) : Resource(name),
     IResourceWithConnectionString,
     IResourceWithParent<AzureBlobStorageResource>

--- a/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageContainerResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
@@ -14,6 +15,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="blobContainerName">The name of the blob container.</param>
 /// <param name="parent">The <see cref="AzureBlobStorageResource"/> that the resource is stored in.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, BlobContainer = {BlobContainerName}", Name = "{Name}")]
 public class AzureBlobStorageContainerResource(string name, string blobContainerName, AzureBlobStorageResource parent) : Resource(name),
     IResourceWithConnectionString,
     IResourceWithParent<AzureBlobStorageResource>

--- a/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageContainerResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureBlobStorageContainerResource.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="blobContainerName">The name of the blob container.</param>
 /// <param name="parent">The <see cref="AzureBlobStorageResource"/> that the resource is stored in.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, BlobContainer = {BlobContainerName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, BlobContainer = {BlobContainerName,nq}")]
 public class AzureBlobStorageContainerResource(string name, string blobContainerName, AzureBlobStorageResource parent) : Resource(name),
     IResourceWithConnectionString,
     IResourceWithParent<AzureBlobStorageResource>

--- a/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageQueueResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageQueueResource.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="queueName">The name of the queue.</param>
 /// <param name="parent">The <see cref="AzureQueueStorageResource"/> that the resource is stored in.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Queue = {QueueName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Queue = {QueueName,nq}")]
 public class AzureQueueStorageQueueResource(string name, string queueName, AzureQueueStorageResource parent) : Resource(name),
     IResourceWithConnectionString,
     IResourceWithParent<AzureQueueStorageResource>

--- a/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageQueueResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageQueueResource.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="queueName">The name of the queue.</param>
 /// <param name="parent">The <see cref="AzureQueueStorageResource"/> that the resource is stored in.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Queue = {QueueName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Queue = {QueueName}")]
 public class AzureQueueStorageQueueResource(string name, string queueName, AzureQueueStorageResource parent) : Resource(name),
     IResourceWithConnectionString,
     IResourceWithParent<AzureQueueStorageResource>

--- a/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageQueueResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureQueueStorageQueueResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
@@ -14,6 +15,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="queueName">The name of the queue.</param>
 /// <param name="parent">The <see cref="AzureQueueStorageResource"/> that the resource is stored in.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Queue = {QueueName}", Name = "{Name}")]
 public class AzureQueueStorageQueueResource(string name, string queueName, AzureQueueStorageResource parent) : Resource(name),
     IResourceWithConnectionString,
     IResourceWithParent<AzureQueueStorageResource>

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubHubResource.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubHubResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Azure.Provisioning.WebPubSub;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -10,6 +11,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="webpubsub">The <see cref="AzureWebPubSubResource"/> that the resource belongs to.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Hub = {HubName}", Name = "{Name}")]
 public class AzureWebPubSubHubResource(string name, AzureWebPubSubResource webpubsub) : Resource(name),
     IResourceWithParent<AzureWebPubSubResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubHubResource.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubHubResource.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="webpubsub">The <see cref="AzureWebPubSubResource"/> that the resource belongs to.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Hub = {HubName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Hub = {HubName}")]
 public class AzureWebPubSubHubResource(string name, AzureWebPubSubResource webpubsub) : Resource(name),
     IResourceWithParent<AzureWebPubSubResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubHubResource.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubHubResource.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="webpubsub">The <see cref="AzureWebPubSubResource"/> that the resource belongs to.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Hub = {HubName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Hub = {HubName,nq}")]
 public class AzureWebPubSubHubResource(string name, AzureWebPubSubResource webpubsub) : Resource(name),
     IResourceWithParent<AzureWebPubSubResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResource.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.DevTunnels;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.DevTunnels;
 /// <param name="command"></param>
 /// <param name="workingDirectory"></param>
 /// <param name="options"></param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, TunnelId = {TunnelId}", Name = "{Name}")]
 public sealed class DevTunnelResource(string name, string tunnelId, string command, string workingDirectory, DevTunnelOptions? options = null)
     : ExecutableResource(name, command, workingDirectory)
 {

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResource.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.DevTunnels;
 /// <param name="command"></param>
 /// <param name="workingDirectory"></param>
 /// <param name="options"></param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, TunnelId = {TunnelId,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, TunnelId = {TunnelId}")]
 public sealed class DevTunnelResource(string name, string tunnelId, string command, string workingDirectory, DevTunnelOptions? options = null)
     : ExecutableResource(name, command, workingDirectory)
 {

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResource.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.DevTunnels;
 /// <param name="command"></param>
 /// <param name="workingDirectory"></param>
 /// <param name="options"></param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, TunnelId = {TunnelId}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, TunnelId = {TunnelId,nq}")]
 public sealed class DevTunnelResource(string name, string tunnelId, string command, string workingDirectory, DevTunnelOptions? options = null)
     : ExecutableResource(name, command, workingDirectory)
 {

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.GitHub.Models;
 /// <summary>
 /// Represents a GitHub Model resource.
 /// </summary>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Model = {Model}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Model = {Model,nq}")]
 public class GitHubModelResource : Resource, IResourceWithConnectionString
 {
     internal ParameterResource DefaultKeyParameter { get; set; }

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.GitHub.Models;
@@ -8,6 +9,7 @@ namespace Aspire.Hosting.GitHub.Models;
 /// <summary>
 /// Represents a GitHub Model resource.
 /// </summary>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Model = {Model}", Name = "{Name}")]
 public class GitHubModelResource : Resource, IResourceWithConnectionString
 {
     internal ParameterResource DefaultKeyParameter { get; set; }

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelResource.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.GitHub.Models;
 /// <summary>
 /// Represents a GitHub Model resource.
 /// </summary>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Model = {Model,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Model = {Model}")]
 public class GitHubModelResource : Resource, IResourceWithConnectionString
 {
     internal ParameterResource DefaultKeyParameter { get; set; }

--- a/src/Aspire.Hosting.Milvus/MilvusDatabaseResource.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The Milvus parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
 public class MilvusDatabaseResource(string name, string databaseName, MilvusServerResource parent) : Resource(name), IResourceWithParent<MilvusServerResource>, IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Milvus/MilvusDatabaseResource.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The Milvus parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Database = {DatabaseName}")]
 public class MilvusDatabaseResource(string name, string databaseName, MilvusServerResource parent) : Resource(name), IResourceWithParent<MilvusServerResource>, IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Milvus/MilvusDatabaseResource.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusDatabaseResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.Milvus;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The Milvus parent resource associated with this database.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
 public class MilvusDatabaseResource(string name, string databaseName, MilvusServerResource parent) : Resource(name), IResourceWithParent<MilvusServerResource>, IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBDatabaseResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -12,6 +13,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The MongoDB server resource associated with this database.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
 public class MongoDBDatabaseResource(string name, string databaseName, MongoDBServerResource parent)
     : Resource(name), IResourceWithParent<MongoDBServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBDatabaseResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The MongoDB server resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Database = {DatabaseName}")]
 public class MongoDBDatabaseResource(string name, string databaseName, MongoDBServerResource parent)
     : Resource(name), IResourceWithParent<MongoDBServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBDatabaseResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The MongoDB server resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
 public class MongoDBDatabaseResource(string name, string databaseName, MongoDBServerResource parent)
     : Resource(name), IResourceWithParent<MongoDBServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The MySQL parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
 public class MySqlDatabaseResource(string name, string databaseName, MySqlServerResource parent)
     : Resource(name), IResourceWithParent<MySqlServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The MySQL parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Database = {DatabaseName}")]
 public class MySqlDatabaseResource(string name, string databaseName, MySqlServerResource parent)
     : Resource(name), IResourceWithParent<MySqlServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using MySqlConnector;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The MySQL parent resource associated with this database.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
 public class MySqlDatabaseResource(string name, string databaseName, MySqlServerResource parent)
     : Resource(name), IResourceWithParent<MySqlServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.OpenAI/OpenAIModelResource.cs
+++ b/src/Aspire.Hosting.OpenAI/OpenAIModelResource.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.OpenAI;
 /// <summary>
 /// Represents an OpenAI Model resource.
 /// </summary>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Model = {Model,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Model = {Model}")]
 public class OpenAIModelResource : Resource, IResourceWithParent<OpenAIResource>, IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.OpenAI/OpenAIModelResource.cs
+++ b/src/Aspire.Hosting.OpenAI/OpenAIModelResource.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.OpenAI;
 /// <summary>
 /// Represents an OpenAI Model resource.
 /// </summary>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Model = {Model}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Model = {Model,nq}")]
 public class OpenAIModelResource : Resource, IResourceWithParent<OpenAIResource>, IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.OpenAI/OpenAIModelResource.cs
+++ b/src/Aspire.Hosting.OpenAI/OpenAIModelResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.OpenAI;
@@ -8,6 +9,7 @@ namespace Aspire.Hosting.OpenAI;
 /// <summary>
 /// Represents an OpenAI Model resource.
 /// </summary>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Model = {Model}", Name = "{Name}")]
 public class OpenAIModelResource : Resource, IResourceWithParent<OpenAIResource>, IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The Oracle Database parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Database = {DatabaseName}")]
 public class OracleDatabaseResource(string name, string databaseName, OracleDatabaseServerResource parent)
     : Resource(name), IResourceWithParent<OracleDatabaseServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The Oracle Database parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
 public class OracleDatabaseResource(string name, string databaseName, OracleDatabaseServerResource parent)
     : Resource(name), IResourceWithParent<OracleDatabaseServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -12,6 +13,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The Oracle Database parent resource associated with this database.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
 public class OracleDatabaseResource(string name, string databaseName, OracleDatabaseServerResource parent)
     : Resource(name), IResourceWithParent<OracleDatabaseServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="postgresParentResource">The PostgreSQL parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
 public class PostgresDatabaseResource(string name, string databaseName, PostgresServerResource postgresParentResource)
     : Resource(name), IResourceWithParent<PostgresServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="postgresParentResource">The PostgreSQL parent resource associated with this database.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Database = {DatabaseName}")]
 public class PostgresDatabaseResource(string name, string databaseName, PostgresServerResource postgresParentResource)
     : Resource(name), IResourceWithParent<PostgresServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data.Common;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="postgresParentResource">The PostgreSQL parent resource associated with this database.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
 public class PostgresDatabaseResource(string name, string databaseName, PostgresServerResource postgresParentResource)
     : Resource(name), IResourceWithParent<PostgresServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The parent SQL Server server resource.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Database = {DatabaseName}")]
 public class SqlServerDatabaseResource(string name, string databaseName, SqlServerServerResource parent)
     : Resource(name), IResourceWithParent<SqlServerServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.Data.SqlClient;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The parent SQL Server server resource.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
 public class SqlServerDatabaseResource(string name, string databaseName, SqlServerServerResource parent)
     : Resource(name), IResourceWithParent<SqlServerServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The parent SQL Server server resource.</param>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Database = {DatabaseName}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Database = {DatabaseName,nq}")]
 public class SqlServerDatabaseResource(string name, string databaseName, SqlServerServerResource parent)
     : Resource(name), IResourceWithParent<SqlServerServerResource>, IResourceWithConnectionString
 {

--- a/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
@@ -3,6 +3,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -12,6 +13,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="entrypoint">An optional container entrypoint.</param>
+[DebuggerDisplay("{GetDebuggerString(),nq}", Name = "{Name}")]
 public class ContainerResource(string name, string? entrypoint = null)
     : Resource(name), IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints, IResourceWithWaitSupport, IResourceWithProbes,
     IComputeResource
@@ -27,4 +29,14 @@ public class ContainerResource(string name, string? entrypoint = null)
     /// </summary>
     [Experimental("ASPIRECONTAINERSHELLEXECUTION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public bool? ShellExecution { get; set; }
+
+    private string GetDebuggerString()
+    {
+        if (!this.TryGetContainerImageName(out var imageName))
+        {
+            imageName = "<unknown>";
+        }
+
+        return $@"Type = {GetType().Name}, Image = {imageName}";
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="entrypoint">An optional container entrypoint.</param>
-[DebuggerDisplay("{GetDebuggerString(),nq}")]
+[DebuggerDisplay("{DebuggerToString(),nq}")]
 public class ContainerResource(string name, string? entrypoint = null)
     : Resource(name), IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints, IResourceWithWaitSupport, IResourceWithProbes,
     IComputeResource
@@ -30,13 +30,13 @@ public class ContainerResource(string name, string? entrypoint = null)
     [Experimental("ASPIRECONTAINERSHELLEXECUTION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public bool? ShellExecution { get; set; }
 
-    private string GetDebuggerString()
+    private string DebuggerToString()
     {
         if (!this.TryGetContainerImageName(out var imageName))
         {
             imageName = "<unknown>";
         }
 
-        return $@"Type = {GetType().Name}, Name = {Name}, Image = {imageName}";
+        return $@"Type = {GetType().Name}, Name = ""{Name}"", Image = ""{imageName}""";
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="entrypoint">An optional container entrypoint.</param>
-[DebuggerDisplay("{GetDebuggerString(),nq}", Name = "{Name}")]
+[DebuggerDisplay("{GetDebuggerString(),nq}")]
 public class ContainerResource(string name, string? entrypoint = null)
     : Resource(name), IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints, IResourceWithWaitSupport, IResourceWithProbes,
     IComputeResource
@@ -37,6 +37,6 @@ public class ContainerResource(string name, string? entrypoint = null)
             imageName = "<unknown>";
         }
 
-        return $@"Type = {GetType().Name}, Image = {imageName}";
+        return $@"Type = {GetType().Name}, Name = {Name}, Image = {imageName}";
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModel.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModel.cs
@@ -23,5 +23,6 @@ public class DistributedApplicationModel(IResourceCollection resources)
     /// <summary>
     /// Gets the collection of resources associated with the distributed application.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
     public IResourceCollection Resources { get; } = resources ?? throw new ArgumentNullException(nameof(resources));
 }

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -3,6 +3,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -17,6 +18,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <para/> 
 /// To run an executable file that's in the current directory, specify the full path or use the relative path <c>./</c> to represent the current directory.
 /// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Command = {Command,nq}", Name = "{Name}")]
 public class ExecutableResource : Resource, IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints, IResourceWithWaitSupport, IResourceWithProbes,
     IComputeResource
 {

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -18,7 +18,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <para/> 
 /// To run an executable file that's in the current directory, specify the full path or use the relative path <c>./</c> to represent the current directory.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Command = {Command,nq}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Command = {Command}")]
 public class ExecutableResource : Resource, IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints, IResourceWithWaitSupport, IResourceWithProbes,
     IComputeResource
 {

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -18,7 +18,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <para/> 
 /// To run an executable file that's in the current directory, specify the full path or use the relative path <c>./</c> to represent the current directory.
 /// </remarks>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Command = {Command,nq}", Name = "{Name}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name,nq}, Command = {Command,nq}")]
 public class ExecutableResource : Resource, IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints, IResourceWithWaitSupport, IResourceWithProbes,
     IComputeResource
 {

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -21,7 +21,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// A resource that represents a specified .NET project.
 /// </summary>
-[DebuggerDisplay("{DebuggerToString(),nq}", Name = "{Name}")]
+[DebuggerDisplay("{DebuggerToString(),nq}")]
 public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWithArgs, IResourceWithServiceDiscovery, IResourceWithWaitSupport, IResourceWithProbes,
     IComputeResource, IContainerFilesDestinationResource
 {
@@ -295,6 +295,6 @@ public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWith
             path = metadata.ProjectPath;
         }
 
-        return $@"Type = {GetType().Name}, Path = {path}";
+        return $@"Type = {GetType().Name}, Name = {Name}, Path = {path}";
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -295,6 +295,6 @@ public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWith
             path = metadata.ProjectPath;
         }
 
-        return $@"Type = {GetType().Name}, Name = {Name}, Path = {path}";
+        return $@"Type = {GetType().Name}, Name = ""{Name}"", Path = ""{path}""";
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -9,6 +9,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Hosting.ApplicationModel.Docker;
 using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Publishing;
@@ -20,6 +21,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// A resource that represents a specified .NET project.
 /// </summary>
+[DebuggerDisplay("{DebuggerToString(),nq}", Name = "{Name}")]
 public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWithArgs, IResourceWithServiceDiscovery, IResourceWithWaitSupport, IResourceWithProbes,
     IComputeResource, IContainerFilesDestinationResource
 {
@@ -283,5 +285,16 @@ public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWith
             logger.LogDebug(ex, "Error getting ContainerWorkingDirectory. Using default /app");
             return "/app";
         }
+    }
+
+    private string DebuggerToString()
+    {
+        var path = "<unknown>";
+        if (this.TryGetLastAnnotation<IProjectMetadata>(out var metadata))
+        {
+            path = metadata.ProjectPath;
+        }
+
+        return $@"Type = {GetType().Name}, Path = {path}";
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/Resource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Resource.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents an abstract resource that can be used by an application, that implements <see cref="IResource"/>.
 /// </summary>
-[DebuggerDisplay("{DebuggerToString(),nq}")]
+[DebuggerDisplay("{DebuggerToString(),nq}", Name = "{Name}")]
 public abstract class Resource : IResource
 {
     /// <summary>
@@ -34,6 +34,6 @@ public abstract class Resource : IResource
 
     private string DebuggerToString()
     {
-        return $@"Type = {GetType().Name}, Name = ""{Name}"", Annotations = {Annotations.Count}";
+        return $@"Type = {GetType().Name}, Annotations = {Annotations.Count}";
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/Resource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Resource.cs
@@ -34,6 +34,6 @@ public abstract class Resource : IResource
 
     private string DebuggerToString()
     {
-        return $@"Type = {GetType().Name}, Name = {Name}, Annotations = {Annotations.Count}";
+        return $@"Type = {GetType().Name}, Name = ""{Name}"", Annotations = {Annotations.Count}";
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/Resource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Resource.cs
@@ -34,6 +34,6 @@ public abstract class Resource : IResource
 
     private string DebuggerToString()
     {
-        return $@"Type = {GetType().Name}, Annotations = {Annotations.Count}";
+        return $@"Type = {GetType().Name}, Name = {Name}, Annotations = {Annotations.Count}";
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/Resource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Resource.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents an abstract resource that can be used by an application, that implements <see cref="IResource"/>.
 /// </summary>
-[DebuggerDisplay("{DebuggerToString(),nq}", Name = "{Name}")]
+[DebuggerDisplay("{DebuggerToString(),nq}")]
 public abstract class Resource : IResource
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
@@ -33,10 +33,13 @@ internal sealed class ResourceCollection : IResourceCollection
     private sealed class ApplicationResourceCollectionDebugView(ResourceCollection collection)
     {
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public DebugView[] Items => collection.Select(x => new DebugView(x)).ToArray();
+        public DebugView[] Items => [.. collection.Select(x => new DebugView { Resource = x })];
 
         [DebuggerDisplay("{Resource}", Name = "{Resource.Name}")]
-        public record struct DebugView(IResource Resource);
+        public struct DebugView()
+        {
+            public required IResource Resource { get; init; }
+        };
     }
 }
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
@@ -33,14 +33,14 @@ internal sealed class ResourceCollection : IResourceCollection
     private sealed class ApplicationResourceCollectionDebugView(ResourceCollection collection)
     {
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public DebugView[] Items => [.. collection.Select(x => new DebugView { Resource = x })];
+        public ResourceDebugView[] Items => [.. collection.Select(x => new ResourceDebugView { Resource = x })];
 
         [DebuggerDisplay("{Resource}", Name = "{Resource.Name}")]
-        public struct DebugView()
+        public sealed class ResourceDebugView
         {
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
             public required IResource Resource { get; init; }
-        };
+        }
     }
 }
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
@@ -33,7 +33,10 @@ internal sealed class ResourceCollection : IResourceCollection
     private sealed class ApplicationResourceCollectionDebugView(ResourceCollection collection)
     {
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public IResource[] Items => collection.ToArray();
+        public DebugView[] Items => collection.Select(x => new DebugView(x)).ToArray();
+
+        [DebuggerDisplay("{Resource}", Name = "{Resource.Name}")]
+        public record struct DebugView(IResource Resource);
     }
 }
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
@@ -38,6 +38,7 @@ internal sealed class ResourceCollection : IResourceCollection
         [DebuggerDisplay("{Resource}", Name = "{Resource.Name}")]
         public struct DebugView()
         {
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
             public required IResource Resource { get; init; }
         };
     }

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -575,15 +575,23 @@ public class DistributedApplication : IHost, IAsyncDisposable
                         foreach(var instance in dcpInstancesAnnotation.Instances)
                         {
                             app.ResourceNotifications.TryGetCurrentState(instance.Name, out var resourceEvent);
-                            results.Add(new() { ResourceId = instance.Name, Resource = resource, Snapshot = resourceEvent?.Snapshot });
+                            results.Add(new() { ResourceId = instance.Name, Resource = resource, Snapshot = GetSnapshot(resourceEvent) });
                         }
                     }
                     else
                     {
                         app.ResourceNotifications.TryGetCurrentState(resource.Name, out var resourceEvent);
-                        results.Add(new() { ResourceId = resource.Name, Resource = resource, Snapshot = resourceEvent?.Snapshot });
+                        results.Add(new() { ResourceId = resource.Name, Resource = resource, Snapshot = GetSnapshot(resourceEvent)});
                     }
+
+                    CustomResourceSnapshot GetSnapshot(ResourceEvent? evt) => evt?.Snapshot
+                        ?? new CustomResourceSnapshot
+                        {
+                            ResourceType = resource.GetType().Name,
+                            Properties = []
+                        };
                 }
+
                 return results;
             }
         }
@@ -597,7 +605,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
             public required IResource Resource { get; init; }
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public CustomResourceSnapshot? Snapshot { get; init; }
+            public required CustomResourceSnapshot Snapshot { get; init; }
         }
     }
 }

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -555,7 +555,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
 
     internal struct DistributedApplicationDebuggerProxy(DistributedApplication app)
     {
-        public IHost Host => app._host;
+        public readonly IHost Host => app._host;
 
         public List<ResourceState> Resources
         {
@@ -575,21 +575,14 @@ public class DistributedApplication : IHost, IAsyncDisposable
                         foreach(var instance in dcpInstancesAnnotation.Instances)
                         {
                             app.ResourceNotifications.TryGetCurrentState(instance.Name, out var resourceEvent);
-                            results.Add(new() { ResourceId = instance.Name, Resource = resource, Snapshot = GetSnapshot(resourceEvent) });
+                            results.Add(new() { ResourceId = instance.Name, Resource = resource, Snapshot = resourceEvent?.Snapshot });
                         }
                     }
                     else
                     {
                         app.ResourceNotifications.TryGetCurrentState(resource.Name, out var resourceEvent);
-                        results.Add(new() { ResourceId = resource.Name, Resource = resource, Snapshot = GetSnapshot(resourceEvent)});
+                        results.Add(new() { ResourceId = resource.Name, Resource = resource, Snapshot = resourceEvent?.Snapshot });
                     }
-
-                    CustomResourceSnapshot GetSnapshot(ResourceEvent? evt) => evt?.Snapshot
-                        ?? new CustomResourceSnapshot
-                        {
-                            ResourceType = resource.GetType().Name,
-                            Properties = []
-                        };
                 }
 
                 return results;
@@ -604,8 +597,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
 
             public required IResource Resource { get; init; }
 
-            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public required CustomResourceSnapshot Snapshot { get; init; }
+            public required CustomResourceSnapshot? Snapshot { get; init; }
         }
     }
 }

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -557,7 +557,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     {
         public readonly IHost Host => app._host;
 
-        public List<ResourceState> Resources
+        public List<ResourceStateDebugView> Resources
         {
             get
             {
@@ -566,7 +566,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
                     return [];
                 }
 
-                var results = new List<ResourceState>(app._model.Resources.Count);
+                var results = new List<ResourceStateDebugView>(app._model.Resources.Count);
                 foreach (var resource in app._model.Resources)
                 {
                     resource.TryGetLastAnnotation<DcpInstancesAnnotation>(out var dcpInstancesAnnotation);
@@ -575,13 +575,13 @@ public class DistributedApplication : IHost, IAsyncDisposable
                         foreach(var instance in dcpInstancesAnnotation.Instances)
                         {
                             app.ResourceNotifications.TryGetCurrentState(instance.Name, out var resourceEvent);
-                            results.Add(new() { ResourceId = instance.Name, Resource = resource, Snapshot = resourceEvent?.Snapshot });
+                            results.Add(new() { Resource = resource, Snapshot = resourceEvent?.Snapshot });
                         }
                     }
                     else
                     {
                         app.ResourceNotifications.TryGetCurrentState(resource.Name, out var resourceEvent);
-                        results.Add(new() { ResourceId = resource.Name, Resource = resource, Snapshot = resourceEvent?.Snapshot });
+                        results.Add(new() { Resource = resource, Snapshot = resourceEvent?.Snapshot });
                     }
                 }
 
@@ -589,12 +589,9 @@ public class DistributedApplication : IHost, IAsyncDisposable
             }
         }
 
-        [DebuggerDisplay("{Snapshot}", Name = "{ResourceId}", Type = "{Resource.GetType().FullName,nq}")]
-        internal class ResourceState
+        [DebuggerDisplay("{Resource}", Name = "{Resource.Name}", Type = "{Resource.GetType().FullName,nq}")]
+        internal class ResourceStateDebugView
         {
-            [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-            public required string ResourceId { get; init; }
-
             public required IResource Resource { get; init; }
 
             public required CustomResourceSnapshot? Snapshot { get; init; }

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -589,12 +589,48 @@ public class DistributedApplication : IHost, IAsyncDisposable
             }
         }
 
-        [DebuggerDisplay("{Resource}", Name = "{Resource.Name}", Type = "{Resource.GetType().FullName,nq}")]
+        [DebuggerDisplay("{DebuggerToString(),nq}", Name = "{Resource.Name}", Type = "{Resource.GetType().FullName,nq}")]
         internal class ResourceStateDebugView
         {
             public required IResource Resource { get; init; }
 
             public required CustomResourceSnapshot? Snapshot { get; init; }
+
+            private string DebuggerToString()
+            {
+                var value = $@"Type = {Resource.GetType().Name}, Name = ""{Resource.Name}"", State = {GetDebugText(Snapshot?.State?.Text)}";
+
+                if (Snapshot?.HealthStatus != null)
+                {
+                    value += $", HealthStatus = {GetDebugText(Snapshot?.HealthStatus)}";
+                }
+
+                if (KnownResourceStates.TerminalStates.Contains(Snapshot?.State?.Text, StringComparers.ResourceState))
+                {
+                    if (Snapshot?.ExitCode != null)
+                    {
+                        value += $", ExitCode = {GetDebugText(Snapshot?.ExitCode)}";
+                    }
+                }
+
+                return value;
+            }
+
+            private static string GetDebugText(object? value)
+            {
+                if (value is null)
+                {
+                    return "(null)";
+                }
+                else if (value is string)
+                {
+                    return $@"""{value}""";
+                }
+                else
+                {
+                    return value?.ToString() ?? string.Empty;
+                }
+            }
         }
     }
 }

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -556,19 +556,18 @@ public class DistributedApplication : IHost, IAsyncDisposable
     internal class DistributedApplicationDebuggerProxy(DistributedApplication app)
     {
         public IHost Host => app._host;
-        public DistributedApplicationModel? Model => app._model;
 
-        public List<ResourceState> ResourceStates
+        public List<ResourceState> Resources
         {
             get
             {
-                if (Model == null)
+                if (app._model == null)
                 {
                     return [];
                 }
 
-                var results = new List<ResourceState>(Model.Resources.Count);
-                foreach (var resource in Model.Resources)
+                var results = new List<ResourceState>(app._model.Resources.Count);
+                foreach (var resource in app._model.Resources)
                 {
                     //TODO: This probably doesn't handle replicas properly...
                     if (app.ResourceNotifications.TryGetCurrentState(resource.Name, out var resourceEvent) && resourceEvent != null)

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -598,38 +598,22 @@ public class DistributedApplication : IHost, IAsyncDisposable
 
             private string DebuggerToString()
             {
-                var value = $@"Type = {Resource.GetType().Name}, Name = ""{Resource.Name}"", State = {GetDebugText(Snapshot?.State?.Text)}";
+                var value = $@"Type = {Resource.GetType().Name}, Name = ""{Resource.Name}"", State = {Snapshot?.State?.Text ?? "(null)"}";
 
-                if (Snapshot?.HealthStatus != null)
+                if (Snapshot?.HealthStatus is { } healthStatus)
                 {
-                    value += $", HealthStatus = {GetDebugText(Snapshot?.HealthStatus)}";
+                    value += $", HealthStatus = {healthStatus}";
                 }
 
                 if (KnownResourceStates.TerminalStates.Contains(Snapshot?.State?.Text, StringComparers.ResourceState))
                 {
-                    if (Snapshot?.ExitCode != null)
+                    if (Snapshot?.ExitCode is { } exitCode)
                     {
-                        value += $", ExitCode = {GetDebugText(Snapshot?.ExitCode)}";
+                        value += $", ExitCode = {exitCode}";
                     }
                 }
 
                 return value;
-            }
-
-            private static string GetDebugText(object? value)
-            {
-                if (value is null)
-                {
-                    return "(null)";
-                }
-                else if (value is string)
-                {
-                    return $@"""{value}""";
-                }
-                else
-                {
-                    return value?.ToString() ?? string.Empty;
-                }
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes #5632

Add `DebuggerDisplayAttribute` to various resource types
- Set the `Name` property to `Name`, so that resources lists in the debugger show up more like a dictionary
- Show a `Type` in the debugger view, and one relevant resource specific property.
- Add a debug view to `DistributedApplication`, exposing much of the information that is otherwise only available on the dashboard.  (Which doesn't usually run in tests)./

I'm sure there are still further improvements that can be made - particularly to the `DistributedApplication` view.  (e.g. A buffer of the last 50 logs or so), but what we have here is a vast improvement over what we have, and provides a way to help troubleshoot why tests are failing without the dashboard.

`DistributedApplication` After:
<img width="2051" height="1004" alt="image" src="https://github.com/user-attachments/assets/efbd0a58-7cba-4f93-9c41-e2bbe3cb1d91" />

`DistributedApplication` Before:
<img width="2009" height="227" alt="image" src="https://github.com/user-attachments/assets/11fbd46c-0076-44f4-9e7f-d3ed4e256520" />


`ResourceCollection` After:
<img width="1341" height="256" alt="image" src="https://github.com/user-attachments/assets/61893f09-bb92-4a85-86fe-36a07ff87071" />

`ResourceCollection`  Before:
<img width="751" height="253" alt="image" src="https://github.com/user-attachments/assets/21faa0a9-d011-4b6e-a2cc-99c729129abd" />


## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
