### PR TITLE
[release/13.1] Undo the changes to bump PostgreSql to 18 until we validate No Data Checksums

### DIFF
--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -107,10 +107,7 @@ public static class PostgresBuilderExtensions
                       .WithImageRegistry(PostgresContainerImageTags.Registry)
                       .WithIconName("DatabaseMultiple")
                       .WithEnvironment("POSTGRES_HOST_AUTH_METHOD", "scram-sha-256")
-                      // PostgreSQL 18+ enables data checksums by default. We disable them to maintain backward compatibility
-                      // with existing volumes that don't have checksums enabled, preventing initialization failures when
-                      // reusing data directories from earlier versions.
-                      .WithEnvironment("POSTGRES_INITDB_ARGS", "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums")
+                      .WithEnvironment("POSTGRES_INITDB_ARGS", "--auth-host=scram-sha-256 --auth-local=scram-sha-256")
                       .WithEnvironment(context =>
                       {
                           context.EnvironmentVariables[UserEnvVarName] = postgresServer.UserNameReference;
@@ -373,12 +370,8 @@ public static class PostgresBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        // PostgreSQL 18+ Docker images changed the data directory structure to use major-version-specific
-        // subdirectories (e.g., /var/lib/postgresql/data/18). The mount point must be /var/lib/postgresql
-        // instead of /var/lib/postgresql/data to accommodate this change. Prior to PostgreSQL 18, the
-        // mount point was /var/lib/postgresql/data.
         return builder.WithVolume(name ?? VolumeNameGenerator.Generate(builder, "data"),
-            "/var/lib/postgresql", isReadOnly);
+            "/var/lib/postgresql/data", isReadOnly);
     }
 
     /// <summary>
@@ -393,11 +386,7 @@ public static class PostgresBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(source);
 
-        // PostgreSQL 18+ Docker images changed the data directory structure to use major-version-specific
-        // subdirectories (e.g., /var/lib/postgresql/data/18). The mount point must be /var/lib/postgresql
-        // instead of /var/lib/postgresql/data to accommodate this change. Prior to PostgreSQL 18, the
-        // mount point was /var/lib/postgresql/data.
-        return builder.WithBindMount(source, "/var/lib/postgresql", isReadOnly);
+        return builder.WithBindMount(source, "/var/lib/postgresql/data", isReadOnly);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
@@ -11,8 +11,8 @@ internal static class PostgresContainerImageTags
     /// <remarks>library/postgres</remarks>
     public const string Image = "library/postgres";
 
-    /// <remarks>18.0</remarks>
-    public const string Tag = "18.0";
+    /// <remarks>17.6</remarks>
+    public const string Tag = "17.6";
 
     /// <remarks>docker.io</remarks>
     public const string PgAdminRegistry = "docker.io";
@@ -20,8 +20,8 @@ internal static class PostgresContainerImageTags
     /// <remarks>dpage/pgadmin4</remarks>
     public const string PgAdminImage = "dpage/pgadmin4";
 
-    /// <remarks>9.9.0</remarks>
-    public const string PgAdminTag = "9.9.0";
+    /// <remarks>9.7.0</remarks>
+    public const string PgAdminTag = "9.7.0";
 
     /// <remarks>docker.io</remarks>
     public const string PgWebRegistry = "docker.io";

--- a/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
@@ -20,8 +20,8 @@ internal static class PostgresContainerImageTags
     /// <remarks>dpage/pgadmin4</remarks>
     public const string PgAdminImage = "dpage/pgadmin4";
 
-    /// <remarks>9.7.0</remarks>
-    public const string PgAdminTag = "9.7.0";
+    /// <remarks>9.9.0</remarks>
+    public const string PgAdminTag = "9.9.0";
 
     /// <remarks>docker.io</remarks>
     public const string PgWebRegistry = "docker.io";

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -79,7 +79,7 @@ public class AddPostgresTests
             env =>
             {
                 Assert.Equal("POSTGRES_INITDB_ARGS", env.Key);
-                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums", env.Value);
+                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256", env.Value);
             },
             env =>
             {
@@ -133,7 +133,7 @@ public class AddPostgresTests
             env =>
             {
                 Assert.Equal("POSTGRES_INITDB_ARGS", env.Key);
-                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums", env.Value);
+                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256", env.Value);
             },
             env =>
             {
@@ -226,7 +226,7 @@ public class AddPostgresTests
             env =>
             {
                 Assert.Equal("POSTGRES_INITDB_ARGS", env.Key);
-                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums", env.Value);
+                Assert.Equal("--auth-host=scram-sha-256 --auth-local=scram-sha-256", env.Value);
             },
             env =>
             {
@@ -257,7 +257,7 @@ public class AddPostgresTests
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
+                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
                 "POSTGRES_USER": "postgres",
                 "POSTGRES_PASSWORD": "{pg-password.value}"
               },
@@ -300,7 +300,7 @@ public class AddPostgresTests
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
+                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
                 "POSTGRES_USER": "{user.value}",
                 "POSTGRES_PASSWORD": "{pass.value}"
               },
@@ -326,7 +326,7 @@ public class AddPostgresTests
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
+                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
                 "POSTGRES_USER": "{user.value}",
                 "POSTGRES_PASSWORD": "{pg2-password.value}"
               },
@@ -352,7 +352,7 @@ public class AddPostgresTests
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
+                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
                 "POSTGRES_USER": "postgres",
                 "POSTGRES_PASSWORD": "{pass.value}"
               },

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -441,7 +441,7 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
                   "image": "{{ComponentTestConstants.AspireTestContainerRegistry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
                   "env": {
                     "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
-                    "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256 --no-data-checksums",
+                    "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
                     "POSTGRES_USER": "postgres",
                     "POSTGRES_PASSWORD": "{postgres-password.value}",
                     "POSTGRES_DB": "postgresdb"


### PR DESCRIPTION
cc: @eerhardt @DamianEdwards 

As discussed offline, this is reverting the bump to 18 while we more carefully analyze what should be done about the `--no-data-checksums` argument for initdb starting from 18. We want to prevent adding an argument as default that many consumers might not want and instead identify if this should be an opt-in instead.